### PR TITLE
Allow (ignored) standard options for terraform clean

### DIFF
--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -9,6 +9,19 @@ job "terraform clean" {
     type        = string
   }
 
+  option "environment" {
+    default     = ""
+    type        = string
+    description = "(ignored, provided for compatibility with other commands)"
+    short       = "e"
+  }
+
+  option "stage" {
+    type        = string
+    description = "(ignored, provided for compatibility with other commands)"
+    short       = "s"
+  }
+
   step "clean shell" {
     run "terraform shell" {
       project = param.project


### PR DESCRIPTION
## what

- Allow `terraform clean` to take `--stage` and `--environment` options, even though they will be ignored

## why

- Some scripts and tools provide those options for all Terraform commands that operate on a project, so it is convenient to allow them to provide the options to `terraform clean` even if they will be ignored, rather than raise an error about unknown options