### PR TITLE
Update helmfile CLI

### DIFF
--- a/example/cli/main.variant
+++ b/example/cli/main.variant
@@ -13,9 +13,9 @@ option "kubeconfig-path" {
   type        = string
 }
 
-option "kubeconfig-profile-pattern" {
+option "aws-profile-pattern" {
   default     = "{namespace}-{environment}-{stage}-helm"
-  description = "AWS profile pattern for kubeconfig"
+  description = "AWS profile pattern for kubeconfig, helm and helmfile"
   type        = string
 }
 

--- a/example/cli/main.variant
+++ b/example/cli/main.variant
@@ -13,9 +13,9 @@ option "kubeconfig-path" {
   type        = string
 }
 
-option "aws-profile-pattern" {
+option "helm-aws-profile-pattern" {
   default     = "{namespace}-{environment}-{stage}-helm"
-  description = "AWS profile pattern for kubeconfig, helm and helmfile"
+  description = "AWS profile pattern for helm and helmfile"
   type        = string
 }
 

--- a/example/stacks/globals.yaml
+++ b/example/stacks/globals.yaml
@@ -1,3 +1,1 @@
 namespace: eg
-
-kubeconfig_profile_environment: gbl

--- a/modules/helmfile/helmfile-core.variant
+++ b/modules/helmfile/helmfile-core.variant
@@ -99,7 +99,7 @@ job "helmfile subcommand" {
   variable "aws-profile" {
     value = {
       AWS_PROFILE = can(conf.stack-config.aws_profile) ? conf.stack-config.aws_profile : replace(replace(replace(
-        opt.aws-profile-pattern,
+        opt.helm-aws-profile-pattern,
         "{environment}", var.stack-config.environment),
         "{stage}", var.stack-config.stage),
         "{namespace}", var.stack-config.namespace)

--- a/modules/helmfile/helmfile-core.variant
+++ b/modules/helmfile/helmfile-core.variant
@@ -97,7 +97,13 @@ job "helmfile subcommand" {
   }
 
   variable "aws-profile" {
-    value = can(conf.stack-config.aws_profile) ? { AWS_PROFILE = conf.stack-config.aws_profile} : {}
+    value = {
+      AWS_PROFILE = can(conf.stack-config.aws_profile) ? conf.stack-config.aws_profile : replace(replace(replace(
+        opt.aws-profile-pattern,
+        "{environment}", var.stack-config.environment),
+        "{stage}", var.stack-config.stage),
+        "{namespace}", var.stack-config.namespace)
+    }
   }
 
   step "helmfile kubeconfig" {

--- a/modules/helmfile/helmfile-core.variant
+++ b/modules/helmfile/helmfile-core.variant
@@ -100,9 +100,9 @@ job "helmfile subcommand" {
     value = {
       AWS_PROFILE = can(conf.stack-config.aws_profile) ? conf.stack-config.aws_profile : replace(replace(replace(
         opt.helm-aws-profile-pattern,
-        "{environment}", var.stack-config.environment),
-        "{stage}", var.stack-config.stage),
-        "{namespace}", var.stack-config.namespace)
+        "{environment}", conf.stack-config.environment),
+        "{stage}", conf.stack-config.stage),
+        "{namespace}", conf.stack-config.namespace)
     }
   }
 

--- a/modules/kubeconfig/kubeconfig.variant
+++ b/modules/kubeconfig/kubeconfig.variant
@@ -41,7 +41,7 @@ job "aws eks kubeconfig" {
   variable "kubeconfig-profile" {
     type  = string
     value = replace(replace(replace(
-        opt.aws-profile-pattern,
+        opt.helm-aws-profile-pattern,
         "{environment}", var.stack-config.environment),
         "{stage}", var.stack-config.stage),
         "{namespace}", var.stack-config.namespace)

--- a/modules/kubeconfig/kubeconfig.variant
+++ b/modules/kubeconfig/kubeconfig.variant
@@ -41,8 +41,8 @@ job "aws eks kubeconfig" {
   variable "kubeconfig-profile" {
     type  = string
     value = replace(replace(replace(
-        opt.kubeconfig-profile-pattern,
-        "{environment}", var.stack-config.kubeconfig_profile_environment),
+        opt.aws-profile-pattern,
+        "{environment}", var.stack-config.environment),
         "{stage}", var.stack-config.stage),
         "{namespace}", var.stack-config.namespace)
   }


### PR DESCRIPTION
## what
* Rename `kubeconfig-profile-pattern` to `helm-aws-profile-pattern`
* Use `helm-aws-profile-pattern` to select an AWS profile for helmfile commands

## why
* `helm-aws-profile-pattern` is used not only for kubeconfig, but also for helm and helmfile
* By default, assume the role specified by the `helm-aws-profile-pattern` when calling the helmfile CLI (still having the option to specify a different AWS profile)
