### PR TITLE
chmod kubeconfig to 600 to avoid warning messages

### DIFF
--- a/modules/kubeconfig/kubeconfig.variant
+++ b/modules/kubeconfig/kubeconfig.variant
@@ -13,6 +13,35 @@ job "aws eks kubeconfig" {
     description = "Region"
   }
 
+  step "aws eks kubeconfig write" {
+    run "aws eks kubeconfig write" {
+      stack  = opt.stack
+      region = opt.region
+    }
+  }
+  step "aws eks kubeconfig chmod" {
+    run "shell" {
+      command = "chmod"
+      args = ["600", "${opt.kubeconfig-path}/${opt.stack}-kubecfg"]
+    }
+  }
+}
+
+job "aws eks kubeconfig write" {
+  description = "Download the kubeconfig from the cluster and save it in 'kubeconfig-path'"
+  private     = true
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "region" {
+    type        = string
+    description = "Region"
+  }
+
   variable "cmd-name" {
     value = "aws"
     type  = string


### PR DESCRIPTION
## what
- `chmod` kubeconfig to `600` to avoid warning messages

## why
- Avoid warnings like
```
  WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /dev/shm/uw2-demo-kubecfg
  WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /dev/shm/uw2-demo-kubecfg
```
