### PR TITLE
Publish Binary Release Artifact for Atmos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
            sudo mv variant /usr/local/bin/variant2 && \
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
-          variant2 export binary ./ ./atmos/atmos
+          variant2 export binary $PWD $PWD/atmos/atmos
           ./atmos help
 
       # Attach Go binaries to GitHub Release
@@ -40,4 +40,4 @@ jobs:
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: ./atmos*
+          INPUT_PATH: $PWD/atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
       # Checkout the repo
       - name: 'Checkout'
         uses: actions/checkout@v2
-        with:
-          path: /${{ github.repository }}
 
       # Setup Go
       - name: 'Setup Go'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'Build CLI and attach binary to GitHub release'
+name: 'Build CLI and attach to GitHub release'
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: 'Build CLI and attach binary to GitHub release'
+    name: 'Build CLI and attach to GitHub release'
     runs-on: ubuntu-latest
 
     steps:
@@ -25,19 +25,19 @@ jobs:
       - name: 'Build CLI'
         run: |
           set -e -x
-          sudo apt-get update && sudo apt-get install -y -u wget
           export VARIANT_VERSION=0.37.0
-          wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
-           tar -zvxf variant*.tar.gz variant && \
-           sudo mv variant /usr/local/bin/variant2 && \
-           rm -f variant*.tar.gz
           export CGO_ENABLED=1
-          variant2 export binary $PWD ${{ github.workspace }}/atmos/atmos
-          $PWD/atmos/atmos help
+          sudo apt-get update && sudo apt-get install -y -u wget
+          wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
+            tar -zvxf variant*.tar.gz variant && \
+            sudo mv variant /usr/local/bin/variant2 && \
+            rm -f variant*.tar.gz
+          variant2 export binary $PWD ${{ github.workspace }}/atmos
+          ${{ github.workspace }}/atmos help
 
-      # Attach Go binaries to GitHub Release
+      # Attach CLI binary to GitHub release
       - name: 'Attach CLI binary to GitHub release'
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: ${{ github.workspace }}/atmos/atmos
+          INPUT_PATH: ${{ github.workspace }}/atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: $PWD/atmos
+          INPUT_PATH: $PWD/atmos/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
            sudo mv variant /usr/local/bin/variant2 && \
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
-          variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos
+          variant2 export binary ./ ./atmos
           ./atmos help
 
       # Attach Go binaries to GitHub Release
@@ -40,4 +40,4 @@ jobs:
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_*
+          INPUT_PATH: ./atmos*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
            sudo mv variant /usr/local/bin/variant2 && \
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
-          variant2 export binary ./ ./atmos
+          variant2 export binary ./ ./atmos/atmos
           ./atmos help
 
       # Attach Go binaries to GitHub Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: $PWD/atmos/*
+          INPUT_PATH: $PWD/atmos/atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
       - name: 'Build CLI'
         run: |
           set -e -x
+          sudo apt update
+          sudo apt install cloudposse
           sudo apt-get update && sudo apt-get install -y -u variant2
           export CGO_ENABLED=1
           variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
            sudo mv variant /usr/local/bin/variant2 && \
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
-          variant2 export binary $PWD $PWD/atmos/atmos
+          variant2 export binary $PWD ${{ github.workspace }}/atmos/atmos
           $PWD/atmos/atmos help
 
       # Attach Go binaries to GitHub Release
@@ -40,4 +40,4 @@ jobs:
         uses: cloudposse/actions/github/release-assets@0.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PATH: $PWD/atmos/atmos
+          INPUT_PATH: ${{ github.workspace }}/atmos/atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,8 @@ jobs:
           export CGO_ENABLED=1
           sudo apt-get update && sudo apt-get install -y -u wget
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
-            tar -zvxf variant*.tar.gz variant && \
-            sudo mv variant /usr/local/bin/variant2 && \
-            rm -f variant*.tar.gz
-          variant2 export binary $PWD ${{ github.workspace }}/atmos
+            tar -zvxf variant*.tar.gz variant
+          ./variant export binary $PWD ${{ github.workspace }}/atmos
           ${{ github.workspace }}/atmos help
 
       # Attach CLI binary to GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,8 @@ jobs:
           export CGO_ENABLED=1
           sudo apt-get update && sudo apt-get install -y -u wget
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
-            tar -zvxf variant*.tar.gz variant && \
-            sudo mv variant /usr/local/bin/variant2 && \
-            rm -f variant*.tar.gz
-          variant2 export binary $PWD ${{ github.workspace }}/atmos
+            tar -zvxf variant*.tar.gz variant
+          variant export binary $PWD ${{ github.workspace }}/atmos
           ${{ github.workspace }}/atmos help
 
       # Attach CLI binary to GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Build CLI'
         run: |
           set -e -x
-          sudo apt-get update && apt-get install -y -u variant2
+          sudo apt-get update && sudo apt-get install -y -u variant2
           export CGO_ENABLED=1
           variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos
           ./atmos help

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: 'Build CLI and attach to GitHub release'
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   build:
@@ -29,8 +29,10 @@ jobs:
           export CGO_ENABLED=1
           sudo apt-get update && sudo apt-get install -y -u wget
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
-            tar -zvxf variant*.tar.gz variant
-          ./variant export binary $PWD ${{ github.workspace }}/atmos
+            tar -zvxf variant*.tar.gz variant && \
+            sudo mv variant /usr/local/bin/variant2 && \
+            rm -f variant*.tar.gz
+          variant2 export binary $PWD ${{ github.workspace }}/atmos
           ${{ github.workspace }}/atmos help
 
       # Attach CLI binary to GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,9 @@ jobs:
       - name: 'Build CLI'
         run: |
           set -e -x
-          sudo apt update
-          sudo apt install cloudposse
+          sudo apt-get update
+          sudo apt-get install software-properties-common
+          sudo add-apt-repository cloudposse
           sudo apt-get update && sudo apt-get install -y -u variant2
           export CGO_ENABLED=1
           variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y -u wget
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
             tar -zvxf variant*.tar.gz variant
-          variant export binary $PWD ${{ github.workspace }}/atmos
+          ./variant export binary $PWD ${{ github.workspace }}/atmos
           ${{ github.workspace }}/atmos help
 
       # Attach CLI binary to GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,12 @@ jobs:
       - name: 'Build CLI'
         run: |
           set -e -x
-          sudo apt-get update
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository cloudposse
-          sudo apt-get update && sudo apt-get install -y -u variant2
+          sudo apt-get update && sudo apt-get install -y -u wget
+          export VARIANT_VERSION=0.37.0
+          wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
+           tar -zvxf variant*.tar.gz variant && \
+           mv variant /usr/local/bin/variant2 && \
+           rm -f variant*.tar.gz
           export CGO_ENABLED=1
           variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos
           ./atmos help

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
           variant2 export binary $PWD $PWD/atmos/atmos
-          ./atmos help
+          $PWD/atmos/atmos help
 
       # Attach Go binaries to GitHub Release
       - name: 'Attach CLI binary to GitHub release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: 'Build CLI and attach binary to GitHub release'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: 'Build CLI and attach binary to GitHub release'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repo
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          path: /${{ github.repository }}
+
+      # Setup Go
+      - name: 'Setup Go'
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - run: go version
+
+      # Build CLI binaries
+      - name: 'Build CLI'
+        run: |
+          set -e -x
+          sudo apt-get update && apt-get install -y -u variant2
+          export CGO_ENABLED=1
+          variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos
+          ./atmos help
+
+      # Attach Go binaries to GitHub Release
+      - name: 'Attach CLI binary to GitHub release'
+        uses: cloudposse/actions/github/release-assets@0.23.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           export VARIANT_VERSION=0.37.0
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
            tar -zvxf variant*.tar.gz variant && \
-           mv variant /usr/local/bin/variant2 && \
+           sudo mv variant /usr/local/bin/variant2 && \
            rm -f variant*.tar.gz
           export CGO_ENABLED=1
           variant2 export binary ${{ github.workspace }}/release/${{ github.event.repository.name }}_ atmos

--- a/main.variant
+++ b/main.variant
@@ -1,0 +1,62 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+option "dry-run" {
+  default     = false
+  description = "Disable execution of any commands and echo the command instead"
+  type        = bool
+}
+
+option "kubeconfig-path" {
+  default     = "/dev/shm"
+  description = "folder to save kubeconfig"
+  type        = string
+}
+
+option "helm-aws-profile-pattern" {
+  default     = "{namespace}-{environment}-{stage}-helm"
+  description = "AWS profile pattern for helm and helmfile"
+  type        = string
+}
+
+option "cluster-name-pattern" {
+  default     = "{namespace}-{environment}-{stage}-eks-cluster"
+  description = "Cluster name pattern"
+  type        = string
+}
+
+option "terraform-dir" {
+  default     = "./components/terraform"
+  description = "Terraform components directory"
+  type        = string
+}
+
+option "helmfile-dir" {
+  default     = "./components/helmfile"
+  description = "Helmfile components directory"
+  type        = string
+}
+
+option "config-dir" {
+  default     = "./stacks"
+  description = "Stacks config directory"
+  type        = string
+}
+
+option "vendor-config-path" {
+  default     = "./vendir.yml"
+  description = "Path to the vendor configuration file"
+  type        = string
+}
+
+imports = [
+  "./modules/utils",
+  "./modules/shell",
+  "./modules/kubeconfig",
+  "./modules/terraform",
+  "./modules/helmfile",
+  "./modules/helm",
+  "./modules/workflow",
+  "./modules/istio",
+  "./modules/vendor"
+]


### PR DESCRIPTION
## what
* Publish Binary Release Artifact for Atmos

## why
* Allow using the `atmos` binary in other projects and containers
* Speed up Docker image build time (building `atmos` binary takes time)

## references
* https://cloudposse.atlassian.net/browse/CPCO-227
* https://github.com/cloudposse/atmos/releases/tag/0.0.2
