### PR TITLE
Add `component` attribute to stack configs. Allow configuring and provisioning many instances of the same component.

### DIFF
--- a/example/stacks/ue2-dev.yaml
+++ b/example/stacks/ue2-dev.yaml
@@ -24,6 +24,10 @@ components:
     vpc:
       vars:
         cidr_block: "10.100.0.0/18"
+    vpc2:
+      component: vpc
+      vars:
+        cidr_block: "10.108.0.0/18"
     eks:
       vars:
         test-map:

--- a/example/stacks/ue2-prod.yaml
+++ b/example/stacks/ue2-prod.yaml
@@ -16,6 +16,11 @@ components:
       command: "/usr/bin/terraform-0.13"
       vars:
         cidr_block: "10.102.0.0/18"
+    vpc2:
+      command: "/usr/bin/terraform-0.13"
+      component: vpc
+      vars:
+        cidr_block: "10.109.0.0/18"
     eks:
       vars: {}
 

--- a/example/stacks/ue2-staging.yaml
+++ b/example/stacks/ue2-staging.yaml
@@ -15,6 +15,10 @@ components:
     vpc:
       vars:
         cidr_block: "10.104.0.0/18"
+    vpc2:
+      component: vpc
+      vars:
+        cidr_block: "10.110.0.0/18"
     eks:
       vars: {}
 

--- a/modules/terraform/terraform-apply.variant
+++ b/modules/terraform/terraform-apply.variant
@@ -60,6 +60,7 @@ job "terraform apply" {
   step "apply clean" {
     run "terraform shell" {
       component = param.component
+      stack     = opt.stack
 
       commands = [
         "rm",

--- a/modules/terraform/terraform-clean.variant
+++ b/modules/terraform/terraform-clean.variant
@@ -15,6 +15,7 @@ job "terraform clean" {
   step "clean shell" {
     run "terraform shell" {
       component = param.component
+      stack     = opt.stack
 
       commands = [
         "rm -rf .terraform *.planfile"

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -81,7 +81,7 @@ job "terraform subcommand" {
   }
 
   variable "component" {
-    value = conf.config-component != null ? conf.config-component : param.component
+    value = coalesce(conf.config-component, param.component)
   }
 
   exec {
@@ -127,7 +127,7 @@ job "terraform shell" {
   }
 
   variable "component" {
-    value = conf.config-component != null ? conf.config-component : param.component
+    value = coalesce(conf.config-component, param.component)
   }
 
   run "shell" {
@@ -184,7 +184,7 @@ job "terraform write varfile" {
   }
 
   variable "component" {
-    value = conf.config-component != null ? conf.config-component : param.component
+    value = coalesce(conf.config-component, param.component)
   }
 
   exec {
@@ -272,7 +272,7 @@ job "terraform write override" {
   }
 
   variable "component" {
-    value = conf.config-component != null ? conf.config-component : param.component
+    value = coalesce(conf.config-component, param.component)
   }
 
   exec {

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -81,7 +81,7 @@ job "terraform subcommand" {
   }
 
   variable "component" {
-    value = conf.config-component.component != null ? conf.config-component.component : param.component
+    value = conf.config-component != null ? conf.config-component : param.component
   }
 
   exec {
@@ -127,7 +127,7 @@ job "terraform shell" {
   }
 
   variable "component" {
-    value = conf.config-component.component != null ? conf.config-component.component : param.component
+    value = conf.config-component != null ? conf.config-component : param.component
   }
 
   run "shell" {
@@ -184,7 +184,7 @@ job "terraform write varfile" {
   }
 
   variable "component" {
-    value = conf.config-component.component != null ? conf.config-component.component : param.component
+    value = conf.config-component != null ? conf.config-component : param.component
   }
 
   exec {
@@ -272,7 +272,7 @@ job "terraform write override" {
   }
 
   variable "component" {
-    value = conf.config-component.component != null ? conf.config-component.component : param.component
+    value = conf.config-component != null ? conf.config-component : param.component
   }
 
   exec {

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -28,15 +28,15 @@ job "terraform subcommand" {
   }
 
   option "args" {
+    type        = list(string)
     default     = []
     description = "args to pass to the subcommand"
-    type        = list(string)
   }
 
   option "env" {
+    type        = map(string)
     default     = {}
     description = "Environment variables for the subcommand"
-    type        = map(string)
   }
 
   option "interactive" {

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -113,6 +113,23 @@ job "terraform shell" {
     type        = list(string)
   }
 
+  config "config-component" {
+    source job {
+      name = "stack config"
+      args = {
+        component-type = "terraform"
+        config-type    = "component"
+        component      = param.component
+        stack          = opt.stack
+        format         = "json"
+      }
+    }
+  }
+
+  variable "component" {
+    value = conf.config-component.component != null ? conf.config-component.component : param.component
+  }
+
   run "shell" {
     command = "bash"
 
@@ -121,7 +138,7 @@ job "terraform shell" {
       join(" ", opt.commands)
     ]
 
-    dir = "${opt.terraform-dir}/${param.component}"
+    dir = "${opt.terraform-dir}/${var.component}"
   }
 }
 
@@ -153,6 +170,23 @@ job "terraform write varfile" {
     }
   }
 
+  config "config-component" {
+    source job {
+      name = "stack config"
+      args = {
+        component-type = "terraform"
+        config-type    = "component"
+        component      = param.component
+        stack          = opt.stack
+        format         = "json"
+      }
+    }
+  }
+
+  variable "component" {
+    value = conf.config-component.component != null ? conf.config-component.component : param.component
+  }
+
   exec {
     command = "echo"
 
@@ -167,7 +201,7 @@ job "terraform write varfile" {
       format    = event.exec.args[0]
     }
 
-    file = "${opt.terraform-dir}/${param.component}/${opt.stack}-${param.component}.terraform.tfvars.json"
+    file = "${opt.terraform-dir}/${var.component}/${opt.stack}-${var.component}.terraform.tfvars.json"
   }
 }
 
@@ -204,6 +238,12 @@ job "terraform write override" {
     description = "Component"
   }
 
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
   option "role" {
     type        = string
     description = "Role to assume"
@@ -216,6 +256,23 @@ job "terraform write override" {
         role = opt.role
       }
     }
+  }
+
+  config "config-component" {
+    source job {
+      name = "stack config"
+      args = {
+        component-type = "terraform"
+        config-type    = "component"
+        component      = param.component
+        stack          = opt.stack
+        format         = "json"
+      }
+    }
+  }
+
+  variable "component" {
+    value = conf.config-component.component != null ? conf.config-component.component : param.component
   }
 
   exec {
@@ -231,7 +288,7 @@ job "terraform write override" {
       format    = event.exec.args[0]
     }
 
-    file = "${opt.terraform-dir}/${param.component}/override.tf.json"
+    file = "${opt.terraform-dir}/${var.component}/override.tf.json"
   }
 }
 

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -67,10 +67,27 @@ job "terraform subcommand" {
     value = compact(concat(list(opt.dry-run ? conf.terraform-command.command : ""), list(opt.subcommand), opt.args))
   }
 
+  config "config-component" {
+    source job {
+      name = "stack config"
+      args = {
+        component-type = "terraform"
+        config-type    = "component"
+        component      = param.component
+        stack          = opt.stack
+        format         = "json"
+      }
+    }
+  }
+
+  variable "component" {
+    value = conf.config-component.component != null ? conf.config-component.component : param.component
+  }
+
   exec {
     command     = var.exec-cmd
     args        = var.exec-args
-    dir         = "${opt.terraform-dir}/${param.component}"
+    dir         = "${opt.terraform-dir}/${var.component}"
     env         = opt.env
     interactive = true  # currently `variant` does not support interpolation in the `interactive` attribute, so `opt.interactive` does not work
   }
@@ -83,6 +100,12 @@ job "terraform shell" {
   parameter "component" {
     type        = string
     description = "Component"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
   }
 
   option "commands" {

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -81,7 +81,7 @@ job "terraform subcommand" {
   }
 
   variable "component" {
-    value = coalesce(conf.config-component, param.component)
+    value = coalesce(conf.config-component.component, param.component)
   }
 
   exec {
@@ -127,7 +127,7 @@ job "terraform shell" {
   }
 
   variable "component" {
-    value = coalesce(conf.config-component, param.component)
+    value = coalesce(conf.config-component.component, param.component)
   }
 
   run "shell" {
@@ -184,7 +184,7 @@ job "terraform write varfile" {
   }
 
   variable "component" {
-    value = coalesce(conf.config-component, param.component)
+    value = coalesce(conf.config-component.component, param.component)
   }
 
   exec {
@@ -272,7 +272,7 @@ job "terraform write override" {
   }
 
   variable "component" {
-    value = coalesce(conf.config-component, param.component)
+    value = coalesce(conf.config-component.component, param.component)
   }
 
   exec {

--- a/modules/terraform/terraform-core.variant
+++ b/modules/terraform/terraform-core.variant
@@ -201,7 +201,7 @@ job "terraform write varfile" {
       format    = event.exec.args[0]
     }
 
-    file = "${opt.terraform-dir}/${var.component}/${opt.stack}-${var.component}.terraform.tfvars.json"
+    file = "${opt.terraform-dir}/${var.component}/${opt.stack}-${param.component}.terraform.tfvars.json"
   }
 }
 

--- a/modules/terraform/terraform-destroy.variant
+++ b/modules/terraform/terraform-destroy.variant
@@ -86,6 +86,7 @@ job "terraform destroy" {
   step "destroy clean" {
     run "terraform shell" {
       component = param.component
+      stack     = opt.stack
 
       commands = [
         "rm",

--- a/modules/terraform/terraform-import.variant
+++ b/modules/terraform/terraform-import.variant
@@ -96,6 +96,8 @@ job "terraform import" {
   step "apply clean" {
     run "terraform shell" {
       component = param.component
+      stack     = opt.stack
+
       commands  = ["rm", "override.tf.json"]
     }
   }

--- a/modules/terraform/terraform-import.variant
+++ b/modules/terraform/terraform-import.variant
@@ -78,6 +78,7 @@ job "terraform import" {
   step "write provider override" {
     run "terraform write override" {
       component = param.component
+      stack     = opt.stack
       role      = opt.role
     }
   }

--- a/modules/terraform/terraform-workspace.variant
+++ b/modules/terraform/terraform-workspace.variant
@@ -44,7 +44,7 @@ job "terraform workspace" {
   }
 
   variable "workspace" {
-    value = conf.config-component.component != null ? format("%s-%s", opt.stack, conf.config-component.component) : opt.stack
+    value = conf.config-component.component != null ? format("%s-%s", opt.stack, param.component) : opt.stack
   }
 
   run "terraform shell" {

--- a/modules/terraform/terraform-workspace.variant
+++ b/modules/terraform/terraform-workspace.variant
@@ -44,7 +44,7 @@ job "terraform workspace" {
   }
 
   variable "workspace" {
-    value = conf.config-component.component != null ? format("%s-%s", opt.stack, conf.config-component.component) : opt.stack
+    value = conf.config-component != null ? format("%s-%s", opt.stack, conf.config-component) : opt.stack
   }
 
   run "terraform shell" {

--- a/modules/terraform/terraform-workspace.variant
+++ b/modules/terraform/terraform-workspace.variant
@@ -44,7 +44,7 @@ job "terraform workspace" {
   }
 
   variable "workspace" {
-    value = conf.config-component != null ? format("%s-%s", opt.stack, conf.config-component) : opt.stack
+    value = conf.config-component.component != null ? format("%s-%s", opt.stack, conf.config-component.component) : opt.stack
   }
 
   run "terraform shell" {

--- a/modules/terraform/terraform-workspace.variant
+++ b/modules/terraform/terraform-workspace.variant
@@ -30,10 +30,29 @@ job "terraform workspace" {
     }
   }
 
+  config "config-component" {
+    source job {
+      name = "stack config"
+      args = {
+        component-type = "terraform"
+        config-type    = "component"
+        component      = param.component
+        stack          = opt.stack
+        format         = "json"
+      }
+    }
+  }
+
+  variable "workspace" {
+    value = conf.config-component.component != null ? format("%s-%s", opt.stack, conf.config-component.component) : opt.stack
+  }
+
   run "terraform shell" {
     component = param.component
+    stack     = opt.stack
+
     commands  = [
-      "${conf.terraform-command.command} workspace select ${opt.stack} || ${conf.terraform-command.command} workspace new ${opt.stack}"
+      "${conf.terraform-command.command} workspace select ${var.workspace} || ${conf.terraform-command.command} workspace new ${var.workspace}"
     ]
   }
 }

--- a/modules/utils/stack-config.variant
+++ b/modules/utils/stack-config.variant
@@ -77,7 +77,11 @@ job "stack config" {
     }
   }
 
-  # Deep-merge all variables in this order: global-scoped, component-type-scoped, and component-scoped
+  variable "component" {
+    value = try(conf.all.components[opt.component-type][param.component]["component"], null)
+  }
+
+  # Deep-merge all variables in this order: global-scoped, component-type-scoped, component-scoped, component-instance-scoped
   config "vars" {
     source job {
       name = "stack-config-echo"
@@ -85,12 +89,21 @@ job "stack config" {
         opt1 = yamlencode(try(conf.all["vars"], {}))
       }
     }
+    # Component type vars override global vars
     source job {
       name = "stack-config-echo"
       args = {
         opt1 = yamlencode(try(conf.all[opt.component-type]["vars"], {}))
       }
     }
+    # Component vars override component type and global vars
+    source job {
+      name = "stack-config-echo"
+      args = {
+        opt1 = yamlencode(try(conf.all.components[opt.component-type][var.component]["vars"], {}))
+      }
+    }
+    # Component instance vars override component, component type and global vars
     source job {
       name = "stack-config-echo"
       args = {
@@ -137,10 +150,6 @@ job "stack config" {
         opt1 = yamlencode(try(conf.all.components[opt.component-type][param.component]["backend"][var.backend-type], {}))
       }
     }
-  }
-
-  variable "component" {
-    value = try(conf.all.components[opt.component-type][param.component]["component"], null)
   }
 
   variable "output" {

--- a/modules/utils/stack-config.variant
+++ b/modules/utils/stack-config.variant
@@ -139,13 +139,18 @@ job "stack config" {
     }
   }
 
+  variable "component" {
+    value = try(conf.all.components[opt.component-type][param.component]["component"], null)
+  }
+
   variable "output" {
     value = {
       vars         = conf.vars,
       command      = { command = var.command },
       backend      = { "${var.backend-type}" = conf.backend },
       backend-type = var.backend-type,
-      all          = conf.all
+      all          = conf.all,
+      component    = var.component
     }
   }
 

--- a/modules/utils/stack-config.variant
+++ b/modules/utils/stack-config.variant
@@ -150,7 +150,7 @@ job "stack config" {
       backend      = { "${var.backend-type}" = conf.backend },
       backend-type = var.backend-type,
       all          = conf.all,
-      component    = var.component
+      component    = { component = var.component }
     }
   }
 


### PR DESCRIPTION
## what
* Add `component` attribute to stack configs

## why
* Allow specifying YAML configs and provisioning many instances of the same component type.
For example, we can specify the following config to provision many different instances of AWS Aurora clusters by referencing the common  `aurora-postgres` component:

```
components:
  terraform:
    db1:
      component: aurora-postgres
      vars:
        instance_type: db.r4.large
        cluster_size: 1
    db2:
      component: aurora-postgres
      vars:
        instance_type: db.r4.large
        cluster_size: 1
    db3:
      component: aurora-postgres
      vars:
        instance_type: db.r1.large
        cluster_size: 1
    db4:
      component: aurora-postgres
      vars:
        instance_type: db.r8.large
        cluster_size: 1
```

and then use the following commands to plan/apply the database components:

```
atmos terraform plan db1 -s uw2-prod
atmos terraform apply db1 -s uw2-prod

atmos terraform plan db2 -s uw2-prod
atmos terraform apply db2 -s uw2-prod

atmos terraform plan db3 -s uw2-prod
atmos terraform apply db3 -s uw2-prod

```


