### PR TITLE
Fix `terraform backend generate component` command. Add `version` command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y -u wget
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
             tar -zvxf variant*.tar.gz variant
+          sed -i 's/%CUSTOM%/${{ github.event.release.tag_name }}/' modules/utils/version.variant
           ./variant export binary $PWD ${{ github.workspace }}/atmos
           ${{ github.workspace }}/atmos help
 

--- a/modules/shell/shell.variant
+++ b/modules/shell/shell.variant
@@ -38,9 +38,9 @@ job "shell" {
   }
 
   parameter "args" {
-    default = []
     description = "List of arguments for the command to execute"
     type        = list(string)
+    default     = []
   }
 
   variable "cmd-name" {
@@ -54,7 +54,7 @@ job "shell" {
   }
 
   variable "cmd-args" {
-    type = list(string)
+    type  = list(string)
     value = compact(concat(list(opt.dry-run ? var.cmd-name : ""), param.args))
   }
 

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -65,6 +65,7 @@ job "terraform backend generate component" {
 
   run "shell" {
     command = format("jq -M -n %s | tee backend.tf.json", var.data)
+    args    = [""]
     dir     = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -65,7 +65,7 @@ job "terraform backend generate component" {
           }
         }
       ),
-      "> backend.tf.json"
+      "| tee backend.tf.json"
     ]
 
     dir = "${opt.terraform-dir}/${param.component}"

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -52,7 +52,7 @@ job "terraform backend generate component" {
     }
   }
 
-  variable "data" {
+  variable "backend_config" {
     type  = string
     value = jsonencode(
       {

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -64,8 +64,8 @@ job "terraform backend generate component" {
   }
 
   run "shell" {
-    command = format("jq -M -n '%s' | tee backend.tf.json", var.data)
-    args    = [""]
+    command = "jq"
+    args    = [format("-M -n '%s' | tee backend.tf.json", var.data)]
     dir     = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -68,7 +68,7 @@ job "terraform backend generate component" {
 
     args = [
       "-c",
-      format("jq -M -n '%s' | tee backend.tf.json", var.data)
+      format("jq -M -n '%s' | tee backend.tf.json", var.backend_config)
     ]
 
     dir = "${opt.terraform-dir}/${param.component}"

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -70,7 +70,7 @@ job "terraform backend generate component" {
   log {
     collect {
       condition = event.type == "exec"
-      format    = event.exec.args[2]
+      format    = "exec=${event.exec}"
     }
 
     file = "${opt.terraform-dir}/${param.component}/backend.tf.json"

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -52,22 +52,19 @@ job "terraform backend generate component" {
     }
   }
 
-  run "shell" {
-    command = "jq"
-
-    args = [
-      "-M",
-      "-n",
-      jsonencode(
-        {
-          "terraform" = {
-            "backend" = conf.stack-config
-          }
+  variable "data" {
+    type  = string
+    value = jsonencode(
+      {
+        "terraform" = {
+          "backend" = conf.stack-config
         }
-      ),
-      "| tee backend.tf.json"
-    ]
+      }
+    )
+  }
 
-    dir = "${opt.terraform-dir}/${param.component}"
+  run "shell" {
+    command = format("jq -M -n %s | tee backend.tf.json", var.data)
+    dir     = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -71,6 +71,6 @@ job "terraform backend generate component" {
       format("jq -M -n '%s' | tee backend.tf.json", var.data)
     ]
 
-    dir     = "${opt.terraform-dir}/${param.component}"
+    dir = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -52,8 +52,9 @@ job "terraform backend generate component" {
     }
   }
 
-  exec {
+  run "shell" {
     command = "jq"
+
     args = [
       "-M",
       "-n",
@@ -63,16 +64,11 @@ job "terraform backend generate component" {
             "backend" = conf.stack-config
           }
         }
-      )
+      ),
+      "| tee",
+      "backend.tf.json"
     ]
-  }
 
-  log {
-    collect {
-      condition = event.type == "exec"
-      format    = "exec=${event.exec}"
-    }
-
-    file = "${opt.terraform-dir}/${param.component}/backend.tf.json"
+    dir = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -70,7 +70,7 @@ job "terraform backend generate component" {
   log {
     collect {
       condition = event.type == "exec"
-      format    = event.exec.args[0]
+      format    = event.exec.args[2]
     }
 
     file = "${opt.terraform-dir}/${param.component}/backend.tf.json"

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -65,8 +65,7 @@ job "terraform backend generate component" {
           }
         }
       ),
-      "| tee",
-      "backend.tf.json"
+      "> backend.tf.json"
     ]
 
     dir = "${opt.terraform-dir}/${param.component}"

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -64,7 +64,7 @@ job "terraform backend generate component" {
   }
 
   run "shell" {
-    command = format("jq -M -n %s | tee backend.tf.json", var.data)
+    command = format("jq -M -n '%s' | tee backend.tf.json", var.data)
     args    = [""]
     dir     = "${opt.terraform-dir}/${param.component}"
   }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -64,8 +64,8 @@ job "terraform backend generate component" {
   }
 
   run "shell" {
-    command = "jq"
-    args    = [format("-M -n '%s' | tee backend.tf.json", var.data)]
+    command = format("jq -M -n '%s' | tee backend.tf.json", var.data)
+    args    = []
     dir     = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/terraform/terraform-backend.variant
+++ b/modules/terraform/terraform-backend.variant
@@ -64,8 +64,13 @@ job "terraform backend generate component" {
   }
 
   run "shell" {
-    command = format("jq -M -n '%s' | tee backend.tf.json", var.data)
-    args    = []
+    command = "bash"
+
+    args = [
+      "-c",
+      format("jq -M -n '%s' | tee backend.tf.json", var.data)
+    ]
+
     dir     = "${opt.terraform-dir}/${param.component}"
   }
 }

--- a/modules/utils/version.variant
+++ b/modules/utils/version.variant
@@ -3,7 +3,7 @@ job "version" {
 
   variable "atmos_version" {
     type  = string
-    value = "0.16.0"
+    value = "%CUSTOM%"
   }
 
   exec {

--- a/modules/utils/version.variant
+++ b/modules/utils/version.variant
@@ -1,0 +1,13 @@
+variable "atmos_version" {
+  type  = string
+  value = "0.16.0"
+}
+
+job "version" {
+  description = "Shows CLI version"
+
+  exec {
+    command = "echo"
+    args    = [var.atmos_version]
+  }
+}

--- a/modules/utils/version.variant
+++ b/modules/utils/version.variant
@@ -1,10 +1,10 @@
-variable "atmos_version" {
-  type  = string
-  value = "0.16.0"
-}
-
 job "version" {
   description = "Shows CLI version"
+
+  variable "atmos_version" {
+    type  = string
+    value = "0.16.0"
+  }
 
   exec {
     command = "echo"


### PR DESCRIPTION
## what
* Fix `terraform backend generate component` command while keeping JSON pretty printing
* Add `version` command

## why
* `jq` in `terraform backend generate component` command was just outputting to `stdout`, not to the backend file 
* Simplify `terraform backend generate component` command
* `atmos version` command is useful to show the CLI version

## references
* Closes #18 

## test

```
 > atmos terraform backend generate component vpc -s uw2-demo
{
  "terraform": {
    "backend": {
      "s3": {
        "acl": "bucket-owner-full-control",
        "bucket": "xxxxx-uw2-root-tfstate",
        "dynamodb_table": "xxxxxx-uw2-root-tfstate-lock",
        "encrypt": true,
        "key": "terraform.tfstate",
        "region": "us-west-2",
        "role_arn": "arn:aws:iam::xxxxxxx:role/xxxxxx-gbl-root-terraform",
        "workspace_key_prefix": "vpc"
      }
    }
  }
}
```

```
> atmos version
0.16.0
```

