### PR TITLE
Fix `helm-aws-profile-pattern` option

### DIFF
--- a/example/cli/main.variant
+++ b/example/cli/main.variant
@@ -14,7 +14,7 @@ option "kubeconfig-path" {
 }
 
 option "helm-aws-profile-pattern" {
-  default     = "{namespace}-{environment}-{stage}-helm"
+  default     = "{namespace}-gbl-{stage}-helm"
   description = "AWS profile pattern for helm and helmfile"
   type        = string
 }

--- a/main.variant
+++ b/main.variant
@@ -14,7 +14,7 @@ option "kubeconfig-path" {
 }
 
 option "helm-aws-profile-pattern" {
-  default     = "{namespace}-{environment}-{stage}-helm"
+  default     = "{namespace}-gbl-{stage}-helm"
   description = "AWS profile pattern for helm and helmfile"
   type        = string
 }


### PR DESCRIPTION
## what
* Fix `helm-aws-profile-pattern` option

## why
* Helm/helmfile/kubeconfig AWS profiles use `gbl` environment in their names (since IAM roles are global)
* Replacing `{environment}` with the environment values from the YAML stack configs does not work when running `atmos helmfile ...` commands for the environments other than `gbl`


