### PR TITLE
Cross-compile atmos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,10 @@ jobs:
           sed -i "s/%CUSTOM%/${{ github.event.release.tag_name }} ($(git log -n 1 --format=%h))/" atmos/modules/utils/version.variant
           # Convert into go code
           ./variant export go atmos build
-          # Download go modules once so that parallel builds do not try to download them in parallel and clash with each other
-          cd build && go mod tidy
           # reset the variant script so we have a clean git repo matching the tag commit SHA (required by goreleaser)
           git checkout -- atmos/modules/utils/version.variant
+          # Download go modules once so that parallel builds do not try to download them in parallel and clash with each other
+          cd build && go mod tidy
 
       # Build and release
       - name: Run GoReleaser


### PR DESCRIPTION
what
- Use [goreleaser](https://github.com/goreleaser/goreleaser) to cross-compile and release
- Fix issues with #32 that caused preparation step to fail

## why
- Make binaries available for other platforms

## notes
- At this time, Windows builds fail due to `syscall` in `k-kinzal/aliases@v0.5.1` being undefined, so we are not yet distributing Windows binaries
- At this time, builds using `go` 1.16 fail due to an incompatibility with Variant 0.37.1, so we must use `go` 1.15 and cannot build binaries for Apple M1 because that requires `go` 1.16.
- The preferred way to set the version is by having the `go` linker set the value of a global variable, but there is no way to reference a global `go` variable inside a `variant` job.

## references
- https://github.com/mumoshu/variant2/issues/48
- https://github.com/mumoshu/variant2/issues/49