### PR TITLE
Cross-complie atmos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 **/.helmfile/
 .DS_Store
 /variant
+*.tar
+*.gz


### PR DESCRIPTION
what
- Use [goreleaser](https://github.com/goreleaser/goreleaser) to cross-compile and release
- Fix issues with #33 that caused preparation step to fail

## why
- Make binaries available for other platforms

## notes
- At this time, Windows builds fail due to `syscall` in `k-kinzal/aliases@v0.5.1` being undefined, so we are not yet distributing Windows binaries
- At this time, builds using `go` 1.16 fail due to an incompatibility with Variant 0.37.1, so we must use `go` 1.15 and cannot build binaries for Apple M1 because that requires `go` 1.16.
- The preferred way to set the version is by having the `go` linker set the value of a global variable, but there is currently no way to reference a global `go` variable inside a `variant` job.

## references
- https://github.com/mumoshu/variant2/issues/48
- https://github.com/mumoshu/variant2/issues/49
- https://github.com/mumoshu/variant2/issues/16
- https://github.com/mumoshu/variant2/issues/50