### PR TITLE
fix: refer to correct module

### DIFF
--- a/example/cli/main.variant
+++ b/example/cli/main.variant
@@ -58,5 +58,5 @@ imports = [
   "git::https://git@github.com/cloudposse/atmos@atmos/modules/helm?ref=master",
   "git::https://git@github.com/cloudposse/atmos@atmos/modules/workflow?ref=master",
   "git::https://git@github.com/cloudposse/atmos@atmos/modules/istio?ref=master",
-  "git::https://git@github.com/cloudposse/atmos@atmos/modules/vendor?ref=master"
+  "git::https://git@github.com/cloudposse/atmos@atmos/modules/vendir?ref=master"
 ]


### PR DESCRIPTION
## what
* Fix the module reference in the example

## why
* It points to a non-existent module, and causes the docker build to fail

## references
* n/a
