### PR TITLE
Refer to proper module

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ __NOTE:__ For the example, we import all the CLI modules, but they could be incl
         "git::https://git@github.com/cloudposse/atmos@modules/helm?ref=master",
         "git::https://git@github.com/cloudposse/atmos@modules/workflow?ref=master",
         "git::https://git@github.com/cloudposse/atmos@modules/istio?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/vendor?ref=master"
+        "git::https://git@github.com/cloudposse/atmos@modules/vendir?ref=master"
     ]
   ```
 


### PR DESCRIPTION
## what
* Fix the documentation to refer to the correct module. This should have been fixed in #35, but was forgotten.

## why
* Module import reference is incorrect

## references
* #35 
