### PR TITLE
Add new `terraform` and `helmfile` commands

### DIFF
--- a/atmos/modules/helmfile/helmfile-list.variant
+++ b/atmos/modules/helmfile/helmfile-list.variant
@@ -1,0 +1,52 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "helmfile list" {
+  description = "List releases"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "helmfile"
+    type        = string
+    description = "Command to execute, e.g. 'helmfile', or path to the command, e.g. '/usr/local/bin/helmfile'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile command"
+    type        = string
+  }
+
+  option "sub-args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile subcommand"
+    type        = string
+  }
+
+  option "kube-namespace" {
+    default     = ""
+    description = "kube namespace"
+    short       = "n"
+    type        = string
+  }
+
+  run "helmfile subcommand" {
+    command        = opt.command
+    subcommand     = "list"
+    component       = param.component
+    stack          = opt.stack
+    args           = opt.args
+    sub-args       = opt.sub-args
+    kube-namespace = opt.kube-namespace
+  }
+}

--- a/atmos/modules/helmfile/helmfile-status.variant
+++ b/atmos/modules/helmfile/helmfile-status.variant
@@ -1,0 +1,52 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "helmfile status" {
+  description = "Retrieve status of releases"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "helmfile"
+    type        = string
+    description = "Command to execute, e.g. 'helmfile', or path to the command, e.g. '/usr/local/bin/helmfile'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile command"
+    type        = string
+  }
+
+  option "sub-args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile subcommand"
+    type        = string
+  }
+
+  option "kube-namespace" {
+    default     = ""
+    description = "kube namespace"
+    short       = "n"
+    type        = string
+  }
+
+  run "helmfile subcommand" {
+    command        = opt.command
+    subcommand     = "status"
+    component       = param.component
+    stack          = opt.stack
+    args           = opt.args
+    sub-args       = opt.sub-args
+    kube-namespace = opt.kube-namespace
+  }
+}

--- a/atmos/modules/helmfile/helmfile-template.variant
+++ b/atmos/modules/helmfile/helmfile-template.variant
@@ -1,0 +1,52 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "helmfile template" {
+  description = "Render Kubernetes manifests for releases"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "helmfile"
+    type        = string
+    description = "Command to execute, e.g. 'helmfile', or path to the command, e.g. '/usr/local/bin/helmfile'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile command"
+    type        = string
+  }
+
+  option "sub-args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile subcommand"
+    type        = string
+  }
+
+  option "kube-namespace" {
+    default     = ""
+    description = "kube namespace"
+    short       = "n"
+    type        = string
+  }
+
+  run "helmfile subcommand" {
+    command        = opt.command
+    subcommand     = "template"
+    component       = param.component
+    stack          = opt.stack
+    args           = opt.args
+    sub-args       = opt.sub-args
+    kube-namespace = opt.kube-namespace
+  }
+}

--- a/atmos/modules/helmfile/helmfile-test.variant
+++ b/atmos/modules/helmfile/helmfile-test.variant
@@ -1,0 +1,52 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "helmfile test" {
+  description = "Test releases"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "helmfile"
+    type        = string
+    description = "Command to execute, e.g. 'helmfile', or path to the command, e.g. '/usr/local/bin/helmfile'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile command"
+    type        = string
+  }
+
+  option "sub-args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile subcommand"
+    type        = string
+  }
+
+  option "kube-namespace" {
+    default     = ""
+    description = "kube namespace"
+    short       = "n"
+    type        = string
+  }
+
+  run "helmfile subcommand" {
+    command        = opt.command
+    subcommand     = "test"
+    component       = param.component
+    stack          = opt.stack
+    args           = opt.args
+    sub-args       = opt.sub-args
+    kube-namespace = opt.kube-namespace
+  }
+}

--- a/atmos/modules/helmfile/helmfile-write-values.variant
+++ b/atmos/modules/helmfile/helmfile-write-values.variant
@@ -1,0 +1,52 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "helmfile write values" {
+  description = "Write values files for releases"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "helmfile"
+    type        = string
+    description = "Command to execute, e.g. 'helmfile', or path to the command, e.g. '/usr/local/bin/helmfile'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile command"
+    type        = string
+  }
+
+  option "sub-args" {
+    default     = ""
+    description = "A string of arguments to supply to the helmfile subcommand"
+    type        = string
+  }
+
+  option "kube-namespace" {
+    default     = ""
+    description = "kube namespace"
+    short       = "n"
+    type        = string
+  }
+
+  run "helmfile subcommand" {
+    command        = opt.command
+    subcommand     = "write-values"
+    component       = param.component
+    stack          = opt.stack
+    args           = opt.args
+    sub-args       = opt.sub-args
+    kube-namespace = opt.kube-namespace
+  }
+}

--- a/atmos/modules/helmfile/helmfile-write-values.variant
+++ b/atmos/modules/helmfile/helmfile-write-values.variant
@@ -1,7 +1,7 @@
 #!/usr/bin/env variant
 # vim: filetype=hcl
 
-job "helmfile write values" {
+job "helmfile write-values" {
   description = "Write values files for releases"
 
   parameter "component" {

--- a/atmos/modules/terraform/terraform-apply.variant
+++ b/atmos/modules/terraform/terraform-apply.variant
@@ -35,6 +35,11 @@ job "terraform apply" {
     default     = false
   }
 
+  variable "args" {
+    type  = list(string)
+    value = concat(compact(split(" ", opt.args)), ["${opt.stack}-${param.component}.planfile"])
+  }
+
   step "terraform workspace" {
     run "terraform workspace" {
       component = param.component
@@ -50,10 +55,7 @@ job "terraform apply" {
       command     = opt.command
       subcommand  = "apply"
       interactive = opt.interactive
-
-      args = [
-        "${opt.stack}-${param.component}.planfile"
-      ]
+      args        = var.args
     }
   }
 

--- a/atmos/modules/terraform/terraform-console.variant
+++ b/atmos/modules/terraform/terraform-console.variant
@@ -32,7 +32,7 @@ job "terraform console" {
     type        = bool
     description = "Interactive"
     short       = "i"
-    default     = false
+    default     = true
   }
 
   variable "args" {

--- a/atmos/modules/terraform/terraform-console.variant
+++ b/atmos/modules/terraform/terraform-console.variant
@@ -1,0 +1,76 @@
+#!/usr/bin/env variant
+# vim: filetype=hcl
+
+job "terraform console" {
+  concurrency = 1
+  description = "Run 'terraform console'"
+
+  parameter "component" {
+    type        = string
+    description = "Component"
+  }
+
+  option "command" {
+    default     = "terraform"
+    type        = string
+    description = "Command to execute, e.g. 'terraform', or path to the command, e.g. '/usr/local/terraform/0.13/bin/terraform'"
+  }
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to the terraform command"
+    type        = string
+  }
+
+  option "interactive" {
+    type        = bool
+    description = "Interactive"
+    short       = "i"
+    default     = false
+  }
+
+  variable "args" {
+    type  = list(string)
+    value = compact(split(" ", opt.args))
+  }
+
+  step "write varfile" {
+    run "terraform write varfile" {
+      component   = param.component
+      stack       = opt.stack
+    }
+  }
+
+  step "terraform init" {
+    run "terraform init" {
+      component   = param.component
+      stack       = opt.stack
+      command     = opt.command
+    }
+  }
+
+  step "terraform workspace" {
+    run "terraform workspace" {
+      component = param.component
+      command   = opt.command
+      stack     = opt.stack
+    }
+  }
+
+  step "console cmd" {
+    run "terraform subcommand" {
+      component   = param.component
+      stack       = opt.stack
+      command     = opt.command
+      subcommand  = "console"
+      interactive = opt.interactive
+      args        = var.args
+    }
+  }
+}

--- a/atmos/modules/terraform/terraform-show.variant
+++ b/atmos/modules/terraform/terraform-show.variant
@@ -1,9 +1,9 @@
 #!/usr/bin/env variant
 # vim: filetype=hcl
 
-job "terraform apply" {
+job "terraform show" {
   concurrency = 1
-  description = "Run 'terraform apply'"
+  description = "Run 'terraform show'"
 
   parameter "component" {
     type        = string
@@ -48,27 +48,14 @@ job "terraform apply" {
     }
   }
 
-  step "apply cmd" {
+  step "show cmd" {
     run "terraform subcommand" {
       component   = param.component
       stack       = opt.stack
       command     = opt.command
-      subcommand  = "apply"
+      subcommand  = "show"
       interactive = opt.interactive
       args        = var.args
-    }
-  }
-
-  step "apply clean" {
-    run "terraform shell" {
-      component = param.component
-      stack     = opt.stack
-
-      commands = [
-        "rm",
-        "${opt.stack}-${param.component}.planfile",
-        "${opt.stack}-${param.component}.terraform.tfvars.json"
-      ]
     }
   }
 }

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -53,11 +53,10 @@ ENV AWS_DEFAULT_REGION=us-east-2
 RUN apk add kubectl-1.17@cloudposse
 
 # Install terraform.
-# Install the latest 0.12 and 0.13 versions of terraform
-RUN apk add -u terraform-0.12@cloudposse terraform-0.13@cloudposse~=0.13.3
-# Set Terraform 0.13.x as the default `terraform`. You can still use
-# `terraform-0.12` or `terraform-0.13` to be explicit when needed.
-RUN update-alternatives --set terraform /usr/share/terraform/0.13/bin/terraform
+RUN apk add -u terraform-0.12@cloudposse==0.12.30-r0 terraform-0.13@cloudposse==0.13.7-r0 terraform-0.14@cloudposse==0.14.11-r0 terraform-0.15@cloudposse==0.15.4-r0
+# Set Terraform 0.14.x as the default `terraform`. You can still use
+# `terraform-0.12`, `terraform-0.13` or `terraform-0.15` to be explicit when needed.
+RUN update-alternatives --set terraform /usr/share/terraform/0.14/bin/terraform
 
 # Install vendir
 RUN apk add vendir@cloudposse


### PR DESCRIPTION
## what
* Add new `terraform` and `helmfile` commands
* Terraform commands: `console`, `show`
* `helmfile` commands: `template`, `list`, `status`, `test`, `write-values`

## why
* More native Terraform and `helmfile` command supported by `atmos`

## references
*  https://github.com/roboll/helmfile#cli-reference
 

## test

```
 √ . example ⨠ atmos terraform console vpc -s ue2-dev
{"cidr_block":"10.100.0.0/18","environment":"ue2","namespace":"eg","region":"us-east-2","stage":"dev","test-map":{"a":"a3","atr":{"atr1":"1-1","atr2":"2-3","atr3":3,"atr4":4,"list":["1b"]},"atr-2":{"atr1":1,"atr2":2},"b":"b2","c":"c1","d":"d3","e":"e3","g":"g1","list":[4,5,6],"list2":[1,2,3]}}
Initializing modules...
Downloading git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.39.1 for subnets...
- subnets in .terraform/modules/subnets
Downloading cloudposse/label/null 0.24.1 for subnets.nat_instance_label...
- subnets.nat_instance_label in .terraform/modules/subnets.nat_instance_label
Downloading cloudposse/label/null 0.24.1 for subnets.nat_label...
- subnets.nat_label in .terraform/modules/subnets.nat_label
Downloading cloudposse/label/null 0.24.1 for subnets.private_label...
- subnets.private_label in .terraform/modules/subnets.private_label

Initializing the backend...

Terraform has been successfully initialized!

Workspace "ue2-dev" doesn't exist.

You can create this workspace with the "new" subcommand.
Created and switched to workspace "ue2-dev"!

You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
for this configuration.
> 1 + 1
2
>
```

