### PR TITLE
Add removing `.terraform.lock.hcl` with `atmos terraform clean`

### DIFF
--- a/atmos/modules/terraform/terraform-clean.variant
+++ b/atmos/modules/terraform/terraform-clean.variant
@@ -25,7 +25,7 @@ job "terraform clean" {
 
   step "clean log" {
     run "echo" {
-      message = "Removed .terraform folder and all planfiles"
+      message = "Removed .terraform folder, .terraform.lock.hcl, and all planfiles"
     }
   }
 }

--- a/atmos/modules/terraform/terraform-clean.variant
+++ b/atmos/modules/terraform/terraform-clean.variant
@@ -18,7 +18,7 @@ job "terraform clean" {
       stack     = opt.stack
 
       commands = [
-        "rm -rf .terraform *.planfile"
+        "rm -rf .terraform .terraform.lock.hcl *.planfile"
       ]
     }
   }

--- a/atmos/modules/terraform/terraform-clean.variant
+++ b/atmos/modules/terraform/terraform-clean.variant
@@ -1,5 +1,5 @@
 job "terraform clean" {
-  description = "Remove terraform planfiles and .terraform folder"
+  description = "Remove terraform planfiles, .terraform.lock.hcl, and .terraform folder"
 
   parameter "component" {
     type        = string


### PR DESCRIPTION
## what
* Add removing `.terraform.lock.hcl` with `atmos terraform clean`

## why
* This prevents `terraform-docs` from picking up local provider versions (changes `n/a` to hard coded values in `.terraform.lock.hcl`) and conflicting with the pre commit hook which then reverts the local changes (changes hard coded values to `n/a`)

## references
* N/A

