### PR TITLE
feat: adds --args option to atmos terraform init

### DIFF
--- a/atmos/modules/terraform/terraform-init.variant
+++ b/atmos/modules/terraform/terraform-init.variant
@@ -25,12 +25,24 @@ job "terraform init" {
     default     = false
   }
 
+  option "args" {
+    default     = ""
+    description = "A string of arguments to supply to `terraform plan`"
+    type        = string
+  }
+
+  variable "args" {
+    type  = list(string)
+    value = compact(split(" ", opt.args))
+  }
+
+
   run "terraform subcommand" {
     component   = param.component
     stack       = opt.stack
     command     = opt.command
     subcommand  = "init"
-    args        = []
+    args        = var.args
     interactive = opt.interactive
   }
 }


### PR DESCRIPTION
## what
* Adds the ability to add `--args` to `atmos terraform init`

## why
* In newer versions of terraform, to migrate state we now need to pass `terraform init -migrate-state` which this enables

![CleanShot 2021-07-01 at 17 26 51](https://user-images.githubusercontent.com/1392040/124200048-a0557400-da91-11eb-9f1f-1aac2b27bb1e.png)

