### PR TITLE
Build Atmos for Apple M1 chip. No functional changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,13 @@ jobs:
       - name: 'Setup Go'
         uses: actions/setup-go@v2
         with:
-          # Go 1.16 is not supported by Variant yet.
-          # See https://github.com/mumoshu/variant2/issues/48
-          # When Go 1.16 is supported, enable darwin_arm64 builds
           go-version: '1.16'
       - run: go version
 
       # Generate Go code
       - name: 'Generate Go Code'
         env:
-          VARIANT_VERSION: "0.37.1"
+          VARIANT_VERSION: "0.38.0"
         run: |
           set -e -x
           wget -q https://github.com/mumoshu/variant2/releases/download/v${VARIANT_VERSION}/variant_${VARIANT_VERSION}_linux_amd64.tar.gz && \
@@ -42,8 +39,6 @@ jobs:
           git checkout -- atmos/modules/utils/version.variant
           # Download go modules once so that parallel builds do not try to download them in parallel and clash with each other
           cd build && go mod tidy
-          # PATCH FOR VARIANT 0.37.1 and go 1.16. REMOVE on next Variant release
-          printf '\nfunc (TestDeps) SetPanicOnExit0(bool) {}\n\n' >> $(go env GOPATH)/pkg/mod/github.com/mumoshu/variant2@v0.37.1/pkg/app/app.go
 
       # Build and release
       - name: Run GoReleaser


### PR DESCRIPTION
## what
- Build Atmos for Apple M1 chip. No functional changes.

## why
- Support Apple hardware

## references
- https://github.com/mumoshu/variant2/releases/tag/v0.38.0