### PR TITLE
Fix: Ensure `atmos terraform clean` gets rid of `tfvars.json` files

### DIFF
--- a/atmos/modules/terraform/terraform-clean.variant
+++ b/atmos/modules/terraform/terraform-clean.variant
@@ -1,5 +1,5 @@
 job "terraform clean" {
-  description = "Remove terraform planfiles, .terraform.lock.hcl, and .terraform folder"
+  description = "Remove terraform planfiles, tfvars.json files, .terraform.lock.hcl, and .terraform folder"
 
   parameter "component" {
     type        = string
@@ -18,14 +18,14 @@ job "terraform clean" {
       stack     = opt.stack
 
       commands = [
-        "rm -rf .terraform .terraform.lock.hcl *.planfile"
+        "rm -rf .terraform .terraform.lock.hcl *.planfile *.tfvars.json"
       ]
     }
   }
 
   step "clean log" {
     run "echo" {
-      message = "Removed .terraform folder, .terraform.lock.hcl, and all planfiles"
+      message = "Removed .terraform folder, .terraform.lock.hcl, tfvars.json files and all planfiles"
     }
   }
 }


### PR DESCRIPTION
## what
* Ensure `atmos terraform clean` gets rid of `tfvars.json` files.

## why
* `atmos terraform clean` does not get rid of `tfvars.json` files. `atmos terraform clean` should completely clean the component directory, such that the component can be made ready for upstreaming or porting to another IaC repo.

## references
* N/A

