### PR TITLE
feat(terraform-output): add support for args

### DIFF
--- a/atmos/modules/terraform/terraform-output.variant
+++ b/atmos/modules/terraform/terraform-output.variant
@@ -29,6 +29,12 @@ job "terraform output" {
     default     = false
   }
 
+  option "args" {
+    description = "A string of arguments to supply to `terraform output`"
+    type        = string
+    default     = ""
+  }
+
   step "write varfile" {
     run "terraform write varfile" {
       component   = param.component
@@ -52,13 +58,18 @@ job "terraform output" {
     }
   }
 
+  variable "args" {
+    type  = list(string)
+    value = compact(split(" ", opt.args))
+  }
+
   step "output cmd" {
     run "terraform subcommand" {
       component   = param.component
       stack       = opt.stack
       command     = opt.command
       subcommand  = "output"
-      args        = []
+      args        = var.args
       interactive = opt.interactive
     }
   }


### PR DESCRIPTION
## what
* Adds the ability to add `--args` to atmos terraform output

## why
* Allows us to view the value of a specific output within a module. Useful for **sensitive** outputs.

## references
* closes #54

