### PR TITLE
Improvements and new features

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -15,7 +15,7 @@ components:
     base_path: "./examples/complete/components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
-    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -40,3 +40,7 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+logs:
+  verbose: true
+  colors: true

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -44,5 +44,5 @@ stacks:
   name_pattern: "{tenant}-{environment}-{stage}"
 
 logs:
-  verbose: true
+  verbose: false
   colors: true

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -15,6 +15,8 @@ components:
     base_path: "./examples/complete/components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -25,10 +25,6 @@ var describeComponentCmd = &cobra.Command{
 func init() {
 	describeComponentCmd.DisableFlagParsing = false
 	describeComponentCmd.PersistentFlags().StringP("stack", "s", "", "")
-	describeComponentCmd.PersistentFlags().StringP("--terraform-dir", "", "", "")
-	describeComponentCmd.PersistentFlags().StringP("--helmfile-dir", "", "", "")
-	describeComponentCmd.PersistentFlags().StringP("--config-dir", "", "", "")
-	describeComponentCmd.PersistentFlags().StringP("--stacks-dir", "", "", "")
 
 	err := describeComponentCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -26,9 +26,6 @@ func init() {
 	// https://github.com/spf13/cobra/issues/739
 	helmfileCmd.DisableFlagParsing = true
 	helmfileCmd.PersistentFlags().StringP("stack", "s", "", "")
-	helmfileCmd.PersistentFlags().StringP("--helmfile-dir", "", "", "")
-	helmfileCmd.PersistentFlags().StringP("--config-dir", "", "", "")
-	helmfileCmd.PersistentFlags().StringP("--stacks-dir", "", "", "")
 
 	err := helmfileCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -26,9 +26,6 @@ func init() {
 	// https://github.com/spf13/cobra/issues/739
 	terraformCmd.DisableFlagParsing = true
 	terraformCmd.PersistentFlags().StringP("stack", "s", "", "")
-	terraformCmd.PersistentFlags().StringP("--terraform-dir", "", "", "")
-	terraformCmd.PersistentFlags().StringP("--config-dir", "", "", "")
-	terraformCmd.PersistentFlags().StringP("--stacks-dir", "", "", "")
 
 	err := terraformCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/examples/complete/atmos.yaml
+++ b/examples/complete/atmos.yaml
@@ -15,7 +15,7 @@ components:
     base_path: "./components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
-    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument

--- a/examples/complete/atmos.yaml
+++ b/examples/complete/atmos.yaml
@@ -15,6 +15,8 @@ components:
     base_path: "./components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths

--- a/examples/complete/atmos.yaml
+++ b/examples/complete/atmos.yaml
@@ -40,3 +40,7 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+logs:
+  verbose: true
+  colors: true

--- a/examples/complete/atmos.yaml
+++ b/examples/complete/atmos.yaml
@@ -44,5 +44,5 @@ stacks:
   name_pattern: "{tenant}-{environment}-{stage}"
 
 logs:
-  verbose: true
+  verbose: false
   colors: true

--- a/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -15,7 +15,7 @@ components:
     base_path: "./components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
-    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument

--- a/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -15,6 +15,8 @@ components:
     base_path: "./components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var
+    deploy_run_init: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths

--- a/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -40,3 +40,7 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+logs:
+  verbose: true
+  colors: true

--- a/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -44,5 +44,5 @@ stacks:
   name_pattern: "{tenant}-{environment}-{stage}"
 
 logs:
-  verbose: true
+  verbose: false
   colors: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,10 @@ var (
 				"**/*globals*",
 			},
 		},
+		Logs: Logs{
+			Verbose: true,
+			Colors:  true,
+		},
 	}
 
 	// Config is the CLI configuration structure

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,7 +244,7 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 
 	if stackIsPhysicalPath == true {
 		if g.LogVerbose {
-			color.Cyan(fmt.Sprintf("Stack '%s' is a directory, it matches the stack config file %s",
+			color.Cyan(fmt.Sprintf("The stack '%s' matches the stack config file %s",
 				configAndStacksInfo.Stack,
 				stackConfigFilesRelativePaths[0]),
 			)
@@ -258,14 +258,14 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 
 		if len(stackParts) == len(stackNamePatternParts) {
 			if g.LogVerbose {
-				color.Cyan(fmt.Sprintf("Stack '%s' matches the stack name pattern '%s'",
+				color.Cyan(fmt.Sprintf("The stack '%s' matches the stack name pattern '%s'",
 					configAndStacksInfo.Stack,
 					Config.Stacks.NamePattern),
 				)
 			}
 			ProcessedConfig.StackType = "Logical"
 		} else {
-			errorMessage := fmt.Sprintf("Stack '%s' does not exist in the config directories, and it does not match the stack name pattern '%s'",
+			errorMessage := fmt.Sprintf("The stack '%s' does not exist in the config directories, and it does not match the stack name pattern '%s'",
 				configAndStacksInfo.Stack,
 				Config.Stacks.NamePattern,
 			)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ var (
 	ProcessedConfig ProcessedConfiguration
 )
 
-// InitConfig processes and merges configurations in the following order: system dir, home dir, current dir, ENV vars
+// InitConfig processes and merges configurations in the following order: system dir, home dir, current dir, ENV vars, command-line arguments
 // https://dev.to/techschoolguru/load-config-from-file-environment-variables-in-golang-with-viper-2j2d
 // https://medium.com/@bnprashanth256/reading-configuration-files-and-environment-variables-in-go-golang-c2607f912b63
 func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
@@ -81,7 +81,8 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	}
 
 	if g.LogVerbose {
-		color.Cyan("\nProcessing and merging configurations in the following order:\nsystem dir, home dir, current dir, ENV vars, command-line arguments\n")
+		color.Cyan("\nProcessing and merging configurations in the following order:\n")
+		fmt.Println("system dir, home dir, current dir, ENV vars, command-line arguments\n")
 	}
 
 	v := viper.New()
@@ -244,7 +245,7 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 
 	if stackIsPhysicalPath == true {
 		if g.LogVerbose {
-			color.Cyan(fmt.Sprintf("The stack '%s' matches the stack config file %s",
+			color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack config file %s\n",
 				configAndStacksInfo.Stack,
 				stackConfigFilesRelativePaths[0]),
 			)
@@ -258,14 +259,14 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 
 		if len(stackParts) == len(stackNamePatternParts) {
 			if g.LogVerbose {
-				color.Cyan(fmt.Sprintf("The stack '%s' matches the stack name pattern '%s'",
+				color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack name pattern '%s'",
 					configAndStacksInfo.Stack,
 					Config.Stacks.NamePattern),
 				)
 			}
 			ProcessedConfig.StackType = "Logical"
 		} else {
-			errorMessage := fmt.Sprintf("The stack '%s' does not exist in the config directories, and it does not match the stack name pattern '%s'",
+			errorMessage := fmt.Sprintf("\nThe stack '%s' does not exist in the config directories, and it does not match the stack name pattern '%s'",
 				configAndStacksInfo.Stack,
 				Config.Stacks.NamePattern,
 			)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ var (
 			Terraform: Terraform{
 				BasePath:         "./components/terraform",
 				ApplyAutoApprove: false,
+				DeployRunInit:    true,
 			},
 			Helmfile: Helmfile{
 				BasePath:              "./components/helmfile",
@@ -51,7 +52,7 @@ var (
 			},
 		},
 		Logs: Logs{
-			Verbose: true,
+			Verbose: false,
 			Colors:  true,
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	}
 
 	if g.LogVerbose {
-		color.Cyan("\nProcessing and merging configurations in the following order: system dir, home dir, current dir, ENV vars\n")
+		color.Cyan("\nProcessing and merging configurations in the following order:\nsystem dir, home dir, current dir, ENV vars, command-line arguments\n")
 	}
 
 	v := viper.New()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,6 @@ import (
 	"strings"
 )
 
-const (
-	configFileName          = "atmos.yaml"
-	systemDirConfigFilePath = "/usr/local/etc/atmos"
-	windowsAppDataEnvVar    = "LOCALAPPDATA"
-)
-
 var (
 	// Default values
 	defaultConfig = Configuration{
@@ -108,16 +102,16 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	// https://softwareengineering.stackexchange.com/questions/299869/where-is-the-appropriate-place-to-put-application-configuration-files-for-each-p
 	// https://stackoverflow.com/questions/37946282/why-does-appdata-in-windows-7-seemingly-points-to-wrong-folder
 	if runtime.GOOS == "windows" {
-		appDataDir := os.Getenv(windowsAppDataEnvVar)
+		appDataDir := os.Getenv(g.WindowsAppDataEnvVar)
 		if len(appDataDir) > 0 {
 			configFilePath1 = appDataDir
 		}
 	} else {
-		configFilePath1 = systemDirConfigFilePath
+		configFilePath1 = g.SystemDirConfigFilePath
 	}
 
 	if len(configFilePath1) > 0 {
-		configFile1 := path.Join(configFilePath1, configFileName)
+		configFile1 := path.Join(configFilePath1, g.ConfigFileName)
 		err = processConfigFile(configFile1, v)
 		if err != nil {
 			return err
@@ -129,7 +123,7 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	if err != nil {
 		return err
 	}
-	configFile2 := path.Join(configFilePath2, ".atmos", configFileName)
+	configFile2 := path.Join(configFilePath2, ".atmos", g.ConfigFileName)
 	err = processConfigFile(configFile2, v)
 	if err != nil {
 		return err
@@ -140,7 +134,7 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	if err != nil {
 		return err
 	}
-	configFile3 := path.Join(configFilePath3, configFileName)
+	configFile3 := path.Join(configFilePath3, g.ConfigFileName)
 	err = processConfigFile(configFile3, v)
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -169,6 +170,14 @@ func InitConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	if len(configAndStacksInfo.StacksDir) > 0 {
 		Config.Stacks.BasePath = configAndStacksInfo.StacksDir
 		color.Cyan(fmt.Sprintf("Using command line argument '%s' as stacks directory", configAndStacksInfo.StacksDir))
+	}
+	if len(configAndStacksInfo.DeployRunInit) > 0 {
+		deployRunInitBool, err := strconv.ParseBool(configAndStacksInfo.DeployRunInit)
+		if err != nil {
+			return err
+		}
+		Config.Components.Terraform.DeployRunInit = deployRunInitBool
+		color.Cyan(fmt.Sprintf("Using command line argument '%s=%s'", g.DeployRunInitFlag, configAndStacksInfo.DeployRunInit))
 	}
 
 	// Check config

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -78,4 +78,5 @@ type ConfigAndStacksInfo struct {
 	ConfigDir               string
 	StacksDir               string
 	Context                 Context
+	ContextPrefix           string
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -3,6 +3,7 @@ package config
 type Terraform struct {
 	BasePath         string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
 	ApplyAutoApprove bool   `yaml:"apply_auto_approve" json:"apply_auto_approve" mapstructure:"apply_auto_approve"`
+	DeployRunInit    bool   `yaml:"deploy_run_init" json:"deploy_run_init" mapstructure:"deploy_run_init"`
 }
 
 type Helmfile struct {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -24,9 +24,15 @@ type Stacks struct {
 	NamePattern   string   `yaml:"name_pattern" json:"name_pattern" mapstructure:"name_pattern"`
 }
 
+type Logs struct {
+	Verbose bool `yaml:"verbose" json:"verbose" mapstructure:"verbose"`
+	Colors  bool `yaml:"colors" json:"colors" mapstructure:"colors"`
+}
+
 type Configuration struct {
 	Components Components
 	Stacks     Stacks
+	Logs       Logs
 }
 
 type ProcessedConfiguration struct {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -77,4 +77,5 @@ type ConfigAndStacksInfo struct {
 	HelmfileDir             string
 	ConfigDir               string
 	StacksDir               string
+	Context                 Context
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -64,6 +64,7 @@ type ArgsAndFlagsInfo struct {
 	HelmfileDir            string
 	ConfigDir              string
 	StacksDir              string
+	DeployRunInit          string
 }
 
 type ConfigAndStacksInfo struct {
@@ -86,4 +87,5 @@ type ConfigAndStacksInfo struct {
 	StacksDir               string
 	Context                 Context
 	ContextPrefix           string
+	DeployRunInit           string
 }

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -75,37 +75,37 @@ func findAllStackConfigsInPaths(
 func processEnvVars() error {
 	stacksBasePath := os.Getenv("ATMOS_STACKS_BASE_PATH")
 	if len(stacksBasePath) > 0 {
-		color.Green("Found ENV var 'ATMOS_STACKS_BASE_PATH': %s", stacksBasePath)
+		color.Green("Found ENV var ATMOS_STACKS_BASE_PATH=%s", stacksBasePath)
 		Config.Stacks.BasePath = stacksBasePath
 	}
 
 	stacksIncludedPaths := os.Getenv("ATMOS_STACKS_INCLUDED_PATHS")
 	if len(stacksIncludedPaths) > 0 {
-		color.Green("Found ENV var 'ATMOS_STACKS_INCLUDED_PATHS': %s", stacksIncludedPaths)
+		color.Green("Found ENV var ATMOS_STACKS_INCLUDED_PATHS=%s", stacksIncludedPaths)
 		Config.Stacks.IncludedPaths = strings.Split(stacksIncludedPaths, ",")
 	}
 
 	stacksExcludedPaths := os.Getenv("ATMOS_STACKS_EXCLUDED_PATHS")
 	if len(stacksExcludedPaths) > 0 {
-		color.Green("Found ENV var 'ATMOS_STACKS_EXCLUDED_PATHS': %s", stacksExcludedPaths)
+		color.Green("Found ENV var ATMOS_STACKS_EXCLUDED_PATHS=%s", stacksExcludedPaths)
 		Config.Stacks.ExcludedPaths = strings.Split(stacksExcludedPaths, ",")
 	}
 
 	stacksNamePattern := os.Getenv("ATMOS_STACKS_NAME_PATTERN")
 	if len(stacksNamePattern) > 0 {
-		color.Green("Found ENV var 'ATMOS_STACKS_NAME_PATTERN': %s", stacksNamePattern)
+		color.Green("Found ENV var ATMOS_STACKS_NAME_PATTERN=%s", stacksNamePattern)
 		Config.Stacks.NamePattern = stacksNamePattern
 	}
 
 	componentsTerraformBasePath := os.Getenv("ATMOS_COMPONENTS_TERRAFORM_BASE_PATH")
 	if len(componentsTerraformBasePath) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_TERRAFORM_BASE_PATH': %s", componentsTerraformBasePath)
+		color.Green("Found ENV var ATMOS_COMPONENTS_TERRAFORM_BASE_PATH=%s", componentsTerraformBasePath)
 		Config.Components.Terraform.BasePath = componentsTerraformBasePath
 	}
 
 	componentsTerraformApplyAutoApprove := os.Getenv("ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE")
 	if len(componentsTerraformApplyAutoApprove) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE': %s", componentsTerraformApplyAutoApprove)
+		color.Green("Found ENV var ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE=%s", componentsTerraformApplyAutoApprove)
 		applyAutoApproveBool, err := strconv.ParseBool(componentsTerraformApplyAutoApprove)
 		if err != nil {
 			return err
@@ -115,25 +115,25 @@ func processEnvVars() error {
 
 	componentsHelmfileBasePath := os.Getenv("ATMOS_COMPONENTS_HELMFILE_BASE_PATH")
 	if len(componentsHelmfileBasePath) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_HELMFILE_BASE_PATH': %s", componentsHelmfileBasePath)
+		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_BASE_PATH=%s", componentsHelmfileBasePath)
 		Config.Components.Helmfile.BasePath = componentsHelmfileBasePath
 	}
 
 	componentsHelmfileKubeconfigPath := os.Getenv("ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH")
 	if len(componentsHelmfileKubeconfigPath) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH': %s", componentsHelmfileKubeconfigPath)
+		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH=%s", componentsHelmfileKubeconfigPath)
 		Config.Components.Helmfile.KubeconfigPath = componentsHelmfileKubeconfigPath
 	}
 
 	componentsHelmfileHelmAwsProfilePattern := os.Getenv("ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN")
 	if len(componentsHelmfileHelmAwsProfilePattern) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN': %s", componentsHelmfileHelmAwsProfilePattern)
+		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN=%s", componentsHelmfileHelmAwsProfilePattern)
 		Config.Components.Helmfile.HelmAwsProfilePattern = componentsHelmfileHelmAwsProfilePattern
 	}
 
 	componentsHelmfileClusterNamePattern := os.Getenv("ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN")
 	if len(componentsHelmfileClusterNamePattern) > 0 {
-		color.Green("Found ENV var 'ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN': %s", componentsHelmfileClusterNamePattern)
+		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN=%s", componentsHelmfileClusterNamePattern)
 		Config.Components.Helmfile.ClusterNamePattern = componentsHelmfileClusterNamePattern
 	}
 
@@ -142,11 +142,11 @@ func processEnvVars() error {
 
 func checkConfig() error {
 	if len(Config.Stacks.BasePath) < 1 {
-		return errors.New("stack base path must be provided in 'stacks.base_path' config or 'ATMOS_STACKS_BASE_PATH' ENV variable")
+		return errors.New("stack base path must be provided in 'stacks.base_path' config or ATMOS_STACKS_BASE_PATH' ENV variable")
 	}
 
 	if len(Config.Stacks.IncludedPaths) < 1 {
-		return errors.New("at least one path must be provided in 'stacks.included_paths' config or 'ATMOS_STACKS_INCLUDED_PATHS' ENV variable")
+		return errors.New("at least one path must be provided in 'stacks.included_paths' config or ATMOS_STACKS_INCLUDED_PATHS' ENV variable")
 	}
 
 	return nil

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -75,37 +75,37 @@ func findAllStackConfigsInPaths(
 func processEnvVars() error {
 	stacksBasePath := os.Getenv("ATMOS_STACKS_BASE_PATH")
 	if len(stacksBasePath) > 0 {
-		color.Green("Found ENV var ATMOS_STACKS_BASE_PATH=%s", stacksBasePath)
+		color.Cyan("Found ENV var ATMOS_STACKS_BASE_PATH=%s", stacksBasePath)
 		Config.Stacks.BasePath = stacksBasePath
 	}
 
 	stacksIncludedPaths := os.Getenv("ATMOS_STACKS_INCLUDED_PATHS")
 	if len(stacksIncludedPaths) > 0 {
-		color.Green("Found ENV var ATMOS_STACKS_INCLUDED_PATHS=%s", stacksIncludedPaths)
+		color.Cyan("Found ENV var ATMOS_STACKS_INCLUDED_PATHS=%s", stacksIncludedPaths)
 		Config.Stacks.IncludedPaths = strings.Split(stacksIncludedPaths, ",")
 	}
 
 	stacksExcludedPaths := os.Getenv("ATMOS_STACKS_EXCLUDED_PATHS")
 	if len(stacksExcludedPaths) > 0 {
-		color.Green("Found ENV var ATMOS_STACKS_EXCLUDED_PATHS=%s", stacksExcludedPaths)
+		color.Cyan("Found ENV var ATMOS_STACKS_EXCLUDED_PATHS=%s", stacksExcludedPaths)
 		Config.Stacks.ExcludedPaths = strings.Split(stacksExcludedPaths, ",")
 	}
 
 	stacksNamePattern := os.Getenv("ATMOS_STACKS_NAME_PATTERN")
 	if len(stacksNamePattern) > 0 {
-		color.Green("Found ENV var ATMOS_STACKS_NAME_PATTERN=%s", stacksNamePattern)
+		color.Cyan("Found ENV var ATMOS_STACKS_NAME_PATTERN=%s", stacksNamePattern)
 		Config.Stacks.NamePattern = stacksNamePattern
 	}
 
 	componentsTerraformBasePath := os.Getenv("ATMOS_COMPONENTS_TERRAFORM_BASE_PATH")
 	if len(componentsTerraformBasePath) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_TERRAFORM_BASE_PATH=%s", componentsTerraformBasePath)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_TERRAFORM_BASE_PATH=%s", componentsTerraformBasePath)
 		Config.Components.Terraform.BasePath = componentsTerraformBasePath
 	}
 
 	componentsTerraformApplyAutoApprove := os.Getenv("ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE")
 	if len(componentsTerraformApplyAutoApprove) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE=%s", componentsTerraformApplyAutoApprove)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE=%s", componentsTerraformApplyAutoApprove)
 		applyAutoApproveBool, err := strconv.ParseBool(componentsTerraformApplyAutoApprove)
 		if err != nil {
 			return err
@@ -113,27 +113,37 @@ func processEnvVars() error {
 		Config.Components.Terraform.ApplyAutoApprove = applyAutoApproveBool
 	}
 
+	componentsTerraformDeployRunInit := os.Getenv("ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT")
+	if len(componentsTerraformDeployRunInit) > 0 {
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT=%s", componentsTerraformDeployRunInit)
+		deployRunInitBool, err := strconv.ParseBool(componentsTerraformDeployRunInit)
+		if err != nil {
+			return err
+		}
+		Config.Components.Terraform.DeployRunInit = deployRunInitBool
+	}
+
 	componentsHelmfileBasePath := os.Getenv("ATMOS_COMPONENTS_HELMFILE_BASE_PATH")
 	if len(componentsHelmfileBasePath) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_BASE_PATH=%s", componentsHelmfileBasePath)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_HELMFILE_BASE_PATH=%s", componentsHelmfileBasePath)
 		Config.Components.Helmfile.BasePath = componentsHelmfileBasePath
 	}
 
 	componentsHelmfileKubeconfigPath := os.Getenv("ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH")
 	if len(componentsHelmfileKubeconfigPath) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH=%s", componentsHelmfileKubeconfigPath)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH=%s", componentsHelmfileKubeconfigPath)
 		Config.Components.Helmfile.KubeconfigPath = componentsHelmfileKubeconfigPath
 	}
 
 	componentsHelmfileHelmAwsProfilePattern := os.Getenv("ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN")
 	if len(componentsHelmfileHelmAwsProfilePattern) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN=%s", componentsHelmfileHelmAwsProfilePattern)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN=%s", componentsHelmfileHelmAwsProfilePattern)
 		Config.Components.Helmfile.HelmAwsProfilePattern = componentsHelmfileHelmAwsProfilePattern
 	}
 
 	componentsHelmfileClusterNamePattern := os.Getenv("ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN")
 	if len(componentsHelmfileClusterNamePattern) > 0 {
-		color.Green("Found ENV var ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN=%s", componentsHelmfileClusterNamePattern)
+		color.Cyan("Found ENV var ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN=%s", componentsHelmfileClusterNamePattern)
 		Config.Components.Helmfile.ClusterNamePattern = componentsHelmfileClusterNamePattern
 	}
 
@@ -155,7 +165,7 @@ func checkConfig() error {
 func processLogsConfig() error {
 	logVerbose := os.Getenv("ATMOS_LOGS_VERBOSE")
 	if len(logVerbose) > 0 {
-		color.Green("Found ENV var ATMOS_LOGS_VERBOSE=%s", logVerbose)
+		color.Cyan("Found ENV var ATMOS_LOGS_VERBOSE=%s", logVerbose)
 		logVerboseBool, err := strconv.ParseBool(logVerbose)
 		if err != nil {
 			return err

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -151,3 +151,17 @@ func checkConfig() error {
 
 	return nil
 }
+
+func processLogsConfig() error {
+	logVerbose := os.Getenv("ATMOS_LOGS_VERBOSE")
+	if len(logVerbose) > 0 {
+		color.Green("Found ENV var ATMOS_LOGS_VERBOSE=%s", logVerbose)
+		logVerboseBool, err := strconv.ParseBool(logVerbose)
+		if err != nil {
+			return err
+		}
+		Config.Logs.Verbose = logVerboseBool
+		g.LogVerbose = logVerboseBool
+	}
+	return nil
+}

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -14,7 +14,7 @@ import (
 // ExecuteDescribeComponent executes `describe component` command
 func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("invalid arguments. Command requires one argument `component`")
+		return errors.New("invalid arguments. The command requires one argument `component`")
 	}
 	flags := cmd.Flags()
 
@@ -132,14 +132,14 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 			}
 
 			if tenantFound == true && environmentFound == true && stageFound == true {
-				color.Green("Found stack config for component '%s' in stack '%s'\n\n", component, stackName)
+				color.Green("Found stack config for component '%s' in the stack '%s'\n\n", component, stackName)
 				stack = stackName
 				break
 			}
 		}
 
 		if tenantFound == false || environmentFound == false || stageFound == false {
-			return errors.New(fmt.Sprintf("\nCould not find config for component '%s' for stack '%s'.\n"+
+			return errors.New(fmt.Sprintf("\nCould not find config for the component '%s' in the stack '%s'.\n"+
 				"Check that all attributes in the stack name pattern '%s' are defined in stack config files.\n"+
 				"Are the component and stack names correct? Did you forget an import?",
 				component,

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	c "atmos/internal/config"
+	g "atmos/internal/globals"
 	s "atmos/internal/stack"
 	u "atmos/internal/utils"
 	"fmt"
@@ -34,18 +35,20 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 	component := args[0]
 
 	// Print the stack config files
-	fmt.Println()
-	var msg string
-	if c.ProcessedConfig.StackType == "Directory" {
-		msg = "Found the config file for the provided stack:"
-	} else {
-		msg = "Found config files:"
-	}
-	color.Cyan(msg)
+	if g.LogVerbose {
+		fmt.Println()
+		var msg string
+		if c.ProcessedConfig.StackType == "Directory" {
+			msg = "Found the config file for the provided stack:"
+		} else {
+			msg = "Found config files:"
+		}
+		color.Cyan(msg)
 
-	err = u.PrintAsYAML(c.ProcessedConfig.StackConfigFilesRelativePaths)
-	if err != nil {
-		return err
+		err = u.PrintAsYAML(c.ProcessedConfig.StackConfigFilesRelativePaths)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, stacksMap, err := s.ProcessYAMLConfigFiles(
@@ -71,7 +74,9 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
-		color.Cyan("Searching for stack config where the component '%s' is defined\n", component)
+		if g.LogVerbose {
+			color.Cyan("Searching for stack config where the component '%s' is defined\n", component)
+		}
 
 		if len(c.Config.Stacks.NamePattern) < 1 {
 			return errors.New("stack name pattern must be provided in 'stacks.name_pattern' config or 'ATMOS_STACKS_NAME_PATTERN' ENV variable")
@@ -149,7 +154,10 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	color.Cyan("\nComponent config:\n\n")
+	if g.LogVerbose {
+		color.Cyan("\nComponent config:\n\n")
+	}
+
 	err = u.PrintAsYAML(componentSection)
 	if err != nil {
 		return err

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -137,7 +137,9 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 			}
 
 			if tenantFound == true && environmentFound == true && stageFound == true {
-				color.Green("Found stack config for component '%s' in the stack '%s'\n\n", component, stackName)
+				if g.LogVerbose == true {
+					color.Cyan("Found stack config for component '%s' in the stack '%s'\n\n", component, stackName)
+				}
 				stack = stackName
 				break
 			}

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 	"path"
-	"strings"
 )
 
 // ExecuteHelmfile executes helmfile commands
@@ -39,15 +38,13 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		))
 	}
 
-	stackNameFormatted := strings.Replace(info.Stack, "/", "-", -1)
-
 	// Write variables to a file
 	var varFileName string
 	if len(info.ComponentFolderPrefix) == 0 {
 		varFileName = fmt.Sprintf("%s/%s/%s-%s.helmfile.vars.yaml",
 			c.Config.Components.Helmfile.BasePath,
 			info.Component,
-			stackNameFormatted,
+			info.ContextPrefix,
 			info.Component,
 		)
 	} else {
@@ -55,7 +52,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 			c.Config.Components.Helmfile.BasePath,
 			info.ComponentFolderPrefix,
 			info.Component,
-			stackNameFormatted,
+			info.ContextPrefix,
 			info.Component,
 		)
 	}
@@ -79,7 +76,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	color.Cyan(fmt.Sprintf("\nUsing AWS_PROFILE=%s\n\n", helmAwsProfile))
 
 	// Download kubeconfig by running `aws eks update-kubeconfig`
-	kubeconfigPath := fmt.Sprintf("%s/%s-kubecfg", c.Config.Components.Helmfile.KubeconfigPath, stackNameFormatted)
+	kubeconfigPath := fmt.Sprintf("%s/%s-kubecfg", c.Config.Components.Helmfile.KubeconfigPath, info.ContextPrefix)
 	clusterName := replaceContextTokens(context, c.Config.Components.Helmfile.ClusterNamePattern)
 	color.Cyan(fmt.Sprintf("Downloading kubeconfig from the cluster '%s' and saving it to %s\n\n", clusterName, kubeconfigPath))
 
@@ -120,20 +117,15 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	color.Green("Stack: " + info.Stack)
 
 	var workingDir string
-	if len(info.ComponentNamePrefix) == 0 {
+	if len(info.ComponentFolderPrefix) == 0 {
 		workingDir = fmt.Sprintf("%s/%s", c.Config.Components.Helmfile.BasePath, info.Component)
 	} else {
-		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Helmfile.BasePath, info.ComponentNamePrefix, info.Component)
+		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Helmfile.BasePath, info.ComponentFolderPrefix, info.Component)
 	}
 	color.Green(fmt.Sprintf("Working dir: %s\n\n", workingDir))
 	fmt.Println()
 
-	var varFile string
-	if len(info.ComponentNamePrefix) == 0 {
-		varFile = fmt.Sprintf("%s-%s.helmfile.vars.yaml", stackNameFormatted, info.Component)
-	} else {
-		varFile = fmt.Sprintf("%s-%s-%s.helmfile.vars.yaml", stackNameFormatted, info.ComponentNamePrefix, info.Component)
-	}
+	varFile := fmt.Sprintf("%s-%s.helmfile.vars.yaml", info.ContextPrefix, info.Component)
 
 	// Prepare arguments and flags
 	allArgsAndFlags := []string{"--state-values-file", varFile}
@@ -152,7 +144,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("ENVIRONMENT=%s", context.Environment),
 		fmt.Sprintf("STAGE=%s", context.Stage),
 		fmt.Sprintf("REGION=%s", context.Region),
-		fmt.Sprintf("STACK=%s", stackNameFormatted),
+		fmt.Sprintf("STACK=%s", info.Stack),
 	}
 
 	err = execCommand(info.Command, allArgsAndFlags, componentPath, envVars)
@@ -161,10 +153,9 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Cleanup
-	varFilePath := fmt.Sprintf("%s/%s/%s", c.ProcessedConfig.HelmfileDirAbsolutePath, info.Component, varFile)
-	err = os.Remove(varFilePath)
+	err = os.Remove(varFileName)
 	if err != nil {
-		color.Yellow("Error deleting helmfile var file: %s\n", err)
+		color.Yellow("Error deleting helmfile varfile: %s\n", err)
 	}
 
 	return nil

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -99,22 +99,22 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 
 	// Print command info
 	color.Cyan("\nCommand info:")
-	color.Green("Helmfile binary: " + info.Command)
-	color.Green("Helmfile command: " + info.SubCommand)
+	fmt.Println("Helmfile binary: " + info.Command)
+	fmt.Println("Helmfile command: " + info.SubCommand)
 
 	// https://github.com/roboll/helmfile#cli-reference
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options "--no-color --namespace=test"
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options "--no-color --namespace test"
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options="--no-color --namespace=test"
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options="--no-color --namespace test"
-	color.Green("Global options: %v", info.GlobalOptions)
+	fmt.Println(fmt.Sprintf("Global options: %v", info.GlobalOptions))
 
-	color.Green("Arguments and flags: %v", info.AdditionalArgsAndFlags)
-	color.Green("Component: " + info.ComponentFromArg)
+	fmt.Println(fmt.Sprintf("Arguments and flags: %v", info.AdditionalArgsAndFlags))
+	fmt.Println("Component: " + info.ComponentFromArg)
 	if len(info.BaseComponent) > 0 {
-		color.Green("Base component: " + info.BaseComponent)
+		fmt.Println("Base component: " + info.BaseComponent)
 	}
-	color.Green("Stack: " + info.Stack)
+	fmt.Println("Stack: " + info.Stack)
 
 	var workingDir string
 	if len(info.ComponentFolderPrefix) == 0 {
@@ -122,8 +122,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	} else {
 		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Helmfile.BasePath, info.ComponentFolderPrefix, info.Component)
 	}
-	color.Green(fmt.Sprintf("Working dir: %s\n\n", workingDir))
-	fmt.Println()
+	fmt.Println(fmt.Sprintf("Working dir: %s\n\n", workingDir))
 
 	varFile := fmt.Sprintf("%s-%s.helmfile.vars.yaml", info.ContextPrefix, info.Component)
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -182,11 +182,11 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	if os.Stdin == nil && !u.SliceContainsString(info.AdditionalArgsAndFlags, autoApproveFlag) {
 		errorMessage := ""
 		if info.SubCommand == "apply" {
-			errorMessage = "`terraform apply` requires a user interaction, but it's running without `tty` or `stdin` attached." +
-				"\nUse `terraform apply -auto-approve` or `terraform deploy` instead."
+			errorMessage = "'terraform apply' requires a user interaction, but it's running without `tty` or `stdin` attached." +
+				"\nUse 'terraform apply -auto-approve' or 'terraform deploy' instead."
 		} else if info.SubCommand == "destroy" {
-			errorMessage = "`terraform destroy` requires a user interaction, but it's running without `tty` or `stdin` attached." +
-				"\nUse `terraform destroy -auto-approve` if you need to destroy resources without asking the user for confirmation."
+			errorMessage = "'terraform destroy' requires a user interaction, but it's running without `tty` or `stdin` attached." +
+				"\nUse 'terraform destroy -auto-approve' if you need to destroy resources without asking the user for confirmation."
 		}
 		if errorMessage != "" {
 			return errors.New(errorMessage)

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -191,10 +191,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	if cleanUp == true {
 		planFilePath := fmt.Sprintf("%s/%s", workingDir, planFile)
-		err = os.Remove(planFilePath)
-		if err != nil {
-			color.Yellow("Error deleting terraform plan file: %s\n", err)
-		}
+		_ = os.Remove(planFilePath)
 
 		err = os.Remove(varFileName)
 		if err != nil {

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -97,7 +97,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run `terraform init`
-	if info.SubCommand != "init" && info.SubCommand != "deploy" && info.SubCommand != "workspace" {
+	runTerraformInit := true
+	if info.SubCommand == "init" ||
+		info.SubCommand == "workspace" ||
+		(info.SubCommand == "deploy" && c.Config.Components.Terraform.DeployRunInit == false) {
+		runTerraformInit = false
+	}
+	if runTerraformInit == true {
 		err = execCommand(info.Command, []string{"init"}, componentPath, nil)
 		if err != nil {
 			return err

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 	"path"
-	"strings"
 )
 
 const (
@@ -50,8 +49,6 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		))
 	}
 
-	stackNameFormatted := strings.Replace(info.Stack, "/", "-", -1)
-
 	// Write variables to a file
 	var varFileName, varFileNameFromArg string
 
@@ -72,7 +69,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 			varFileName = fmt.Sprintf("%s/%s/%s-%s.terraform.tfvars.json",
 				c.Config.Components.Terraform.BasePath,
 				finalComponent,
-				stackNameFormatted,
+				info.ContextPrefix,
 				info.Component,
 			)
 		} else {
@@ -80,7 +77,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 				c.Config.Components.Terraform.BasePath,
 				info.ComponentFolderPrefix,
 				finalComponent,
-				stackNameFormatted,
+				info.ContextPrefix,
 				info.Component,
 			)
 		}
@@ -126,36 +123,22 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	color.Green("Stack: " + info.Stack)
 
 	var workingDir string
-	if len(info.ComponentNamePrefix) == 0 {
-		workingDir = fmt.Sprintf("%s/%s", c.Config.Components.Terraform.BasePath, info.Component)
+	if len(info.ComponentFolderPrefix) == 0 {
+		workingDir = fmt.Sprintf("%s/%s", c.Config.Components.Terraform.BasePath, finalComponent)
 	} else {
-		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Terraform.BasePath, info.ComponentNamePrefix, info.Component)
+		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Terraform.BasePath, info.ComponentFolderPrefix, finalComponent)
 	}
 	color.Green(fmt.Sprintf("Working dir: %s", workingDir))
 	fmt.Println()
 
-	var planFile, varFile string
-	if len(info.ComponentNamePrefix) == 0 {
-		planFile = fmt.Sprintf("%s-%s.planfile", stackNameFormatted, info.Component)
-		varFile = fmt.Sprintf("%s-%s.terraform.tfvars.json", stackNameFormatted, info.Component)
-	} else {
-		planFile = fmt.Sprintf("%s-%s-%s.planfile", stackNameFormatted, info.ComponentNamePrefix, info.Component)
-		varFile = fmt.Sprintf("%s-%s-%s.terraform.tfvars.json", stackNameFormatted, info.ComponentNamePrefix, info.Component)
-	}
+	planFile := fmt.Sprintf("%s-%s.planfile", info.ContextPrefix, info.Component)
+	varFile := fmt.Sprintf("%s-%s.terraform.tfvars.json", info.ContextPrefix, info.Component)
 
 	var workspaceName string
-	if len(info.ComponentNamePrefix) == 0 {
-		if len(info.BaseComponent) > 0 {
-			workspaceName = fmt.Sprintf("%s-%s", stackNameFormatted, info.Component)
-		} else {
-			workspaceName = stackNameFormatted
-		}
+	if len(info.BaseComponent) > 0 {
+		workspaceName = fmt.Sprintf("%s-%s", info.ContextPrefix, info.Component)
 	} else {
-		if len(info.BaseComponent) > 0 {
-			workspaceName = fmt.Sprintf("%s-%s-%s", info.ComponentNamePrefix, stackNameFormatted, info.Component)
-		} else {
-			workspaceName = fmt.Sprintf("%s-%s", info.ComponentNamePrefix, stackNameFormatted)
-		}
+		workspaceName = info.ContextPrefix
 	}
 
 	cleanUp := false

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -113,14 +113,14 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	// Print command info
 	color.Cyan("\nCommand info:")
-	color.Green("Terraform binary: " + info.Command)
-	color.Green("Terraform command: " + info.SubCommand)
-	color.Green("Arguments and flags: %v", info.AdditionalArgsAndFlags)
-	color.Green("Component: " + info.ComponentFromArg)
+	fmt.Println("Terraform binary: " + info.Command)
+	fmt.Println("Terraform command: " + info.SubCommand)
+	fmt.Println(fmt.Sprintf("Arguments and flags: %v", info.AdditionalArgsAndFlags))
+	fmt.Println("Component: " + info.ComponentFromArg)
 	if len(info.BaseComponentPath) > 0 {
-		color.Green("Base component: " + info.BaseComponentPath)
+		fmt.Println("Base component: " + info.BaseComponentPath)
 	}
-	color.Green("Stack: " + info.Stack)
+	fmt.Println("Stack: " + info.Stack)
 
 	var workingDir string
 	if len(info.ComponentFolderPrefix) == 0 {
@@ -128,8 +128,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	} else {
 		workingDir = fmt.Sprintf("%s/%s/%s", c.Config.Components.Terraform.BasePath, info.ComponentFolderPrefix, finalComponent)
 	}
-	color.Green(fmt.Sprintf("Working dir: %s", workingDir))
-	fmt.Println()
+	fmt.Println(fmt.Sprintf(fmt.Sprintf("Working dir: %s", workingDir)))
 
 	planFile := fmt.Sprintf("%s-%s.planfile", info.ContextPrefix, info.Component)
 	varFile := fmt.Sprintf("%s-%s.terraform.tfvars.json", info.ContextPrefix, info.Component)

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -148,7 +148,6 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		workspaceName = info.ContextPrefix
 	}
 
-	cleanUp := false
 	allArgsAndFlags := append([]string{info.SubCommand}, info.AdditionalArgsAndFlags...)
 
 	switch info.SubCommand {
@@ -157,11 +156,9 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		break
 	case "destroy":
 		allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
-		cleanUp = true
 		break
 	case "apply":
 		allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
-		cleanUp = true
 		break
 	}
 
@@ -182,14 +179,15 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if cleanUp == true {
+	// Clean up
+	if info.SubCommand != "plan" {
 		planFilePath := fmt.Sprintf("%s/%s", workingDir, planFile)
 		_ = os.Remove(planFilePath)
+	}
 
-		err = os.Remove(varFileName)
-		if err != nil {
-			color.Yellow("Error deleting terraform var file: %s\n", err)
-		}
+	err = os.Remove(varFileName)
+	if err != nil {
+		color.Yellow("Error deleting terraform varfile: %s\n", err)
 	}
 
 	return nil

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -207,11 +207,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	if cleanUp == true {
-		planFilePath := fmt.Sprintf("%s/%s/%s", c.ProcessedConfig.TerraformDirAbsolutePath, info.Component, planFile)
-		_ = os.Remove(planFilePath)
+		planFilePath := fmt.Sprintf("%s/%s", workingDir, planFile)
+		err = os.Remove(planFilePath)
+		if err != nil {
+			color.Yellow("Error deleting terraform plan file: %s\n", err)
+		}
 
-		varFilePath := fmt.Sprintf("%s/%s/%s", c.ProcessedConfig.TerraformDirAbsolutePath, info.Component, varFile)
-		err = os.Remove(varFilePath)
+		err = os.Remove(varFileName)
 		if err != nil {
 			color.Yellow("Error deleting terraform var file: %s\n", err)
 		}

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -96,6 +96,14 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Run `terraform init`
+	if info.SubCommand != "init" && info.SubCommand != "deploy" && info.SubCommand != "workspace" {
+		err = execCommand(info.Command, []string{"init"}, componentPath, nil)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Handle `terraform deploy` custom command
 	if info.SubCommand == "deploy" {
 		info.SubCommand = "apply"
@@ -152,23 +160,9 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		cleanUp = true
 		break
 	case "apply":
-		// Use the planfile if `-auto-approve` flag is not specified
-		// Use the varfile if `-auto-approve` flag is specified
-		if !u.SliceContainsString(allArgsAndFlags, autoApproveFlag) {
-			allArgsAndFlags = append(allArgsAndFlags, []string{planFile}...)
-		} else {
-			allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
-		}
+		allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
 		cleanUp = true
 		break
-	}
-
-	// Run `terraform init`
-	if info.SubCommand != "init" {
-		err = execCommand(info.Command, []string{"init"}, componentPath, nil)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Run `terraform workspace`

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -177,7 +177,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check if the terraform command requires user interaction,
+	// Check if the terraform command requires a user interaction,
 	// but it's running in a scripted environment (where a `tty` is not attached or `stdin` is not attached)
 	if os.Stdin == nil && !u.SliceContainsString(info.AdditionalArgsAndFlags, autoApproveFlag) {
 		errorMessage := ""

--- a/internal/exec/terraform_generate.go
+++ b/internal/exec/terraform_generate.go
@@ -14,7 +14,7 @@ import (
 // ExecuteTerraformGenerateBackend executes `terraform generate backend` command
 func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("invalid arguments. Command requires one argument `component`")
+		return errors.New("invalid arguments. The command requires one argument `component`")
 	}
 	flags := cmd.Flags()
 

--- a/internal/exec/terraform_generate.go
+++ b/internal/exec/terraform_generate.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	c "atmos/internal/config"
+	g "atmos/internal/globals"
 	s "atmos/internal/stack"
 	u "atmos/internal/utils"
 	"fmt"
@@ -34,18 +35,20 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 	component := args[0]
 
 	// Print the stack config files
-	fmt.Println()
-	var msg string
-	if c.ProcessedConfig.StackType == "Directory" {
-		msg = "Found the config file for the provided stack:"
-	} else {
-		msg = "Found config files:"
-	}
-	color.Cyan(msg)
+	if g.LogVerbose {
+		fmt.Println()
+		var msg string
+		if c.ProcessedConfig.StackType == "Directory" {
+			msg = "Found the config file for the provided stack:"
+		} else {
+			msg = "Found config files:"
+		}
+		color.Cyan(msg)
 
-	err = u.PrintAsYAML(c.ProcessedConfig.StackConfigFilesRelativePaths)
-	if err != nil {
-		return err
+		err = u.PrintAsYAML(c.ProcessedConfig.StackConfigFilesRelativePaths)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, stacksMap, err := s.ProcessYAMLConfigFiles(

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -321,6 +321,8 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 		}
 	}
 
+	configAndStacksInfo.Context = getContextFromVars(configAndStacksInfo.ComponentVarsSection)
+
 	return configAndStacksInfo, nil
 }
 

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -60,16 +60,16 @@ func checkStackConfig(
 		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("Stack '%s' does not exist", stack))
 	}
 	if componentsSection, ok = stackSection["components"].(map[string]interface{}); !ok {
-		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("'components' section is missing in stack '%s'", stack))
+		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("'components' section is missing in the stack '%s'", stack))
 	}
 	if componentTypeSection, ok = componentsSection[componentType].(map[string]interface{}); !ok {
-		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("'components/%s' section is missing in stack '%s'", componentType, stack))
+		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("'components/%s' section is missing in the stack '%s'", componentType, stack))
 	}
 	if componentSection, ok = componentTypeSection[component].(map[string]interface{}); !ok {
-		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("Invalid or missing configuration for component '%s' in stack '%s'", component, stack))
+		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("Invalid or missing configuration for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentVarsSection, ok = componentSection["vars"].(map[interface{}]interface{}); !ok {
-		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("Missing 'vars' section for component '%s' in stack '%s'", component, stack))
+		return nil, nil, nil, "", "", errors.New(fmt.Sprintf("Missing 'vars' section for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentBackendSection, ok = componentSection["backend"].(map[interface{}]interface{}); !ok {
 		componentBackendSection = nil
@@ -104,16 +104,16 @@ func findComponentConfig(
 		return nil, nil, nil, errors.New(fmt.Sprintf("Stack '%s' does not exist", stack))
 	}
 	if componentsSection, ok = stackSection["components"].(map[string]interface{}); !ok {
-		return nil, nil, nil, errors.New(fmt.Sprintf("'components' section is missing in stack '%s'", stack))
+		return nil, nil, nil, errors.New(fmt.Sprintf("'components' section is missing in the stack '%s'", stack))
 	}
 	if componentTypeSection, ok = componentsSection[componentType].(map[string]interface{}); !ok {
-		return nil, nil, nil, errors.New(fmt.Sprintf("'components/%s' section is missing in stack '%s'", componentType, stack))
+		return nil, nil, nil, errors.New(fmt.Sprintf("'components/%s' section is missing in the stack '%s'", componentType, stack))
 	}
 	if componentSection, ok = componentTypeSection[component].(map[string]interface{}); !ok {
-		return nil, nil, nil, errors.New(fmt.Sprintf("Invalid or missing configuration for component '%s' in stack '%s'", component, stack))
+		return nil, nil, nil, errors.New(fmt.Sprintf("Invalid or missing configuration for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentVarsSection, ok = componentSection["vars"].(map[interface{}]interface{}); !ok {
-		return nil, nil, nil, errors.New(fmt.Sprintf("Missing 'vars' section for component '%s' in stack '%s'", component, stack))
+		return nil, nil, nil, errors.New(fmt.Sprintf("Missing 'vars' section for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentBackendSection, ok = componentSection["backend"].(map[interface{}]interface{}); !ok {
 		componentBackendSection = nil

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -305,7 +305,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 	if finalComponentPathPartsLength > 1 {
 		componentFromArgPartsWithoutLast := finalComponentPathParts[:finalComponentPathPartsLength-1]
 		configAndStacksInfo.ComponentFolderPrefix = strings.Join(componentFromArgPartsWithoutLast, "/")
-		configAndStacksInfo.ComponentFolderPrefix = strings.Join(componentFromArgPartsWithoutLast, "-")
+		configAndStacksInfo.ComponentNamePrefix = strings.Join(componentFromArgPartsWithoutLast, "-")
 		configAndStacksInfo.Component = finalComponentPathParts[finalComponentPathPartsLength-1]
 	} else {
 		configAndStacksInfo.Component = configAndStacksInfo.ComponentFromArg

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -3,3 +3,7 @@ package globals
 const (
 	DefaultStackConfigFileExtension = ".yaml"
 )
+
+var (
+	LogVerbose = false
+)

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -5,6 +5,16 @@ const (
 	ConfigFileName                  = "atmos.yaml"
 	SystemDirConfigFilePath         = "/usr/local/etc/atmos"
 	WindowsAppDataEnvVar            = "LOCALAPPDATA"
+
+	// Custom flag to specify helmfile `GLOBAL OPTIONS`
+	// https://github.com/roboll/helmfile#cli-reference
+	GlobalOptionsFlag = "--global-options"
+
+	TerraformDirFlag  = "--terraform-dir"
+	HelmfileDirFlag   = "--helmfile-dir"
+	ConfigDirFlag     = "--config-dir"
+	StackDirFlag      = "--stacks-dir"
+	DeployRunInitFlag = "--deploy-run-init"
 )
 
 var (

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -2,6 +2,9 @@ package globals
 
 const (
 	DefaultStackConfigFileExtension = ".yaml"
+	ConfigFileName                  = "atmos.yaml"
+	SystemDirConfigFilePath         = "/usr/local/etc/atmos"
+	WindowsAppDataEnvVar            = "LOCALAPPDATA"
 )
 
 var (

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -152,7 +152,7 @@ func ProcessYAMLConfigFile(
 			impWithExtPath := path.Join(basePath, impWithExt)
 
 			if impWithExtPath == filePath {
-				errorMessage := fmt.Sprintf("Invalid import in config file %s.\nThe file imports itself in import: '%s'",
+				errorMessage := fmt.Sprintf("Invalid import in the config file %s.\nThe file imports itself in '%s'",
 					filePath,
 					strings.Replace(impWithExt, basePath+"/", "", 1))
 				return nil, nil, errors.New(errorMessage)
@@ -165,7 +165,7 @@ func ProcessYAMLConfigFile(
 			}
 
 			if matches == nil {
-				errorMessage := fmt.Sprintf("Invalid import in config file %s.\nNo matches found for import: '%s'",
+				errorMessage := fmt.Sprintf("Invalid import in the config file %s.\nNo matches found for the import '%s'",
 					filePath,
 					strings.Replace(impWithExt, basePath+"/", "", 1))
 				return nil, nil, errors.New(errorMessage)


### PR DESCRIPTION
## what
* Improvements and new features

## why
* `atmos terraform apply` made 100% compatible with `terraform apply`:
  - does not run `terraform plan`
  - `atmos terraform apply` does not use `planfile` (by default)
  - `atmos terraform apply` will ask for the confirmation to apply
  - `atmos terraform apply -auto-approve` will apply without asking for the confirmation to apply
  - The above behavior can be overridden. If `apply_auto_approve` config (or ENV var `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE `) is set to `true`, `atmos terraform apply` will not ask for the confirmation to apply regardless of whether the `-auto-approve` is specified or not

* `atmos terraform deploy`:
  - behaves like `atmos terraform apply -auto-approve`
  - does not run `terraform plan`
  - If `deploy_run_init` config (or ENV var `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT`, or `--deploy-run-init` command-line argument) is set to `true`, `atmos terraform deploy` will first run `terraform init` to initialize modules. Otherwise, it will not run `terraform init`, and `atmos terraform init` will need to be run first at least once

  ```
  ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT=false atmos terraform deploy top-level-component1 -s tenant1-ue2-dev
  ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT=true atmos terraform deploy top-level-component1 -s tenant1-ue2-dev
  ```

  ```
  atmos terraform deploy top-level-component1 -s tenant1/ue2/dev --deploy-run-init=false
  
  Using command line argument '--deploy-run-init=false'
  ```

  ```
  ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT=false atmos terraform deploy top-level-component1 -s tenant1/ue2/dev --deploy-run-init=true
  
  Found ENV var ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT=false
  Using command line argument '--deploy-run-init=true'
  ```


* Log level control:
  - If ENV var `ATMOS_LOGS_VERBOSE ` is set to `false` (default), the CLI will not print all the information about the config, stacks and component (and how it searches them), but will just output the essential info for each command

    ```
    ATMOS_LOGS_VERBOSE=true atmos terraform deploy top-level-component1 -s tenant1-ue2-dev
    ```

* Check if terraform commands require user interaction, but running in a scripted environment (where a `tty` is not attached or `stdin` is not attached)

* Use logical `context` to generate terraform workspaces and file names for `planfile` and `varfile`:
  - Instead of using the physical paths derived from the provided stack names to generate terraform workspaces and the names of  `planfile` and `varfile` (which the old variant-based `atmos` did as well), find the logical `context` for the specified component in the specified stack (from the deep-merged vars). The logical `context` consist of `tenant` (if used), `environment` and `stage`, and is controlled by the `name_pattern: "{tenant}-{environment}-{stage}"` CLI config
  - This makes it completely independent of the folder structure where the YAML stack config files are defined - don't use the physical structure, look at the logical structure
  - Bonus:
    - You will be able move around the top-level YAML config files (that are not imported into other stacks) to any folder at any level (under `stacks` parent folder) "on-the-fly" , or change the names of the folders, WITHOUT needing to change anything - terraform workspace remains the same, the CLI will find the context from the deep-merged vars, and it just works
    - You can also move around the YAML config files even if they are already imported into other stacks, you will just need to update the `import` paths, but all CLI commands will continue working without making any changes to terraform state

