### PR TITLE
Fix `go.mod` module name. Make all imports absolute paths

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,9 +18,8 @@ jobs:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
-        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:
-          publish: true
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
           prerelease: false
           config-name: auto-release.yml
         env:

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	e "atmos/internal/exec"
+	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	e "atmos/internal/exec"
+	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	e "atmos/internal/exec"
+	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/cmd/terraform_generate_backend.go
+++ b/cmd/terraform_generate_backend.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	e "atmos/internal/exec"
+	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	e "atmos/internal/exec"
+	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module atmos
+module github.com/cloudposse/atmos
 
 go 1.17
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	g "atmos/internal/globals"
-	u "atmos/internal/utils"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	g "github.com/cloudposse/atmos/internal/globals"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	g "atmos/internal/globals"
-	u "atmos/internal/utils"
 	"errors"
 	"github.com/bmatcuk/doublestar"
+	g "github.com/cloudposse/atmos/internal/globals"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"os"
 	"path/filepath"

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -1,11 +1,11 @@
 package exec
 
 import (
-	c "atmos/internal/config"
-	g "atmos/internal/globals"
-	s "atmos/internal/stack"
-	u "atmos/internal/utils"
 	"fmt"
+	c "github.com/cloudposse/atmos/internal/config"
+	g "github.com/cloudposse/atmos/internal/globals"
+	s "github.com/cloudposse/atmos/internal/stack"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -3,9 +3,9 @@
 package exec
 
 import (
-	c "atmos/internal/config"
-	u "atmos/internal/utils"
 	"fmt"
+	c "github.com/cloudposse/atmos/internal/config"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -1,9 +1,9 @@
 package exec
 
 import (
-	c "atmos/internal/config"
-	u "atmos/internal/utils"
 	"fmt"
+	c "github.com/cloudposse/atmos/internal/config"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/internal/exec/terraform_generate.go
+++ b/internal/exec/terraform_generate.go
@@ -1,11 +1,11 @@
 package exec
 
 import (
-	c "atmos/internal/config"
-	g "atmos/internal/globals"
-	s "atmos/internal/stack"
-	u "atmos/internal/utils"
 	"fmt"
+	c "github.com/cloudposse/atmos/internal/config"
+	g "github.com/cloudposse/atmos/internal/globals"
+	s "github.com/cloudposse/atmos/internal/stack"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -1,12 +1,12 @@
 package exec
 
 import (
-	c "atmos/internal/config"
-	g "atmos/internal/globals"
-	s "atmos/internal/stack"
-	u "atmos/internal/utils"
 	"errors"
 	"fmt"
+	c "github.com/cloudposse/atmos/internal/config"
+	g "github.com/cloudposse/atmos/internal/globals"
+	s "github.com/cloudposse/atmos/internal/stack"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"os"

--- a/internal/spacelift/spacelift_stack_processor.go
+++ b/internal/spacelift/spacelift_stack_processor.go
@@ -1,9 +1,9 @@
 package spacelift
 
 import (
-	s "atmos/internal/stack"
-	u "atmos/internal/utils"
 	"fmt"
+	s "github.com/cloudposse/atmos/internal/stack"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/pkg/errors"
 	"strings"
 )

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -1,12 +1,12 @@
 package stack
 
 import (
-	c "atmos/internal/convert"
-	g "atmos/internal/globals"
-	m "atmos/internal/merge"
-	u "atmos/internal/utils"
 	"fmt"
 	"github.com/bmatcuk/doublestar"
+	c "github.com/cloudposse/atmos/internal/convert"
+	g "github.com/cloudposse/atmos/internal/globals"
+	m "github.com/cloudposse/atmos/internal/merge"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -1,8 +1,8 @@
 package stack
 
 import (
-	c "atmos/internal/convert"
-	u "atmos/internal/utils"
+	c "github.com/cloudposse/atmos/internal/convert"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +39,7 @@ func TestStackProcessor(t *testing.T) {
 	mapConfig2 := mapResult["tenant1/ue2/dev"]
 	assert.Equal(t, len(imports), len(mapConfig2.(map[interface{}]interface{})["imports"].([]string)))
 
-	assert.Equal(t, 15, len(imports))
+	assert.Equal(t, 16, len(imports))
 	assert.Equal(t, "catalog/helmfile/echo-server", imports[0])
 	assert.Equal(t, "catalog/helmfile/infra-server", imports[1])
 	assert.Equal(t, "catalog/terraform/services/service-1", imports[2])
@@ -48,13 +48,14 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, "catalog/terraform/services/service-2-override", imports[5])
 	assert.Equal(t, "catalog/terraform/services/top-level-service-1", imports[6])
 	assert.Equal(t, "catalog/terraform/services/top-level-service-2", imports[7])
-	assert.Equal(t, "catalog/terraform/test-component", imports[8])
-	assert.Equal(t, "catalog/terraform/test-component-override", imports[9])
-	assert.Equal(t, "catalog/terraform/top-level-component1", imports[10])
-	assert.Equal(t, "catalog/terraform/vpc", imports[11])
-	assert.Equal(t, "globals/globals", imports[12])
-	assert.Equal(t, "globals/tenant1-globals", imports[13])
-	assert.Equal(t, "globals/ue2-globals", imports[14])
+	assert.Equal(t, "catalog/terraform/tenant1-ue2-dev", imports[8])
+	assert.Equal(t, "catalog/terraform/test-component", imports[9])
+	assert.Equal(t, "catalog/terraform/test-component-override", imports[10])
+	assert.Equal(t, "catalog/terraform/top-level-component1", imports[11])
+	assert.Equal(t, "catalog/terraform/vpc", imports[12])
+	assert.Equal(t, "globals/globals", imports[13])
+	assert.Equal(t, "globals/tenant1-globals", imports[14])
+	assert.Equal(t, "globals/ue2-globals", imports[15])
 
 	yamlConfig, err := yaml.Marshal(mapConfig1)
 	assert.Nil(t, err)

--- a/internal/stack/stack_processor_utils.go
+++ b/internal/stack/stack_processor_utils.go
@@ -1,8 +1,8 @@
 package stack
 
 import (
-	g "atmos/internal/globals"
-	u "atmos/internal/utils"
+	g "github.com/cloudposse/atmos/internal/globals"
+	u "github.com/cloudposse/atmos/internal/utils"
 	"os"
 	"path"
 	"path/filepath"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"atmos/cmd"
+	"github.com/cloudposse/atmos/cmd"
 	"github.com/fatih/color"
 	"os"
 )


### PR DESCRIPTION
## what
* Fix `go.mod` module name
* Make all imports absolute paths
* Fix test

## why
* To be able to import modules from `atmos` in other Go repos (e.g. `terraform-provider-utils`)
* Otherwise, the following errors gets thrown

```
module declares its path as: atmos
          but was required as: github.com
```

