### PR TITLE
Update `auto-release.yml`

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,6 +1,10 @@
 name-template: 'v$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+
+# https://golang.org/ref/mod#versions
+tag-template: 'v$RESOLVED_VERSION'
+
 version-template: '$MAJOR.$MINOR.$PATCH'
+
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
## what
* Update `auto-release.yml`

## why
* If we use the atmos modules in other repos (e.g. `terraform-provider-utils`, the release tag require `v` in the tag names, see https://golang.org/ref/mod#versions 
