### PR TITLE
Update stack processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 SHELL := /bin/bash
+GOOS=darwin
+#GOOS=linux
+GOARCH=amd64
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md
@@ -8,3 +11,9 @@ export README_DEPS ?= docs/targets.md
 ## Lint terraform code
 lint:
 	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate
+
+build:
+	env GOOS=${GOOS} GOARCH=${GOARCH} go build -o build/atmos
+
+deps:
+	go mod download

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 GOOS=darwin
 #GOOS=linux
 GOARCH=amd64
+VERSION=test2
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md
@@ -13,7 +14,7 @@ lint:
 	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate
 
 build:
-	env GOOS=${GOOS} GOARCH=${GOARCH} go build -o build/atmos
+	env GOOS=${GOOS} GOARCH=${GOARCH} go build -o build/atmos -v -ldflags "-X 'github.com/cloudposse/atmos/cmd.Version=${VERSION}'"
 
 deps:
 	go mod download

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -10,12 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
-)
-
-var (
-	// Mutex to serialize reading YAML config files
-	readYAMLConfigFileLock = &sync.Mutex{}
 )
 
 // findAllStackConfigsInPaths finds all stack config files in the paths specified by globs
@@ -38,9 +32,7 @@ func findAllStackConfigsInPaths(
 		}
 
 		// Find all matches in the glob
-		readYAMLConfigFileLock.Lock()
 		matches, err := doublestar.Glob(pathWithExt)
-		readYAMLConfigFileLock.Unlock()
 		if err != nil {
 			return nil, nil, false, err
 		}

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -10,6 +10,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+)
+
+var (
+	// Mutex to serialize reading YAML config files
+	readYAMLConfigFileLock = &sync.Mutex{}
 )
 
 // findAllStackConfigsInPaths finds all stack config files in the paths specified by globs
@@ -32,7 +38,9 @@ func findAllStackConfigsInPaths(
 		}
 
 		// Find all matches in the glob
+		readYAMLConfigFileLock.Lock()
 		matches, err := doublestar.Glob(pathWithExt)
+		readYAMLConfigFileLock.Unlock()
 		if err != nil {
 			return nil, nil, false, err
 		}

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/bmatcuk/doublestar"
 	g "github.com/cloudposse/atmos/internal/globals"
+	s "github.com/cloudposse/atmos/pkg/stack"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/fatih/color"
 	"os"
@@ -32,7 +33,7 @@ func findAllStackConfigsInPaths(
 		}
 
 		// Find all matches in the glob
-		matches, err := doublestar.Glob(pathWithExt)
+		matches, err := s.GetGlobMatches(pathWithExt)
 		if err != nil {
 			return nil, nil, false, err
 		}

--- a/pkg/component/component_processor.go
+++ b/pkg/component/component_processor.go
@@ -105,7 +105,6 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 			}
 
 			if tenantFound == true && environmentFound == true && stageFound == true {
-				stack = stackName
 				break
 			}
 		}

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -2,7 +2,6 @@ package stack
 
 import (
 	"fmt"
-	"github.com/bmatcuk/doublestar"
 	g "github.com/cloudposse/atmos/internal/globals"
 	c "github.com/cloudposse/atmos/pkg/convert"
 	m "github.com/cloudposse/atmos/pkg/merge"
@@ -150,7 +149,7 @@ func ProcessYAMLConfigFile(
 			}
 
 			// Find all import matches in the glob
-			importMatches, err := doublestar.Glob(impWithExtPath)
+			importMatches, err := GetGlobMatches(impWithExtPath)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -1,13 +1,20 @@
 package stack
 
 import (
+	"fmt"
 	g "github.com/cloudposse/atmos/internal/globals"
 	"github.com/cloudposse/atmos/pkg/utils"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+)
+
+var (
+	syncMap = sync.Map{}
 )
 
 // FindComponentStacks finds all infrastructure stack config files where the component or the base component is defined
@@ -195,4 +202,21 @@ func CreateComponentStackMap(basePath string, filePath string) (map[string]map[s
 	}
 
 	return componentStackMap, nil
+}
+
+// getFileContent tries to read and return the file content from the sync map if it exists in the map,
+// otherwise it reads the file, stores its content in the map and returns the content
+func getFileContent(filePath string) (string, error) {
+	existingContent, found := syncMap.Load(filePath)
+	if found == true && existingContent != nil {
+		return fmt.Sprintf("%s", existingContent), nil
+	}
+
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	syncMap.Store(filePath, content)
+
+	return string(content), nil
 }


### PR DESCRIPTION
## what
* Update stack processor
* Cache the YAML file contents and Glob matches in memory (sync map)

## why
* Prevent concurrency issues when many gorotines call `Glob` to find import matches in the same folders 
* Speed it up, especially when working on `localhost` and reading the YAML config files on the host from a Docker container (don't read the same files and the same glob matches more than once)
* The total speed up is about 10-20x


