### PR TITLE
Add `--from-plan` flag to terraform apply/deploy commands. Add `describe config` CLI command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,5 @@ build:
 
 deps:
 	go mod download
+
+.PHONY: lint build deps

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -8,7 +8,7 @@ import (
 var describeCmd = &cobra.Command{
 	Use:                "describe",
 	Short:              "describe",
-	Long:               `This command shows configuration for cli, stacks and components`,
+	Long:               `This command shows configuration for CLI, stacks and components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 }
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -8,7 +8,7 @@ import (
 var describeCmd = &cobra.Command{
 	Use:                "describe",
 	Short:              "describe",
-	Long:               `This command shows configuration for stacks and components`,
+	Long:               `This command shows configuration for cli, stacks and components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 }
 

--- a/cmd/describe_config.go
+++ b/cmd/describe_config.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	e "github.com/cloudposse/atmos/internal/exec"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// describeComponentCmd describes configuration for components
+var describeConfigCmd = &cobra.Command{
+	Use:                "config",
+	Short:              "describe config",
+	Long:               `This command shows CLI configuration`,
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := e.ExecuteDescribeConfig(cmd, args)
+		if err != nil {
+			color.Red("%s\n", err)
+			fmt.Println()
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	describeConfigCmd.DisableFlagParsing = false
+	describeConfigCmd.PersistentFlags().StringP("format", "f", "json", "'atmos describe config -f json' or 'atmos describe config -f yaml'")
+
+	describeCmd.AddCommand(describeConfigCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/atmos
 go 1.16
 
 require (
-	github.com/bmatcuk/doublestar v1.3.4
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/fatih/color v1.13.0
 	github.com/imdario/mergo v0.3.12
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
-github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
-github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -201,12 +201,16 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	allArgsAndFlags = append(allArgsAndFlags, info.AdditionalArgsAndFlags...)
 
 	// Run `terraform workspace`
-	err = execCommand(info.Command, []string{"workspace", "select", workspaceName}, componentPath, nil)
-	if err != nil {
-		err = execCommand(info.Command, []string{"workspace", "new", workspaceName}, componentPath, nil)
+	if info.SubCommand != "clean" {
+		err = execCommand(info.Command, []string{"workspace", "select", workspaceName}, componentPath, nil)
 		if err != nil {
-			return err
+			err = execCommand(info.Command, []string{"workspace", "new", workspaceName}, componentPath, nil)
+			if err != nil {
+				return err
+			}
 		}
+	} else {
+		return errors.New("terraform clean not implemented")
 	}
 
 	// Check if the terraform command requires a user interaction,

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -138,13 +138,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	// Handle `terraform deploy` custom command
 	if info.SubCommand == "deploy" {
 		info.SubCommand = "apply"
-		if !utils.SliceContainsString(info.AdditionalArgsAndFlags, autoApproveFlag) {
+		if info.UseTerraformPlan == false && !utils.SliceContainsString(info.AdditionalArgsAndFlags, autoApproveFlag) {
 			info.AdditionalArgsAndFlags = append(info.AdditionalArgsAndFlags, autoApproveFlag)
 		}
 	}
 
 	// Handle Config.Components.Terraform.ApplyAutoApprove flag
-	if info.SubCommand == "apply" && c.Config.Components.Terraform.ApplyAutoApprove == true {
+	if info.SubCommand == "apply" && c.Config.Components.Terraform.ApplyAutoApprove == true && info.UseTerraformPlan == false {
 		if !utils.SliceContainsString(info.AdditionalArgsAndFlags, autoApproveFlag) {
 			info.AdditionalArgsAndFlags = append(info.AdditionalArgsAndFlags, autoApproveFlag)
 		}
@@ -189,7 +189,11 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
 		break
 	case "apply":
-		allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
+		if info.UseTerraformPlan == true {
+			allArgsAndFlags = append(allArgsAndFlags, []string{planFile}...)
+		} else {
+			allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
+		}
 		break
 	}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -125,6 +125,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	runTerraformInit := true
 	if info.SubCommand == "init" ||
 		info.SubCommand == "workspace" ||
+		info.SubCommand == "clean" ||
 		(info.SubCommand == "deploy" && c.Config.Components.Terraform.DeployRunInit == false) {
 		runTerraformInit = false
 	}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -27,6 +27,7 @@ var (
 		g.GlobalOptionsFlag,
 		g.DeployRunInitFlag,
 		g.AutoGenerateBackendFileFlag,
+		g.FromPlanFlag,
 	}
 )
 
@@ -125,6 +126,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 	configAndStacksInfo.ConfigDir = argsAndFlagsInfo.ConfigDir
 	configAndStacksInfo.DeployRunInit = argsAndFlagsInfo.DeployRunInit
 	configAndStacksInfo.AutoGenerateBackendFile = argsAndFlagsInfo.AutoGenerateBackendFile
+	configAndStacksInfo.UseTerraformPlan = argsAndFlagsInfo.UseTerraformPlan
 
 	// Check if component was provided
 	if len(configAndStacksInfo.ComponentFromArg) < 1 {
@@ -452,6 +454,10 @@ func processArgsAndFlags(inputArgsAndFlags []string) (config.ArgsAndFlagsInfo, e
 				return info, errors.New(fmt.Sprintf("invalid flag: %s", arg))
 			}
 			info.AutoGenerateBackendFile = autoGenerateBackendFileFlagParts[1]
+		}
+
+		if arg == g.FromPlanFlag {
+			info.UseTerraformPlan = true
 		}
 
 		for _, f := range commonFlags {

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"os"
-
-	cmd "github.com/cloudposse/atmos/cmd"
+	"github.com/cloudposse/atmos/cmd"
 	"github.com/fatih/color"
+	"os"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/cloudposse/atmos/cmd"
-	"github.com/fatih/color"
 	"os"
+
+	cmd "github.com/cloudposse/atmos/cmd"
+	"github.com/fatih/color"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/cloudposse/atmos/cmd"
 	"github.com/fatih/color"
-	"os"
 )
 
 func main() {

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -67,6 +67,7 @@ type ArgsAndFlagsInfo struct {
 	StacksDir               string
 	DeployRunInit           string
 	AutoGenerateBackendFile string
+	UseTerraformPlan        bool
 }
 
 type ConfigAndStacksInfo struct {
@@ -92,4 +93,5 @@ type ConfigAndStacksInfo struct {
 	ContextPrefix           string
 	DeployRunInit           string
 	AutoGenerateBackendFile string
+	UseTerraformPlan        bool
 }

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"errors"
-	"github.com/bmatcuk/doublestar"
+	"github.com/bmatcuk/doublestar/v4"
 	g "github.com/cloudposse/atmos/pkg/globals"
 	s "github.com/cloudposse/atmos/pkg/stack"
 	u "github.com/cloudposse/atmos/pkg/utils"

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -16,6 +16,8 @@ const (
 	StackDirFlag                = "--stacks-dir"
 	DeployRunInitFlag           = "--deploy-run-init"
 	AutoGenerateBackendFileFlag = "--auto-generate-backend-file"
+
+	FromPlanFlag = "--from-plan"
 )
 
 var (

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -2,18 +2,17 @@ package stack
 
 import (
 	"fmt"
-	"path"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
-
 	c "github.com/cloudposse/atmos/pkg/convert"
 	g "github.com/cloudposse/atmos/pkg/globals"
 	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
 )
 
 var (
@@ -160,6 +159,11 @@ func ProcessYAMLConfigFile(
 					filePath,
 					imp,
 					impWithExtPath)
+
+				importMatches, err = GetGlobMatches(impWithExtPath)
+				if err != nil {
+					return nil, nil, err
+				}
 				if importMatches == nil {
 					return nil, nil, errors.New(errorMessage)
 				}

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -2,17 +2,18 @@ package stack
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
 	c "github.com/cloudposse/atmos/pkg/convert"
 	g "github.com/cloudposse/atmos/pkg/globals"
 	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"path"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
 )
 
 var (

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -6,7 +6,6 @@ import (
 	g "github.com/cloudposse/atmos/pkg/globals"
 	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/utils"
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	"path"
@@ -164,8 +163,6 @@ func ProcessYAMLConfigFile(
 					filePath,
 					imp,
 					impWithExtPath)
-				color.Red(errorMessage)
-
 				time.Sleep(1 * time.Second)
 				importMatches, err = GetGlobMatches(impWithExtPath)
 				if err != nil {

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 )
 
 var (
@@ -155,19 +154,11 @@ func ProcessYAMLConfigFile(
 				return nil, nil, err
 			}
 
-			// There seems to be some underlying issues with `doublestar.Glob` not returning any matches (and no error) in concurrent execution
-			// Check if `doublestar.Glob` returned any matches.
-			// If not, try it again
 			if importMatches == nil {
 				errorMessage := fmt.Sprintf("Invalid import in the config file %s.\nNo matches found for the import '%s' using the pattern '%s'",
 					filePath,
 					imp,
 					impWithExtPath)
-				time.Sleep(1 * time.Second)
-				importMatches, err = GetGlobMatches(impWithExtPath)
-				if err != nil {
-					return nil, nil, err
-				}
 				if importMatches == nil {
 					return nil, nil, errors.New(errorMessage)
 				}

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -248,7 +248,7 @@ func GetGlobMatches(pattern string) ([]string, error) {
 
 	var fullMatches []string
 	for _, match := range matches {
-		fullMatches = append(fullMatches, base+"/"+match)
+		fullMatches = append(fullMatches, path.Join(base, match))
 	}
 
 	getGlobMatchesSyncMap.Store(pattern, strings.Join(fullMatches, ","))

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -2,10 +2,6 @@ package stack
 
 import (
 	"fmt"
-	"github.com/bmatcuk/doublestar/v4"
-	g "github.com/cloudposse/atmos/pkg/globals"
-	"github.com/cloudposse/atmos/pkg/utils"
-	"github.com/fatih/color"
 	"io/ioutil"
 	"os"
 	"path"
@@ -13,6 +9,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
+	g "github.com/cloudposse/atmos/pkg/globals"
+	"github.com/cloudposse/atmos/pkg/utils"
+	"github.com/fatih/color"
 )
 
 var (

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -240,6 +241,7 @@ func GetGlobMatches(pattern string) ([]string, error) {
 	// Check if `doublestar.Glob` returned any matches.
 	// If not, try it again
 	if matches == nil {
+		time.Sleep(1 * time.Second)
 		matches, err = doublestar.Glob(pattern)
 		if err != nil {
 			return nil, err

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 )
 
 var (
@@ -235,17 +234,6 @@ func GetGlobMatches(pattern string) ([]string, error) {
 	matches, err := doublestar.Glob(pattern)
 	if err != nil {
 		return nil, err
-	}
-
-	// There seems to be some underlying issues with `doublestar.Glob` not returning any matches (and no error) in concurrent execution
-	// Check if `doublestar.Glob` returned any matches.
-	// If not, try it again
-	if matches == nil {
-		time.Sleep(1 * time.Second)
-		matches, err = doublestar.Glob(pattern)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if matches == nil {

--- a/pkg/stack/stack_processor_utils.go
+++ b/pkg/stack/stack_processor_utils.go
@@ -235,6 +235,21 @@ func GetGlobMatches(pattern string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// There seems to be some underlying issues with `doublestar.Glob` not returning any matches (and no error) in concurrent execution
+	// Check if `doublestar.Glob` returned any matches.
+	// If not, try it again
+	if matches == nil {
+		matches, err = doublestar.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if matches == nil {
+		return nil, nil
+	}
+
 	getGlobMatchesSyncMap.Store(pattern, strings.Join(matches, ","))
 
 	return matches, nil


### PR DESCRIPTION
## what
* Add `--from-plan` flag to terraform apply/deploy commands
* Add `describe config` CLI command

## why
* Allow using terraform `planfile` (previously generated with `atmos terraform plan`) in `atmos terraform apply/deploy` commands

```
atmos terraform plan test/test-component-override -s tenant1/ue2/dev
atmos terraform apply test/test-component-override -s tenant1-ue2-dev --from-plan
atmos terraform deploy test/test-component-override -s tenant1-ue2-dev --from-plan
```

* `describe config` command shows CLI configuration, processed and deep-merged from these locations

```
- system dir (`/usr/local/etc/atmos/atmos.yaml` on Linux, `%LOCALAPPDATA%/atmos/atmos.yaml` on Windows)
- home dir (~/.atmos/atmos.yaml)
- `atmos.yaml` in the current directory
```

```
atmos describe config -help
atmos describe config

atmos describe config --format=json
atmos describe config --format json
atmos describe config -f=json
atmos describe config -f json

atmos describe config --format=yaml
atmos describe config --format yaml
atmos describe config -f=yaml
atmos describe config -f yaml
```

## references

* https://github.com/cloudposse/geodesic/pull/734#issuecomment-936265546