### PR TITLE
Change misspelled error messages

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -32,7 +32,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	componentPath := path.Join(c.ProcessedConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.Component)
 	componentPathExists, err := utils.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {
-		return errors.New(fmt.Sprintf("Component '%s' does not exixt in %s",
+		return errors.New(fmt.Sprintf("Component '%s' does not exist in %s",
 			info.Component,
 			path.Join(c.ProcessedConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix),
 		))

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -43,7 +43,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	componentPath := path.Join(c.ProcessedConfig.TerraformDirAbsolutePath, info.ComponentFolderPrefix, finalComponent)
 	componentPathExists, err := utils.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {
-		return errors.New(fmt.Sprintf("Component '%s' does not exixt in %s",
+		return errors.New(fmt.Sprintf("Component '%s' does not exist in %s",
 			finalComponent,
 			path.Join(c.ProcessedConfig.TerraformDirAbsolutePath, info.ComponentFolderPrefix),
 		))


### PR DESCRIPTION
## what

* Fixed misspelling in error message

## why

* `Component 'eks' does not exixt in /atmos_root/components/terraform`

## references
