### PR TITLE
Disable component inheritance chain

### DIFF
--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -15,7 +15,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = CreateSpaceliftStacks("", nil, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 24, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackInfrastructureStackName := tenant1Ue2DevInfraVpcStack["stack"].(string)
@@ -82,7 +82,7 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = CreateSpaceliftStacks(basePath, filePaths, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 24, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackBackend := tenant1Ue2DevInfraVpcStack["backend"].(map[interface{}]interface{})

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -669,19 +669,20 @@ func processBaseComponentConfig(
 		baseComponentMap = baseComponentSection.(map[interface{}]interface{})
 
 		// First, process the base component of this base component
-		if baseComponentOfBaseComponent, baseComponentOfBaseComponentExist := baseComponentMap["component"]; baseComponentOfBaseComponentExist {
-			err := processBaseComponentConfig(
-				baseComponentConfig,
-				allTerraformComponentsMap,
-				baseComponent,
-				stack,
-				baseComponentOfBaseComponent.(string),
-			)
-
-			if err != nil {
-				return err
-			}
-		}
+		// TODO: Review/fix this for some edge cases of stacks config
+		//if baseComponentOfBaseComponent, baseComponentOfBaseComponentExist := baseComponentMap["component"]; baseComponentOfBaseComponentExist {
+		//	err := processBaseComponentConfig(
+		//		baseComponentConfig,
+		//		allTerraformComponentsMap,
+		//		baseComponent,
+		//		stack,
+		//		baseComponentOfBaseComponent.(string),
+		//	)
+		//
+		//	if err != nil {
+		//		return err
+		//	}
+		//}
 
 		if baseComponentVarsSection, baseComponentVarsSectionExist := baseComponentMap["vars"]; baseComponentVarsSectionExist {
 			baseComponentVars = baseComponentVarsSection.(map[interface{}]interface{})

--- a/pkg/stack/stack_processor_test.go
+++ b/pkg/stack/stack_processor_test.go
@@ -124,19 +124,20 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, "top-level-component1", topLevelComponent1BackendWorkspaceKeyPrefix)
 	assert.Equal(t, "top-level-component1", topLevelComponent1RemoteStateBackendWorkspaceKeyPrefix)
 
-	testTestComponentOverrideComponent2 := terraformComponents["test/test-component-override-2"].(map[interface{}]interface{})
-	testTestComponentOverrideComponentBackend2 := testTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
-	testTestComponentOverrideComponentBackendType2 := testTestComponentOverrideComponent2["backend_type"]
-	testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2 := testTestComponentOverrideComponentBackend2["workspace_key_prefix"]
-	testTestComponentOverrideComponentBackendBucket2 := testTestComponentOverrideComponentBackend2["bucket"]
-	testTestComponentOverrideComponentBaseComponent2 := testTestComponentOverrideComponent2["component"]
-	testTestComponentOverrideInheritance2 := testTestComponentOverrideComponent2["inheritance"].([]interface{})
-	assert.Equal(t, "test-test-component", testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2)
-	assert.Equal(t, "eg-ue2-root-tfstate", testTestComponentOverrideComponentBackendBucket2)
-	assert.Equal(t, "test/test-component", testTestComponentOverrideComponentBaseComponent2)
-	assert.Equal(t, "s3", testTestComponentOverrideComponentBackendType2)
-	assert.Equal(t, "test/test-component-override", testTestComponentOverrideInheritance2[0])
-	assert.Equal(t, "test/test-component", testTestComponentOverrideInheritance2[1])
+	// TODO: uncomment after the inheritance chain is fixed
+	//testTestComponentOverrideComponent2 := terraformComponents["test/test-component-override-2"].(map[interface{}]interface{})
+	//testTestComponentOverrideComponentBackend2 := testTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
+	//testTestComponentOverrideComponentBackendType2 := testTestComponentOverrideComponent2["backend_type"]
+	//testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2 := testTestComponentOverrideComponentBackend2["workspace_key_prefix"]
+	//testTestComponentOverrideComponentBackendBucket2 := testTestComponentOverrideComponentBackend2["bucket"]
+	//testTestComponentOverrideComponentBaseComponent2 := testTestComponentOverrideComponent2["component"]
+	//testTestComponentOverrideInheritance2 := testTestComponentOverrideComponent2["inheritance"].([]interface{})
+	//assert.Equal(t, "test-test-component", testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2)
+	//assert.Equal(t, "eg-ue2-root-tfstate", testTestComponentOverrideComponentBackendBucket2)
+	//assert.Equal(t, "test/test-component", testTestComponentOverrideComponentBaseComponent2)
+	//assert.Equal(t, "s3", testTestComponentOverrideComponentBackendType2)
+	//assert.Equal(t, "test/test-component-override", testTestComponentOverrideInheritance2[0])
+	//assert.Equal(t, "test/test-component", testTestComponentOverrideInheritance2[1])
 
 	yamlConfig, err := yaml.Marshal(mapConfig1)
 	assert.Nil(t, err)


### PR DESCRIPTION
## what
* Disable component inheritance chain for now to make all stacks work

## why
* While it's working in all the tests, and in 99% of the real infra stacks, some edge cases of stack config are not handled correctly and cause gorotine panic
* All edge cases will be tested and fixed in the consecutive PR

