### PR TITLE
comment out DisableFlagParsing as it breaks the help for command

### DIFF
--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
-	e "github.com/cloudposse/atmos/internal/exec"
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"os"
+
+	e "github.com/cloudposse/atmos/internal/exec"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -24,7 +26,7 @@ var helmfileCmd = &cobra.Command{
 
 func init() {
 	// https://github.com/spf13/cobra/issues/739
-	helmfileCmd.DisableFlagParsing = true
+	//helmfileCmd.DisableFlagParsing = true  // This breaks the help for this command
 	helmfileCmd.PersistentFlags().StringP("stack", "s", "", "")
 
 	err := helmfileCmd.MarkPersistentFlagRequired("stack")

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
-	e "github.com/cloudposse/atmos/internal/exec"
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"os"
+
+	e "github.com/cloudposse/atmos/internal/exec"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -24,7 +26,7 @@ var terraformCmd = &cobra.Command{
 
 func init() {
 	// https://github.com/spf13/cobra/issues/739
-	terraformCmd.DisableFlagParsing = true
+	//terraformCmd.DisableFlagParsing = true  // This breaks the help for this command
 	terraformCmd.PersistentFlags().StringP("stack", "s", "", "")
 
 	err := terraformCmd.MarkPersistentFlagRequired("stack")


### PR DESCRIPTION
## what
* Comment out the DisableFlagParsing = true from the `terraform` and `helmfile` commands as it breaks the help for that command.

## why
* In the current state having that option enabled doesn't allow the end user to see the help for the `terraform` or `helmfile` commands so the only way to know how to use those commands is to look at the source code.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* closes #74

