### PR TITLE
Improve `terraform import`. Add help for all `atmos` commands

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2021 Cloud Posse, LLC
+   Copyright 2020-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -7,7 +7,7 @@ import (
 // describeCmd describes configuration for stacks and components
 var describeCmd = &cobra.Command{
 	Use:                "describe",
-	Short:              "describe",
+	Short:              "Execute 'describe' commands",
 	Long:               `This command shows configuration for CLI, stacks and components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 }

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -11,7 +11,7 @@ import (
 var describeComponentCmd = &cobra.Command{
 	Use:                "component",
 	Short:              "Execute 'describe component' command",
-	Long:               `This command shows configuration for components`,
+	Long:               `This command shows configuration for a component in a stack: atmos describe component <component> -s <stack>`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeComponent(cmd, args)

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -24,7 +24,7 @@ var describeComponentCmd = &cobra.Command{
 
 func init() {
 	describeComponentCmd.DisableFlagParsing = false
-	describeComponentCmd.PersistentFlags().StringP("stack", "s", "", "")
+	describeComponentCmd.PersistentFlags().StringP("stack", "s", "", "atmos describe component <component> -s <stack>")
 
 	err := describeComponentCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -10,7 +10,7 @@ import (
 // describeComponentCmd describes configuration for components
 var describeComponentCmd = &cobra.Command{
 	Use:                "component",
-	Short:              "describe component",
+	Short:              "Execute 'describe component' command",
 	Long:               `This command shows configuration for components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/describe_config.go
+++ b/cmd/describe_config.go
@@ -11,7 +11,7 @@ import (
 // describeComponentCmd describes configuration for components
 var describeConfigCmd = &cobra.Command{
 	Use:                "config",
-	Short:              "describe config",
+	Short:              "Execute 'describe config' command",
 	Long:               `This command shows CLI configuration`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/describe_config.go
+++ b/cmd/describe_config.go
@@ -12,7 +12,7 @@ import (
 var describeConfigCmd = &cobra.Command{
 	Use:                "config",
 	Short:              "Execute 'describe config' command",
-	Long:               `This command shows CLI configuration`,
+	Long:               `This command shows the final (deep-merged) CLI configuration: atmos describe config`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeConfig(cmd, args)

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -10,7 +10,7 @@ import (
 // terraformCmd represents the base command for all terraform sub-commands
 var helmfileCmd = &cobra.Command{
 	Use:                "helmfile",
-	Short:              "helmfile command",
+	Short:              "Execute 'helmfile' commands",
 	Long:               `This command runs helmfile sub-commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -26,12 +26,5 @@ func init() {
 	// https://github.com/spf13/cobra/issues/739
 	helmfileCmd.DisableFlagParsing = true
 	helmfileCmd.PersistentFlags().StringP("stack", "s", "", "atmos helmfile <helmfile_command> <component> -s <stack>")
-
-	err := helmfileCmd.MarkPersistentFlagRequired("stack")
-	if err != nil {
-		color.Red("%s\n\n", err)
-		os.Exit(1)
-	}
-
 	RootCmd.AddCommand(helmfileCmd)
 }

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -11,7 +11,7 @@ import (
 var helmfileCmd = &cobra.Command{
 	Use:                "helmfile",
 	Short:              "Execute 'helmfile' commands",
-	Long:               `This command runs helmfile sub-commands`,
+	Long:               `This command runs helmfile commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteHelmfile(cmd, args)

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -25,7 +25,7 @@ var helmfileCmd = &cobra.Command{
 func init() {
 	// https://github.com/spf13/cobra/issues/739
 	helmfileCmd.DisableFlagParsing = true
-	helmfileCmd.PersistentFlags().StringP("stack", "s", "", "")
+	helmfileCmd.PersistentFlags().StringP("stack", "s", "", "atmos helmfile <helmfile_command> <component> -s <stack>")
 
 	err := helmfileCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "atmos",
 	Short: "Universal Tool for DevOps and Cloud Automation",
-	Long:  `'atmos'' is universal tool for DevOps and cloud automation used for provisioning, managing and orchestrating workflows across various toolchains`,
+	Long:  `'atmos'' is a universal tool for DevOps and cloud automation used for provisioning, managing and orchestrating workflows across various toolchains`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -10,7 +10,7 @@ import (
 // terraformCmd represents the base command for all terraform sub-commands
 var terraformCmd = &cobra.Command{
 	Use:                "terraform",
-	Short:              "terraform command",
+	Short:              "Execute 'terraform' commands",
 	Long:               `This command runs terraform sub-commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -11,7 +11,7 @@ import (
 var terraformCmd = &cobra.Command{
 	Use:                "terraform",
 	Short:              "Execute 'terraform' commands",
-	Long:               `This command runs terraform sub-commands`,
+	Long:               `This command runs terraform commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteTerraform(cmd, args)
@@ -25,7 +25,7 @@ var terraformCmd = &cobra.Command{
 func init() {
 	// https://github.com/spf13/cobra/issues/739
 	terraformCmd.DisableFlagParsing = true
-	terraformCmd.PersistentFlags().StringP("stack", "s", "", "")
+	terraformCmd.PersistentFlags().StringP("stack", "s", "", "atmos terraform <terraform_command> <component> -s <stack>")
 
 	err := terraformCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -26,12 +26,5 @@ func init() {
 	// https://github.com/spf13/cobra/issues/739
 	terraformCmd.DisableFlagParsing = true
 	terraformCmd.PersistentFlags().StringP("stack", "s", "", "atmos terraform <terraform_command> <component> -s <stack>")
-
-	err := terraformCmd.MarkPersistentFlagRequired("stack")
-	if err != nil {
-		color.Red("%s\n\n", err)
-		os.Exit(1)
-	}
-
 	RootCmd.AddCommand(terraformCmd)
 }

--- a/cmd/terraform_generate.go
+++ b/cmd/terraform_generate.go
@@ -7,7 +7,7 @@ import (
 // terraformGenerateCmd generates backends and variables for terraform components
 var terraformGenerateCmd = &cobra.Command{
 	Use:                "generate",
-	Short:              "generate",
+	Short:              "Execute 'terraform generate' commands",
 	Long:               "This command generates backend configs and variable configs for terraform components",
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 }

--- a/cmd/terraform_generate_backend.go
+++ b/cmd/terraform_generate_backend.go
@@ -10,7 +10,7 @@ import (
 // terraformGenerateBackendCmd generates backend config for a terraform components
 var terraformGenerateBackendCmd = &cobra.Command{
 	Use:                "backend",
-	Short:              "generate backend",
+	Short:              "Execute 'terraform generate backend' command",
 	Long:               `This command generates the backend config for a terraform component`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/terraform_generate_backend.go
+++ b/cmd/terraform_generate_backend.go
@@ -11,7 +11,7 @@ import (
 var terraformGenerateBackendCmd = &cobra.Command{
 	Use:                "backend",
 	Short:              "Execute 'terraform generate backend' command",
-	Long:               `This command generates the backend config for a terraform component`,
+	Long:               `This command generates the backend config for a terraform component: atmos terraform generate backend <component> -s <stack>`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteTerraformGenerateBackend(cmd, args)
@@ -24,7 +24,7 @@ var terraformGenerateBackendCmd = &cobra.Command{
 
 func init() {
 	terraformGenerateBackendCmd.DisableFlagParsing = false
-	terraformGenerateBackendCmd.PersistentFlags().StringP("stack", "s", "", "")
+	terraformGenerateBackendCmd.PersistentFlags().StringP("stack", "s", "", "atmos terraform generate backend <component> -s <stack>")
 
 	err := terraformGenerateBackendCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {

--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -10,7 +10,7 @@ import (
 // terraformGenerateBackendsCmd generates backend configs for all terraform components
 var terraformGenerateBackendsCmd = &cobra.Command{
 	Use:                "backends",
-	Short:              "generate backends",
+	Short:              "Execute 'terraform generate backends' command",
 	Long:               `This command generates the backend configs for all terraform components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -32,5 +32,5 @@ func init() {
 		os.Exit(1)
 	}
 
-	terraformGenerateCmd.AddCommand(terraformGenerateBackendsCmd)
+	// terraformGenerateCmd.AddCommand(terraformGenerateBackendsCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ var Version = "0.0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "version command",
+	Short: "Execute 'version' command",
 	Long:  `This command prints the CLI version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(Version)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ var Version = "0.0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Execute 'version' command",
+	Short: "Print the CLI version",
 	Long:  `This command prints the CLI version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(Version)

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -20,6 +20,10 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if info.NeedHelp == true {
+		return nil
+	}
+
 	if len(info.Stack) < 1 {
 		return errors.New("stack must be specified")
 	}

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -1,10 +1,34 @@
 package exec
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/fatih/color"
+)
 
 // processHelp processes help commands
 func processHelp(componentType string, command string) error {
-	message := fmt.Sprintf("Help for atmos %s %s", componentType, command)
-	fmt.Println(message)
+	if len(command) == 0 {
+		fmt.Println(fmt.Sprintf("'atmos' supports all native '%s' commands.", componentType))
+		fmt.Println(fmt.Sprintf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack."))
+		color.Cyan(fmt.Sprintf("atmos %s <command> <component> -s <stack> [options]", componentType))
+		color.Cyan(fmt.Sprintf("atmos %s <command> <component> --stack <stack> [options]", componentType))
+
+		err := execCommand(componentType, []string{"--help"}, "", nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Println(fmt.Sprintf("'atmos' supports native '%s %s' command with all the options, arguments and flags.", componentType, command))
+		fmt.Println(fmt.Sprintf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack."))
+		color.Cyan(fmt.Sprintf("atmos %s %s <component> -s <stack> [options]", componentType, command))
+		color.Cyan(fmt.Sprintf("atmos %s %s <component> --stack <stack> [options]", componentType, command))
+
+		err := execCommand(componentType, []string{command, "--help"}, "", nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println()
 	return nil
 }

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -1,0 +1,10 @@
+package exec
+
+import "fmt"
+
+// processHelp processes help commands
+func processHelp(componentType string, command string) error {
+	message := fmt.Sprintf("Help for atmos %s %s", componentType, command)
+	fmt.Println(message)
+	return nil
+}

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -16,7 +16,7 @@ func processHelp(componentType string, command string) error {
 		if componentType == "terraform" {
 			fmt.Println()
 			color.Cyan("Differences from native terraform:")
-			fmt.Println(" - before executing other 'terraform' commands, `atmos` calls 'terraform init'")
+			fmt.Println(" - before executing other 'terraform' commands, 'atmos' calls 'terraform init'")
 			fmt.Println(" - 'atmos' supports 'terraform deploy' command which calls 'terraform plan' and then 'terraform apply'")
 			fmt.Println(" - 'terraform deploy' command supports '--deploy-run-init=true/false' flag to enable/disable running 'terraform init' " +
 				"before executing the command")
@@ -25,9 +25,9 @@ func processHelp(componentType string, command string) error {
 				"will use the previously generated 'planfile' instead of generating a new 'varfile'")
 			fmt.Println(" - 'atmos' supports 'terraform clean' command which deletes the '.terraform' folder, '.terraform.lock.hcl' lock file, " +
 				"and the previously generated 'planfile' and 'varfile' for the specified component and stack")
-			fmt.Println(" - 'atmos terraform workspace' command first calls 'terraform init -reconfigure', then `terraform workspace select', " +
+			fmt.Println(" - 'atmos terraform workspace' command first calls 'terraform init -reconfigure', then 'terraform workspace select', " +
 				"and if the workspace was not created before, it then calls 'terraform workspace new'")
-			fmt.Println(" - 'atmos terraform import' looks for `region` in the variables for the specified component and stack, and if it finds it, " +
+			fmt.Println(" - 'atmos terraform import' looks for 'region' in the variables for the specified component and stack, and if it finds it, " +
 				"sets 'AWS_REGION=<region>' ENV var before executing the command")
 		}
 

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -13,6 +13,33 @@ func processHelp(componentType string, command string) error {
 		color.Cyan(fmt.Sprintf("atmos %s <command> <component> -s <stack> [options]", componentType))
 		color.Cyan(fmt.Sprintf("atmos %s <command> <component> --stack <stack> [options]", componentType))
 
+		if componentType == "terraform" {
+			fmt.Println()
+			color.Cyan("Differences from native terraform:")
+			fmt.Println(" - before executing other 'terraform' commands, `atmos` calls 'terraform init'")
+			fmt.Println(" - 'atmos' supports 'terraform deploy' command which calls 'terraform plan' and then 'terraform apply'")
+			fmt.Println(" - 'terraform deploy' command supports '--deploy-run-init=true/false' flag to enable/disable running 'terraform init' " +
+				"before executing the command")
+			fmt.Println(" - 'terraform deploy' command sets '-auto-approve' flag before running 'terraform apply'")
+			fmt.Println(" - 'terraform apply' and 'terraform deploy' commands support '--from-plan' flag. If the flag is specified, the commands " +
+				"will use the previously generated 'planfile' instead of generating a new 'varfile'")
+			fmt.Println(" - 'atmos' supports 'terraform clean' command which deletes the '.terraform' folder, '.terraform.lock.hcl' lock file, " +
+				"and the previously generated 'planfile' and 'varfile' for the specified component and stack")
+			fmt.Println(" - 'atmos terraform workspace' command first calls 'terraform init -reconfigure', then `terraform workspace select', " +
+				"and if the workspace was not created before, it then calls 'terraform workspace new'")
+			fmt.Println(" - 'atmos terraform import' looks for `region` in the variables for the specified component and stack, and if it finds it, " +
+				"sets 'AWS_REGION=<region>' ENV var before executing the command")
+		}
+
+		if componentType == "helmfile" {
+			fmt.Println()
+			color.Cyan("Differences from native helmfile:")
+			fmt.Println(" - 'atmos helmfile' commands support '[global options]' in the command-line argument '--global-options'. " +
+				"Usage: atmos helmfile <command> <component> -s <stack> [command options] [arguments...] --global-options=\"--no-color --namespace=test\"")
+			fmt.Println(" - before executing the 'helmfile' commands, 'atmos' calls 'aws eks update-kubeconfig' to read kubeconfig from the EKS cluster " +
+				"and use it to authenticate with the cluster")
+		}
+
 		err := execCommand(componentType, []string{"--help"}, "", nil)
 		if err != nil {
 			return err

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -23,6 +23,10 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if info.NeedHelp == true {
+		return nil
+	}
+
 	if len(info.Stack) < 1 {
 		return errors.New("stack must be specified")
 	}

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -277,6 +277,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check `region` for `terraform import`
+	if info.SubCommand == "import" {
+		if region, regionExist := info.ComponentVarsSection["region"].(string); regionExist {
+			info.ComponentEnvList = append(info.ComponentEnvList, fmt.Sprintf("AWS_REGION=%s", region))
+		}
+	}
+
 	// Execute the command
 	if info.SubCommand != "workspace" {
 		err = execCommand(info.Command, allArgsAndFlags, componentPath, info.ComponentEnvList)

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -129,6 +129,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 	if err != nil {
 		return configAndStacksInfo, err
 	}
+
 	flags := cmd.Flags()
 
 	configAndStacksInfo.Stack, err = flags.GetString("stack")

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -148,15 +148,15 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 	configAndStacksInfo.DeployRunInit = argsAndFlagsInfo.DeployRunInit
 	configAndStacksInfo.AutoGenerateBackendFile = argsAndFlagsInfo.AutoGenerateBackendFile
 	configAndStacksInfo.UseTerraformPlan = argsAndFlagsInfo.UseTerraformPlan
+	configAndStacksInfo.NeedHelp = argsAndFlagsInfo.NeedHelp
 
 	// Check if `-h` or `--help` flags are specified
 	if argsAndFlagsInfo.NeedHelp == true {
-		subCommand := ""
-		if len(configAndStacksInfo.SubCommand) > 0 {
-			subCommand = configAndStacksInfo.SubCommand
+		err = processHelp(componentType, argsAndFlagsInfo.SubCommand)
+		if err != nil {
+			return configAndStacksInfo, err
 		}
-		message := fmt.Sprintf("Help for atmos %s %s", componentType, subCommand)
-		return configAndStacksInfo, errors.New(message)
+		return configAndStacksInfo, nil
 	}
 
 	flags := cmd.Flags()

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -158,7 +158,8 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 
 	// Check if component was provided
 	if len(configAndStacksInfo.ComponentFromArg) < 1 {
-		return configAndStacksInfo, errors.New("'component' is required")
+		message := fmt.Sprintf("'component' is required. Usage: atmos %s <component> <arguments_and_flags>", argsAndFlagsInfo.SubCommand)
+		return configAndStacksInfo, errors.New(message)
 	}
 
 	// Process and merge CLI configurations
@@ -486,15 +487,22 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 		}
 	}
 
-	// Handle the legacy command `terraform write varfile`
-	if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {
-		info.SubCommand = "write varfile"
-		info.ComponentFromArg = additionalArgsAndFlags[2]
-		info.AdditionalArgsAndFlags = additionalArgsAndFlags[3:]
-	} else {
-		info.SubCommand = additionalArgsAndFlags[0]
-		info.ComponentFromArg = additionalArgsAndFlags[1]
-		info.AdditionalArgsAndFlags = additionalArgsAndFlags[2:]
+	if info.NeedHelp == false {
+		if len(additionalArgsAndFlags) > 0 {
+			// Handle the legacy command `terraform write varfile`
+			if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {
+				info.SubCommand = "write varfile"
+				info.ComponentFromArg = additionalArgsAndFlags[2]
+				info.AdditionalArgsAndFlags = additionalArgsAndFlags[3:]
+			} else {
+				info.SubCommand = additionalArgsAndFlags[0]
+				info.ComponentFromArg = additionalArgsAndFlags[1]
+				info.AdditionalArgsAndFlags = additionalArgsAndFlags[2:]
+			}
+		} else {
+			message := "invalid number of arguments. Usage: atmos <command> <component> <arguments_and_flags>"
+			return info, errors.New(message)
+		}
 	}
 
 	info.GlobalOptions = globalOptions

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -28,6 +28,8 @@ var (
 		g.DeployRunInitFlag,
 		g.AutoGenerateBackendFileFlag,
 		g.FromPlanFlag,
+		g.HelpFlag1,
+		g.HelpFlag2,
 	}
 )
 
@@ -453,6 +455,10 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 
 		if arg == g.FromPlanFlag {
 			info.UseTerraformPlan = true
+		}
+
+		if arg == g.HelpFlag1 || arg == g.HelpFlag2 {
+			info.NeedHelp = true
 		}
 
 		for _, f := range commonFlags {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -132,13 +132,6 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 		return configAndStacksInfo, err
 	}
 
-	flags := cmd.Flags()
-
-	configAndStacksInfo.Stack, err = flags.GetString("stack")
-	if err != nil {
-		return configAndStacksInfo, err
-	}
-
 	argsAndFlagsInfo, err := processArgsAndFlags(args)
 	if err != nil {
 		return configAndStacksInfo, err
@@ -156,9 +149,31 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 	configAndStacksInfo.AutoGenerateBackendFile = argsAndFlagsInfo.AutoGenerateBackendFile
 	configAndStacksInfo.UseTerraformPlan = argsAndFlagsInfo.UseTerraformPlan
 
+	// Check if `-h` or `--help` flags are specified
+	if argsAndFlagsInfo.NeedHelp == true {
+		subCommand := ""
+		if len(configAndStacksInfo.SubCommand) > 0 {
+			subCommand = configAndStacksInfo.SubCommand
+		}
+		message := fmt.Sprintf("Help for atmos %s %s", componentType, subCommand)
+		return configAndStacksInfo, errors.New(message)
+	}
+
+	flags := cmd.Flags()
+	configAndStacksInfo.Stack, err = flags.GetString("stack")
+	if err != nil {
+		return configAndStacksInfo, err
+	}
+
+	// Check if stack was provided
+	if len(configAndStacksInfo.Stack) < 1 {
+		message := fmt.Sprintf("'stack' is required. Usage: atmos %s <command> <component> -s <stack>", componentType)
+		return configAndStacksInfo, errors.New(message)
+	}
+
 	// Check if component was provided
 	if len(configAndStacksInfo.ComponentFromArg) < 1 {
-		message := fmt.Sprintf("'component' is required. Usage: atmos %s <component> <arguments_and_flags>", argsAndFlagsInfo.SubCommand)
+		message := fmt.Sprintf("'component' is required. Usage: atmos %s <command> <component> <arguments_and_flags>", componentType)
 		return configAndStacksInfo, errors.New(message)
 	}
 

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -502,25 +502,30 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 		}
 	}
 
-	if info.NeedHelp == false {
+	info.GlobalOptions = globalOptions
+
+	if info.NeedHelp == true {
 		if len(additionalArgsAndFlags) > 0 {
-			// Handle the legacy command `terraform write varfile`
-			if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {
-				info.SubCommand = "write varfile"
-				info.ComponentFromArg = additionalArgsAndFlags[2]
-				info.AdditionalArgsAndFlags = additionalArgsAndFlags[3:]
-			} else {
-				info.SubCommand = additionalArgsAndFlags[0]
-				info.ComponentFromArg = additionalArgsAndFlags[1]
-				info.AdditionalArgsAndFlags = additionalArgsAndFlags[2:]
-			}
-		} else {
-			message := "invalid number of arguments. Usage: atmos <command> <component> <arguments_and_flags>"
-			return info, errors.New(message)
+			info.SubCommand = additionalArgsAndFlags[0]
 		}
+		return info, nil
 	}
 
-	info.GlobalOptions = globalOptions
+	if len(additionalArgsAndFlags) > 1 {
+		// Handle the legacy command `terraform write varfile`
+		if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {
+			info.SubCommand = "write varfile"
+			info.ComponentFromArg = additionalArgsAndFlags[2]
+			info.AdditionalArgsAndFlags = additionalArgsAndFlags[3:]
+		} else {
+			info.SubCommand = additionalArgsAndFlags[0]
+			info.ComponentFromArg = additionalArgsAndFlags[1]
+			info.AdditionalArgsAndFlags = additionalArgsAndFlags[2:]
+		}
+	} else {
+		message := "invalid number of arguments. Usage: atmos <command> <component> <arguments_and_flags>"
+		return info, errors.New(message)
+	}
 
 	return info, nil
 }

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -97,4 +97,5 @@ type ConfigAndStacksInfo struct {
 	AutoGenerateBackendFile   string
 	UseTerraformPlan          bool
 	ComponentInheritanceChain []string
+	Help                      bool
 }

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -68,6 +68,7 @@ type ArgsAndFlagsInfo struct {
 	DeployRunInit           string
 	AutoGenerateBackendFile string
 	UseTerraformPlan        bool
+	NeedHelp                bool
 }
 
 type ConfigAndStacksInfo struct {
@@ -97,5 +98,5 @@ type ConfigAndStacksInfo struct {
 	AutoGenerateBackendFile   string
 	UseTerraformPlan          bool
 	ComponentInheritanceChain []string
-	Help                      bool
+	NeedHelp                  bool
 }

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -18,6 +18,9 @@ const (
 	AutoGenerateBackendFileFlag = "--auto-generate-backend-file"
 
 	FromPlanFlag = "--from-plan"
+
+	HelpFlag1 = "-h"
+	HelpFlag2 = "--help"
 )
 
 var (


### PR DESCRIPTION
## what
* Improve `terraform import`
* Add help for all `atmos` commands

## why
* Since `terraform import` command requires a region, `atmos terraform import` looks for `region` in the variables for the specified component and stack, and if it finds it, sets `AWS_REGION=<region>` ENV var before executing the command

* Help needed for all `atmos` commands and subcommands

## related
* Closes https://github.com/cloudposse/atmos/pull/92
* Closes https://github.com/cloudposse/atmos/issues/74

## test

### atmos --help

![image](https://user-images.githubusercontent.com/7356997/146869721-8ba0fc69-ff1f-47da-b633-2beaaf0f9ccf.png)

### atmos terraform --help

![image](https://user-images.githubusercontent.com/7356997/146870093-3e896e01-aea6-4881-9c55-97a32bf85fe6.png)

### atmos terraform plan --help

![image](https://user-images.githubusercontent.com/7356997/146870044-5f01b2e9-8f55-464b-812f-2aeda21eea6f.png)

### atmos helmfile --help

![image](https://user-images.githubusercontent.com/7356997/146870122-4bc8bb43-6474-4d54-9d71-472892b1ae33.png)

### atmos helmfile diff --help

![image](https://user-images.githubusercontent.com/7356997/146870160-4ab7dc51-f830-4dd8-b544-87e18cf06742.png)

