### PR TITLE
Auto generate backend key based on component name for azurerm

### DIFF
--- a/examples/complete/stacks/globals/globals.yaml
+++ b/examples/complete/stacks/globals/globals.yaml
@@ -4,7 +4,7 @@ vars:
 terraform:
   vars: {}
 
-  backend_type: s3 # s3, remote, vault, static, etc.
+  backend_type: s3 # s3, remote, vault, static, azurerm, etc.
   backend:
     s3:
       encrypt: true
@@ -14,6 +14,12 @@ terraform:
       acl: "bucket-owner-full-control"
       region: "us-east-2"
       role_arn: null
+    azurerm:
+      subscription_id: 88888-8888-8888-8888-8888888888
+      resource_group_name: rg-terraform-state
+      storage_account_name: staterraformstate
+      container_name: dev-tfstate
+      key: dev.atmos
     remote:
     vault:
 


### PR DESCRIPTION
## what
When using the AzureRM backend type, automatically generate backend key based on component name if the backend key is not specified at the component level:
- Key is created in `{Global Backend Key value}/{component name}.terraform.tfstate` format. Places all component states in a storage account folder with the name of the global backend key value.
- If the key is specified at the component level, the backend key **is not** automatically generated.

**Before**:
```
terraform:
  backend_type: azurerm
  backend:
    azurerm:
      subscription_id: 88888-8888-8888-8888-8888888888
      resource_group_name: rg-terraform-state
      storage_account_name: staterraformstate
      container_name: dev-tfstate

components:
  terraform:
    "monitoring":
      backend:
          azurerm:
            key: dev.atmos/monitoring.terraform.tfstate
        
    "networking":
      backend:
          azurerm:
            key: dev.atmos/networking.terraform.tfstate
```


**After**:
```
terraform:
  backend_type: azurerm
  backend:
    azurerm:
      subscription_id: 88888-8888-8888-8888-8888888888
      resource_group_name: rg-terraform-state
      storage_account_name: staterraformstate
      container_name: dev-tfstate
      key: dev.atmos

components:
  terraform:
    "rg": {}

    "monitoring": {}

    "vault": {}
```
**backend.tf**:
```
{
  "terraform": {
    "backend": {
      "azurerm": {
        "subscription_id": "88888-8888-8888-8888-8888888888",
        "container_name": "dev-tfstate",
        "key": "dev.atmos/rg.terraform.tfstate",
        "resource_group_name": "rg-terraform-state",
        "storage_account_name": "staterraformstate"
      }
    }
  }
}
```


## why
The (azure backend) does not currently have a prefix option for workspaces. When using Atmos with Azure, users are forced to specify each backend key for every component.

## references
https://github.com/hashicorp/terraform/issues/28985

