### PR TITLE
Feat: Add Base Path Override to Component Processor (WIP)

### DIFF
--- a/pkg/component/component_processor.go
+++ b/pkg/component/component_processor.go
@@ -10,8 +10,16 @@ import (
 
 // ProcessComponentInStack accepts a component and a stack name and returns the component configuration in the stack
 func ProcessComponentInStack(component string, stack string) (map[string]interface{}, error) {
+	return ProcessComponentInStackWithPath(component, stack, "")
+}
+
+func ProcessComponentInStackWithPath(component string, stack string, basePath string) (map[string]interface{}, error) {
 	var configAndStacksInfo config.ConfigAndStacksInfo
 	configAndStacksInfo.Stack = stack
+
+	if len(basePath) > 0 {
+		configAndStacksInfo.ConfigDir = basePath
+	}
 
 	err := config.InitConfig()
 	if err != nil {
@@ -139,6 +147,10 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 
 // ProcessComponentFromContext accepts context (tenant, environment, stage) and returns the component configuration in the stack
 func ProcessComponentFromContext(component string, tenant string, environment string, stage string) (map[string]interface{}, error) {
+	return ProcessComponentFromContextWithPath(component, tenant, environment, stage, "")
+}
+
+func ProcessComponentFromContextWithPath(component string, tenant string, environment string, stage string, basePath string) (map[string]interface{}, error) {
 	var stack string
 
 	err := config.InitConfig()
@@ -183,7 +195,7 @@ func ProcessComponentFromContext(component string, tenant string, environment st
 		}
 	}
 
-	return ProcessComponentInStack(component, stack)
+	return ProcessComponentInStackWithPath(component, stack, basePath)
 }
 
 // findComponentConfig finds component config sections


### PR DESCRIPTION
## what
* Add base path override to component processor.

## why
* Allows for `cloudposse/utils` to have a `base_path` attribute and override the base path being used when calling `ProcessComponentInStack` and `ProcessComponentFromContext` (https://github.com/cloudposse/terraform-provider-utils/blob/e1a3c1a5656dc15334fe9ea95e02a3e7f3235065/internal/provider/data_source_component_config.go#L68-L78)

## references
* https://github.com/cloudposse/terraform-yaml-stack-config/pull/39

