### PR TITLE
Add `metadata` top-level section to all components. Add `type` attribute to the `metadata` section (`metadata.type`). Update README

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -51,7 +51,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ We use it extensively for automating cloud infrastructure and [Kubernetes](https
    - ... and many more
 
 In essence, it's a tool that orchestrates the other CLI tools in a consistent and self-explaining manner.
-It's a superset of all other tools and task runners (e.g. `make`, `terragrunt`, `terraform`, `aws` cli, `gcloud`, etc)
-and intended to be used to tie everything together, so you can provide a simple CLI interface for your organization.
+It's a superset of all other tools and task runners (e.g. `make`, `terragrunt`, `terraform`, `aws` cli, `gcloud`, etc.)
+and is intended to be used to tie everything together, so you can provide a simple CLI interface for your organization.
 
 Moreover, `atmos` is not only a command-line interface for managing clouds and clusters. It provides many useful patterns and best practices, such as:
 
@@ -86,37 +86,7 @@ Moreover, `atmos` is not only a command-line interface for managing clouds and c
 - Provides separation of configuration and code (so the same code could be easily deployed to different regions, environments and stages)
 - It can be extended to include new features, commands, and workflows
 - The commands have a clean, consistent and easy to understand syntax
-- The CLI can be compiled into a binary and included in other tools and containers for DevOps, cloud automation and CI/CD
 - The CLI code is modular and self-documenting
-
-
-## CLI Structure
-
-The CLI is built with [variant2](https://github.com/mumoshu/variant2) using [HCL syntax](https://www.terraform.io/docs/configuration/index.html).
-
-`*.variant` files are combined like Terraform files.
-
-See `variant` docs for more information on [writing commands](https://github.com/mumoshu/variant2#writing-commands).
-
-The CLI code consists of self-documenting [modules](atmos/modules) (separating the files into modules is done for cleanliness):
-
-  - utils - a collection of utilities to use in other modules
-  - shell - `shell` commands and helpers for the other modules
-  - terraform - `terraform` commands (`plan`, `apply`, `deploy`, `destroy`, `import`, etc.)
-  - helm - `helm` commands (e.g. `list`)
-  - helmfile - `helmfile` commands (`diff`, `apply`, `deploy`, `destroy`, `sync`, `lint`, etc.)
-  - kubeconfig - commands to download and manage `kubeconfig` from EKS clusters
-  - istio - commands to manage `istio` using `istio-operator` and `helmfile`
-  - workflow - commands to construct and execute cloud automation workflows
-
-
-## Developing Your Own CLI
-
-One way to use this project is by writing your own custom CLI that leverages our atmos.
-
-This is ideal when you have your own workflows that you want to develop in addition to using the ones we've developed for you.
-
-For example, maybe you have your own existing CLI tools (e.g. using `terragrunt`). In this case, you may want to start by developing your own CLI.
 
 ## Install
 
@@ -152,7 +122,8 @@ go install github.com/cloudposse/atmos
 
 Get a specific version
 
-__NOTE:__ Since the version is passed in via `-ldflags` during build, when running `go install` without using `-ldflags`, the CLI will return `0.0.1` when running `atmos version`.
+__NOTE:__ Since the version is passed in via `-ldflags` during build, when running `go install` without using `-ldflags`, 
+the CLI will return `0.0.1` when running `atmos version`.
 
 ```
 go install github.com/cloudposse/atmos@v1.3.9
@@ -173,11 +144,6 @@ go build -o build/atmos -v -ldflags "-X 'github.com/cloudposse/atmos/cmd.Version
 ## Usage
 
 There are a number of ways you can leverage this project:
-
-  1. As a **standalone CLI** - you can use our CLI without any modification and get immediate gratification
-  2. As a **library** - you can import our `variant` modules into your own CLI and expand the workflows for your needs
-  3. As a **Docker image** - you can use our [Docker image](example/Dockerfile) the way you would the `cli` and run the workflows
-
 
 ## Recommended Layout
 
@@ -218,91 +184,22 @@ Our recommended filesystem layout looks like this:
 
 ## Example
 
-The [example](example) folder contains a complete solution that shows how to:
+The [example](examples/complete) folder contains a complete solution that shows how to:
 
   - Structure the Terraform and helmfile components
-  - Configure the CLI top-level module [main.variant](example/cli/main.variant)
-  - Add [stack configurations](example/stacks) for the Terraform and helmfile components (to provision them to different environments and stages)
-  - Create a [Dockerfile](example/Dockerfile) with commands to build and include the CLI into the container
-  - Combine many CLI commands into workflows and run the workflows to provision resources
-
-In the example, we show how to create and provision (using the CLI) the following resources for three different environments/stages:
-
-  - VPCs for `dev`, `staging` and `prod` stages in the `us-east-2` region (which we refer to as `ue2` environment)
-  - EKS clusters in the `ue2` environment for `dev`, `staging` and `prod`
-  - `nginx-ingress` helmfile to be deployed on all EKS clusters
+  - Configure the CLI
+  - Add [stack configurations](examples/complete/stacks) for the Terraform and helmfile components (to provision them to different environments and stages)
 
 
 ## CLI Configuration
-
-  The CLI top-level module [main.variant](example/cli/main.variant) contains the global settings (options) for the CLI, including the location of the Terraform components,
-  helmfiles, and stack configurations.
-
-  It's configured for that particular example project, but can be changed to reflect the desired project structure.
-
-In the example we have the following:
-
-  - The terraform components are in the `components/terraform` folder - we set that global option in [main.variant](example/cli/main.variant)
-  ```hcl
-    option "terraform-dir" {
-      default     = "./components/terraform"
-      description = "Terraform components directory"
-      type        = string
-    }
-  ```
-
-  - The helmfiles are in the `components/helmfile` folder - we set that global option in [main.variant](example/cli/main.variant)
-  ```hcl
-    option "helmfile-dir" {
-      default     = "./components/helmfile"
-      description = "Helmfile components directory"
-      type        = string
-    }
-  ```
-
-  - The stack configurations (Terraform and helmfile variables) are in the [stacks](example/stacks) folder - we set that global option in [main.variant](example/cli/main.variant)
-  ```hcl
-    option "config-dir" {
-      default     = "./stacks"
-      description = "Stacks config directory"
-      type        = string
-    }
-  ```
-
-[main.variant](example/cli/main.variant) also includes the `imports` statement that imports all the required modules from the `atmos` repo.
-
-__NOTE:__ For the example, we import all the CLI modules, but they could be included selectively depending on a particular usage.
-
-  ```hcl
-      imports = [
-        "git::https://git@github.com/cloudposse/atmos@modules/utils?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/shell?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/kubeconfig?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/terraform?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/helmfile?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/helm?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/workflow?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/istio?ref=master",
-        "git::https://git@github.com/cloudposse/atmos@modules/vendir?ref=master"
-    ]
-  ```
-
-__NOTE:__ `imports` statement supports `https`, `http`, and `ssh` protocols.
-
-__NOTE:__ The global options from [main.variant](example/cli/main.variant) are propagated to all the downloaded modules,
-so they need to be specified only in one place - in the top-level module.
-
-When we build the Docker image, all the modules from the `imports` statement are downloaded, combined with the top-level module [main.variant](example/cli/main.variant),
-and compiled into a binary, which then included in the Docker container.
-
 
 ## Centralized Project Configuration
 
 `atmos` provides separation of configuration and code, allowing you to provision the same code into different regions, environments and stages.
 
-In our example, all the code (Terraform and helmfiles) is in the [components](example/components) folder.
+In our example, all the code (Terraform and helmfiles) is in the [components](examples/complete/components) folder.
 
-The centralized stack configurations (variables for the Terraform and helmfile components) are in the [stacks](example/stacks) folder.
+The centralized stack configurations (variables for the Terraform and helmfile components) are in the [stacks](examples/complete/stacks) folder.
 
 In the example, all stack configuration files are broken down by environments and stages and use the predefined format `$environment-$stage.yaml`.
 
@@ -323,9 +220,6 @@ __NOTE:__ The stack configuration structure and the file names described above a
 You can choose any file name for a stack. You can also include other configuration files (e.g. globals for the environment, and globals for the entire solution)
 into a stack config using the `import` directive.
 
-__NOTE:__ Currently `atmos` supports 10 levels of imports, e.g. you can import another config into a stack config, which in turn can import yet another config, etc.
-See [stacks](example/stacks) for more details.
-
 Stack configuration files have a predefined format:
 
   ```yaml
@@ -344,7 +238,7 @@ Stack configuration files have a predefined format:
     components:
       terraform:
         vpc:
-          command: "/usr/bin/terraform-0.13"
+          command: "/usr/bin/terraform-0.15"
           backend:
             s3:
               workspace_key_prefix: "vpc"
@@ -360,9 +254,6 @@ Stack configuration files have a predefined format:
         nginx-ingress:
           vars:
             installed: true
-
-    workflows:
-      deploy-all:
   ```
 
 It has the following main sections:
@@ -372,7 +263,6 @@ It has the following main sections:
   - `terraform` - (optional) configuration (variables) for all Terraform components
   - `helmfile` - (optional) configuration (variables) for all helmfile components
   - `components` - (required) configuration for the Terraform and helmfile components
-  - `workflows` - (optional) workflow definitions for the stack (see [Workflows](#Workflows) section below for the more detailed description of workflows)
 
 The `components` section consists of the following:
 
@@ -389,16 +279,6 @@ To run the example, execute the following commands in a terminal:
 
   - `cd example`
   - `make all` - it will build the Docker image, build the CLI tool inside the image, and then start the container
-
-Note that the name of the CLI executable is configurable.
-
-In the [Dockerfile](example/Dockerfile) for the example, we've chosen the name `atmos`, but it could be any name you want, for example
-`ops`, `cli`, `ops-exe`, etc. The name of the CLI executable is configured using `ARG CLI_NAME=atmos` in the Dockerfile.
-
-After the container starts, run `atmos help` to see the available commands and available flags.
-
-__NOTE:__ We use the Cloud Posse [geodesic](https://github.com/cloudposse/geodesic) image as the base image for the container.
-This is not strictly a requirement, but our base image ships with all the standard tools for cloud automation that we depend on (e.g. `terraform`, `helm`, `helmfile`, etc).
 
 
 ## Provision Terraform Component
@@ -527,19 +407,6 @@ execute the following command:
 
 
 
-## Share the Love
-
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/atmos)! (it helps us **a lot**)
-
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
-
-
-
-## Related Projects
-
-Check out these related projects.
-
-- [variant2](https://github.com/mumoshu/variant2) - Turn your bash scripts into a modern, single-executable CLI app today
 
 ## Help
 
@@ -612,7 +479,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -12,11 +12,6 @@ badges:
     image: https://slack.cloudposse.com/badge.svg
     url: https://slack.cloudposse.com
 
-related:
-  - name: variant2
-    description: Turn your bash scripts into a modern, single-executable CLI app today
-    url: https://github.com/mumoshu/variant2
-
 categories:
   - cli
   - automation
@@ -51,8 +46,8 @@ introduction: |-
      - ... and many more
 
   In essence, it's a tool that orchestrates the other CLI tools in a consistent and self-explaining manner.
-  It's a superset of all other tools and task runners (e.g. `make`, `terragrunt`, `terraform`, `aws` cli, `gcloud`, etc)
-  and intended to be used to tie everything together, so you can provide a simple CLI interface for your organization.
+  It's a superset of all other tools and task runners (e.g. `make`, `terragrunt`, `terraform`, `aws` cli, `gcloud`, etc.)
+  and is intended to be used to tie everything together, so you can provide a simple CLI interface for your organization.
 
   Moreover, `atmos` is not only a command-line interface for managing clouds and clusters. It provides many useful patterns and best practices, such as:
 
@@ -60,37 +55,7 @@ introduction: |-
   - Provides separation of configuration and code (so the same code could be easily deployed to different regions, environments and stages)
   - It can be extended to include new features, commands, and workflows
   - The commands have a clean, consistent and easy to understand syntax
-  - The CLI can be compiled into a binary and included in other tools and containers for DevOps, cloud automation and CI/CD
   - The CLI code is modular and self-documenting
-
-
-  ## CLI Structure
-
-  The CLI is built with [variant2](https://github.com/mumoshu/variant2) using [HCL syntax](https://www.terraform.io/docs/configuration/index.html).
-
-  `*.variant` files are combined like Terraform files.
-
-  See `variant` docs for more information on [writing commands](https://github.com/mumoshu/variant2#writing-commands).
-
-  The CLI code consists of self-documenting [modules](atmos/modules) (separating the files into modules is done for cleanliness):
-
-    - utils - a collection of utilities to use in other modules
-    - shell - `shell` commands and helpers for the other modules
-    - terraform - `terraform` commands (`plan`, `apply`, `deploy`, `destroy`, `import`, etc.)
-    - helm - `helm` commands (e.g. `list`)
-    - helmfile - `helmfile` commands (`diff`, `apply`, `deploy`, `destroy`, `sync`, `lint`, etc.)
-    - kubeconfig - commands to download and manage `kubeconfig` from EKS clusters
-    - istio - commands to manage `istio` using `istio-operator` and `helmfile`
-    - workflow - commands to construct and execute cloud automation workflows
-
-
-  ## Developing Your Own CLI
-
-  One way to use this project is by writing your own custom CLI that leverages our atmos.
-
-  This is ideal when you have your own workflows that you want to develop in addition to using the ones we've developed for you.
-
-  For example, maybe you have your own existing CLI tools (e.g. using `terragrunt`). In this case, you may want to start by developing your own CLI.
 
   ## Install
 
@@ -126,8 +91,9 @@ introduction: |-
   
   Get a specific version
  
-  __NOTE:__ Since the version is passed in via `-ldflags` during build, when running `go install` without using `-ldflags`, the CLI will return `0.0.1` when running `atmos version`.
- 
+  __NOTE:__ Since the version is passed in via `-ldflags` during build, when running `go install` without using `-ldflags`, 
+  the CLI will return `0.0.1` when running `atmos version`.
+
   ```
   go install github.com/cloudposse/atmos@v1.3.9
   ```
@@ -147,11 +113,6 @@ introduction: |-
   ## Usage
 
   There are a number of ways you can leverage this project:
-
-    1. As a **standalone CLI** - you can use our CLI without any modification and get immediate gratification
-    2. As a **library** - you can import our `variant` modules into your own CLI and expand the workflows for your needs
-    3. As a **Docker image** - you can use our [Docker image](example/Dockerfile) the way you would the `cli` and run the workflows
-
 
   ## Recommended Layout
 
@@ -192,91 +153,22 @@ introduction: |-
 
   ## Example
 
-  The [example](example) folder contains a complete solution that shows how to:
+  The [example](examples/complete) folder contains a complete solution that shows how to:
 
     - Structure the Terraform and helmfile components
-    - Configure the CLI top-level module [main.variant](example/cli/main.variant)
-    - Add [stack configurations](example/stacks) for the Terraform and helmfile components (to provision them to different environments and stages)
-    - Create a [Dockerfile](example/Dockerfile) with commands to build and include the CLI into the container
-    - Combine many CLI commands into workflows and run the workflows to provision resources
-
-  In the example, we show how to create and provision (using the CLI) the following resources for three different environments/stages:
-
-    - VPCs for `dev`, `staging` and `prod` stages in the `us-east-2` region (which we refer to as `ue2` environment)
-    - EKS clusters in the `ue2` environment for `dev`, `staging` and `prod`
-    - `nginx-ingress` helmfile to be deployed on all EKS clusters
+    - Configure the CLI
+    - Add [stack configurations](examples/complete/stacks) for the Terraform and helmfile components (to provision them to different environments and stages)
 
 
   ## CLI Configuration
-
-    The CLI top-level module [main.variant](example/cli/main.variant) contains the global settings (options) for the CLI, including the location of the Terraform components,
-    helmfiles, and stack configurations.
-
-    It's configured for that particular example project, but can be changed to reflect the desired project structure.
-
-  In the example we have the following:
-
-    - The terraform components are in the `components/terraform` folder - we set that global option in [main.variant](example/cli/main.variant)
-    ```hcl
-      option "terraform-dir" {
-        default     = "./components/terraform"
-        description = "Terraform components directory"
-        type        = string
-      }
-    ```
-
-    - The helmfiles are in the `components/helmfile` folder - we set that global option in [main.variant](example/cli/main.variant)
-    ```hcl
-      option "helmfile-dir" {
-        default     = "./components/helmfile"
-        description = "Helmfile components directory"
-        type        = string
-      }
-    ```
-
-    - The stack configurations (Terraform and helmfile variables) are in the [stacks](example/stacks) folder - we set that global option in [main.variant](example/cli/main.variant)
-    ```hcl
-      option "config-dir" {
-        default     = "./stacks"
-        description = "Stacks config directory"
-        type        = string
-      }
-    ```
-
-  [main.variant](example/cli/main.variant) also includes the `imports` statement that imports all the required modules from the `atmos` repo.
-
-  __NOTE:__ For the example, we import all the CLI modules, but they could be included selectively depending on a particular usage.
-
-    ```hcl
-        imports = [
-          "git::https://git@github.com/cloudposse/atmos@modules/utils?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/shell?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/kubeconfig?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/terraform?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/helmfile?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/helm?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/workflow?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/istio?ref=master",
-          "git::https://git@github.com/cloudposse/atmos@modules/vendir?ref=master"
-      ]
-    ```
-
-  __NOTE:__ `imports` statement supports `https`, `http`, and `ssh` protocols.
-
-  __NOTE:__ The global options from [main.variant](example/cli/main.variant) are propagated to all the downloaded modules,
-  so they need to be specified only in one place - in the top-level module.
-
-  When we build the Docker image, all the modules from the `imports` statement are downloaded, combined with the top-level module [main.variant](example/cli/main.variant),
-  and compiled into a binary, which then included in the Docker container.
-
 
   ## Centralized Project Configuration
 
   `atmos` provides separation of configuration and code, allowing you to provision the same code into different regions, environments and stages.
 
-  In our example, all the code (Terraform and helmfiles) is in the [components](example/components) folder.
+  In our example, all the code (Terraform and helmfiles) is in the [components](examples/complete/components) folder.
 
-  The centralized stack configurations (variables for the Terraform and helmfile components) are in the [stacks](example/stacks) folder.
+  The centralized stack configurations (variables for the Terraform and helmfile components) are in the [stacks](examples/complete/stacks) folder.
 
   In the example, all stack configuration files are broken down by environments and stages and use the predefined format `$environment-$stage.yaml`.
 
@@ -297,9 +189,6 @@ introduction: |-
   You can choose any file name for a stack. You can also include other configuration files (e.g. globals for the environment, and globals for the entire solution)
   into a stack config using the `import` directive.
 
-  __NOTE:__ Currently `atmos` supports 10 levels of imports, e.g. you can import another config into a stack config, which in turn can import yet another config, etc.
-  See [stacks](example/stacks) for more details.
-
   Stack configuration files have a predefined format:
 
     ```yaml
@@ -318,7 +207,7 @@ introduction: |-
       components:
         terraform:
           vpc:
-            command: "/usr/bin/terraform-0.13"
+            command: "/usr/bin/terraform-0.15"
             backend:
               s3:
                 workspace_key_prefix: "vpc"
@@ -334,9 +223,6 @@ introduction: |-
           nginx-ingress:
             vars:
               installed: true
-
-      workflows:
-        deploy-all:
     ```
 
   It has the following main sections:
@@ -346,7 +232,6 @@ introduction: |-
     - `terraform` - (optional) configuration (variables) for all Terraform components
     - `helmfile` - (optional) configuration (variables) for all helmfile components
     - `components` - (required) configuration for the Terraform and helmfile components
-    - `workflows` - (optional) workflow definitions for the stack (see [Workflows](#Workflows) section below for the more detailed description of workflows)
 
   The `components` section consists of the following:
 
@@ -363,16 +248,6 @@ introduction: |-
 
     - `cd example`
     - `make all` - it will build the Docker image, build the CLI tool inside the image, and then start the container
-
-  Note that the name of the CLI executable is configurable.
-
-  In the [Dockerfile](example/Dockerfile) for the example, we've chosen the name `atmos`, but it could be any name you want, for example
-  `ops`, `cli`, `ops-exe`, etc. The name of the CLI executable is configured using `ARG CLI_NAME=atmos` in the Dockerfile.
-
-  After the container starts, run `atmos help` to see the available commands and available flags.
-
-  __NOTE:__ We use the Cloud Posse [geodesic](https://github.com/cloudposse/geodesic) image as the base image for the container.
-  This is not strictly a requirement, but our base image ships with all the standard tools for cloud automation that we depend on (e.g. `terraform`, `helm`, `helmfile`, etc).
 
 
   ## Provision Terraform Component

--- a/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
@@ -14,6 +14,12 @@ components:
       # By using `component` attribute, `test-component-override` inherits from `test-component` and can override its variables
       # In this example, variables for each service are overridden in `catalog/services/service-?-override.*`
       component: "test/test-component-override"
+      # Setting `deployable: false` explicitly prohibits the component from being deployed
+      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
+      # `terraform apply` and `terraform deploy` will fail with an error
+      # All other terraform commands on this component will succeed
+      # If `deployable` attribute is not specified, it defaults to `true`
+      deployable: true
       # Other variables can be overridden here
       vars: {}
       env:

--- a/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
@@ -11,17 +11,14 @@ components:
     "test/test-component-override-2":
       # Specify terraform binary to run
       command: "/usr/local/bin/terraform"
-      # By using `component` attribute, `test-component-override` inherits from `test-component` and can override its variables
-      # In this example, variables for each service are overridden in `catalog/services/service-?-override.*`
+      # The `component` attribute specifies that `test-component-override-2` inherits from the `test-component-override` base component,
+      # which in turn inherits from `test-component` (inheritance chain).
+      # `test-component-override-2` can override all the variables and other settings of all its base components (except the `metadata` section).
+      # In this example, variables for each service are overridden in `catalog/services/service-?-override-2.*`
       component: "test/test-component-override"
-      # Setting `deployable: false` explicitly prohibits the component from being deployed
-      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
-      # `terraform apply` and `terraform deploy` will fail with an error
-      # All other terraform commands on this component will succeed
-      # If `deployable` attribute is not specified, it defaults to `true`
-      deployable: true
       # Other variables can be overridden here
       vars: {}
+      # Other ENV vars can be overridden here
       env:
         TEST_ENV_VAR1: "val1-override-2"
         TEST_ENV_VAR2: "val2-override-2"

--- a/examples/complete/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override.yaml
@@ -16,6 +16,10 @@ components:
       component: "test/test-component"
       # Other variables can be overridden here
       vars: {}
+      # Explicitly prohibit the component from being deployed
+      # `terraform apply` and `terraform deploy` will fail with an error
+      # All other terraform commands on this component will succeed
+      deployable: false
       env:
         TEST_ENV_VAR1: "val1-override"
         TEST_ENV_VAR3: "val3-override"

--- a/examples/complete/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override.yaml
@@ -16,10 +16,12 @@ components:
       component: "test/test-component"
       # Other variables can be overridden here
       vars: {}
-      # Explicitly prohibit the component from being deployed
+      # Setting `deployable: false` explicitly prohibits the component from being deployed
+      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
       # `terraform apply` and `terraform deploy` will fail with an error
       # All other terraform commands on this component will succeed
-      deployable: false
+      # If `deployable` attribute is not specified, it defaults to `true`
+      deployable: true
       env:
         TEST_ENV_VAR1: "val1-override"
         TEST_ENV_VAR3: "val3-override"

--- a/examples/complete/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override.yaml
@@ -11,17 +11,13 @@ components:
     "test/test-component-override":
       # Specify terraform binary to run
       command: "/usr/local/bin/terraform"
-      # By using `component` attribute, `test-component-override` inherits from `test-component` and can override its variables
+      # The `component` attribute specifies that `test-component-override` inherits from the `test-component` base component.
+      # `test-component-override` can override all the variables and other settings of the base component (except the `metadata` section).
       # In this example, variables for each service are overridden in `catalog/services/service-?-override.*`
       component: "test/test-component"
       # Other variables can be overridden here
       vars: {}
-      # Setting `deployable: false` explicitly prohibits the component from being deployed
-      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
-      # `terraform apply` and `terraform deploy` will fail with an error
-      # All other terraform commands on this component will succeed
-      # If `deployable` attribute is not specified, it defaults to `true`
-      deployable: true
+      # Other ENV vars can be overridden here
       env:
         TEST_ENV_VAR1: "val1-override"
         TEST_ENV_VAR3: "val3-override"

--- a/examples/complete/stacks/catalog/terraform/test-component.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component.yaml
@@ -13,6 +13,12 @@ components:
       settings:
         spacelift:
           workspace_enabled: true
+      # Setting `deployable: false` explicitly prohibits the component from being deployed
+      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
+      # `terraform apply` and `terraform deploy` will fail with an error
+      # All other terraform commands on this component will succeed
+      # If `deployable` attribute is not specified, it defaults to `true`
+      deployable: true
       vars:
         enabled: true
       env:

--- a/examples/complete/stacks/catalog/terraform/test-component.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component.yaml
@@ -20,7 +20,7 @@ components:
       # All other terraform commands on this component will succeed.
       # If `metadata.type` attribute is not specified, it defaults to `real` (which means the component can be provisioned).
       metadata:
-        type: abstract
+        type: real # `real` is implicit, you don't need to specify it; `abstract` makes the component protected from being deployed
       vars:
         enabled: true
       env:

--- a/examples/complete/stacks/catalog/terraform/test-component.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component.yaml
@@ -13,12 +13,14 @@ components:
       settings:
         spacelift:
           workspace_enabled: true
-      # Setting `deployable: false` explicitly prohibits the component from being deployed
-      # and Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`)
-      # `terraform apply` and `terraform deploy` will fail with an error
-      # All other terraform commands on this component will succeed
-      # If `deployable` attribute is not specified, it defaults to `true`
-      deployable: true
+      # Setting `metadata.type: abstract` makes the component `abstract` (similar to OOP abstract classes, which can't be instantiated),
+      # explicitly prohibiting the component from being deployed,
+      # and a Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`).
+      # `terraform apply` and `terraform deploy` will fail with an error that the component cannot be provisioned.
+      # All other terraform commands on this component will succeed.
+      # If `metadata.type` attribute is not specified, it defaults to `real` (which means the component can be provisioned).
+      metadata:
+        type: abstract
       vars:
         enabled: true
       env:

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -73,12 +73,12 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 	if c.ProcessedConfig.StackType == "Directory" {
 		componentSection,
 			componentVarsSection,
-			_, _, _, _, _, _,
+			_, _, _, _, _, _, _,
 			err = findComponentConfig(stack, stacksMap, "terraform", component)
 		if err != nil {
 			componentSection,
 				componentVarsSection,
-				_, _, _, _, _, _,
+				_, _, _, _, _, _, _,
 				err = findComponentConfig(stack, stacksMap, "helmfile", component)
 			if err != nil {
 				return err
@@ -116,12 +116,12 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 		for stackName := range stacksMap {
 			componentSection,
 				componentVarsSection,
-				_, _, _, _, _, _,
+				_, _, _, _, _, _, _,
 				err = findComponentConfig(stackName, stacksMap, "terraform", component)
 			if err != nil {
 				componentSection,
 					componentVarsSection,
-					_, _, _, _, _, _,
+					_, _, _, _, _, _, _,
 					err = findComponentConfig(stackName, stacksMap, "helmfile", component)
 				if err != nil {
 					continue

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -34,7 +34,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
-	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
+	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract == false {
 		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
 			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -35,7 +35,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly disabled from beign deployed "+
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from beign deployed "+
 			"with 'deployable: false' attribute", info.Component))
 	}
 

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -33,7 +33,13 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Check if the component exists as helmfile component
+	// Check if the component is allowed to be provisioned (`deployable` attribute)
+	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly disabled from beign deployed "+
+			"with 'deployable: false' attribute", info.Component))
+	}
+
+	// Check if the component exists as a helmfile component
 	componentPath := path.Join(c.ProcessedConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.Component)
 	componentPathExists, err := utils.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -33,10 +33,10 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Check if the component is allowed to be provisioned (`deployable` attribute)
-	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
+	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
+	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract {
+		return errors.New(fmt.Sprintf("Abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
+			"with 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}
 
 	// Check if the component exists as a helmfile component

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -35,7 +35,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from beign deployed "+
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
 			"with 'deployable: false' attribute", info.Component))
 	}
 

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -36,7 +36,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
 		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"with 'deployable: false' attribute", info.Component))
+			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}
 
 	// Check if the component exists as a helmfile component

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -46,7 +46,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly disabled from beign deployed "+
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from beign deployed "+
 			"with 'deployable: false' attribute", info.Component))
 	}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -46,7 +46,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from beign deployed "+
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
 			"with 'deployable: false' attribute", info.Component))
 	}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -47,7 +47,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
 	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
 		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"with 'deployable: false' attribute", info.Component))
+			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}
 
 	// Check if the component (or base component) exists as Terraform component

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -44,10 +44,10 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		finalComponent = info.Component
 	}
 
-	// Check if the component is allowed to be provisioned (`deployable` attribute)
-	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract == false {
-		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
+	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
+	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract {
+		return errors.New(fmt.Sprintf("Abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
+			"with 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}
 
 	// Check if the component (or base component) exists as Terraform component

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -44,7 +44,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		finalComponent = info.Component
 	}
 
-	// Check if the component exists as Terraform component
+	// Check if the component is allowed to be provisioned (`deployable` attribute)
+	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
+		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly disabled from beign deployed "+
+			"with 'deployable: false' attribute", info.Component))
+	}
+
+	// Check if the component (or base component) exists as Terraform component
 	componentPath := path.Join(c.ProcessedConfig.TerraformDirAbsolutePath, info.ComponentFolderPrefix, finalComponent)
 	componentPathExists, err := utils.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -45,7 +45,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if the component is allowed to be provisioned (`deployable` attribute)
-	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsDeployable == false {
+	if (info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract == false {
 		return errors.New(fmt.Sprintf("Component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
 			"with 'deployable: false' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}

--- a/internal/exec/terraform_generate.go
+++ b/internal/exec/terraform_generate.go
@@ -79,7 +79,7 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 			_,
 			componentBackendSection,
 			componentBackendType,
-			_, _, _,
+			_, _, _, _,
 			err = findComponentConfig(stack, stacksMap, "terraform", component)
 		if err != nil {
 			return err
@@ -119,7 +119,7 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 				_,
 				componentBackendSection,
 				componentBackendType,
-				_, _, _,
+				_, _, _, _,
 				err = findComponentConfig(stackName, stacksMap, "terraform", component)
 			if err != nil {
 				continue

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -62,7 +62,7 @@ func findComponentConfig(
 	var baseComponentPath string
 	var command string
 	var componentInheritanceChain []string
-	var componentIsDeployable bool
+	var componentIsAbstract bool
 	var ok bool
 
 	if len(stack) == 0 {
@@ -107,8 +107,13 @@ func findComponentConfig(
 	if componentInheritanceChain, ok = componentSection["inheritance"].([]string); !ok {
 		componentInheritanceChain = []string{}
 	}
-	if componentIsDeployable, ok = componentSection["deployable"].(bool); !ok {
-		componentIsDeployable = true
+	if componentMetadataSection, componentMetadataSectionExists := componentSection["metadata"]; componentMetadataSectionExists {
+		componentMetadata := componentMetadataSection.(map[interface{}]interface{})
+		if componentMetadataType, componentMetadataTypeAttributeExists := componentMetadata["type"].(string); componentMetadataTypeAttributeExists {
+			if componentMetadataType == "abstract" {
+				componentIsAbstract = true
+			}
+		}
 	}
 
 	return componentSection,
@@ -119,7 +124,7 @@ func findComponentConfig(
 		baseComponentPath,
 		command,
 		componentInheritanceChain,
-		componentIsDeployable,
+		componentIsAbstract,
 		nil
 }
 

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -47,6 +47,7 @@ func findComponentConfig(
 	string,
 	string,
 	[]string,
+	bool,
 	error,
 ) {
 
@@ -61,31 +62,32 @@ func findComponentConfig(
 	var baseComponentPath string
 	var command string
 	var componentInheritanceChain []string
+	var componentIsDeployable bool
 	var ok bool
 
 	if len(stack) == 0 {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New("stack must be provided and must not be empty")
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New("stack must be provided and must not be empty")
 	}
 	if len(component) == 0 {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New("component must be provided and must not be empty")
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New("component must be provided and must not be empty")
 	}
 	if len(componentType) == 0 {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New("component type must be provided and must not be empty")
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New("component type must be provided and must not be empty")
 	}
 	if stackSection, ok = stacksMap[stack].(map[interface{}]interface{}); !ok {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New(fmt.Sprintf("Stack '%s' does not exist", stack))
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New(fmt.Sprintf("Stack '%s' does not exist", stack))
 	}
 	if componentsSection, ok = stackSection["components"].(map[string]interface{}); !ok {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New(fmt.Sprintf("'components' section is missing in the stack '%s'", stack))
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New(fmt.Sprintf("'components' section is missing in the stack '%s'", stack))
 	}
 	if componentTypeSection, ok = componentsSection[componentType].(map[string]interface{}); !ok {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New(fmt.Sprintf("'components/%s' section is missing in the stack '%s'", componentType, stack))
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New(fmt.Sprintf("'components/%s' section is missing in the stack '%s'", componentType, stack))
 	}
 	if componentSection, ok = componentTypeSection[component].(map[string]interface{}); !ok {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New(fmt.Sprintf("Invalid or missing configuration for the component '%s' in the stack '%s'", component, stack))
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New(fmt.Sprintf("Invalid or missing configuration for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentVarsSection, ok = componentSection["vars"].(map[interface{}]interface{}); !ok {
-		return nil, nil, nil, nil, "", "", "", nil, errors.New(fmt.Sprintf("Missing 'vars' section for the component '%s' in the stack '%s'", component, stack))
+		return nil, nil, nil, nil, "", "", "", nil, false, errors.New(fmt.Sprintf("Missing 'vars' section for the component '%s' in the stack '%s'", component, stack))
 	}
 	if componentBackendSection, ok = componentSection["backend"].(map[interface{}]interface{}); !ok {
 		componentBackendSection = nil
@@ -105,6 +107,9 @@ func findComponentConfig(
 	if componentInheritanceChain, ok = componentSection["inheritance"].([]string); !ok {
 		componentInheritanceChain = []string{}
 	}
+	if componentIsDeployable, ok = componentSection["deployable"].(bool); !ok {
+		componentIsDeployable = true
+	}
 
 	return componentSection,
 		componentVarsSection,
@@ -114,6 +119,7 @@ func findComponentConfig(
 		baseComponentPath,
 		command,
 		componentInheritanceChain,
+		componentIsDeployable,
 		nil
 }
 
@@ -231,6 +237,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 			configAndStacksInfo.BaseComponentPath,
 			configAndStacksInfo.Command,
 			configAndStacksInfo.ComponentInheritanceChain,
+			configAndStacksInfo.ComponentIsDeployable,
 			err = findComponentConfig(configAndStacksInfo.Stack, stacksMap, componentType, configAndStacksInfo.ComponentFromArg)
 		if err != nil {
 			return configAndStacksInfo, err
@@ -275,6 +282,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 				configAndStacksInfo.BaseComponentPath,
 				configAndStacksInfo.Command,
 				configAndStacksInfo.ComponentInheritanceChain,
+				configAndStacksInfo.ComponentIsDeployable,
 				err = findComponentConfig(stackName, stacksMap, componentType, configAndStacksInfo.ComponentFromArg)
 			if err != nil {
 				continue

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -237,7 +237,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 			configAndStacksInfo.BaseComponentPath,
 			configAndStacksInfo.Command,
 			configAndStacksInfo.ComponentInheritanceChain,
-			configAndStacksInfo.ComponentIsDeployable,
+			configAndStacksInfo.ComponentIsAbstract,
 			err = findComponentConfig(configAndStacksInfo.Stack, stacksMap, componentType, configAndStacksInfo.ComponentFromArg)
 		if err != nil {
 			return configAndStacksInfo, err
@@ -282,7 +282,7 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 				configAndStacksInfo.BaseComponentPath,
 				configAndStacksInfo.Command,
 				configAndStacksInfo.ComponentInheritanceChain,
-				configAndStacksInfo.ComponentIsDeployable,
+				configAndStacksInfo.ComponentIsAbstract,
 				err = findComponentConfig(stackName, stacksMap, componentType, configAndStacksInfo.ComponentFromArg)
 			if err != nil {
 				continue

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -99,5 +99,5 @@ type ConfigAndStacksInfo struct {
 	UseTerraformPlan          bool
 	ComponentInheritanceChain []string
 	NeedHelp                  bool
-	ComponentIsDeployable     bool
+	ComponentIsAbstract       bool
 }

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -99,4 +99,5 @@ type ConfigAndStacksInfo struct {
 	UseTerraformPlan          bool
 	ComponentInheritanceChain []string
 	NeedHelp                  bool
+	ComponentIsDeployable     bool
 }

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -491,15 +491,15 @@ func ProcessConfig(
 				// If it does not, use the component name instead and format it with the global backend key name to auto generate a unique tf state key
 				// The backend state file will be formatted like so: {global key name}/{component name}.terraform.tfstate
 				if finalComponentBackendType == "azurerm" {
-					if azurerm, ok2 := componentBackendSection["azurerm"].(map[interface{}]interface{}); !ok2 {
-						if _, ok2 := azurerm["key"].(string); !ok2 {
+					if componentAzurerm, componentAzurermExists := componentBackendSection["azurerm"].(map[interface{}]interface{}); !componentAzurermExists {
+						if _, componentAzurermKeyExists := componentAzurerm["key"].(string); !componentAzurermKeyExists {
 							azureKeyPrefixComponent := component
 							baseKeyName := ""
 							if baseComponentName != "" {
 								azureKeyPrefixComponent = baseComponentName
 							}
-							if azurerm, ok2 := globalBackendSection["azurerm"].(map[interface{}]interface{}); ok2 {
-								baseKeyName = azurerm["key"].(string)
+							if globalAzurerm, globalAzurermExists := globalBackendSection["azurerm"].(map[interface{}]interface{}); globalAzurermExists {
+								baseKeyName = globalAzurerm["key"].(string)
 							}
 							componentKeyName := strings.Replace(azureKeyPrefixComponent, "/", "-", -1)
 							finalComponentBackend["key"] = fmt.Sprintf("%s/%s.terraform.tfstate", baseKeyName, componentKeyName)

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -817,18 +817,21 @@ func processBaseComponentConfig(
 			baseComponentConfig.FinalBaseComponentName = baseComponent
 		}
 
+		// Base component `vars`
 		merged, err := m.Merge([]map[interface{}]interface{}{baseComponentConfig.BaseComponentVars, baseComponentVars})
 		if err != nil {
 			return err
 		}
 		baseComponentConfig.BaseComponentVars = merged
 
+		// Base component `settings`
 		merged, err = m.Merge([]map[interface{}]interface{}{baseComponentConfig.BaseComponentSettings, baseComponentSettings})
 		if err != nil {
 			return err
 		}
 		baseComponentConfig.BaseComponentSettings = merged
 
+		// Base component `env`
 		merged, err = m.Merge([]map[interface{}]interface{}{baseComponentConfig.BaseComponentEnv, baseComponentEnv})
 		if err != nil {
 			return err
@@ -836,15 +839,16 @@ func processBaseComponentConfig(
 		baseComponentConfig.BaseComponentEnv = merged
 
 		baseComponentConfig.BaseComponentCommand = baseComponentCommand
-
 		baseComponentConfig.BaseComponentBackendType = baseComponentBackendType
 
+		// Base component `backend`
 		merged, err = m.Merge([]map[interface{}]interface{}{baseComponentConfig.BaseComponentBackendSection, baseComponentBackendSection})
 		if err != nil {
 			return err
 		}
 		baseComponentConfig.BaseComponentBackendSection = merged
 
+		// Base component `backend_type`
 		baseComponentConfig.BaseComponentRemoteStateBackendType = baseComponentRemoteStateBackendType
 
 		merged, err = m.Merge([]map[interface{}]interface{}{baseComponentConfig.BaseComponentRemoteStateBackendSection, baseComponentRemoteStateBackendSection})

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -552,7 +552,8 @@ func ProcessConfig(
 				// If the component is not deployable (`deployable: false`), remove `settings.spacelift.workspace_enabled` from the map).
 				// This will prevent derived components from inheriting `settings.spacelift.workspace_enabled=false` of not-deployable component
 				// Also, removing `settings.spacelift.workspace_enabled` will effectively make it `false`
-				// and `spacelift_stack_processor` will not create a Spacelift stack for the component.
+				// and `spacelift_stack_processor` will not create a Spacelift stack for the component
+				// even if `settings.spacelift.workspace_enabled` was set to `true`
 				if componentIsDeployable == false {
 					if i, ok2 := finalComponentSettings["spacelift"]; ok2 {
 						spaceliftSettings := i.(map[interface{}]interface{})

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -397,6 +397,13 @@ func ProcessConfig(
 					componentTerraformCommand = i.(string)
 				}
 
+				// Check if the component can be deployed (`deployable` attribute)
+				// This is per component, not deep-merged and not inherited from base components and globals
+				componentIsDeployable := true
+				if i, ok2 := componentMap["deployable"]; ok2 {
+					componentIsDeployable = i.(bool)
+				}
+
 				// Process base component(s)
 				baseComponentVars := map[interface{}]interface{}{}
 				baseComponentSettings := map[interface{}]interface{}{}
@@ -413,6 +420,7 @@ func ProcessConfig(
 				if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
 					baseComponentName = baseComponent.(string)
 
+					// Process the base components recursively to find `componentInheritanceChain`
 					err = processBaseComponentConfig(&baseComponentConfig, allTerraformComponentsMap, component, stack, baseComponentName)
 					if err != nil {
 						return nil, err
@@ -551,6 +559,7 @@ func ProcessConfig(
 				comp["remote_state_backend"] = finalComponentRemoteStateBackend
 				comp["command"] = finalComponentTerraformCommand
 				comp["inheritance"] = componentInheritanceChain
+				comp["deployable"] = componentIsDeployable
 
 				if baseComponentName != "" {
 					comp["component"] = baseComponentName
@@ -612,6 +621,13 @@ func ProcessConfig(
 					componentHelmfileCommand = i.(string)
 				}
 
+				// Check if the component can be deployed (`deployable` attribute)
+				// This is per component, not deep-merged and not inherited from base components and globals
+				componentIsDeployable := true
+				if i, ok2 := componentMap["deployable"]; ok2 {
+					componentIsDeployable = i.(bool)
+				}
+
 				// Process base component(s)
 				baseComponentVars := map[interface{}]interface{}{}
 				baseComponentSettings := map[interface{}]interface{}{}
@@ -621,6 +637,7 @@ func ProcessConfig(
 				var baseComponentConfig BaseComponentConfig
 				var componentInheritanceChain []string
 
+				// Process the base components recursively to find `componentInheritanceChain`
 				if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
 					baseComponentName = baseComponent.(string)
 
@@ -667,6 +684,7 @@ func ProcessConfig(
 				comp["env"] = finalComponentEnv
 				comp["command"] = finalComponentHelmfileCommand
 				comp["inheritance"] = componentInheritanceChain
+				comp["deployable"] = componentIsDeployable
 
 				if baseComponentName != "" {
 					comp["component"] = baseComponentName

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -549,6 +549,20 @@ func ProcessConfig(
 					finalComponentTerraformCommand = componentTerraformCommand
 				}
 
+				// If the component is not deployable (`deployable: false`), remove `settings.spacelift.workspace_enabled` from the map).
+				// This will prevent derived components from inheriting `settings.spacelift.workspace_enabled=false` of not-deployable component
+				// Also, removing `settings.spacelift.workspace_enabled` will effectively make it `false`
+				// and `spacelift_stack_processor` will not create a Spacelift stack for the component.
+				if componentIsDeployable == false {
+					if i, ok2 := finalComponentSettings["spacelift"]; ok2 {
+						spaceliftSettings := i.(map[interface{}]interface{})
+
+						if _, ok3 := spaceliftSettings["workspace_enabled"]; ok3 {
+							delete(spaceliftSettings, "workspace_enabled")
+						}
+					}
+				}
+
 				comp := map[string]interface{}{}
 				comp["vars"] = finalComponentVars
 				comp["settings"] = finalComponentSettings

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -481,7 +481,7 @@ func ProcessConfig(
 
 				// Check if component `backend` section has `key` for `azurerm` backend type
 				// If it does not, use the component name instead and format it with the global backend key name to auto generate a unique tf state key
-				// The backend state file will be formated like so: {global key name}/{component name}.terraform.tfstate
+				// The backend state file will be formatted like so: {global key name}/{component name}.terraform.tfstate
 				if finalComponentBackendType == "azurerm" {
 					if azurerm, ok2 := componentBackendSection["azurerm"].(map[interface{}]interface{}); !ok2 {
 						if _, ok2 := azurerm["key"].(string); !ok2 {
@@ -498,7 +498,6 @@ func ProcessConfig(
 
 						}
 					}
-
 				}
 
 				// Final remote state backend


### PR DESCRIPTION
## what
* Update README
* Add `metadata` top-level section to all components
* Add `type` attribute to the `metadata` section (`metadata.type`)

## why
* Remove the old/obsolete sections from README (new README with new `atmos` features coming soon)

* The `metadata` section is used to describe metadata for a component (it's for the component only, not deep-merged with base components or globals). Other attributes might be added to the section in the future to describe component types, kinds and different behaviors

* `type` attribute in the `metadata` section specifies the component type: `real` (implicit and default, and can be provisioned) or `abstract` (non-deployable, just a base class for derived components, like abstract classes in OOP)

```
components:
  terraform:
    "test/test-component":
      settings:
        spacelift:
          workspace_enabled: true
      # Setting `metadata.type: abstract` makes the component `abstract` (similar to OOP abstract classes, which can't be instantiated),
      # explicitly prohibiting the component from being deployed,
      # and a Spacelift stack from being created for the component (even if `settings.spacelift.workspace_enabled: true`).
      # `terraform apply` and `terraform deploy` will fail with an error that the component cannot be provisioned.
      # All other terraform commands on this component will succeed.
      # If `metadata.type` attribute is not specified, it defaults to `real` (which means the component can be provisioned).
      metadata:
        type: real # `real` is implicit, you don't need to specify it; `abstract` makes the component protected from being deployed
```

* `metadata.type` attribute in the `metadata` section allows explicitly disabling a component from being deployed. This is useful for non-deployable base components (which are just blueprints for derived components) if we need to prohibit the base components from being deployed (accidentally via CLI or via Spacelift).
For Spacelift, this will prevent derived components from inheriting `settings.spacelift.workspace_enabled=false` of not-deployable component (allowing specifying settings.spacelift.workspace_enabled=true` at a global level making the config DRY)


## test

```
components:
  terraform:
    "test/test-component":
      settings:
        spacelift:
          workspace_enabled: false
      metadata:
        type: abstract
```

```
atmos terraform apply test/test-component -s=tenant1-ue2-dev  
```

```
Variables for the component 'test/test-component' in the stack 'tenant1/ue2/dev':

enabled: true
environment: ue2
namespace: eg
region: us-east-2
service_1_name: service-1
service_2_name: service-2
stage: dev
tenant: tenant1

Abstract component 'test/test-component' cannot be provisioned 
since it's explicitly prohibited from being deployed with 'metadata.type: abstract' attribute

```

Spacelift config 

```
settings:
  spacelift:
    workspace_enabled: false
```


```
atmos describe component test/test-component -s=tenant1-ue2-dev
```

results in:

```
settings:
  spacelift: {}
```

