### PR TITLE
Set default `base_path` to an empty string

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ import (
 var (
 	// Default values
 	defaultConfig = Configuration{
-		BasePath: ".",
+		BasePath: "",
 		Components: Components{
 			Terraform: Terraform{
 				BasePath:                "components/terraform",


### PR DESCRIPTION
## what
* Set default `base_path` to an empty string

## why
* For the existing deployments (using `atmos` and the `utils` provider), an empty `base_path` is backwards compatible. It will consider the stacks and components base paths as separate (not joined with the global base path)
* Setting it to an empty string will not require updating all existing `atmos.yaml` configs to set `base_path` to an empty string

```
# Base path for components and stacks configurations.
# Can also be set using `ATMOS_BASE_PATH` ENV var, or `--base-path` command-line argument.
# Supports both absolute and relative paths.
# If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
# are independent settings (supporting both absolute and relative paths).
# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
# are considered paths relative to `base_path`.
base_path: ""
```


