### PR TITLE
Allow overriding terraform workspace per component using `metadata.terraform_workspace` attribute

### DIFF
--- a/examples/complete/stacks/catalog/terraform/test-component-override-3.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override-3.yaml
@@ -37,3 +37,6 @@ components:
           - "test/test-component-override-2"
           - "mixin/test-1"
           - "mixin/test-2"
+        # Override Terraform workspace
+        # Note that by default, Terraform workspace is generated from the context, e.g. `<environment>-<stage>`
+        terraform_workspace: test-component-override-3-workspace

--- a/internal/exec/describe.go
+++ b/internal/exec/describe.go
@@ -73,12 +73,12 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 	if c.ProcessedConfig.StackType == "Directory" {
 		componentSection,
 			componentVarsSection,
-			_, _, _, _, _, _, _,
+			_, _, _, _, _, _, _, _,
 			err = findComponentConfig(stack, stacksMap, "terraform", component)
 		if err != nil {
 			componentSection,
 				componentVarsSection,
-				_, _, _, _, _, _, _,
+				_, _, _, _, _, _, _, _,
 				err = findComponentConfig(stack, stacksMap, "helmfile", component)
 			if err != nil {
 				return err
@@ -116,12 +116,12 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 		for stackName := range stacksMap {
 			componentSection,
 				componentVarsSection,
-				_, _, _, _, _, _, _,
+				_, _, _, _, _, _, _, _,
 				err = findComponentConfig(stackName, stacksMap, "terraform", component)
 			if err != nil {
 				componentSection,
 					componentVarsSection,
-					_, _, _, _, _, _, _,
+					_, _, _, _, _, _, _, _,
 					err = findComponentConfig(stackName, stacksMap, "helmfile", component)
 				if err != nil {
 					continue

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -232,7 +232,10 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	var workspaceName string
-	if len(info.BaseComponent) > 0 {
+	if len(info.TerraformWorkspace) > 0 {
+		// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
+		workspaceName = info.TerraformWorkspace
+	} else if len(info.BaseComponent) > 0 {
 		workspaceName = fmt.Sprintf("%s-%s", info.ContextPrefix, info.Component)
 	} else {
 		workspaceName = info.ContextPrefix

--- a/internal/exec/terraform_generate.go
+++ b/internal/exec/terraform_generate.go
@@ -80,7 +80,7 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 			componentBackendSection,
 			componentBackendType,
 			baseComponentName,
-			_, _, _,
+			_, _, _, _,
 			err = findComponentConfig(stack, stacksMap, "terraform", component)
 		if err != nil {
 			return err
@@ -121,7 +121,7 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 				componentBackendSection,
 				componentBackendType,
 				baseComponentName,
-				_, _, _,
+				_, _, _, _,
 				err = findComponentConfig(stackName, stacksMap, "terraform", component)
 			if err != nil {
 				continue

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -103,4 +103,6 @@ type ConfigAndStacksInfo struct {
 	ComponentInheritanceChain []string
 	NeedHelp                  bool
 	ComponentIsAbstract       bool
+	ComponentMetadataSection  map[interface{}]interface{}
+	TerraformWorkspace        string
 }

--- a/pkg/stack/stack_processor_test.go
+++ b/pkg/stack/stack_processor_test.go
@@ -159,6 +159,11 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, "infra/infra-server", infraInfraServerOverrideComponentInheritance[0])
 	assert.Equal(t, "1_override", infraInfraServerOverrideComponentVarsA)
 
+	testTestComponentOverrideComponent3 := terraformComponents["test/test-component-override-3"].(map[interface{}]interface{})
+	testTestComponentOverrideComponent3Metadata := testTestComponentOverrideComponent3["metadata"].(map[interface{}]interface{})
+	testTestComponentOverrideComponent3TerraformWorkspace := testTestComponentOverrideComponent3Metadata["terraform_workspace"]
+	assert.Equal(t, "test-component-override-3-workspace", testTestComponentOverrideComponent3TerraformWorkspace)
+
 	yamlConfig, err := yaml.Marshal(mapConfig1)
 	assert.Nil(t, err)
 	t.Log(string(yamlConfig))


### PR DESCRIPTION
## what
* Allow overriding terraform workspace per component using `metadata.terraform_workspace` attribute

## why
* For backwards compatibility with the old `atmos` versions and some existing stack configs where Terraform workspace was generated by using the names of the stack files (instead of being generated from the `context` as `atmos` `1.x.x` does)
* By explicitly setting the old/existing TF workspace, terraform will not try to recreate those components

## test

```
atmos describe component  test/test-component-override-3 -s=tenant1-ue2-dev
```

```
component: test/test-component
inheritance:
- mixin/test-2
- mixin/test-1
- test/test-component-override-2
- test/test-component-override
- test/test-component
metadata:
  component: test/test-component
  inherits:
  - test/test-component-override
  - test/test-component-override-2
  - mixin/test-1
  - mixin/test-2
  terraform_workspace: test-component-override-3-workspace
```

```
atmos terraform plan test/test-component-override-3 -s=tenant1-ue2-dev
```

```
Command info:
Terraform binary: terraform
Terraform command: plan
Arguments and flags: []
Component: test/test-component-override-3
Terraform component: test/test-component
Inheritance: test/test-component-override-3 -> mixin/test-2 -> mixin/test-1 -> test/test-component-override-2 -> test/test-component-override -> test/test-component
Stack: tenant1/ue2/dev
Working dir: examples/complete/components/terraform/test/test-component

Executing command:
/usr/local/bin/terraform workspace select test-component-override-3-workspace

Workspace "test-component-override-3-workspace" doesn't exist.

You can create this workspace with the "new" subcommand.

Executing command:
/usr/local/bin/terraform workspace new test-component-override-3-workspace
Created and switched to workspace "test-component-override-3-workspace"!

You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
for this configuration.

```


