### PR TITLE
Fix `varfile` and `planfile` names

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -50,10 +50,11 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write variables to a file
-	varFile := fmt.Sprintf("%s-%s-%s.helmfile.vars.yaml", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
+	var varFile string
 	var varFileName string
 
 	if len(info.ComponentFolderPrefix) == 0 {
+		varFile = fmt.Sprintf("%s-%s.helmfile.vars.yaml", info.ContextPrefix, info.Component)
 		varFileName = path.Join(
 			c.Config.BasePath,
 			c.Config.Components.Helmfile.BasePath,
@@ -61,6 +62,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 			varFile,
 		)
 	} else {
+		varFile = fmt.Sprintf("%s-%s-%s.helmfile.vars.yaml", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
 		varFileName = path.Join(
 			c.Config.BasePath,
 			c.Config.Components.Helmfile.BasePath,

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -60,8 +60,16 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 			"with 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
 	}
 
-	varFile := fmt.Sprintf("%s-%s-%s.terraform.tfvars.json", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
-	planFile := fmt.Sprintf("%s-%s-%s.planfile", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
+	var varFile string
+	var planFile string
+
+	if len(info.ComponentFolderPrefix) == 0 {
+		varFile = fmt.Sprintf("%s-%s.terraform.tfvars.json", info.ContextPrefix, info.Component)
+		planFile = fmt.Sprintf("%s-%s.planfile", info.ContextPrefix, info.Component)
+	} else {
+		varFile = fmt.Sprintf("%s-%s-%s.terraform.tfvars.json", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
+		planFile = fmt.Sprintf("%s-%s-%s.planfile", info.ContextPrefix, info.ComponentFolderPrefix, info.Component)
+	}
 
 	if info.SubCommand == "clean" {
 		fmt.Println("Deleting '.terraform' folder")


### PR DESCRIPTION
## what
* Fix `varfile` and `planfile` names

## why
* If components are not in separate sub-folders (just in `component/terraform` or `components/helmfile` top level folders), don't use sub-folders in `varfile` and `planfile` names

