### PR TITLE
Spacelift and Component processors should use the overridden Terraform workspace per component

### DIFF
--- a/examples/complete/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override.yaml
@@ -30,3 +30,7 @@ components:
           val2: "2"
           val3: 3
           val4: null
+      metadata:
+        # Override Terraform workspace
+        # Note that by default, Terraform workspace is generated from the context, e.g. `<environment>-<stage>`
+        terraform_workspace: test-component-override-workspace-override

--- a/pkg/component/component_processor.go
+++ b/pkg/component/component_processor.go
@@ -125,9 +125,18 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 		baseComponentName = baseComponent.(string)
 	}
 
+	// metadata
+	componentMetadata := map[interface{}]interface{}{}
+	if i, ok2 := componentSection["metadata"]; ok2 {
+		componentMetadata = i.(map[interface{}]interface{})
+	}
+
 	// workspace
 	var workspace string
-	if len(baseComponentName) == 0 {
+	// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
+	if componentTerraformWorkspace, componentTerraformWorkspaceExist := componentMetadata["terraform_workspace"].(string); componentTerraformWorkspaceExist {
+		workspace = componentTerraformWorkspace
+	} else if len(baseComponentName) == 0 {
 		workspace = stack
 	} else {
 		workspace = fmt.Sprintf("%s-%s", stack, component)

--- a/pkg/component/component_processor_test.go
+++ b/pkg/component/component_processor_test.go
@@ -82,7 +82,7 @@ func TestComponentProcessor(t *testing.T) {
 	tenant1Ue2DevTestTestComponentOverrideComponentRemoteStateBackendVal2 := tenant1Ue2DevTestTestComponentOverrideComponentRemoteStateBackend["val2"].(string)
 	assert.Equal(t, "test-test-component", tenant1Ue2DevTestTestComponentOverrideComponentBackendWorkspaceKeyPrefix)
 	assert.Equal(t, "test/test-component", tenant1Ue2DevTestTestComponentOverrideComponentBaseComponent)
-	assert.Equal(t, "tenant1-ue2-dev-test-test-component-override", tenant1Ue2DevTestTestComponentOverrideComponentWorkspace)
+	assert.Equal(t, "test-component-override-workspace-override", tenant1Ue2DevTestTestComponentOverrideComponentWorkspace)
 	assert.Equal(t, 11, len(tenant1Ue2DevTestTestComponentOverrideComponentDeps))
 	assert.Equal(t, "catalog/terraform/services/service-1", tenant1Ue2DevTestTestComponentOverrideComponentDeps[0])
 	assert.Equal(t, "catalog/terraform/services/service-1-override", tenant1Ue2DevTestTestComponentOverrideComponentDeps[1])

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -381,9 +381,19 @@ func TransformStackConfigToSpaceliftStacks(
 					}
 					spaceliftConfig["backend"] = componentBackend
 
+					// metadata
+					componentMetadata := map[interface{}]interface{}{}
+					if i, ok2 := componentMap["metadata"]; ok2 {
+						componentMetadata = i.(map[interface{}]interface{})
+					}
+					spaceliftConfig["metadata"] = componentMetadata
+
 					// workspace
 					var workspace string
-					if backendTypeName == "s3" && baseComponentName == "" {
+					// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
+					if componentTerraformWorkspace, componentTerraformWorkspaceExist := componentMetadata["terraform_workspace"].(string); componentTerraformWorkspaceExist {
+						workspace = componentTerraformWorkspace
+					} else if backendTypeName == "s3" && baseComponentName == "" {
 						workspace = contextPrefix
 					} else {
 						workspace = fmt.Sprintf("%s-%s", contextPrefix, component)

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -31,6 +31,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 	tenant1Ue2DevTestTestComponentOverrideComponentBackendWorkspaceKeyPrefix := tenant1Ue2DevTestTestComponentOverrideComponentBackend["workspace_key_prefix"].(string)
 	tenant1Ue2DevTestTestComponentOverrideComponentDeps := tenant1Ue2DevTestTestComponentOverrideComponent["deps"].([]string)
 	tenant1Ue2DevTestTestComponentOverrideComponentLabels := tenant1Ue2DevTestTestComponentOverrideComponent["labels"].([]string)
+	tenant1Ue2DevTestTestComponentOverrideTerraformWorkspace := tenant1Ue2DevTestTestComponentOverrideComponent["workspace"]
 	assert.Equal(t, "tenant1-ue2-dev", tenant1Ue2DevTestTestComponentOverrideComponentInfrastructureStackName)
 	assert.Equal(t, "test-test-component", tenant1Ue2DevTestTestComponentOverrideComponentBackendWorkspaceKeyPrefix)
 	assert.Equal(t, "test/test-component", tenant1Ue2DevTestTestComponentOverrideComponentBaseComponent)
@@ -58,6 +59,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 	assert.Equal(t, "deps:stacks/tenant1/ue2/dev.yaml", tenant1Ue2DevTestTestComponentOverrideComponentLabels[33])
 	assert.Equal(t, "folder:component/test/test-component-override", tenant1Ue2DevTestTestComponentOverrideComponentLabels[34])
 	assert.Equal(t, "folder:tenant1/ue2/dev", tenant1Ue2DevTestTestComponentOverrideComponentLabels[35])
+	assert.Equal(t, "test-component-override-workspace-override", tenant1Ue2DevTestTestComponentOverrideTerraformWorkspace)
 
 	yamlSpaceliftStacks, err := yaml.Marshal(spaceliftStacks)
 	assert.Nil(t, err)


### PR DESCRIPTION
## what
* Spacelift and Component processors should use the overridden Terraform workspace per component

## why
* Terraform workspace override was added to Terraform stacks processor in in https://github.com/cloudposse/atmos/pull/104 (so it worked in `atmos`), but Spacelift and Component processors were not updated.
