### PR TITLE
Send errors to std.Error. Better error handling

### DIFF
--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // describeComponentCmd describes configuration for components
@@ -16,8 +15,7 @@ var describeComponentCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeComponent(cmd, args)
 		if err != nil {
-			color.Red("%s\n\n", err)
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }
@@ -28,8 +26,7 @@ func init() {
 
 	err := describeComponentCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {
-		color.Red("%s\n\n", err)
-		os.Exit(1)
+		u.PrintErrorToStdErrorAndExit(err)
 	}
 
 	describeCmd.AddCommand(describeComponentCmd)

--- a/cmd/describe_config.go
+++ b/cmd/describe_config.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // describeComponentCmd describes configuration for components
@@ -17,9 +15,7 @@ var describeConfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeConfig(cmd, args)
 		if err != nil {
-			color.Red("%s\n", err)
-			fmt.Println()
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -16,8 +15,7 @@ var helmfileCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteHelmfile(cmd, args)
 		if err != nil {
-			color.Red("%s\n\n", err)
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -16,8 +15,7 @@ var terraformCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteTerraform(cmd, args)
 		if err != nil {
-			color.Red("%s\n\n", err)
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -4,7 +4,6 @@ import (
 	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -17,7 +16,11 @@ var terraformCmd = &cobra.Command{
 		err := e.ExecuteTerraform(cmd, args)
 		if err != nil {
 			color.Red("%s\n\n", err)
-			os.Exit(1)
+			//_, err2 := fmt.Fprintf(os.Stderr, err.Error())
+			//if err2 != nil {
+			//	color.Red("%s\n\n", err2)
+			//}
+			// os.Exit(1)
 		}
 	},
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -4,6 +4,7 @@ import (
 	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // terraformCmd represents the base command for all terraform sub-commands
@@ -16,11 +17,7 @@ var terraformCmd = &cobra.Command{
 		err := e.ExecuteTerraform(cmd, args)
 		if err != nil {
 			color.Red("%s\n\n", err)
-			//_, err2 := fmt.Fprintf(os.Stderr, err.Error())
-			//if err2 != nil {
-			//	color.Red("%s\n\n", err2)
-			//}
-			// os.Exit(1)
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/terraform_generate_backend.go
+++ b/cmd/terraform_generate_backend.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // terraformGenerateBackendCmd generates backend config for a terraform components
@@ -16,8 +15,7 @@ var terraformGenerateBackendCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteTerraformGenerateBackend(cmd, args)
 		if err != nil {
-			color.Red("%s\n\n", err)
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }
@@ -28,8 +26,7 @@ func init() {
 
 	err := terraformGenerateBackendCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {
-		color.Red("%s\n\n", err)
-		os.Exit(1)
+		u.PrintErrorToStdErrorAndExit(err)
 	}
 
 	terraformGenerateCmd.AddCommand(terraformGenerateBackendCmd)

--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // terraformGenerateBackendsCmd generates backend configs for all terraform components
@@ -16,8 +15,7 @@ var terraformGenerateBackendsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteTerraformGenerateBackends(cmd, args)
 		if err != nil {
-			color.Red("%s\n\n", err)
-			os.Exit(1)
+			u.PrintErrorToStdErrorAndExit(err)
 		}
 	},
 }
@@ -28,8 +26,7 @@ func init() {
 
 	err := terraformGenerateBackendsCmd.MarkPersistentFlagRequired("stack")
 	if err != nil {
-		color.Red("%s\n\n", err)
-		os.Exit(1)
+		u.PrintErrorToStdErrorAndExit(err)
 	}
 
 	// terraformGenerateCmd.AddCommand(terraformGenerateBackendsCmd)

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -579,7 +579,7 @@ func execCommand(command string, args []string, dir string, env []string) error 
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	fmt.Println()
 	color.Cyan("Executing command:\n")

--- a/main.go
+++ b/main.go
@@ -1,16 +1,13 @@
 package main
 
 import (
-	"os"
-
 	"github.com/cloudposse/atmos/cmd"
-	"github.com/fatih/color"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 func main() {
 	err := cmd.Execute()
 	if err != nil {
-		color.Red("%s", err)
-		os.Exit(1)
+		u.PrintErrorToStdErrorAndExit(err)
 	}
 }

--- a/pkg/utils/os_utils.go
+++ b/pkg/utils/os_utils.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"os"
+)
+
+// PrintErrorToStdErrorAndExit prints errors to std.Error and exits with an error code
+func PrintErrorToStdErrorAndExit(err error) {
+	if err != nil {
+		c := color.New(color.FgRed)
+		_, err2 := c.Fprintln(color.Error, err.Error()+"\n")
+		if err2 != nil {
+			fmt.Println("Error sending the error message to std.Error:")
+			PrintError(err2)
+			fmt.Println("Original error message:")
+			PrintError(err)
+		}
+		os.Exit(1)
+	}
+}
+
+// PrintError prints errors to std.Output
+func PrintError(err error) {
+	if err != nil {
+		color.Red("%s\n\n", err)
+	}
+}


### PR DESCRIPTION
## what
* Send errors to `std.Error`
* Better error handling

## why
* In CI/CD systems we usually disable `std.Output` (to not print all the info to the logs), but want to see the errors printed to `std.Error`
* Put all error handling in separate functions in utils - DRY code

## references
* Closes https://github.com/cloudposse/atmos/issues/112