### PR TITLE
Fix component path prefix if base component provided

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudposse/atmos
 
-go 1.16
+go 1.17
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2
@@ -13,4 +13,28 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -356,33 +356,38 @@ func processConfigAndStacks(componentType string, cmd *cobra.Command, args []str
 		configAndStacksInfo.Command = componentType
 	}
 
+	// Print component variables
 	color.Cyan("\nVariables for the component '%s' in the stack '%s':\n\n", configAndStacksInfo.ComponentFromArg, configAndStacksInfo.Stack)
 	err = utils.PrintAsYAML(configAndStacksInfo.ComponentVarsSection)
 	if err != nil {
 		return configAndStacksInfo, err
 	}
 
+	fmt.Println(configAndStacksInfo.ComponentFromArg)
+	fmt.Println(configAndStacksInfo.BaseComponentPath)
+
+	// Process component path and name
 	configAndStacksInfo.ComponentFolderPrefix = ""
-	configAndStacksInfo.ComponentNamePrefix = ""
-
-	finalComponentPathParts := strings.Split(configAndStacksInfo.ComponentFromArg, "/")
-	finalComponentPathPartsLength := len(finalComponentPathParts)
-
-	if finalComponentPathPartsLength > 1 {
-		componentFromArgPartsWithoutLast := finalComponentPathParts[:finalComponentPathPartsLength-1]
+	componentPathParts := strings.Split(configAndStacksInfo.ComponentFromArg, "/")
+	componentPathPartsLength := len(componentPathParts)
+	if componentPathPartsLength > 1 {
+		componentFromArgPartsWithoutLast := componentPathParts[:componentPathPartsLength-1]
 		configAndStacksInfo.ComponentFolderPrefix = strings.Join(componentFromArgPartsWithoutLast, "/")
-		configAndStacksInfo.ComponentNamePrefix = strings.Join(componentFromArgPartsWithoutLast, "-")
-		configAndStacksInfo.Component = finalComponentPathParts[finalComponentPathPartsLength-1]
+		configAndStacksInfo.Component = componentPathParts[componentPathPartsLength-1]
 	} else {
 		configAndStacksInfo.Component = configAndStacksInfo.ComponentFromArg
 	}
 
+	// Process base component path and name
 	if len(configAndStacksInfo.BaseComponentPath) > 0 {
 		baseComponentPathParts := strings.Split(configAndStacksInfo.BaseComponentPath, "/")
 		baseComponentPathPartsLength := len(baseComponentPathParts)
 		if baseComponentPathPartsLength > 1 {
+			baseComponentFromArgPartsWithoutLast := baseComponentPathParts[:componentPathPartsLength-1]
+			configAndStacksInfo.ComponentFolderPrefix = strings.Join(baseComponentFromArgPartsWithoutLast, "/")
 			configAndStacksInfo.BaseComponent = baseComponentPathParts[baseComponentPathPartsLength-1]
 		} else {
+			configAndStacksInfo.ComponentFolderPrefix = ""
 			configAndStacksInfo.BaseComponent = configAndStacksInfo.BaseComponentPath
 		}
 	}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -77,7 +77,6 @@ type ConfigAndStacksInfo struct {
 	Stack                     string
 	ComponentFromArg          string
 	ComponentFolderPrefix     string
-	ComponentNamePrefix       string
 	Component                 string
 	BaseComponentPath         string
 	BaseComponent             string


### PR DESCRIPTION
## what
* Fix component path prefix if base component is provided
* Update `Go` version
 
## why
* If a component config is a derived component and a base component is specified (which points to the terraform component), don't derive the terraform component path from the derived component, use the base component instead

* In the YAML config like this

```
    eks-example/eks:
      metadata:
        component: eks/eks
        inherits:
          - eks/eks
```

 `eks/eks` is the real terraform component (where the code is defined)
`eks-example/eks` is just the name of the derived component (not related to any real file paths)

The following error was thrown (because the code tried to derive the folder path prefix from the `eks-example/eks` component config, not from the `eks/eks` base terraform component, resulting in the subfolder `eks-example` which does not exist):


```
Component 'eks' does not exist in 'components/terraform/eks-example'
```
