### PR TITLE
Add workflows

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -13,7 +13,7 @@
 # Supports both absolute and relative paths.
 # If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
 # are independent settings (supporting both absolute and relative paths).
-# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
 # are considered paths relative to `base_path`.
 base_path: "./examples/complete"
 
@@ -53,6 +53,11 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
 
 logs:
   verbose: false

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	e "github.com/cloudposse/atmos/internal/exec"
+	u "github.com/cloudposse/atmos/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// workflowCmd executes a workflow
+var workflowCmd = &cobra.Command{
+	Use:                "workflow",
+	Short:              "Execute a workflow",
+	Long:               `This command executes a workflow: atmos workflow <name> -f <file>`,
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := e.ExecuteWorkflow(cmd, args)
+		if err != nil {
+			u.PrintErrorToStdErrorAndExit(err)
+		}
+	},
+}
+
+func init() {
+	workflowCmd.DisableFlagParsing = false
+	workflowCmd.PersistentFlags().StringP("file", "f", "", "atmos workflow <name> -f <file>")
+
+	err := workflowCmd.MarkPersistentFlagRequired("file")
+	if err != nil {
+		u.PrintErrorToStdErrorAndExit(err)
+	}
+
+	RootCmd.AddCommand(workflowCmd)
+}

--- a/examples/complete/atmos.yaml
+++ b/examples/complete/atmos.yaml
@@ -13,7 +13,7 @@
 # Supports both absolute and relative paths.
 # If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
 # are independent settings (supporting both absolute and relative paths).
-# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
 # are considered paths relative to `base_path`.
 base_path: "."
 
@@ -53,6 +53,11 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
 
 logs:
   verbose: false

--- a/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/examples/complete/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -13,7 +13,7 @@
 # Supports both absolute and relative paths.
 # If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
 # are independent settings (supporting both absolute and relative paths).
-# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
 # are considered paths relative to `base_path`.
 base_path: "/"
 
@@ -53,6 +53,11 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
 
 logs:
   verbose: false

--- a/examples/complete/workflows/workflow1.yaml
+++ b/examples/complete/workflows/workflow1.yaml
@@ -14,6 +14,7 @@ workflows:
     description: Run 'terraform plan' on 'test/test-component-override-3' component in all stacks
     steps:
       - command: terraform plan test/test-component-override-3
+        # The step `stack` attribute overrides any stack in the `command` (if specified)
         stack: tenant1-ue2-dev
       - command: terraform plan test/test-component-override-3
         stack: tenant1-ue2-staging
@@ -28,6 +29,8 @@ workflows:
 
   terraform-plan-all-tenant1-ue2-dev:
     description: Run 'terraform plan' on all components in the 'tenant1-ue2-dev' stack
+    # The workflow `stack` attribute overrides any stack in the `command` (if specified)
+    # The step `stack` attribute overrides any stack in the `command` (if specified) and the workflow `stack` attribute
     stack: tenant1-ue2-dev
     steps:
       - command: echo Running terraform plan on the component 'test/test-component' in the stack 'tenant1-ue2-dev'

--- a/examples/complete/workflows/workflow1.yaml
+++ b/examples/complete/workflows/workflow1.yaml
@@ -1,0 +1,50 @@
+workflows:
+
+  terraform-plan-test-component-override-2-all-stacks:
+    description: Run 'terraform plan' on 'test/test-component-override-2' component in all stacks
+    steps:
+      - command: terraform plan test/test-component-override-3 -s tenant1-ue2-dev
+      - command: terraform plan test/test-component-override-3 -s tenant1-ue2-staging
+      - command: terraform plan test/test-component-override-3 -s tenant1-ue2-prod
+      - command: terraform plan test/test-component-override-3 -s tenant2-ue2-dev
+      - command: terraform plan test/test-component-override-3 -s tenant2-ue2-staging
+      - command: terraform plan test/test-component-override-3 -s tenant2-ue2-prod
+
+  terraform-plan-test-component-override-3-all-stacks:
+    description: Run 'terraform plan' on 'test/test-component-override-3' component in all stacks
+    steps:
+      - command: terraform plan test/test-component-override-3
+        stack: tenant1-ue2-dev
+      - command: terraform plan test/test-component-override-3
+        stack: tenant1-ue2-staging
+      - command: terraform plan test/test-component-override-3
+        stack: tenant1-ue2-prod
+      - command: terraform plan test/test-component-override-3
+        stack: tenant2-ue2-dev
+      - command: terraform plan test/test-component-override-3
+        stack: tenant2-ue2-staging
+      - command: terraform plan test/test-component-override-3
+        stack: tenant2-ue2-prod
+
+  terraform-plan-all-tenant1-ue2-dev:
+    description: Run 'terraform plan' on all components in the 'tenant1-ue2-dev' stack
+    stack: tenant1-ue2-dev
+    steps:
+      - command: echo "Running terraform plan on the component 'test/test-component' in the stack 'tenant1-ue2-dev'
+        type: shell
+      - command: terraform plan test/test-component
+        # Type `atmos` is implicit, you don't have to specify it
+        # Other supported types: 'shell'
+        type: atmos
+      - command: echo "Running terraform plan on the component 'test/test-component-override' in the stack 'tenant1-ue2-dev'
+        type: shell
+      - command: terraform plan test/test-component-override
+        type: atmos
+      - command: echo "Running terraform plan on the component 'test/test-component-override-2' in the stack 'tenant1-ue2-dev'
+        type: shell
+      - command: terraform plan test/test-component-override-2
+        type: atmos
+      - command: echo "Running terraform plan on the component 'test/test-component-override-3' in the stack 'tenant1-ue2-dev'
+        type: shell
+      - command: terraform plan test/test-component-override-3
+        type: atmos

--- a/examples/complete/workflows/workflow1.yaml
+++ b/examples/complete/workflows/workflow1.yaml
@@ -30,21 +30,21 @@ workflows:
     description: Run 'terraform plan' on all components in the 'tenant1-ue2-dev' stack
     stack: tenant1-ue2-dev
     steps:
-      - command: echo "Running terraform plan on the component 'test/test-component' in the stack 'tenant1-ue2-dev'
+      - command: echo Running terraform plan on the component 'test/test-component' in the stack 'tenant1-ue2-dev'
         type: shell
       - command: terraform plan test/test-component
         # Type `atmos` is implicit, you don't have to specify it
         # Other supported types: 'shell'
         type: atmos
-      - command: echo "Running terraform plan on the component 'test/test-component-override' in the stack 'tenant1-ue2-dev'
+      - command: echo Running terraform plan on the component 'test/test-component-override' in the stack 'tenant1-ue2-dev'
         type: shell
       - command: terraform plan test/test-component-override
         type: atmos
-      - command: echo "Running terraform plan on the component 'test/test-component-override-2' in the stack 'tenant1-ue2-dev'
+      - command: echo Running terraform plan on the component 'test/test-component-override-2' in the stack 'tenant1-ue2-dev'
         type: shell
       - command: terraform plan test/test-component-override-2
         type: atmos
-      - command: echo "Running terraform plan on the component 'test/test-component-override-3' in the stack 'tenant1-ue2-dev'
+      - command: echo Running terraform plan on the component 'test/test-component-override-3' in the stack 'tenant1-ue2-dev'
         type: shell
       - command: terraform plan test/test-component-override-3
         type: atmos
@@ -52,12 +52,13 @@ workflows:
   test-1:
     description: Test workflow
     steps:
-      - command: echo "Command 1"
+      - command: echo Command 1
         type: shell
-      - command: echo "Command 2"
+      - command: echo Command 2
         type: shell
-      - command: echo "Command 3"
+      - command: echo Command 3
         type: shell
-      - command: echo "Command 4"
+      - command: echo Command 4
         type: shell
-      - command: echo "Command 5"
+      - command: echo Command 5
+        type: shell

--- a/examples/complete/workflows/workflow1.yaml
+++ b/examples/complete/workflows/workflow1.yaml
@@ -48,3 +48,16 @@ workflows:
         type: shell
       - command: terraform plan test/test-component-override-3
         type: atmos
+
+  test-1:
+    description: Test workflow
+    steps:
+      - command: echo "Command 1"
+        type: shell
+      - command: echo "Command 2"
+        type: shell
+      - command: echo "Command 3"
+        type: shell
+      - command: echo "Command 4"
+        type: shell
+      - command: echo "Command 5"

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -170,6 +170,7 @@ func processArgsConfigAndStacks(componentType string, cmd *cobra.Command, args [
 	configAndStacksInfo.HelmfileDir = argsAndFlagsInfo.HelmfileDir
 	configAndStacksInfo.StacksDir = argsAndFlagsInfo.StacksDir
 	configAndStacksInfo.ConfigDir = argsAndFlagsInfo.ConfigDir
+	configAndStacksInfo.WorkflowsDir = argsAndFlagsInfo.WorkflowsDir
 	configAndStacksInfo.DeployRunInit = argsAndFlagsInfo.DeployRunInit
 	configAndStacksInfo.AutoGenerateBackendFile = argsAndFlagsInfo.AutoGenerateBackendFile
 	configAndStacksInfo.UseTerraformPlan = argsAndFlagsInfo.UseTerraformPlan
@@ -536,6 +537,19 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 				return info, errors.New(fmt.Sprintf("invalid flag: %s", arg))
 			}
 			info.AutoGenerateBackendFile = autoGenerateBackendFileFlagParts[1]
+		}
+
+		if arg == g.WorkflowDirFlag {
+			if len(inputArgsAndFlags) <= (i + 1) {
+				return info, errors.New(fmt.Sprintf("invalid flag: %s", arg))
+			}
+			info.WorkflowsDir = inputArgsAndFlags[i+1]
+		} else if strings.HasPrefix(arg+"=", g.WorkflowDirFlag) {
+			var workflowDirFlagParts = strings.Split(arg, "=")
+			if len(workflowDirFlagParts) != 2 {
+				return info, errors.New(fmt.Sprintf("invalid flag: %s", arg))
+			}
+			info.WorkflowsDir = workflowDirFlagParts[1]
 		}
 
 		if arg == g.FromPlanFlag {

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -64,7 +64,7 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	}
 
 	if i, ok := yamlContent["workflows"]; !ok {
-		return errors.New("a workflow file must be a map with top-level 'workflows' key")
+		return errors.New("a workflow file must be a map with top-level 'workflows:' key")
 	} else {
 		workflowConfig = i
 	}
@@ -81,6 +81,11 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	err = u.PrintAsYAML(workflowDefinition)
+	if err != nil {
+		return err
+	}
+
+	err = executeWorkflowSteps(workflowDefinition)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -3,14 +3,22 @@ package exec
 import (
 	"errors"
 	"fmt"
+	c "github.com/cloudposse/atmos/pkg/config"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"path"
 )
 
 // ExecuteWorkflow executes a workflow
 func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("invalid arguments. The command requires one argument `workflow name` and one flag `file name`")
+	}
+
+	err := c.InitConfig()
+	if err != nil {
+		return err
 	}
 
 	flags := cmd.Flags()
@@ -22,7 +30,18 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 
 	workflow := args[0]
 
-	color.Cyan("Executing the workflow '%s' from the file '%s'\n", workflow, workflowFile)
+	var workflowPath string
+	if u.IsPathAbsolute(workflowFile) {
+		workflowPath = workflowFile
+	} else {
+		workflowPath = path.Join(c.Config.Workflows.BasePath, workflowFile)
+	}
+
+	if !u.FileExists(workflowPath) {
+		return errors.New(fmt.Sprintf("File '%s' does not exist", workflowPath))
+	}
+
+	color.Cyan("Executing the workflow '%s' from the file '%s'\n", workflow, workflowPath)
 
 	fmt.Println()
 	return nil

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -4,10 +4,14 @@ import (
 	"errors"
 	"fmt"
 	c "github.com/cloudposse/atmos/pkg/config"
+	g "github.com/cloudposse/atmos/pkg/globals"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"path"
+	"path/filepath"
 )
 
 // ExecuteWorkflow executes a workflow
@@ -28,20 +32,58 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	workflow := args[0]
-
 	var workflowPath string
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile
 	} else {
-		workflowPath = path.Join(c.Config.Workflows.BasePath, workflowFile)
+		workflowPath = path.Join(c.Config.BasePath, c.Config.Workflows.BasePath, workflowFile)
+	}
+
+	// If the file is specified without an extension, use the default extension
+	ext := filepath.Ext(workflowPath)
+	if ext == "" {
+		ext = g.DefaultStackConfigFileExtension
+		workflowPath = workflowPath + ext
 	}
 
 	if !u.FileExists(workflowPath) {
 		return errors.New(fmt.Sprintf("File '%s' does not exist", workflowPath))
 	}
 
-	color.Cyan("Executing the workflow '%s' from the file '%s'\n", workflow, workflowPath)
+	fileContent, err := ioutil.ReadFile(workflowPath)
+	if err != nil {
+		return err
+	}
+
+	var yamlContent c.WorkflowFile
+	var workflowConfig c.WorkflowConfig
+	var workflowDefinition c.WorkflowDefinition
+
+	if err = yaml.Unmarshal(fileContent, &yamlContent); err != nil {
+		return err
+	}
+
+	if i, ok := yamlContent["workflows"]; !ok {
+		return errors.New("a workflow file must be a map with top-level 'workflows' key")
+	} else {
+		workflowConfig = i
+	}
+
+	workflow := args[0]
+
+	if i, ok := workflowConfig[workflow]; !ok {
+		return errors.New(fmt.Sprintf("the file '%s' does not have the '%s' workflow defined", workflowPath, workflow))
+	} else {
+		workflowDefinition = i
+	}
+
+	color.Cyan("\nExecuting the workflow '%s' from '%s'\n", workflow, workflowPath)
+	fmt.Println()
+
+	err = u.PrintAsYAML(workflowDefinition)
+	if err != nil {
+		return err
+	}
 
 	fmt.Println()
 	return nil

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -1,0 +1,29 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// ExecuteWorkflow executes a workflow
+func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("invalid arguments. The command requires one argument `workflow name` and one flag `file name`")
+	}
+
+	flags := cmd.Flags()
+
+	workflowFile, err := flags.GetString("file")
+	if err != nil {
+		return err
+	}
+
+	workflow := args[0]
+
+	color.Cyan("Executing the workflow '%s' from the file '%s'\n", workflow, workflowFile)
+
+	fmt.Println()
+	return nil
+}

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -1,0 +1,1 @@
+package exec

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -19,8 +19,6 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 			commandType = "atmos"
 		}
 
-		color.HiCyan(fmt.Sprintf("Executing workflow step: %s", command))
-
 		if commandType == "shell" {
 			args := strings.Fields(command)
 			if err := execCommand(args[0], args[1:], ".", []string{}); err != nil {
@@ -33,15 +31,19 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 			var stepStack = strings.TrimSpace(step.Stack)
 			var finalStack = ""
 
-			if stepStack != "" {
-				args = append(args, []string{"-s", stepStack}...)
-				finalStack = stepStack
-			} else if workflowStack != "" {
-				args = append(args, []string{"-s", workflowStack}...)
+			color.HiCyan(fmt.Sprintf("Executing workflow step: %s", command))
+
+			// The workflow `stack` attribute overrides any stack in the `command` (if specified)
+			// The step `stack` attribute overrides any stack in the `command` (if specified) and the workflow `stack` attribute
+			if workflowStack != "" {
 				finalStack = workflowStack
+			}
+			if stepStack != "" {
+				finalStack = stepStack
 			}
 
 			if finalStack != "" {
+				args = append(args, []string{"-s", finalStack}...)
 				color.HiCyan(fmt.Sprintf("Stack: %s", finalStack))
 			}
 

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -12,14 +12,14 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 	var steps = workflowDefinition.Steps
 
 	for _, step := range steps {
-		var command = step.Command
-		var commandType = step.Type
+		var command = strings.TrimSpace(step.Command)
+		var commandType = strings.TrimSpace(step.Type)
 
 		if commandType == "" {
 			commandType = "atmos"
 		}
 
-		color.Cyan(fmt.Sprintf("Executing workflow step: %s", command))
+		color.HiCyan(fmt.Sprintf("Executing workflow step: %s", command))
 
 		if commandType == "shell" {
 			args := strings.Fields(command)
@@ -28,11 +28,28 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 			}
 		} else if commandType == "atmos" {
 			args := strings.Fields(command)
+
+			var workflowStack = strings.TrimSpace(workflowDefinition.Stack)
+			var stepStack = strings.TrimSpace(step.Stack)
+			var finalStack = ""
+
+			if stepStack != "" {
+				args = append(args, []string{"-s", stepStack}...)
+				finalStack = stepStack
+			} else if workflowStack != "" {
+				args = append(args, []string{"-s", workflowStack}...)
+				finalStack = workflowStack
+			}
+
+			if finalStack != "" {
+				color.HiCyan(fmt.Sprintf("Stack: %s", finalStack))
+			}
+
 			if err := execCommand("atmos", args, ".", []string{}); err != nil {
 				return err
 			}
 		} else {
-			return errors.New(fmt.Sprintf("invalid workflow step type '%s'", commandType))
+			return errors.New(fmt.Sprintf("invalid workflow step type '%s'. Supported types are 'atmos' and 'shell'", commandType))
 		}
 
 		fmt.Println()

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -1,1 +1,31 @@
 package exec
+
+import (
+	"fmt"
+	c "github.com/cloudposse/atmos/pkg/config"
+	"github.com/fatih/color"
+	"strings"
+)
+
+func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
+	var steps = workflowDefinition.Steps
+
+	for _, step := range steps {
+		var command = step.Command
+		var commandType = step.Type
+
+		color.Cyan(fmt.Sprintf("Executing workflow step: %s", command))
+
+		if commandType == "shell" {
+			args := strings.Fields(command)
+			err := execCommand(args[0], args[1:], ".", []string{})
+			if err != nil {
+				return err
+			}
+		}
+
+		fmt.Println()
+	}
+
+	return nil
+}

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	c "github.com/cloudposse/atmos/pkg/config"
 	"github.com/fatih/color"
@@ -18,10 +19,13 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 
 		if commandType == "shell" {
 			args := strings.Fields(command)
-			err := execCommand(args[0], args[1:], ".", []string{})
-			if err != nil {
+			if err := execCommand(args[0], args[1:], ".", []string{}); err != nil {
 				return err
 			}
+		} else if commandType == "atmos" {
+
+		} else {
+			return errors.New(fmt.Sprintf("invalid workflow step type '%s'", commandType))
 		}
 
 		fmt.Println()

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -15,6 +15,10 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 		var command = step.Command
 		var commandType = step.Type
 
+		if commandType == "" {
+			commandType = "atmos"
+		}
+
 		color.Cyan(fmt.Sprintf("Executing workflow step: %s", command))
 
 		if commandType == "shell" {
@@ -23,7 +27,10 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 				return err
 			}
 		} else if commandType == "atmos" {
-
+			args := strings.Fields(command)
+			if err := execCommand("atmos", args, ".", []string{}); err != nil {
+				return err
+			}
 		} else {
 			return errors.New(fmt.Sprintf("invalid workflow step type '%s'", commandType))
 		}

--- a/pkg/component/atmos.yaml
+++ b/pkg/component/atmos.yaml
@@ -13,7 +13,7 @@
 # Supports both absolute and relative paths.
 # If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
 # are independent settings (supporting both absolute and relative paths).
-# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
 # are considered paths relative to `base_path`.
 base_path: "../../examples/complete"
 
@@ -53,6 +53,11 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
 
 logs:
   verbose: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,9 @@ var (
 				"**/*globals*",
 			},
 		},
+		Workflows: Workflows{
+			BasePath: "workflows",
+		},
 		Logs: Logs{
 			Verbose: false,
 			Colors:  true,

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -26,6 +26,10 @@ type Stacks struct {
 	NamePattern   string   `yaml:"name_pattern" json:"name_pattern" mapstructure:"name_pattern"`
 }
 
+type Workflows struct {
+	BasePath string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
+}
+
 type Logs struct {
 	Verbose bool `yaml:"verbose" json:"verbose" mapstructure:"verbose"`
 	Colors  bool `yaml:"colors" json:"colors" mapstructure:"colors"`
@@ -35,6 +39,7 @@ type Configuration struct {
 	BasePath   string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
 	Components Components
 	Stacks     Stacks
+	Workflows  Workflows
 	Logs       Logs
 }
 
@@ -66,6 +71,7 @@ type ArgsAndFlagsInfo struct {
 	HelmfileDir             string
 	ConfigDir               string
 	StacksDir               string
+	WorkflowsDir            string
 	BasePath                string
 	DeployRunInit           string
 	AutoGenerateBackendFile string
@@ -98,6 +104,7 @@ type ConfigAndStacksInfo struct {
 	HelmfileDir               string
 	ConfigDir                 string
 	StacksDir                 string
+	WorkflowsDir              string
 	Context                   Context
 	ContextPrefix             string
 	DeployRunInit             string

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -123,7 +123,11 @@ type WorkflowStep struct {
 	Type    string `yaml:"type" json:"type" mapstructure:"type"`
 }
 
-type Workflow struct {
+type WorkflowDefinition struct {
 	Description string         `yaml:"description" json:"description" mapstructure:"description"`
 	Steps       []WorkflowStep `yaml:"steps" json:"steps" mapstructure:"steps"`
 }
+
+type WorkflowConfig map[string]WorkflowDefinition
+
+type WorkflowFile map[string]WorkflowConfig

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -116,3 +116,14 @@ type ConfigAndStacksInfo struct {
 	ComponentMetadataSection  map[interface{}]interface{}
 	TerraformWorkspace        string
 }
+
+type WorkflowStep struct {
+	Command string `yaml:"command" json:"command" mapstructure:"command"`
+	Stack   string `yaml:"stack" json:"stack" mapstructure:"stack"`
+	Type    string `yaml:"type" json:"type" mapstructure:"type"`
+}
+
+type Workflow struct {
+	Description string         `yaml:"description" json:"description" mapstructure:"description"`
+	Steps       []WorkflowStep `yaml:"steps" json:"steps" mapstructure:"steps"`
+}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -126,6 +126,7 @@ type WorkflowStep struct {
 type WorkflowDefinition struct {
 	Description string         `yaml:"description" json:"description" mapstructure:"description"`
 	Steps       []WorkflowStep `yaml:"steps" json:"steps" mapstructure:"steps"`
+	Stack       string         `yaml:"stack" json:"stack" mapstructure:"stack"`
 }
 
 type WorkflowConfig map[string]WorkflowDefinition

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -232,6 +232,12 @@ func processEnvVars() error {
 		Config.Components.Helmfile.ClusterNamePattern = componentsHelmfileClusterNamePattern
 	}
 
+	workflowsBasePath := os.Getenv("ATMOS_WORKFLOWS_BASE_PATH")
+	if len(workflowsBasePath) > 0 {
+		color.Cyan("Found ENV var ATMOS_WORKFLOWS_BASE_PATH=%s", workflowsBasePath)
+		Config.Workflows.BasePath = workflowsBasePath
+	}
+
 	return nil
 }
 
@@ -283,6 +289,10 @@ func processCommandLineArgs(configAndStacksInfo ConfigAndStacksInfo) error {
 		}
 		Config.Components.Terraform.AutoGenerateBackendFile = autoGenerateBackendFileBool
 		color.Cyan(fmt.Sprintf("Using command line argument '%s=%s'", g.AutoGenerateBackendFileFlag, configAndStacksInfo.AutoGenerateBackendFile))
+	}
+	if len(configAndStacksInfo.WorkflowsDir) > 0 {
+		Config.Workflows.BasePath = configAndStacksInfo.WorkflowsDir
+		color.Cyan(fmt.Sprintf("Using command line argument '%s' as workflows directory", configAndStacksInfo.WorkflowsDir))
 	}
 	return nil
 }

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -15,6 +15,7 @@ const (
 	ConfigDirFlag    = "--config-dir"
 	StackDirFlag     = "--stacks-dir"
 	BasePathFlag     = "--base-path"
+	WorkflowDirFlag  = "--workflows-dir"
 
 	DeployRunInitFlag           = "--deploy-run-init"
 	AutoGenerateBackendFileFlag = "--auto-generate-backend-file"

--- a/pkg/spacelift/atmos.yaml
+++ b/pkg/spacelift/atmos.yaml
@@ -13,7 +13,7 @@
 # Supports both absolute and relative paths.
 # If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
 # are independent settings (supporting both absolute and relative paths).
-# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
 # are considered paths relative to `base_path`.
 base_path: "../../examples/complete"
 
@@ -53,6 +53,11 @@ stacks:
     - "**/*globals*"
   # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
   name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
 
 logs:
   verbose: false

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -62,3 +62,7 @@ func JoinAbsolutePathWithPaths(basePath string, paths []string) ([]string, error
 func TrimBasePathFromPath(basePath string, path string) string {
 	return strings.TrimPrefix(path, basePath)
 }
+
+func IsPathAbsolute(path string) bool {
+	return filepath.IsAbs(path)
+}


### PR DESCRIPTION
## what
* Add workflows
* Define workflows in YAML
* Support two types of workflows: `atmos` and `shell`
* Allow specifying the atmos stack in 3 different ways:
  - on the command line in the `command` attribute in the workflow steps
  - as `stack` attribute in each workflow step
  - as `stack` attribute in the workflow itself

## why
* Allow sequential execution of `atmos` and `shell` commands 
