### PR TITLE
Add `--dry-run` command-line flag to all commands and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Short versions of the command-line arguments can be used:
     atmos terraform apply eks -s ue2-dev
   ```
 
-To execute `plan` and `apply` in one step, use `terrafrom deploy` command:
+To execute `plan` and `apply` in one step, use `terraform deploy` command:
 
   ```bash
     atmos terraform deploy eks -s ue2-dev

--- a/README.yaml
+++ b/README.yaml
@@ -284,7 +284,7 @@ introduction: |-
       atmos terraform apply eks -s ue2-dev
     ```
 
-  To execute `plan` and `apply` in one step, use `terrafrom deploy` command:
+  To execute `plan` and `apply` in one step, use `terraform deploy` command:
 
     ```bash
       atmos terraform deploy eks -s ue2-dev

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -23,6 +23,7 @@ var workflowCmd = &cobra.Command{
 func init() {
 	workflowCmd.DisableFlagParsing = false
 	workflowCmd.PersistentFlags().StringP("file", "f", "", "atmos workflow <name> -f <file>")
+	workflowCmd.PersistentFlags().Bool("dry-run", false, "atmos workflow <name> -f <file> --dry-run")
 
 	err := workflowCmd.MarkPersistentFlagRequired("file")
 	if err != nil {

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -95,6 +95,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		},
 		componentPath,
 		nil,
+		info.DryRun,
 	)
 	if err != nil {
 		return err
@@ -153,7 +154,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		fmt.Println(v)
 	}
 
-	err = execCommand(info.Command, allArgsAndFlags, componentPath, envVars)
+	err = execCommand(info.Command, allArgsAndFlags, componentPath, envVars, info.DryRun)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -62,9 +62,12 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 
 	color.Cyan("Writing the variables to file:")
 	fmt.Println(varFilePath)
-	err = utils.WriteToFileAsYAML(varFilePath, info.ComponentVarsSection, 0644)
-	if err != nil {
-		return err
+
+	if !info.DryRun {
+		err = utils.WriteToFileAsYAML(varFilePath, info.ComponentVarsSection, 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Handle `helmfile deploy` custom command

--- a/internal/exec/helmfile_generate_varfile.go
+++ b/internal/exec/helmfile_generate_varfile.go
@@ -58,9 +58,12 @@ func ExecuteHelmfileGenerateVarfile(cmd *cobra.Command, args []string) error {
 	// Write the variables to file
 	color.Cyan("Writing the variables to file:")
 	fmt.Println(varFilePath)
-	err = utils.WriteToFileAsYAML(varFilePath, info.ComponentVarsSection, 0644)
-	if err != nil {
-		return err
+
+	if !info.DryRun {
+		err = utils.WriteToFileAsYAML(varFilePath, info.ComponentVarsSection, 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println()

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -44,7 +44,7 @@ func processHelp(componentType string, command string) error {
 				"and use it to authenticate with the cluster")
 		}
 
-		err := execCommand(componentType, []string{"--help"}, "", nil)
+		err := execCommand(componentType, []string{"--help"}, "", nil, false)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func processHelp(componentType string, command string) error {
 		color.Cyan(fmt.Sprintf("atmos %s %s <component> -s <stack> [options]", componentType, command))
 		color.Cyan(fmt.Sprintf("atmos %s %s <component> --stack <stack> [options]", componentType, command))
 
-		err := execCommand(componentType, []string{command, "--help"}, "", nil)
+		err := execCommand(componentType, []string{command, "--help"}, "", nil, false)
 		if err != nil {
 			return err
 		}

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 // execCommand prints and executes the provided command with args and flags
-func execCommand(command string, args []string, dir string, env []string) error {
+func execCommand(command string, args []string, dir string, env []string, dryRun bool) error {
 	cmd := exec.Command(command, args...)
 	cmd.Env = append(os.Environ(), env...)
 	cmd.Dir = dir
@@ -21,6 +21,11 @@ func execCommand(command string, args []string, dir string, env []string) error 
 	fmt.Println()
 	color.Cyan("Executing command:\n")
 	fmt.Println(cmd.String())
+
+	if dryRun {
+		return nil
+	}
+
 	return cmd.Run()
 }
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -156,7 +156,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		if info.SubCommand == "workspace" || c.Config.Components.Terraform.InitRunReconfigure == true {
 			initCommandWithArguments = []string{"init", "-reconfigure"}
 		}
-		err = execCommand(info.Command, initCommandWithArguments, componentPath, info.ComponentEnvList)
+		err = execCommand(info.Command, initCommandWithArguments, componentPath, info.ComponentEnvList, info.DryRun)
 		if err != nil {
 			return err
 		}
@@ -237,9 +237,9 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	// Run `terraform workspace`
 	if info.SubCommand != "init" {
-		err = execCommand(info.Command, []string{"workspace", "select", info.TerraformWorkspace}, componentPath, info.ComponentEnvList)
+		err = execCommand(info.Command, []string{"workspace", "select", info.TerraformWorkspace}, componentPath, info.ComponentEnvList, info.DryRun)
 		if err != nil {
-			err = execCommand(info.Command, []string{"workspace", "new", info.TerraformWorkspace}, componentPath, info.ComponentEnvList)
+			err = execCommand(info.Command, []string{"workspace", "new", info.TerraformWorkspace}, componentPath, info.ComponentEnvList, info.DryRun)
 			if err != nil {
 				return err
 			}
@@ -288,7 +288,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	// Execute the provided command
 	if info.SubCommand != "workspace" {
-		err = execCommand(info.Command, allArgsAndFlags, componentPath, info.ComponentEnvList)
+		err = execCommand(info.Command, allArgsAndFlags, componentPath, info.ComponentEnvList, info.DryRun)
 		if err != nil {
 			return err
 		}

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -116,9 +116,12 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 
 	color.Cyan("Writing the variables to file:")
 	fmt.Println(varFilePath)
-	err = utils.WriteToFileAsJSON(varFilePath, info.ComponentVarsSection, 0644)
-	if err != nil {
-		return err
+
+	if !info.DryRun {
+		err = utils.WriteToFileAsJSON(varFilePath, info.ComponentVarsSection, 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Handle `terraform varfile` and `terraform write varfile` custom commands
@@ -137,10 +140,13 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		color.Cyan("Writing the backend config to file:")
 		fmt.Println(backendFileName)
-		var componentBackendConfig = generateComponentBackendConfig(info.ComponentBackendType, info.ComponentBackendSection)
-		err = utils.WriteToFileAsJSON(backendFileName, componentBackendConfig, 0644)
-		if err != nil {
-			return err
+
+		if !info.DryRun {
+			var componentBackendConfig = generateComponentBackendConfig(info.ComponentBackendType, info.ComponentBackendSection)
+			err = utils.WriteToFileAsJSON(backendFileName, componentBackendConfig, 0644)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -69,9 +69,12 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	color.Cyan("Writing the backend config to file:")
 	fmt.Println(backendFilePath)
-	err = utils.WriteToFileAsJSON(backendFilePath, componentBackendConfig, 0644)
-	if err != nil {
-		return err
+
+	if !info.DryRun {
+		err = utils.WriteToFileAsJSON(backendFilePath, componentBackendConfig, 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println()

--- a/internal/exec/terraform_generate_varfile.go
+++ b/internal/exec/terraform_generate_varfile.go
@@ -58,9 +58,12 @@ func ExecuteTerraformGenerateVarfile(cmd *cobra.Command, args []string) error {
 	// Write the variables to file
 	color.Cyan("Writing the variables to file:")
 	fmt.Println(varFilePath)
-	err = utils.WriteToFileAsJSON(varFilePath, info.ComponentVarsSection, 0644)
-	if err != nil {
-		return err
+
+	if !info.DryRun {
+		err = utils.WriteToFileAsJSON(varFilePath, info.ComponentVarsSection, 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println()

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -16,8 +16,8 @@ var (
 	commonFlags = []string{
 		"--stack",
 		"-s",
-		"--dry-run",
-		"--kubeconfig-path",
+		g.DryRunFlag,
+		g.KubeConfigConfigFlag,
 		g.TerraformDirFlag,
 		g.HelmfileDirFlag,
 		g.ConfigDirFlag,

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -173,6 +173,7 @@ func processArgsConfigAndStacks(componentType string, cmd *cobra.Command, args [
 	configAndStacksInfo.InitRunReconfigure = argsAndFlagsInfo.InitRunReconfigure
 	configAndStacksInfo.AutoGenerateBackendFile = argsAndFlagsInfo.AutoGenerateBackendFile
 	configAndStacksInfo.UseTerraformPlan = argsAndFlagsInfo.UseTerraformPlan
+	configAndStacksInfo.DryRun = argsAndFlagsInfo.DryRun
 	configAndStacksInfo.NeedHelp = argsAndFlagsInfo.NeedHelp
 
 	// Check if `-h` or `--help` flags are specified
@@ -566,6 +567,10 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 
 		if arg == g.FromPlanFlag {
 			info.UseTerraformPlan = true
+		}
+
+		if arg == g.DryRunFlag {
+			info.DryRun = true
 		}
 
 		if arg == g.HelpFlag1 || arg == g.HelpFlag2 {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -622,9 +622,6 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 			info.ComponentFromArg = additionalArgsAndFlags[1]
 			info.AdditionalArgsAndFlags = additionalArgsAndFlags[2:]
 		}
-	} else {
-		message := "invalid number of arguments. Usage: atmos <command> <component> <arguments_and_flags>"
-		return info, errors.New(message)
 	}
 
 	return info, nil

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -85,7 +85,7 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = executeWorkflowSteps(workflowDefinition)
+	err = executeWorkflowSteps(workflowDefinition, false)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -17,7 +17,7 @@ import (
 // ExecuteWorkflow executes a workflow
 func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("invalid arguments. The command requires one argument `workflow name` and one flag `file name`")
+		return errors.New("invalid arguments. The command requires one argument `workflow name`")
 	}
 
 	err := c.InitConfig()
@@ -28,6 +28,11 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	flags := cmd.Flags()
 
 	workflowFile, err := flags.GetString("file")
+	if err != nil {
+		return err
+	}
+
+	dryRun, err := flags.GetBool("dry-run")
 	if err != nil {
 		return err
 	}
@@ -85,7 +90,7 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = executeWorkflowSteps(workflowDefinition, false)
+	err = executeWorkflowSteps(workflowDefinition, dryRun)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
+func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition, dryRun bool) error {
 	var steps = workflowDefinition.Steps
 
 	for _, step := range steps {
@@ -23,7 +23,7 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 
 		if commandType == "shell" {
 			args := strings.Fields(command)
-			if err := execCommand(args[0], args[1:], ".", []string{}); err != nil {
+			if err := execCommand(args[0], args[1:], ".", []string{}, dryRun); err != nil {
 				return err
 			}
 		} else if commandType == "atmos" {
@@ -47,7 +47,7 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition) error {
 				color.HiCyan(fmt.Sprintf("Stack: %s", finalStack))
 			}
 
-			if err := execCommand("atmos", args, ".", []string{}); err != nil {
+			if err := execCommand("atmos", args, ".", []string{}, dryRun); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -79,6 +79,7 @@ type ArgsAndFlagsInfo struct {
 	InitRunReconfigure      string
 	AutoGenerateBackendFile string
 	UseTerraformPlan        bool
+	DryRun                  bool
 	NeedHelp                bool
 }
 
@@ -114,6 +115,7 @@ type ConfigAndStacksInfo struct {
 	InitRunReconfigure        string
 	AutoGenerateBackendFile   string
 	UseTerraformPlan          bool
+	DryRun                    bool
 	ComponentInheritanceChain []string
 	NeedHelp                  bool
 	ComponentIsAbstract       bool

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -10,18 +10,20 @@ const (
 	// https://github.com/roboll/helmfile#cli-reference
 	GlobalOptionsFlag = "--global-options"
 
-	TerraformDirFlag = "--terraform-dir"
-	HelmfileDirFlag  = "--helmfile-dir"
-	ConfigDirFlag    = "--config-dir"
-	StackDirFlag     = "--stacks-dir"
-	BasePathFlag     = "--base-path"
-	WorkflowDirFlag  = "--workflows-dir"
+	TerraformDirFlag     = "--terraform-dir"
+	HelmfileDirFlag      = "--helmfile-dir"
+	ConfigDirFlag        = "--config-dir"
+	StackDirFlag         = "--stacks-dir"
+	BasePathFlag         = "--base-path"
+	WorkflowDirFlag      = "--workflows-dir"
+	KubeConfigConfigFlag = "--kubeconfig-path"
 
 	DeployRunInitFlag           = "--deploy-run-init"
 	AutoGenerateBackendFileFlag = "--auto-generate-backend-file"
 	InitRunReconfigure          = "--init-run-reconfigure"
 
 	FromPlanFlag = "--from-plan"
+	DryRunFlag   = "--dry-run"
 
 	HelpFlag1 = "-h"
 	HelpFlag2 = "--help"


### PR DESCRIPTION
## what
* Add `--dry-run` command-line flag to all commands and workflows

## why
* Helps debugging `atmos` commands and workflows
* The `--dry-run` flag shows all the flow and commands without executing them and without writing files to the file system (e.g. varfiles and backend config are not written)
* The `--dry-run` flag shows all the workflow steps without executing them

## references

* closes #122 

## test

```
atmos terraform plan test/test-component-override -s=tenant1-ue2-dev --dry-run

Variables for the component 'test/test-component-override' in the stack 'tenant1/ue2/dev':

enabled: true
environment: ue2
namespace: eg
region: us-east-2
service_1_list:
- 1
- 2
- 3
service_1_map:
  a: 1
  b: 2
  c: 3
service_1_name: service-1-override-2
service_2_list:
- 1
- 2
- 3
service_2_map:
  a: 1
  b: 2
  c: 3
service_2_name: service-2-override
stage: dev
tenant: tenant1

Writing the variables to file:
examples/complete/components/terraform/test/test-component/tenant1-ue2-dev-test-test-component-override.terraform.tfvars.json

Executing command:
/usr/local/bin/terraform init -reconfigure

Command info:
Terraform binary: /usr/local/bin/terraform
Terraform command: plan
Arguments and flags: []
Component: test/test-component-override
Terraform component: test/test-component
Inheritance: test/test-component-override -> test/test-component
Stack: tenant1-ue2-dev
Stack path: examples/complete/stacks/tenant1/ue2/dev
Working dir: examples/complete/components/terraform/test/test-component

Using ENV vars:
TEST_ENV_VAR2=val2
TEST_ENV_VAR3=val3-override
TEST_ENV_VAR4=val4
TEST_ENV_VAR1=val1-override

Executing command:
/usr/local/bin/terraform workspace select test-component-override-workspace-override

Executing command:
/usr/local/bin/terraform plan -var-file tenant1-ue2-dev-test-test-component-override.terraform.tfvars.json -out tenant1-ue2-dev-test-test-component-override.planfile
```

```
atmos workflow terraform-plan-test-component-override-2-all-stacks -f workflow1 --dry-run

Executing the workflow 'terraform-plan-test-component-override-2-all-stacks' from 'examples/complete/workflows/workflow1.yaml'

description: Run 'terraform plan' on 'test/test-component-override-2' component in
  all stacks
steps:
- command: terraform plan test/test-component-override-2 -s tenant1-ue2-dev
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2 -s tenant1-ue2-staging
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2 -s tenant1-ue2-prod
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2 -s tenant2-ue2-dev
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2 -s tenant2-ue2-staging
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2 -s tenant2-ue2-prod
  stack: ""
  type: ""
stack: ""

Executing workflow step: terraform plan test/test-component-override-2 -s tenant1-ue2-dev

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant1-ue2-dev

Executing workflow step: terraform plan test/test-component-override-2 -s tenant1-ue2-staging

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant1-ue2-staging

Executing workflow step: terraform plan test/test-component-override-2 -s tenant1-ue2-prod

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant1-ue2-prod

Executing workflow step: terraform plan test/test-component-override-2 -s tenant2-ue2-dev

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant2-ue2-dev

Executing workflow step: terraform plan test/test-component-override-2 -s tenant2-ue2-staging

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant2-ue2-staging

Executing workflow step: terraform plan test/test-component-override-2 -s tenant2-ue2-prod

Executing command:
atmos terraform plan test/test-component-override-2 -s tenant2-ue2-prod
```
