### PR TITLE
Add `atmos describe stacks` command

### DIFF
--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -23,8 +23,9 @@ var describeStacksCmd = &cobra.Command{
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
 	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json ('yaml' is default)")
-	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "atmos describe stacks --file=stacks.yaml")
-	describeStacksCmd.PersistentFlags().StringP("component", "c", "", "atmos describe stacks --component=<component>")
+	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "Write the result to file: atmos describe stacks --file=stacks.yaml")
+	describeStacksCmd.PersistentFlags().String("components", "", "Filter by components: atmos describe stacks --components=<component1>,<component2>")
+	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=<vars>,<settings>")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	e "github.com/cloudposse/atmos/internal/exec"
+	u "github.com/cloudposse/atmos/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// describeComponentCmd describes configuration for components
+var describeStacksCmd = &cobra.Command{
+	Use:                "stacks",
+	Short:              "Execute 'describe stacks' command",
+	Long:               `This command shows configuration for stacks and components in the stacks: atmos describe stacks <component> -s <stack>`,
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := e.ExecuteDescribeStacks(cmd, args)
+		if err != nil {
+			u.PrintErrorToStdErrorAndExit(err)
+		}
+	},
+}
+
+func init() {
+	describeStacksCmd.DisableFlagParsing = false
+	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "atmos describe component <component> -s <stack>")
+
+	describeCmd.AddCommand(describeStacksCmd)
+}

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -22,7 +22,6 @@ var describeStacksCmd = &cobra.Command{
 
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
-	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "atmos describe stacks")
 	describeStacksCmd.PersistentFlags().String("format", "", "atmos describe stacks --format=yaml/json")
 
 	describeCmd.AddCommand(describeStacksCmd)

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -26,7 +26,7 @@ func init() {
 	describeStacksCmd.PersistentFlags().String("format", "yaml", "Specify output format: atmos describe stacks --format=yaml/json ('yaml' is default)")
 	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "Filter by a specific stack: atmos describe stacks -s <stack>")
 	describeStacksCmd.PersistentFlags().String("components", "", "Filter by specific components: atmos describe stacks --components=<component1>,<component2>")
-	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=vars,settings. Available sections: backend, backend_type, deps, env, inheritance, metadata, remote_state_backend, remote_state_backend_type, settings, vars")
+	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these component sections: atmos describe stacks --sections=vars,settings. Available component sections: backend, backend_type, deps, env, inheritance, metadata, remote_state_backend, remote_state_backend_type, settings, vars")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -26,6 +26,7 @@ func init() {
 	describeStacksCmd.PersistentFlags().String("format", "yaml", "Specify output format: atmos describe stacks --format=yaml/json ('yaml' is default)")
 	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "Filter by a specific stack: atmos describe stacks -s <stack>")
 	describeStacksCmd.PersistentFlags().String("components", "", "Filter by specific components: atmos describe stacks --components=<component1>,<component2>")
+	describeStacksCmd.PersistentFlags().String("component-types", "", "Filter by specific component types: atmos describe stacks --component-types=terraform,helmfile. Supported component types: terraform, helmfile")
 	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these component sections: atmos describe stacks --sections=vars,settings. Available component sections: backend, backend_type, deps, env, inheritance, metadata, remote_state_backend, remote_state_backend_type, settings, vars")
 
 	describeCmd.AddCommand(describeStacksCmd)

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -25,7 +25,7 @@ func init() {
 	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json ('yaml' is default)")
 	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "Write the result to file: atmos describe stacks --file=stacks.yaml")
 	describeStacksCmd.PersistentFlags().String("components", "", "Filter by components: atmos describe stacks --components=<component1>,<component2>")
-	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=<vars>,<settings>")
+	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=vars,settings")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -22,7 +22,8 @@ var describeStacksCmd = &cobra.Command{
 
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
-	describeStacksCmd.PersistentFlags().String("format", "", "atmos describe stacks --format=yaml/json")
+	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json")
+	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "atmos describe stacks --file=stacks.yaml")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -22,8 +22,9 @@ var describeStacksCmd = &cobra.Command{
 
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
-	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json")
+	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json ('yaml' is default)")
 	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "atmos describe stacks --file=stacks.yaml")
+	describeStacksCmd.PersistentFlags().StringP("component", "c", "", "atmos describe stacks --component=<component>")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -10,7 +10,7 @@ import (
 var describeStacksCmd = &cobra.Command{
 	Use:                "stacks",
 	Short:              "Execute 'describe stacks' command",
-	Long:               `This command shows configuration for stacks and components in the stacks: atmos describe stacks <component> -s <stack>`,
+	Long:               `This command shows configuration for stacks and components in the stacks: atmos describe stacks`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeStacks(cmd, args)
@@ -22,7 +22,8 @@ var describeStacksCmd = &cobra.Command{
 
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
-	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "atmos describe component <component> -s <stack>")
+	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "atmos describe stacks")
+	describeStacksCmd.PersistentFlags().String("format", "", "atmos describe stacks --format=yaml/json")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -25,7 +25,7 @@ func init() {
 	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json ('yaml' is default)")
 	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "Write the result to file: atmos describe stacks --file=stacks.yaml")
 	describeStacksCmd.PersistentFlags().String("components", "", "Filter by components: atmos describe stacks --components=<component1>,<component2>")
-	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=vars,settings")
+	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=vars,settings. Available sections: backend, backend_type, deps, env, inheritance, metadata, remote_state_backend, remote_state_backend_type, settings, vars")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -10,7 +10,7 @@ import (
 var describeStacksCmd = &cobra.Command{
 	Use:                "stacks",
 	Short:              "Execute 'describe stacks' command",
-	Long:               `This command shows configuration for stacks and components in the stacks: atmos describe stacks`,
+	Long:               `This command shows configuration for stacks and components in the stacks: atmos describe stacks <options>`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeStacks(cmd, args)
@@ -22,9 +22,10 @@ var describeStacksCmd = &cobra.Command{
 
 func init() {
 	describeStacksCmd.DisableFlagParsing = false
-	describeStacksCmd.PersistentFlags().String("format", "yaml", "atmos describe stacks --format=yaml/json ('yaml' is default)")
-	describeStacksCmd.PersistentFlags().StringP("file", "f", "", "Write the result to file: atmos describe stacks --file=stacks.yaml")
-	describeStacksCmd.PersistentFlags().String("components", "", "Filter by components: atmos describe stacks --components=<component1>,<component2>")
+	describeStacksCmd.PersistentFlags().String("file", "", "Write the result to file: atmos describe stacks --file=stacks.yaml")
+	describeStacksCmd.PersistentFlags().String("format", "yaml", "Specify output format: atmos describe stacks --format=yaml/json ('yaml' is default)")
+	describeStacksCmd.PersistentFlags().StringP("stack", "s", "", "Filter by a specific stack: atmos describe stacks -s <stack>")
+	describeStacksCmd.PersistentFlags().String("components", "", "Filter by specific components: atmos describe stacks --components=<component1>,<component2>")
 	describeStacksCmd.PersistentFlags().String("sections", "", "Output only these sections: atmos describe stacks --sections=vars,settings. Available sections: backend, backend_type, deps, env, inheritance, metadata, remote_state_backend, remote_state_backend_type, settings, vars")
 
 	describeCmd.AddCommand(describeStacksCmd)

--- a/internal/exec/describe_component.go
+++ b/internal/exec/describe_component.go
@@ -30,10 +30,10 @@ func ExecuteDescribeComponent(cmd *cobra.Command, args []string) error {
 	configAndStacksInfo.Stack = stack
 
 	configAndStacksInfo.ComponentType = "terraform"
-	configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
+	configAndStacksInfo, err = ProcessStacks(configAndStacksInfo, true)
 	if err != nil {
 		configAndStacksInfo.ComponentType = "helmfile"
-		configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
+		configAndStacksInfo, err = ProcessStacks(configAndStacksInfo, true)
 		if err != nil {
 			return err
 		}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -80,19 +80,14 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
 								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
 							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
+							}
 
-							// If `sections` specified, output only the provided sections
-							if len(sections) > 0 {
-								for sectionName, section := range comp.(map[string]interface{}) {
-									if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
-										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
-									}
-									if u.SliceContainsString(sections, sectionName) {
-										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
-									}
+							for sectionName, section := range comp.(map[string]interface{}) {
+								if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
 								}
-							} else {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = comp
 							}
 						}
 					}
@@ -106,19 +101,14 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
 								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
 							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
+							}
 
-							// If `sections` specified, output only the provided sections
-							if len(sections) > 0 {
-								for sectionName, section := range comp.(map[string]interface{}) {
-									if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
-										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
-									}
-									if u.SliceContainsString(sections, sectionName) {
-										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
-									}
+							for sectionName, section := range comp.(map[string]interface{}) {
+								if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
 								}
-							} else {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = comp
 							}
 						}
 					}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -28,32 +28,65 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	component, err := flags.GetString("component")
+	if err != nil {
+		return err
+	}
+
 	var configAndStacksInfo c.ConfigAndStacksInfo
 	stacksMap, err := FindStacksMap(configAndStacksInfo, false)
 	if err != nil {
 		return err
 	}
 
+	finalStacksMap := map[string]interface{}{}
+
+	if component != "" {
+		for stackName, stack := range stacksMap {
+			delete(stack.(map[interface{}]interface{}), "imports")
+			finalStacksMap[stackName] = stack
+		}
+		//for stackName := range stacksMap {
+		//if stackSection, ok := stacksMap[stackName].(map[interface{}]interface{}); !ok {
+		//	return nil, nil, nil, nil, "", "", "", nil, false, nil, errors.New(fmt.Sprintf("Could not find the stack '%s'", stack))
+		//}
+		//if componentsSection, ok = stackSection["components"].(map[string]interface{}); !ok {
+		//	return nil, nil, nil, nil, "", "", "", nil, false, nil, errors.New(fmt.Sprintf("'components' section is missing in the stack '%s'", stack))
+		//}
+		//if componentTypeSection, ok = componentsSection[componentType].(map[string]interface{}); !ok {
+		//	return nil, nil, nil, nil, "", "", "", nil, false, nil, errors.New(fmt.Sprintf("'components/%s' section is missing in the stack '%s'", componentType, stack))
+		//}
+		//if componentSection, ok = componentTypeSection[component].(map[string]interface{}); !ok {
+		//	return nil, nil, nil, nil, "", "", "", nil, false, nil, errors.New(fmt.Sprintf("Invalid or missing configuration for the component '%s' in the stack '%s'", component, stack))
+		//}
+		//}
+	} else {
+		for stackName, stack := range stacksMap {
+			delete(stack.(map[interface{}]interface{}), "imports")
+			finalStacksMap[stackName] = stack
+		}
+	}
+
 	if format == "yaml" {
 		if file == "" {
-			err = u.PrintAsYAML(stacksMap)
+			err = u.PrintAsYAML(finalStacksMap)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = u.WriteToFileAsYAML(file, stacksMap, 0644)
+			err = u.WriteToFileAsYAML(file, finalStacksMap, 0644)
 			if err != nil {
 				return err
 			}
 		}
 	} else if format == "json" {
 		if file == "" {
-			err = u.PrintAsJSON(stacksMap)
+			err = u.PrintAsJSON(finalStacksMap)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = u.WriteToFileAsJSON(file, stacksMap, 0644)
+			err = u.WriteToFileAsJSON(file, finalStacksMap, 0644)
 			if err != nil {
 				return err
 			}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -8,17 +8,9 @@ import (
 
 // ExecuteDescribeStacks executes `describe stacks` command
 func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
-	flags := cmd.Flags()
-
-	stack, err := flags.GetString("stack")
-	if err != nil {
-		return err
-	}
-
 	var configAndStacksInfo c.ConfigAndStacksInfo
-	configAndStacksInfo.Stack = stack
 
-	stacksMap, err := FindStacksMap(configAndStacksInfo)
+	stacksMap, err := FindStacksMap(configAndStacksInfo, false)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -85,10 +85,10 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 								// If `sections` specified, output only the provided sections
 								if len(sections) > 0 {
 									for sectionName, section := range comp.(map[string]interface{}) {
+										if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
+											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
+										}
 										if u.SliceContainsString(sections, sectionName) {
-											if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
-												finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
-											}
 											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
 										}
 									}
@@ -114,10 +114,10 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 								// If `sections` specified, output only the provided sections
 								if len(sections) > 0 {
 									for sectionName, section := range comp.(map[string]interface{}) {
+										if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
+											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
+										}
 										if u.SliceContainsString(sections, sectionName) {
-											if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
-												finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
-											}
 											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
 										}
 									}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -66,70 +66,63 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 			// Delete the stack-wide imports
 			delete(stackSection.(map[interface{}]interface{}), "imports")
 
-			// Filter the stacks by components
-			if len(components) > 0 {
-				if componentsSection, ok := stackSection.(map[interface{}]interface{})["components"].(map[string]interface{}); ok {
-					if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
-						for compName, comp := range terraformSection {
-							if u.SliceContainsString(components, compName) {
-								if !u.MapKeyExists(finalStacksMap, stackName) {
-									finalStacksMap[stackName] = make(map[string]interface{})
-								}
-								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
-									finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
-								}
-								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
-								}
+			if !u.MapKeyExists(finalStacksMap, stackName) {
+				finalStacksMap[stackName] = make(map[string]interface{})
+			}
 
-								// If `sections` specified, output only the provided sections
-								if len(sections) > 0 {
-									for sectionName, section := range comp.(map[string]interface{}) {
-										if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
-											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
-										}
-										if u.SliceContainsString(sections, sectionName) {
-											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
-										}
-									}
-								} else {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = comp
-								}
+			if componentsSection, ok := stackSection.(map[interface{}]interface{})["components"].(map[string]interface{}); ok {
+				if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
+					for compName, comp := range terraformSection {
+						if len(components) == 0 || u.SliceContainsString(components, compName) {
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
 							}
-						}
-					}
-					if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
-						for compName, comp := range helmfileSection {
-							if u.SliceContainsString(components, compName) {
-								if !u.MapKeyExists(finalStacksMap, stackName) {
-									finalStacksMap[stackName] = make(map[string]interface{})
-								}
-								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
-									finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
-								}
-								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
-								}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
+							}
 
-								// If `sections` specified, output only the provided sections
-								if len(sections) > 0 {
-									for sectionName, section := range comp.(map[string]interface{}) {
-										if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
-											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
-										}
-										if u.SliceContainsString(sections, sectionName) {
-											finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
-										}
+							// If `sections` specified, output only the provided sections
+							if len(sections) > 0 {
+								for sectionName, section := range comp.(map[string]interface{}) {
+									if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
 									}
-								} else {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = comp
+									if u.SliceContainsString(sections, sectionName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+									}
 								}
+							} else {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = comp
 							}
 						}
 					}
 				}
-			} else {
-				finalStacksMap[stackName] = stackSection
+				if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
+					for compName, comp := range helmfileSection {
+						if len(components) == 0 || u.SliceContainsString(components, compName) {
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
+							}
+
+							// If `sections` specified, output only the provided sections
+							if len(sections) > 0 {
+								for sectionName, section := range comp.(map[string]interface{}) {
+									if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
+									}
+									if u.SliceContainsString(sections, sectionName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+									}
+								}
+							} else {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = comp
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -1,0 +1,53 @@
+package exec
+
+import (
+	"fmt"
+	c "github.com/cloudposse/atmos/pkg/config"
+	g "github.com/cloudposse/atmos/pkg/globals"
+	u "github.com/cloudposse/atmos/pkg/utils"
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// ExecuteDescribeStacks executes `describe stacks` command
+func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("invalid arguments. The command requires one argument `component`")
+	}
+
+	flags := cmd.Flags()
+
+	stack, err := flags.GetString("stack")
+	if err != nil {
+		return err
+	}
+
+	component := args[0]
+
+	var configAndStacksInfo c.ConfigAndStacksInfo
+	configAndStacksInfo.ComponentFromArg = component
+	configAndStacksInfo.Stack = stack
+
+	configAndStacksInfo.ComponentType = "terraform"
+	configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
+	if err != nil {
+		configAndStacksInfo.ComponentType = "helmfile"
+		configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	if g.LogVerbose {
+		fmt.Println()
+		color.Cyan("Component config:\n\n")
+	}
+
+	err = u.PrintAsYAML(configAndStacksInfo.ComponentSection)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -53,7 +53,8 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 	}
 
 	var configAndStacksInfo c.ConfigAndStacksInfo
-	stacksMap, err := FindStacksMap(configAndStacksInfo, false)
+	configAndStacksInfo.Stack = filterByStack
+	stacksMap, err := FindStacksMap(configAndStacksInfo, filterByStack != "")
 	if err != nil {
 		return err
 	}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -1,21 +1,13 @@
 package exec
 
 import (
-	"fmt"
 	c "github.com/cloudposse/atmos/pkg/config"
-	g "github.com/cloudposse/atmos/pkg/globals"
 	u "github.com/cloudposse/atmos/pkg/utils"
-	"github.com/fatih/color"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // ExecuteDescribeStacks executes `describe stacks` command
 func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments. The command requires one argument `component`")
-	}
-
 	flags := cmd.Flags()
 
 	stack, err := flags.GetString("stack")
@@ -23,28 +15,15 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	component := args[0]
-
 	var configAndStacksInfo c.ConfigAndStacksInfo
-	configAndStacksInfo.ComponentFromArg = component
 	configAndStacksInfo.Stack = stack
 
-	configAndStacksInfo.ComponentType = "terraform"
-	configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
+	stacksMap, err := FindStacksMap(configAndStacksInfo)
 	if err != nil {
-		configAndStacksInfo.ComponentType = "helmfile"
-		configAndStacksInfo, err = ProcessStacks(configAndStacksInfo)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
-	if g.LogVerbose {
-		fmt.Println()
-		color.Cyan("Component config:\n\n")
-	}
-
-	err = u.PrintAsYAML(configAndStacksInfo.ComponentSection)
+	err = u.PrintAsYAML(stacksMap)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -51,25 +51,35 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 		delete(stack.(map[interface{}]interface{}), "imports")
 
 		if len(components) > 0 {
-			finalStacksMap[stackName] = make(map[string]interface{})
-
 			if componentsSection, ok := stack.(map[interface{}]interface{})["components"].(map[string]interface{}); ok {
-				finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
-
 				if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
-					finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
-
 					for compName, comp := range terraformSection {
 						if u.SliceContainsString(components, compName) {
+							if !u.MapKeyExists(finalStacksMap, stackName) {
+								finalStacksMap[stackName] = make(map[string]interface{})
+							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
+							}
 							finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = comp
 						}
 					}
 				}
 				if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
-					finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
-
 					for compName, comp := range helmfileSection {
 						if u.SliceContainsString(components, compName) {
+							if !u.MapKeyExists(finalStacksMap, stackName) {
+								finalStacksMap[stackName] = make(map[string]interface{})
+							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+							}
+							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
+								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
+							}
 							finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = comp
 						}
 					}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -1,6 +1,8 @@
 package exec
 
 import (
+	"errors"
+	"fmt"
 	c "github.com/cloudposse/atmos/pkg/config"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/spf13/cobra"
@@ -8,16 +10,54 @@ import (
 
 // ExecuteDescribeStacks executes `describe stacks` command
 func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
-	var configAndStacksInfo c.ConfigAndStacksInfo
+	flags := cmd.Flags()
 
+	format, err := flags.GetString("format")
+	if err != nil {
+		return err
+	}
+	if format != "" && format != "yaml" && format != "json" {
+		return errors.New(fmt.Sprintf("Invalid '--format' flag '%s'. Valid values are 'yaml' (default) and 'json'", format))
+	}
+	if format == "" {
+		format = "yaml"
+	}
+
+	file, err := flags.GetString("file")
+	if err != nil {
+		return err
+	}
+
+	var configAndStacksInfo c.ConfigAndStacksInfo
 	stacksMap, err := FindStacksMap(configAndStacksInfo, false)
 	if err != nil {
 		return err
 	}
 
-	err = u.PrintAsYAML(stacksMap)
-	if err != nil {
-		return err
+	if format == "yaml" {
+		if file == "" {
+			err = u.PrintAsYAML(stacksMap)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = u.WriteToFileAsYAML(file, stacksMap, 0644)
+			if err != nil {
+				return err
+			}
+		}
+	} else if format == "json" {
+		if file == "" {
+			err = u.PrintAsJSON(stacksMap)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = u.WriteToFileAsJSON(file, stacksMap, 0644)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -43,6 +43,15 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 		components = strings.Split(componentsCsv, ",")
 	}
 
+	componentTypesCsv, err := flags.GetString("component-types")
+	if err != nil {
+		return err
+	}
+	var componentTypes []string
+	if componentTypesCsv != "" {
+		componentTypes = strings.Split(componentTypesCsv, ",")
+	}
+
 	sectionsCsv, err := flags.GetString("sections")
 	if err != nil {
 		return err
@@ -71,43 +80,47 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 			}
 
 			if componentsSection, ok := stackSection.(map[interface{}]interface{})["components"].(map[string]interface{}); ok {
-				if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
-					for compName, comp := range terraformSection {
-						if len(components) == 0 || u.SliceContainsString(components, compName) {
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
-								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
-							}
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
-							}
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
-							}
+				if len(componentTypes) == 0 || u.SliceContainsString(componentTypes, "terraform") {
+					if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
+						for compName, comp := range terraformSection {
+							if len(components) == 0 || u.SliceContainsString(components, compName) {
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+									finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+								}
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "terraform") {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
+								}
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{}), compName) {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = make(map[string]interface{})
+								}
 
-							for sectionName, section := range comp.(map[string]interface{}) {
-								if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+								for sectionName, section := range comp.(map[string]interface{}) {
+									if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+									}
 								}
 							}
 						}
 					}
 				}
-				if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
-					for compName, comp := range helmfileSection {
-						if len(components) == 0 || u.SliceContainsString(components, compName) {
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
-								finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
-							}
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
-							}
-							if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
-								finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
-							}
+				if len(componentTypes) == 0 || u.SliceContainsString(componentTypes, "helmfile") {
+					if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
+						for compName, comp := range helmfileSection {
+							if len(components) == 0 || u.SliceContainsString(components, compName) {
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{}), "components") {
+									finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+								}
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{}), "helmfile") {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
+								}
+								if !u.MapKeyExists(finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{}), compName) {
+									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = make(map[string]interface{})
+								}
 
-							for sectionName, section := range comp.(map[string]interface{}) {
-								if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
-									finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+								for sectionName, section := range comp.(map[string]interface{}) {
+									if len(sections) == 0 || u.SliceContainsString(sections, sectionName) {
+										finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName].(map[string]interface{})[sectionName] = section
+									}
 								}
 							}
 						}

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -44,24 +44,33 @@ func ExecuteDescribeStacks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	finalStacksMap := map[string]interface{}{}
+	finalStacksMap := make(map[string]interface{})
 
 	for stackName, stack := range stacksMap {
+		// Delete the stack-wide imports
 		delete(stack.(map[interface{}]interface{}), "imports")
 
 		if len(components) > 0 {
+			finalStacksMap[stackName] = make(map[string]interface{})
+
 			if componentsSection, ok := stack.(map[interface{}]interface{})["components"].(map[string]interface{}); ok {
+				finalStacksMap[stackName].(map[string]interface{})["components"] = make(map[string]interface{})
+
 				if terraformSection, ok2 := componentsSection["terraform"].(map[string]interface{}); ok2 {
-					for comp, _ := range terraformSection {
-						if u.SliceContainsString(components, comp) {
-							finalStacksMap[stackName] = stack
+					finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"] = make(map[string]interface{})
+
+					for compName, comp := range terraformSection {
+						if u.SliceContainsString(components, compName) {
+							finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["terraform"].(map[string]interface{})[compName] = comp
 						}
 					}
 				}
 				if helmfileSection, ok3 := componentsSection["helmfile"].(map[string]interface{}); ok3 {
-					for comp, _ := range helmfileSection {
-						if u.SliceContainsString(components, comp) {
-							finalStacksMap[stackName] = stack
+					finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"] = make(map[string]interface{})
+
+					for compName, comp := range helmfileSection {
+						if u.SliceContainsString(components, compName) {
+							finalStacksMap[stackName].(map[string]interface{})["components"].(map[string]interface{})["helmfile"].(map[string]interface{})[compName] = comp
 						}
 					}
 				}

--- a/internal/exec/helmfile_generate_varfile.go
+++ b/internal/exec/helmfile_generate_varfile.go
@@ -29,7 +29,7 @@ func ExecuteHelmfileGenerateVarfile(cmd *cobra.Command, args []string) error {
 	info.Stack = stack
 	info.ComponentType = "helmfile"
 
-	info, err = ProcessStacks(info)
+	info, err = ProcessStacks(info, true)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -30,7 +30,7 @@ func ExecuteTerraformGenerateBackend(cmd *cobra.Command, args []string) error {
 	info.Stack = stack
 	info.ComponentType = "terraform"
 
-	info, err = ProcessStacks(info)
+	info, err = ProcessStacks(info, true)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/terraform_generate_varfile.go
+++ b/internal/exec/terraform_generate_varfile.go
@@ -29,7 +29,7 @@ func ExecuteTerraformGenerateVarfile(cmd *cobra.Command, args []string) error {
 	info.Stack = stack
 	info.ComponentType = "terraform"
 
-	info, err = ProcessStacks(info)
+	info, err = ProcessStacks(info, true)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -195,6 +195,33 @@ func processArgsConfigAndStacks(componentType string, cmd *cobra.Command, args [
 	return ProcessStacks(configAndStacksInfo)
 }
 
+// FindStacksMap processes stack config and returns a map of all stacks
+func FindStacksMap(configAndStacksInfo c.ConfigAndStacksInfo) (map[string]interface{}, error) {
+	// Process and merge CLI configurations
+	err := c.InitConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.ProcessConfig(configAndStacksInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process stack config file(s)
+	_, stacksMap, err := s.ProcessYAMLConfigFiles(
+		c.ProcessedConfig.StacksBaseAbsolutePath,
+		c.ProcessedConfig.StackConfigFilesAbsolutePaths,
+		false,
+		true)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stacksMap, nil
+}
+
 // ProcessStacks processes stack config
 func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo) (c.ConfigAndStacksInfo, error) {
 	// Check if stack was provided
@@ -211,24 +238,7 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo) (c.ConfigAndStacks
 
 	configAndStacksInfo.StackFromArg = configAndStacksInfo.Stack
 
-	// Process and merge CLI configurations
-	err := c.InitConfig()
-	if err != nil {
-		return configAndStacksInfo, err
-	}
-
-	err = c.ProcessConfig(configAndStacksInfo)
-	if err != nil {
-		return configAndStacksInfo, err
-	}
-
-	// Process stack config file(s)
-	_, stacksMap, err := s.ProcessYAMLConfigFiles(
-		c.ProcessedConfig.StacksBaseAbsolutePath,
-		c.ProcessedConfig.StackConfigFilesAbsolutePaths,
-		false,
-		true)
-
+	stacksMap, err := FindStacksMap(configAndStacksInfo)
 	if err != nil {
 		return configAndStacksInfo, err
 	}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -192,18 +192,18 @@ func processArgsConfigAndStacks(componentType string, cmd *cobra.Command, args [
 		return configAndStacksInfo, err
 	}
 
-	return ProcessStacks(configAndStacksInfo)
+	return ProcessStacks(configAndStacksInfo, true)
 }
 
 // FindStacksMap processes stack config and returns a map of all stacks
-func FindStacksMap(configAndStacksInfo c.ConfigAndStacksInfo) (map[string]interface{}, error) {
+func FindStacksMap(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (map[string]interface{}, error) {
 	// Process and merge CLI configurations
 	err := c.InitConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.ProcessConfig(configAndStacksInfo)
+	err = c.ProcessConfig(configAndStacksInfo, checkStack)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func FindStacksMap(configAndStacksInfo c.ConfigAndStacksInfo) (map[string]interf
 }
 
 // ProcessStacks processes stack config
-func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo) (c.ConfigAndStacksInfo, error) {
+func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (c.ConfigAndStacksInfo, error) {
 	// Check if stack was provided
 	if len(configAndStacksInfo.Stack) < 1 {
 		message := fmt.Sprintf("'stack' is required. Usage: atmos %s <command> <component> -s <stack>", configAndStacksInfo.ComponentType)
@@ -238,7 +238,7 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo) (c.ConfigAndStacks
 
 	configAndStacksInfo.StackFromArg = configAndStacksInfo.Stack
 
-	stacksMap, err := FindStacksMap(configAndStacksInfo)
+	stacksMap, err := FindStacksMap(configAndStacksInfo, checkStack)
 	if err != nil {
 		return configAndStacksInfo, err
 	}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -225,7 +225,7 @@ func FindStacksMap(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 // ProcessStacks processes stack config
 func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (c.ConfigAndStacksInfo, error) {
 	// Check if stack was provided
-	if len(configAndStacksInfo.Stack) < 1 {
+	if checkStack && len(configAndStacksInfo.Stack) < 1 {
 		message := fmt.Sprintf("'stack' is required. Usage: atmos %s <command> <component> -s <stack>", configAndStacksInfo.ComponentType)
 		return configAndStacksInfo, errors.New(message)
 	}

--- a/pkg/component/component_processor.go
+++ b/pkg/component/component_processor.go
@@ -15,10 +15,10 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 	configAndStacksInfo.Stack = stack
 
 	configAndStacksInfo.ComponentType = "terraform"
-	configAndStacksInfo, err := e.ProcessStacks(configAndStacksInfo)
+	configAndStacksInfo, err := e.ProcessStacks(configAndStacksInfo, true)
 	if err != nil {
 		configAndStacksInfo.ComponentType = "helmfile"
-		configAndStacksInfo, err = e.ProcessStacks(configAndStacksInfo)
+		configAndStacksInfo, err = e.ProcessStacks(configAndStacksInfo, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,7 +158,7 @@ func InitConfig() error {
 }
 
 // ProcessConfig processes and checks CLI configuration
-func ProcessConfig(configAndStacksInfo ConfigAndStacksInfo) error {
+func ProcessConfig(configAndStacksInfo ConfigAndStacksInfo, checkStack bool) error {
 	// Process ENV vars
 	err := processEnvVars()
 	if err != nil {
@@ -240,40 +240,42 @@ func ProcessConfig(configAndStacksInfo ConfigAndStacksInfo) error {
 	ProcessedConfig.StackConfigFilesAbsolutePaths = stackConfigFilesAbsolutePaths
 	ProcessedConfig.StackConfigFilesRelativePaths = stackConfigFilesRelativePaths
 
-	if stackIsPhysicalPath == true {
-		if g.LogVerbose {
-			color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack config file %s\n",
-				configAndStacksInfo.Stack,
-				stackConfigFilesRelativePaths[0]),
-			)
-		}
-		ProcessedConfig.StackType = "Directory"
-	} else {
-		// The stack is a logical name
-		// Check if it matches the pattern specified in 'StackNamePattern'
-		if len(Config.Stacks.NamePattern) == 0 {
-			errorMessage := "\nStack name pattern must be provided and must not be empty. Check the CLI config in 'atmos.yaml'"
-			return errors.New(errorMessage)
-		}
-
-		stackParts := strings.Split(configAndStacksInfo.Stack, "-")
-		stackNamePatternParts := strings.Split(Config.Stacks.NamePattern, "-")
-
-		if len(stackParts) == len(stackNamePatternParts) {
+	if checkStack {
+		if stackIsPhysicalPath == true {
 			if g.LogVerbose {
-				color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack name pattern '%s'",
+				color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack config file %s\n",
 					configAndStacksInfo.Stack,
-					Config.Stacks.NamePattern),
+					stackConfigFilesRelativePaths[0]),
 				)
 			}
-			ProcessedConfig.StackType = "Logical"
+			ProcessedConfig.StackType = "Directory"
 		} else {
-			errorMessage := fmt.Sprintf("\nThe stack '%s' does not exist in the config directories, "+
-				"and it does not match the stack name pattern '%s'",
-				configAndStacksInfo.Stack,
-				Config.Stacks.NamePattern,
-			)
-			return errors.New(errorMessage)
+			// The stack is a logical name
+			// Check if it matches the pattern specified in 'StackNamePattern'
+			if len(Config.Stacks.NamePattern) == 0 {
+				errorMessage := "\nStack name pattern must be provided and must not be empty. Check the CLI config in 'atmos.yaml'"
+				return errors.New(errorMessage)
+			}
+
+			stackParts := strings.Split(configAndStacksInfo.Stack, "-")
+			stackNamePatternParts := strings.Split(Config.Stacks.NamePattern, "-")
+
+			if len(stackParts) == len(stackNamePatternParts) {
+				if g.LogVerbose {
+					color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack name pattern '%s'",
+						configAndStacksInfo.Stack,
+						Config.Stacks.NamePattern),
+					)
+				}
+				ProcessedConfig.StackType = "Logical"
+			} else {
+				errorMessage := fmt.Sprintf("\nThe stack '%s' does not exist in the config directories, "+
+					"and it does not match the stack name pattern '%s'",
+					configAndStacksInfo.Stack,
+					Config.Stacks.NamePattern,
+				)
+				return errors.New(errorMessage)
+			}
 		}
 	}
 


### PR DESCRIPTION
## what
* Add `atmos describe stacks` command
* Allow writing the result to a file by using `--file` command-line flag
* Allow formatting the result as YAML or JSON by using `--format` command-line flag
* Allow filtering of the result by using the command-line flags: `stack`, `components-types`, `components`, `sections`
* Available component sections: `backend`, `backend_type`, `deps`, `env`, `inheritance`, `metadata`, `remote_state_backend`, `remote_state_backend_type`, `settings`, `vars`

## why
* Command to show stack configs and all the components in the stacks
* Slice and dice the stack config to show different information about stacks and components 

## usage

```
atmos describe stacks
atmos describe stacks --component-types=helmfile
atmos describe stacks --component-types=terraform,helmfile
atmos describe stacks --components=infra/vpc
atmos describe stacks --components=echo-server
atmos describe stacks --components=echo-server,infra/vpc
atmos describe stacks --components=echo-server,infra/vpc --sections=vars
atmos describe stacks --components=echo-server,infra/vpc --sections=vars,settings
atmos describe stacks --components=test/test-component-override-3 --sections=inheritance
atmos describe stacks --components=test/test-component-override-3 --sections=component
atmos describe stacks --components=test/test-component-override-3 --sections=deps
atmos describe stacks --components=test/test-component-override-3 --sections=vars,settings --file=stacks.yaml
atmos describe stacks --components=test/test-component-override-3 --sections=vars,settings --format=json --file=stacks.json
atmos describe stacks --components=test/test-component-override-3 --sections=deps,vars -s=tenant2/ue2/staging
```

## tests

### Show all stacks with all the components with all the component sections (Warning: this will dump ALL YAML config for all components for all stacks to the console)

```
atmos describe stacks

......

tenant2/ue2/staging:
  components:
    terraform:
      test/test-component-override-3:
        backend:
          acl: bucket-owner-full-control
          bucket: eg-ue2-root-tfstate
          dynamodb_table: eg-ue2-root-tfstate-lock
          encrypt: true
          key: terraform.tfstate
          region: us-east-2
          role_arn: null
          workspace_key_prefix: test-test-component
        backend_type: s3
        command: terraform
        component: test/test-component
        deps:
        - catalog/terraform/services/service-1
        - catalog/terraform/services/service-2
        - catalog/terraform/test-component
        - catalog/terraform/test-component-override-3
        - globals/globals
        - globals/tenant2-globals
        - globals/ue2-globals
        - tenant2/ue2/staging
        env:
          TEST_ENV_VAR1: val1-override-3
          TEST_ENV_VAR2: val2-override-3
          TEST_ENV_VAR3: val3-override-3
          TEST_ENV_VAR4: val4-override-3
        inheritance:
        - mixin/test-2
        - mixin/test-1
        - test/test-component-override-2
        - test/test-component-override
        - test/test-component
        metadata:
          component: test/test-component
          inherits:
          - test/test-component-override
          - test/test-component-override-2
          - mixin/test-1
          - mixin/test-2
          terraform_workspace: test-component-override-3-workspace
          type: real
        remote_state_backend:
          acl: bucket-owner-full-control
          bucket: eg-ue2-root-tfstate
          dynamodb_table: eg-ue2-root-tfstate-lock
          encrypt: true
          key: terraform.tfstate
          region: us-east-2
          role_arn: arn:aws:iam::123456789012:role/eg-gbl-root-terraform
          workspace_key_prefix: test-test-component
        remote_state_backend_type: s3
        settings:
          spacelift:
            stack_name_pattern: '{tenant}-{environment}-{stage}-new-component'
            workspace_enabled: false
        vars:
          enabled: true
          environment: ue2
          namespace: eg
          region: us-east-2
          service_1_list:
          - 5
          - 6
          - 7
          service_1_map:
            a: 1
            b: 6
            c: 7
            d: 8
          service_1_name: mixin-2
          service_2_list:
          - 4
          - 5
          - 6
          service_2_map:
            a: 4
            b: 5
            c: 6
          service_2_name: service-2-override-2
          stage: staging
          tenant: tenant2

....

```

### Show only stacks with `terraform` components

```
atmos describe stacks --component-types=terraform
```

### Show only stacks with `helmfile` components

```
atmos describe stacks --component-types=helmfile
```

### Show only a specific stack with all the components with all the component sections

```
atmos describe stacks -s=tenant2/ue2/staging
```

### Show only the stacks where a specific component is configured (with all component sections) 

```
atmos describe stacks --components=infra/vpc
```

### Show only the stacks where the specific components are configured (with all component sections) 

```
atmos describe stacks --components=echo-server,infra/vpc
```

### Show only the specific sections for the components in all stacks 

```
atmos describe stacks --components=echo-server,infra/vpc --sections=vars,settings
atmos describe stacks --components=test/test-component-override-3 --sections=inheritance
atmos describe stacks --components=test/test-component-override-3 --sections=component
atmos describe stacks --components=test/test-component-override-3 --sections=deps
```

### Write the result to a file (in YAML format)

```
atmos describe stacks --sections=vars,settings --file=stacks.yaml
```

### Write the result to a file (in JSON format)

```
atmos describe stacks --sections=vars,settings --format=json --file=stacks.json
```

### Show all configured stacks (by specifying a non existing component in the filter)

```
atmos describe stacks --components=none

tenant1/ue2/dev: {}
tenant1/ue2/prod: {}
tenant1/ue2/staging: {}
tenant2/ue2/dev: {}
tenant2/ue2/prod: {}
tenant2/ue2/staging: {}
```

### Show all components in all stacks with just the component names (by specifying a non existing section in the filter)

```
atmos describe stacks --sections=none

tenant1/ue2/dev:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
tenant1/ue2/prod:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
tenant1/ue2/staging:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
tenant2/ue2/dev:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
tenant2/ue2/prod:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
tenant2/ue2/staging:
  components:
    helmfile:
      echo-server: {}
      infra/infra-server: {}
      infra/infra-server-override: {}
    terraform:
      infra/vpc: {}
      mixin/test-1: {}
      mixin/test-2: {}
      test/test-component: {}
      test/test-component-override: {}
      test/test-component-override-2: {}
      test/test-component-override-3: {}
      top-level-component1: {}
```

### Show only a specific component in all stacks with just the component name (by specifying a non existing section in the filter) - this shows in which stacks the specified component exists

```
atmos describe stacks --components=infra/vpc --sections=none

tenant1/ue2/dev:
  components:
    terraform:
      infra/vpc: {}
tenant1/ue2/prod:
  components:
    terraform:
      infra/vpc: {}
tenant1/ue2/staging:
  components:
    terraform:
      infra/vpc: {}
tenant2/ue2/dev:
  components:
    terraform:
      infra/vpc: {}
tenant2/ue2/prod:
  components:
    terraform:
      infra/vpc: {}
tenant2/ue2/staging:
  components:
    terraform:
      infra/vpc: {}
```
