### PR TITLE
  Take into account `init_run_reconfigure` CLI config and `--init-run-reconfigure` command-line argument when running `atmos terraform init ...` command

### DIFF
--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -156,7 +156,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Run `terraform init`
+	// Run `terraform init` before running other commands
 	runTerraformInit := true
 	if info.SubCommand == "init" ||
 		info.SubCommand == "clean" ||
@@ -241,6 +241,11 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 			allArgsAndFlags = append(allArgsAndFlags, []string{planFile}...)
 		} else {
 			allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
+		}
+		break
+	case "init":
+		if c.Config.Components.Terraform.InitRunReconfigure == true {
+			allArgsAndFlags = append(allArgsAndFlags, []string{"-reconfigure"}...)
 		}
 		break
 	}


### PR DESCRIPTION
## what
*   Take into account `init_run_reconfigure` CLI config and `--init-run-reconfigure` command-line argument when running `atmos terraform init ...` command

## why
* `atmos terraform init` must behave the same as all other commands that use `init_run_reconfigure` CLI config and `--init-run-reconfigure` command-line argument

