### PR TITLE
Add `metadata.terraform_workspace_pattern`

### DIFF
--- a/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override-2.yaml
@@ -40,3 +40,7 @@ components:
           val2: "5"
           val3: 7
           val4: null
+      metadata:
+        # Override Terraform workspace
+        # Note that by default, Terraform workspace is generated from the context, e.g. `<environment>-<stage>`
+        terraform_workspace_pattern: "{tenant}-{environment}-{stage}-{component}"

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -1,0 +1,36 @@
+package exec
+
+import (
+	"fmt"
+	c "github.com/cloudposse/atmos/pkg/config"
+	"strings"
+)
+
+// BuildTerraformWorkspace builds Terraform workspace
+func BuildTerraformWorkspace(
+	stack string,
+	stackNamePattern string,
+	componentMetadata map[interface{}]interface{},
+	component string,
+	baseComponent string,
+	context c.Context,
+) (string, error) {
+
+	contextPrefix, err := c.GetContextPrefix(stack, context, stackNamePattern)
+	if err != nil {
+		return "", err
+	}
+
+	var workspace string
+
+	// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
+	if componentTerraformWorkspace, componentTerraformWorkspaceExist := componentMetadata["terraform_workspace"].(string); componentTerraformWorkspaceExist {
+		workspace = componentTerraformWorkspace
+	} else if baseComponent == "" {
+		workspace = contextPrefix
+	} else {
+		workspace = fmt.Sprintf("%s-%s", contextPrefix, component)
+	}
+
+	return strings.Replace(workspace, "/", "-", -1), nil
+}

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -11,8 +11,6 @@ func BuildTerraformWorkspace(
 	stack string,
 	stackNamePattern string,
 	componentMetadata map[interface{}]interface{},
-	component string,
-	baseComponent string,
 	context c.Context,
 ) (string, error) {
 
@@ -23,13 +21,16 @@ func BuildTerraformWorkspace(
 
 	var workspace string
 
-	// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
-	if componentTerraformWorkspace, componentTerraformWorkspaceExist := componentMetadata["terraform_workspace"].(string); componentTerraformWorkspaceExist {
-		workspace = componentTerraformWorkspace
-	} else if baseComponent == "" {
+	if terraformWorkspacePattern, terraformWorkspacePatternExist := componentMetadata["terraform_workspace_pattern"].(string); terraformWorkspacePatternExist {
+		// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace_pattern`
+		workspace = c.ReplaceContextTokens(context, terraformWorkspacePattern)
+	} else if terraformWorkspace, terraformWorkspaceExist := componentMetadata["terraform_workspace"].(string); terraformWorkspaceExist {
+		// Terraform workspace can be overridden per component in YAML config `metadata.terraform_workspace`
+		workspace = terraformWorkspace
+	} else if context.BaseComponent == "" {
 		workspace = contextPrefix
 	} else {
-		workspace = fmt.Sprintf("%s-%s", contextPrefix, component)
+		workspace = fmt.Sprintf("%s-%s", contextPrefix, context.Component)
 	}
 
 	return strings.Replace(workspace, "/", "-", -1), nil

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -418,7 +418,7 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 	// Process context
 	configAndStacksInfo.Context = c.GetContextFromVars(configAndStacksInfo.ComponentVarsSection)
 	configAndStacksInfo.Context.Component = configAndStacksInfo.ComponentFromArg
-	configAndStacksInfo.Context.BaseComponent = configAndStacksInfo.BaseComponent
+	configAndStacksInfo.Context.BaseComponent = configAndStacksInfo.BaseComponentPath
 	configAndStacksInfo.ContextPrefix, err = c.GetContextPrefix(configAndStacksInfo.Stack, configAndStacksInfo.Context, c.Config.Stacks.NamePattern)
 	if err != nil {
 		return configAndStacksInfo, err

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -417,6 +417,8 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 
 	// Process context
 	configAndStacksInfo.Context = c.GetContextFromVars(configAndStacksInfo.ComponentVarsSection)
+	configAndStacksInfo.Context.Component = configAndStacksInfo.ComponentFromArg
+	configAndStacksInfo.Context.BaseComponent = configAndStacksInfo.BaseComponent
 	configAndStacksInfo.ContextPrefix, err = c.GetContextPrefix(configAndStacksInfo.Stack, configAndStacksInfo.Context, c.Config.Stacks.NamePattern)
 	if err != nil {
 		return configAndStacksInfo, err
@@ -427,9 +429,8 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 		configAndStacksInfo.Stack,
 		c.Config.Stacks.NamePattern,
 		configAndStacksInfo.ComponentMetadataSection,
-		configAndStacksInfo.ComponentFromArg,
-		configAndStacksInfo.BaseComponent,
-		configAndStacksInfo.Context)
+		configAndStacksInfo.Context,
+	)
 	if err != nil {
 		return configAndStacksInfo, err
 	}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -637,7 +637,7 @@ func processArgsAndFlags(inputArgsAndFlags []string) (c.ArgsAndFlagsInfo, error)
 	return info, nil
 }
 
-// generateComponentBackendConfig generates backend config components
+// generateComponentBackendConfig generates backend config for components
 func generateComponentBackendConfig(backendType string, backendConfig map[interface{}]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"terraform": map[string]interface{}{

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -56,12 +56,13 @@ type ProcessedConfiguration struct {
 }
 
 type Context struct {
-	Namespace   string
-	Tenant      string
-	Environment string
-	Stage       string
-	Region      string
-	Component   string
+	Namespace     string
+	Tenant        string
+	Environment   string
+	Stage         string
+	Region        string
+	Component     string
+	BaseComponent string
 }
 
 type ArgsAndFlagsInfo struct {

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -428,18 +428,15 @@ func GetContextPrefix(stack string, context Context, stackNamePattern string) (s
 	return contextPrefix, nil
 }
 
-// ReplaceContextTokens replaces tokens in the context pattern
+// ReplaceContextTokens replaces context tokens in the provided pattern and returns a string with all the tokens replaced
 func ReplaceContextTokens(context Context, pattern string) string {
-	return strings.Replace(
-		strings.Replace(
-			strings.Replace(
-				strings.Replace(
-					strings.Replace(
-						strings.Replace(pattern,
-							"{base-component}", context.BaseComponent, 1),
-						"{component}", context.Component, 1),
-					"{namespace}", context.Namespace, 1),
-				"{environment}", context.Environment, 1),
-			"{tenant}", context.Tenant, 1),
-		"{stage}", context.Stage, 1)
+	r := strings.NewReplacer(
+		"{base-component}", context.BaseComponent,
+		"{component}", context.Component,
+		"{namespace}", context.Namespace,
+		"{environment}", context.Environment,
+		"{tenant}", context.Tenant,
+		"{stage}", context.Stage,
+	)
+	return r.Replace(pattern)
 }

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -434,7 +434,9 @@ func ReplaceContextTokens(context Context, pattern string) string {
 		strings.Replace(
 			strings.Replace(
 				strings.Replace(
-					strings.Replace(pattern,
+					strings.Replace(
+						strings.Replace(pattern,
+							"{base-component}", context.BaseComponent, 1),
 						"{component}", context.Component, 1),
 					"{namespace}", context.Namespace, 1),
 				"{environment}", context.Environment, 1),

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -367,7 +367,15 @@ func TransformStackConfigToSpaceliftStacks(
 						componentInheritance = i.([]string)
 					}
 
+					baseComponentName := ""
+					if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
+						baseComponentName = baseComponent.(string)
+					}
+
 					context := c.GetContextFromVars(componentVars)
+					context.Component = component
+					context.BaseComponent = baseComponentName
+
 					contextPrefix, err := c.GetContextPrefix(stackName, context, stackNamePattern)
 					if err != nil {
 						return nil, err
@@ -382,11 +390,6 @@ func TransformStackConfigToSpaceliftStacks(
 					spaceliftConfig["deps"] = componentDeps
 					spaceliftConfig["stacks"] = componentStacks
 					spaceliftConfig["inheritance"] = componentInheritance
-
-					baseComponentName := ""
-					if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
-						baseComponentName = baseComponent.(string)
-					}
 					spaceliftConfig["base_component"] = baseComponentName
 
 					// backend
@@ -414,8 +417,6 @@ func TransformStackConfigToSpaceliftStacks(
 						stackName,
 						stackNamePattern,
 						componentMetadata,
-						component,
-						baseComponentName,
 						context,
 					)
 					if err != nil {
@@ -463,7 +464,6 @@ func TransformStackConfigToSpaceliftStacks(
 					spaceliftConfig["labels"] = u.UniqueStrings(labels)
 
 					// Spacelift stack name
-					context.Component = component
 					spaceliftStackName, spaceliftStackNamePattern := buildSpaceliftStackName(spaceliftSettings, context, contextPrefix)
 
 					// Add Spacelift stack config to the final map

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -367,14 +367,20 @@ func TransformStackConfigToSpaceliftStacks(
 						componentInheritance = i.([]string)
 					}
 
+					// Process base component
+					// Base component can be specified in two places:
+					// `component` attribute (legacy)
+					// `metadata.component` attribute
+					// `metadata.component` takes precedence over `component`
 					baseComponentName := ""
 					if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
 						baseComponentName = baseComponent.(string)
 					}
-
+					// First check if component's `metadata` section exists
+					// Then check if `metadata.component` exists
 					if componentMetadata, componentMetadataExists := componentMap["metadata"].(map[interface{}]interface{}); componentMetadataExists {
-						if componentMetadataComponent, componentMetadataComponentExists := componentMetadata["component"].(string); componentMetadataComponentExists {
-							baseComponentName = componentMetadataComponent
+						if componentFromMetadata, componentFromMetadataExists := componentMetadata["component"].(string); componentFromMetadataExists {
+							baseComponentName = componentFromMetadata
 						}
 					}
 

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -372,6 +372,12 @@ func TransformStackConfigToSpaceliftStacks(
 						baseComponentName = baseComponent.(string)
 					}
 
+					if componentMetadata, componentMetadataExists := componentMap["metadata"].(map[interface{}]interface{}); componentMetadataExists {
+						if componentMetadataComponent, componentMetadataComponentExists := componentMetadata["component"].(string); componentMetadataComponentExists {
+							baseComponentName = componentMetadataComponent
+						}
+					}
+
 					context := c.GetContextFromVars(componentVars)
 					context.Component = component
 					context.BaseComponent = baseComponentName


### PR DESCRIPTION
## what
* Add `metadata.terraform_workspace_pattern`

## why
* We already have `metadata.terraform_workspace` using which we can specify/override the terraform workspace for a component
* `metadata.terraform_workspace_pattern` introduces a pattern to override a terraform workspace for a component 

```
      metadata:
        # Override Terraform workspace
        terraform_workspace: xxxxxxxxxxxxxxx
        terraform_workspace_pattern: "{tenant}-{environment}-{stage}-{component}"
```

* The following tokens are supported in `metadata.terraform_workspace_pattern`:
  - {namespace}
  - {tenant}
  - {environment}
  - {stage}
  - {component}
  - {base-component}
 
* This is useful to when converting YAML stack configs from the old `atmos` based on `variant`. In he old `atmos`, when a `component: xxx` attribute was specified for a component, it was considered as base component even if it was the same as the YAML component itself, in which case the terraform workspace for the component was calculated as `<environment>-<stage>-<component>`. The new `atmos` does not consider the same name for the `component:` attribute as a base component, which leads to the terraform workspace `<environment>-<stage>` (and hence Terraform not seeing the old workspace and wanting to re-create the component. To fix it, add  `terraform_workspace_pattern: "{environment}-{stage}-{component}"` to the component's metadata


