### PR TITLE
If functions that are used by Terraform providers throw errors, print errors to std.Error

### DIFF
--- a/pkg/aws/aws_eks_update_kubeconfig.go
+++ b/pkg/aws/aws_eks_update_kubeconfig.go
@@ -1,12 +1,20 @@
-package exec
+package aws
 
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
 	c "github.com/cloudposse/atmos/pkg/config"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 // ExecuteAwsEksUpdateKubeconfig executes 'aws eks update-kubeconfig'
 // https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html
 func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext c.AwsEksUpdateKubeconfigContext) error {
-	return e.ExecuteAwsEksUpdateKubeconfig(kubeconfigContext)
+	err := e.ExecuteAwsEksUpdateKubeconfig(kubeconfigContext)
+
+	if err != nil {
+		u.PrintErrorToStdError(err)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/component/component_processor.go
+++ b/pkg/component/component_processor.go
@@ -3,6 +3,7 @@ package component
 import (
 	e "github.com/cloudposse/atmos/internal/exec"
 	c "github.com/cloudposse/atmos/pkg/config"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/pkg/errors"
 )
 
@@ -18,6 +19,7 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 		configAndStacksInfo.ComponentType = "helmfile"
 		configAndStacksInfo, err = e.ProcessStacks(configAndStacksInfo, true)
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 	}
@@ -29,15 +31,19 @@ func ProcessComponentInStack(component string, stack string) (map[string]interfa
 func ProcessComponentFromContext(component string, tenant string, environment string, stage string) (map[string]interface{}, error) {
 	err := c.InitConfig()
 	if err != nil {
+		u.PrintErrorToStdError(err)
 		return nil, err
 	}
 
 	if len(c.Config.Stacks.NamePattern) < 1 {
-		return nil, errors.New("stack name pattern must be provided in 'stacks.name_pattern' CLI config or 'ATMOS_STACKS_NAME_PATTERN' ENV variable")
+		er := errors.New("stack name pattern must be provided in 'stacks.name_pattern' CLI config or 'ATMOS_STACKS_NAME_PATTERN' ENV variable")
+		u.PrintErrorToStdError(er)
+		return nil, er
 	}
 
 	stack, err := c.GetStackNameFromContextAndStackNamePattern(tenant, environment, stage, c.Config.Stacks.NamePattern)
 	if err != nil {
+		u.PrintErrorToStdError(err)
 		return nil, err
 	}
 

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/imdario/mergo"
 	"gopkg.in/yaml.v2"
 )
@@ -19,11 +20,13 @@ func MergeWithOptions(inputs []map[interface{}]interface{}, appendSlice, sliceDe
 		// so `mergo` does not have access to the original pointers
 		yamlCurrent, err := yaml.Marshal(current)
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
 		var dataCurrent map[interface{}]interface{}
 		if err = yaml.Unmarshal(yamlCurrent, &dataCurrent); err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
@@ -39,6 +42,7 @@ func MergeWithOptions(inputs []map[interface{}]interface{}, appendSlice, sliceDe
 		}
 
 		if err = mergo.Merge(&merged, dataCurrent, opts...); err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 	}

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -23,6 +23,7 @@ func CreateSpaceliftStacks(
 	if filePaths != nil && len(filePaths) > 0 {
 		_, stacks, err := s.ProcessYAMLConfigFiles(basePath, filePaths, processStackDeps, processComponentDeps)
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
@@ -30,11 +31,13 @@ func CreateSpaceliftStacks(
 	} else {
 		err := c.InitConfig()
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
 		err = c.ProcessConfigForSpacelift()
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
@@ -44,6 +47,7 @@ func CreateSpaceliftStacks(
 			processStackDeps,
 			processComponentDeps)
 		if err != nil {
+			u.PrintErrorToStdError(err)
 			return nil, err
 		}
 
@@ -210,6 +214,7 @@ func LegacyTransformStackConfigToSpaceliftStacks(
 							terraformComponentNamesInCurrentStack,
 							component)
 						if err != nil {
+							u.PrintErrorToStdError(err)
 							return nil, err
 						}
 						labels = append(labels, fmt.Sprintf("depends-on:%s", spaceliftStackName))
@@ -278,6 +283,7 @@ func TransformStackConfigToSpaceliftStacks(
 					context := c.GetContextFromVars(componentVars)
 					contextPrefix, err := c.GetContextPrefix(stackName, context, stackNamePattern)
 					if err != nil {
+						u.PrintErrorToStdError(err)
 						return nil, err
 					}
 
@@ -390,6 +396,7 @@ func TransformStackConfigToSpaceliftStacks(
 
 					contextPrefix, err := c.GetContextPrefix(stackName, context, stackNamePattern)
 					if err != nil {
+						u.PrintErrorToStdError(err)
 						return nil, err
 					}
 
@@ -432,6 +439,7 @@ func TransformStackConfigToSpaceliftStacks(
 						context,
 					)
 					if err != nil {
+						u.PrintErrorToStdError(err)
 						return nil, err
 					}
 					spaceliftConfig["workspace"] = workspace
@@ -465,6 +473,7 @@ func TransformStackConfigToSpaceliftStacks(
 							terraformComponentNamesInCurrentStack,
 							component)
 						if err != nil {
+							u.PrintErrorToStdError(err)
 							return nil, err
 						}
 						labels = append(labels, fmt.Sprintf("depends-on:%s", spaceliftStackNameDependsOn))
@@ -492,7 +501,9 @@ func TransformStackConfigToSpaceliftStacks(
 							stackName,
 							spaceliftStackNamePattern,
 						)
-						return nil, errors.New(errorMessage)
+						er := errors.New(errorMessage)
+						u.PrintErrorToStdError(er)
+						return nil, er
 					}
 				}
 			}

--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -11,7 +11,6 @@ import (
 	c "github.com/cloudposse/atmos/pkg/convert"
 	g "github.com/cloudposse/atmos/pkg/globals"
 	m "github.com/cloudposse/atmos/pkg/merge"
-	"github.com/cloudposse/atmos/pkg/utils"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -57,7 +56,7 @@ func ProcessYAMLConfigFiles(
 				imports = append(imports, k)
 			}
 
-			uniqueImports := utils.UniqueStrings(imports)
+			uniqueImports := u.UniqueStrings(imports)
 			sort.Strings(uniqueImports)
 
 			componentStackMap := map[string]map[string][]string{}
@@ -94,7 +93,7 @@ func ProcessYAMLConfigFiles(
 
 			stackName := strings.TrimSuffix(
 				strings.TrimSuffix(
-					utils.TrimBasePathFromPath(stackBasePath+"/", p),
+					u.TrimBasePathFromPath(stackBasePath+"/", p),
 					g.DefaultStackConfigFileExtension),
 				".yml",
 			)
@@ -110,6 +109,7 @@ func ProcessYAMLConfigFiles(
 	wg.Wait()
 
 	if errorResult != nil {
+		u.PrintErrorToStdError(errorResult)
 		return nil, nil, errorResult
 	}
 	return listResult, mapResult, nil
@@ -224,7 +224,7 @@ func ProcessConfig(
 
 	stackName := strings.TrimSuffix(
 		strings.TrimSuffix(
-			utils.TrimBasePathFromPath(basePath+"/", stack),
+			u.TrimBasePathFromPath(basePath+"/", stack),
 			g.DefaultStackConfigFileExtension),
 		".yml",
 	)

--- a/pkg/utils/os_utils.go
+++ b/pkg/utils/os_utils.go
@@ -9,6 +9,14 @@ import (
 // PrintErrorToStdErrorAndExit prints errors to std.Error and exits with an error code
 func PrintErrorToStdErrorAndExit(err error) {
 	if err != nil {
+		PrintErrorToStdError(err)
+		os.Exit(1)
+	}
+}
+
+// PrintErrorToStdError prints errors to std.Error
+func PrintErrorToStdError(err error) {
+	if err != nil {
 		c := color.New(color.FgRed)
 		_, err2 := c.Fprintln(color.Error, err.Error()+"\n")
 		if err2 != nil {
@@ -17,7 +25,6 @@ func PrintErrorToStdErrorAndExit(err error) {
 			fmt.Println("Original error message:")
 			PrintError(err)
 		}
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## what
* If functions that are used by Terraform providers throw errors, print errors to std.Error

## why
* Terraform providers only see errors that are sent to std.Error


