### PR TITLE
Support dashes `-` in the tenant, environment and stage names

### DIFF
--- a/examples/complete/stacks/tenant1/ue2/test1.yaml
+++ b/examples/complete/stacks/tenant1/ue2/test1.yaml
@@ -1,0 +1,27 @@
+import:
+  - globals/tenant1-globals
+  - globals/ue2-globals
+  - catalog/terraform/top-level-component1
+  - catalog/terraform/test-component
+  - catalog/terraform/test-component-override
+  - catalog/terraform/test-component-override-2
+  - catalog/terraform/test-component-override-3
+  - catalog/terraform/vpc
+  - catalog/helmfile/echo-server
+  - catalog/helmfile/infra-server
+  - catalog/helmfile/infra-server-override
+
+vars:
+  stage: test-1
+
+terraform:
+  vars: {}
+
+helmfile:
+  vars: {}
+
+components:
+  terraform:
+    "infra/vpc":
+      vars:
+        cidr_block: 10.11.0.0/18

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -277,6 +277,15 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 		}
 
 		configAndStacksInfo.ComponentEnvList = convertEnvVars(configAndStacksInfo.ComponentEnvSection)
+
+		// Process context
+		configAndStacksInfo.Context = c.GetContextFromVars(configAndStacksInfo.ComponentVarsSection)
+		configAndStacksInfo.Context.Component = configAndStacksInfo.ComponentFromArg
+		configAndStacksInfo.Context.BaseComponent = configAndStacksInfo.BaseComponentPath
+		configAndStacksInfo.ContextPrefix, err = c.GetContextPrefix(configAndStacksInfo.Stack, configAndStacksInfo.Context, c.Config.Stacks.NamePattern)
+		if err != nil {
+			return configAndStacksInfo, err
+		}
 	} else {
 		if g.LogVerbose {
 			color.Cyan("Searching for stack config where the component '%s' is defined\n", configAndStacksInfo.ComponentFromArg)
@@ -314,7 +323,7 @@ func ProcessStacks(configAndStacksInfo c.ConfigAndStacksInfo, checkStack bool) (
 			// Check if we've found the stack
 			if configAndStacksInfo.Stack == configAndStacksInfo.ContextPrefix {
 				stackFound = true
-				color.Cyan("Found config for the component '%s' in the stack '%s' in the file '%s'\n",
+				color.Cyan("Found config for the component '%s' for the stack '%s' in the file '%s'\n",
 					configAndStacksInfo.ComponentFromArg,
 					configAndStacksInfo.Stack,
 					stackName,

--- a/pkg/component/component_processor_test.go
+++ b/pkg/component/component_processor_test.go
@@ -114,12 +114,27 @@ func TestComponentProcessor(t *testing.T) {
 	stage = "dev"
 	tenant1Ue2DevTestTestComponentOverrideComponent2, err = ProcessComponentFromContext(component, tenant, environment, stage)
 	assert.Nil(t, err)
+	tenant1Ue2DevTestTestComponentOverrideComponent2Backend := tenant1Ue2DevTestTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
 	tenant1Ue2DevTestTestComponentOverrideComponent2Workspace := tenant1Ue2DevTestTestComponentOverrideComponent2["workspace"].(string)
-	tenant1Ue2DevTestTestComponentOverrideComponent2WorkspaceKeyPrefix := tenant1Ue2DevTestTestComponentOverrideComponentBackend["workspace_key_prefix"].(string)
+	tenant1Ue2DevTestTestComponentOverrideComponent2WorkspaceKeyPrefix := tenant1Ue2DevTestTestComponentOverrideComponent2Backend["workspace_key_prefix"].(string)
 	assert.Equal(t, "tenant1-ue2-dev-test-test-component-override-2", tenant1Ue2DevTestTestComponentOverrideComponent2Workspace)
 	assert.Equal(t, "test-test-component", tenant1Ue2DevTestTestComponentOverrideComponent2WorkspaceKeyPrefix)
 
 	yamlConfig, err = yaml.Marshal(tenant1Ue2DevTestTestComponentOverrideComponent2)
 	assert.Nil(t, err)
 	t.Log(string(yamlConfig))
+
+	// Test having a dash `-` in the stage name
+	var tenant1Ue2Test1TestTestComponentOverrideComponent2 map[string]interface{}
+	component = "test/test-component-override-2"
+	tenant = "tenant1"
+	environment = "ue2"
+	stage = "test-1"
+	tenant1Ue2Test1TestTestComponentOverrideComponent2, err = ProcessComponentFromContext(component, tenant, environment, stage)
+	assert.Nil(t, err)
+	tenant1Ue2Test1TestTestComponentOverrideComponent2Backend := tenant1Ue2DevTestTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
+	tenant1Ue2Test1TestTestComponentOverrideComponent2Workspace := tenant1Ue2Test1TestTestComponentOverrideComponent2["workspace"].(string)
+	tenant1Ue2Test1TestTestComponentOverrideComponent2WorkspaceKeyPrefix := tenant1Ue2Test1TestTestComponentOverrideComponent2Backend["workspace_key_prefix"].(string)
+	assert.Equal(t, "tenant1-ue2-test-1-test-test-component-override-2", tenant1Ue2Test1TestTestComponentOverrideComponent2Workspace)
+	assert.Equal(t, "test-test-component", tenant1Ue2Test1TestTestComponentOverrideComponent2WorkspaceKeyPrefix)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 var (
@@ -240,43 +239,17 @@ func ProcessConfig(configAndStacksInfo ConfigAndStacksInfo, checkStack bool) err
 	ProcessedConfig.StackConfigFilesAbsolutePaths = stackConfigFilesAbsolutePaths
 	ProcessedConfig.StackConfigFilesRelativePaths = stackConfigFilesRelativePaths
 
-	if checkStack {
-		if stackIsPhysicalPath == true {
-			if g.LogVerbose {
-				color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack config file %s\n",
-					configAndStacksInfo.Stack,
-					stackConfigFilesRelativePaths[0]),
-				)
-			}
-			ProcessedConfig.StackType = "Directory"
-		} else {
-			// The stack is a logical name
-			// Check if it matches the pattern specified in 'StackNamePattern'
-			if len(Config.Stacks.NamePattern) == 0 {
-				errorMessage := "\nStack name pattern must be provided and must not be empty. Check the CLI config in 'atmos.yaml'"
-				return errors.New(errorMessage)
-			}
-
-			stackParts := strings.Split(configAndStacksInfo.Stack, "-")
-			stackNamePatternParts := strings.Split(Config.Stacks.NamePattern, "-")
-
-			if len(stackParts) == len(stackNamePatternParts) {
-				if g.LogVerbose {
-					color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack name pattern '%s'",
-						configAndStacksInfo.Stack,
-						Config.Stacks.NamePattern),
-					)
-				}
-				ProcessedConfig.StackType = "Logical"
-			} else {
-				errorMessage := fmt.Sprintf("\nThe stack '%s' does not exist in the config directories, "+
-					"and it does not match the stack name pattern '%s'",
-					configAndStacksInfo.Stack,
-					Config.Stacks.NamePattern,
-				)
-				return errors.New(errorMessage)
-			}
+	if stackIsPhysicalPath == true {
+		if g.LogVerbose {
+			color.Cyan(fmt.Sprintf("\nThe stack '%s' matches the stack config file %s\n",
+				configAndStacksInfo.Stack,
+				stackConfigFilesRelativePaths[0]),
+			)
 		}
+		ProcessedConfig.StackType = "Directory"
+	} else {
+		// The stack is a logical name
+		ProcessedConfig.StackType = "Logical"
 	}
 
 	if g.LogVerbose {

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -363,7 +363,7 @@ func GetContextFromVars(vars map[interface{}]interface{}) Context {
 func GetContextPrefix(stack string, context Context, stackNamePattern string) (string, error) {
 	if len(stackNamePattern) == 0 {
 		return "",
-			errors.New(fmt.Sprintf("Stack name pattern must be provided"))
+			errors.New("stack name pattern must be provided in 'stacks.name_pattern' config or 'ATMOS_STACKS_NAME_PATTERN' ENV variable")
 	}
 
 	contextPrefix := ""

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -15,7 +15,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = CreateSpaceliftStacks("", nil, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 35, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackInfrastructureStackName := tenant1Ue2DevInfraVpcStack["stack"].(string)
@@ -82,6 +82,7 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 		"../../examples/complete/stacks/tenant1/ue2/dev.yaml",
 		"../../examples/complete/stacks/tenant1/ue2/prod.yaml",
 		"../../examples/complete/stacks/tenant1/ue2/staging.yaml",
+		"../../examples/complete/stacks/tenant1/ue2/test1.yaml",
 		"../../examples/complete/stacks/tenant2/ue2/dev.yaml",
 		"../../examples/complete/stacks/tenant2/ue2/prod.yaml",
 		"../../examples/complete/stacks/tenant2/ue2/staging.yaml",
@@ -94,7 +95,7 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = CreateSpaceliftStacks(basePath, filePaths, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 35, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackBackend := tenant1Ue2DevInfraVpcStack["backend"].(map[interface{}]interface{})

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -24,6 +24,14 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 	assert.Equal(t, "tenant1-ue2-dev", tenant1Ue2DevInfraVpcStackInfrastructureStackName)
 	assert.Equal(t, "infra-vpc", tenant1Ue2DevInfraVpcStackBackendWorkspaceKeyPrefix)
 
+	// Test having a dash `-` in tenant/environment/stage names
+	tenant1Ue2Test1InfraVpcStack := spaceliftStacks["tenant1-ue2-test-1-infra-vpc"].(map[string]interface{})
+	tenant1Ue2Test1InfraVpcStackInfrastructureStackName := tenant1Ue2Test1InfraVpcStack["stack"].(string)
+	tenant1Ue2Test1InfraVpcStackBackend := tenant1Ue2Test1InfraVpcStack["backend"].(map[interface{}]interface{})
+	tenant1Ue2Test1InfraVpcStackBackendWorkspaceKeyPrefix := tenant1Ue2Test1InfraVpcStackBackend["workspace_key_prefix"].(string)
+	assert.Equal(t, "tenant1-ue2-test-1", tenant1Ue2Test1InfraVpcStackInfrastructureStackName)
+	assert.Equal(t, "infra-vpc", tenant1Ue2Test1InfraVpcStackBackendWorkspaceKeyPrefix)
+
 	tenant1Ue2DevTestTestComponentOverrideComponent := spaceliftStacks["tenant1-ue2-dev-test-test-component-override"].(map[string]interface{})
 	tenant1Ue2DevTestTestComponentOverrideComponentInfrastructureStackName := tenant1Ue2DevTestTestComponentOverrideComponent["stack"].(string)
 	tenant1Ue2DevTestTestComponentOverrideComponentBackend := tenant1Ue2DevTestTestComponentOverrideComponent["backend"].(map[interface{}]interface{})
@@ -69,6 +77,11 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 	newTenant1Ue2DevTestTestComponentOverrideComponent2 := spaceliftStacks["tenant1-ue2-dev-new-component"].(map[string]interface{})
 	newTenant1Ue2DevTestTestComponentOverrideComponent2InfrastructureStackName := newTenant1Ue2DevTestTestComponentOverrideComponent2["stack"].(string)
 	assert.Equal(t, "tenant1-ue2-dev", newTenant1Ue2DevTestTestComponentOverrideComponent2InfrastructureStackName)
+
+	// Test having a dash `-` in tenant/environment/stage names
+	newTenant1Ue2Test1TestTestComponentOverrideComponent2 := spaceliftStacks["tenant1-ue2-test-1-new-component"].(map[string]interface{})
+	newTenant1Ue2Test1TestTestComponentOverrideComponent2InfrastructureStackName := newTenant1Ue2Test1TestTestComponentOverrideComponent2["stack"].(string)
+	assert.Equal(t, "tenant1-ue2-test-1", newTenant1Ue2Test1TestTestComponentOverrideComponent2InfrastructureStackName)
 
 	yamlSpaceliftStacks, err := yaml.Marshal(spaceliftStacks)
 	assert.Nil(t, err)

--- a/pkg/stack/stack_processor_test.go
+++ b/pkg/stack/stack_processor_test.go
@@ -15,6 +15,7 @@ func TestStackProcessor(t *testing.T) {
 		"../../examples/complete/stacks/tenant1/ue2/dev.yaml",
 		"../../examples/complete/stacks/tenant1/ue2/prod.yaml",
 		"../../examples/complete/stacks/tenant1/ue2/staging.yaml",
+		"../../examples/complete/stacks/tenant1/ue2/test1.yaml",
 	}
 
 	processStackDeps := true
@@ -22,13 +23,14 @@ func TestStackProcessor(t *testing.T) {
 
 	var listResult, mapResult, err = ProcessYAMLConfigFiles(basePath, filePaths, processStackDeps, processComponentDeps)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(listResult))
-	assert.Equal(t, 3, len(mapResult))
+	assert.Equal(t, 4, len(listResult))
+	assert.Equal(t, 4, len(mapResult))
 
 	mapResultKeys := u.StringKeysFromMap(mapResult)
 	assert.Equal(t, "tenant1/ue2/dev", mapResultKeys[0])
 	assert.Equal(t, "tenant1/ue2/prod", mapResultKeys[1])
 	assert.Equal(t, "tenant1/ue2/staging", mapResultKeys[2])
+	assert.Equal(t, "tenant1/ue2/test1", mapResultKeys[3])
 
 	mapConfig1, err := c.YAMLToMapOfInterfaces(listResult[0])
 	assert.Nil(t, err)


### PR DESCRIPTION
## what
* Support dashes `-` in the tenant, environment and stage names
* In the examples, add a new stage `test-1` and add tests for components, stacks, and spacelift to test having a dash in the stage name (the file name itself being without dashes)

## why
* The old `atmos` supported it (because it was filename-based, not logical stack name based) 
* Some clients want to name tenants/environment/stages with dashes in the names (and some already have it, so we need to support that when converting from the old to the new `atmos`)

## test

```
atmos terraform plan test/test-component-override-3 -s tenant1-ue2-test-1


Found config for the component 'test/test-component-override-3' for the stack 'tenant1-ue2-test-1' 
in the file 'tenant1/ue2/test1'

Variables for the component 'test/test-component-override-3' in the stack 'tenant1-ue2-test-1':

enabled: true
environment: ue2
namespace: eg
region: us-east-2
service_1_list:
- 5
- 6
- 7

```
