### PR TITLE
Support terraform two-words commands

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -153,7 +153,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("STACK=%s", info.Stack),
 	}...)
 
-	u.PrintInfo("Using ENV vars:\n")
+	u.PrintInfo("Using ENV vars:")
 	for _, v := range envVars {
 		fmt.Println(v)
 	}

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -51,7 +51,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print component variables
-	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n\n", info.ComponentFromArg, info.Stack))
+	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n", info.ComponentFromArg, info.Stack))
 	err = u.PrintAsYAML(info.ComponentVarsSection)
 	if err != nil {
 		return err

--- a/internal/exec/helmfile_generate_varfile.go
+++ b/internal/exec/helmfile_generate_varfile.go
@@ -48,7 +48,7 @@ func ExecuteHelmfileGenerateVarfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print the component variables
-	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n\n", info.ComponentFromArg, info.Stack))
+	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n", info.ComponentFromArg, info.Stack))
 	err = u.PrintAsYAML(info.ComponentVarsSection)
 	if err != nil {
 		return err

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -19,7 +19,7 @@ func ExecuteShellCommand(command string, args []string, dir string, env []string
 	cmd.Stderr = os.Stderr
 
 	fmt.Println()
-	u.PrintInfo("Executing command:\n")
+	u.PrintInfo("Executing command:")
 	fmt.Println(cmd.String())
 
 	if dryRun {

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -224,7 +224,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	allArgsAndFlags := []string{info.SubCommand}
+	allArgsAndFlags := strings.Fields(info.SubCommand)
 
 	switch info.SubCommand {
 	case "plan":

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -254,12 +254,17 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		if c.Config.Components.Terraform.InitRunReconfigure == true {
 			allArgsAndFlags = append(allArgsAndFlags, []string{"-reconfigure"}...)
 		}
+		break
 	case "workspace":
 		if info.SubCommand2 == "list" || info.SubCommand2 == "show" {
 			allArgsAndFlags = append(allArgsAndFlags, []string{info.SubCommand2}...)
 		} else if info.SubCommand2 != "" {
 			allArgsAndFlags = append(allArgsAndFlags, []string{info.SubCommand2, info.TerraformWorkspace}...)
 		}
+		break
+	case "state":
+		allArgsAndFlags = append(allArgsAndFlags, []string{info.SubCommand2}...)
+		allArgsAndFlags = append(allArgsAndFlags, info.AdditionalArgsAndFlags...)
 		break
 	}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -46,7 +46,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		))
 	}
 
-	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
+	// Check if the component is allowed to be provisioned (`metadata.type` attribute is not set to `abstract`)
 	if (info.SubCommand == "plan" || info.SubCommand == "apply" || info.SubCommand == "deploy" || info.SubCommand == "workspace") && info.ComponentIsAbstract {
 		return errors.New(fmt.Sprintf("Abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
 			"by 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component)))
@@ -97,7 +97,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	// Print component variables and write to file
 	// Don't process variables when executing `terraform workspace` command
 	if info.SubCommand != "workspace" {
-		u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n\n", info.ComponentFromArg, info.Stack))
+		u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n", info.ComponentFromArg, info.Stack))
 		err = u.PrintAsYAML(info.ComponentVarsSection)
 		if err != nil {
 			return err

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -106,8 +106,8 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		// Write variables to a file
 		var varFilePath, varFileNameFromArg string
 
-		// Handle `terraform varfile` and `terraform write varfile` custom commands
-		if info.SubCommand == "varfile" || info.SubCommand == "write varfile" {
+		// Handle `terraform varfile` and `terraform write varfile` legacy commands
+		if info.SubCommand == "varfile" || (info.SubCommand == "write" && info.SubCommand2 == "varfile") {
 			if len(info.AdditionalArgsAndFlags) == 2 {
 				fileFlag := info.AdditionalArgsAndFlags[0]
 				if fileFlag == "-f" || fileFlag == "--file" {
@@ -133,8 +133,8 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Handle `terraform varfile` and `terraform write varfile` custom commands
-	if info.SubCommand == "varfile" || info.SubCommand == "write varfile" {
+	// Handle `terraform varfile` and `terraform write varfile` legacy commands
+	if info.SubCommand == "varfile" || (info.SubCommand == "write" && info.SubCommand2 == "varfile") {
 		fmt.Println()
 		return nil
 	}

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -95,8 +95,8 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print component variables and write to file
-	// Don't process variables when executing `terraform workspace` or `terraform state` commands
-	if info.SubCommand != "workspace" && info.SubCommand != "state" {
+	// Don't process variables when executing `terraform workspace` commands
+	if info.SubCommand != "workspace" {
 		u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n", info.ComponentFromArg, info.Stack))
 		err = u.PrintAsYAML(info.ComponentVarsSection)
 		if err != nil {
@@ -262,16 +262,12 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 			allArgsAndFlags = append(allArgsAndFlags, []string{info.SubCommand2, info.TerraformWorkspace}...)
 		}
 		break
-	case "state":
-		allArgsAndFlags = append(allArgsAndFlags, []string{info.SubCommand2}...)
-		allArgsAndFlags = append(allArgsAndFlags, info.AdditionalArgsAndFlags...)
-		break
 	}
 
 	allArgsAndFlags = append(allArgsAndFlags, info.AdditionalArgsAndFlags...)
 
 	// Run `terraform workspace` before executing other terraform commands
-	if info.SubCommand != "init" && !(info.SubCommand == "workspace" && info.SubCommand2 != "") && info.SubCommand != "state" {
+	if info.SubCommand != "init" && !(info.SubCommand == "workspace" && info.SubCommand2 != "") {
 		err = ExecuteShellCommand(info.Command, []string{"workspace", "select", info.TerraformWorkspace}, componentPath, info.ComponentEnvList, info.DryRun)
 		if err != nil {
 			err = ExecuteShellCommand(info.Command, []string{"workspace", "new", info.TerraformWorkspace}, componentPath, info.ComponentEnvList, info.DryRun)

--- a/internal/exec/terraform_generate_varfile.go
+++ b/internal/exec/terraform_generate_varfile.go
@@ -48,7 +48,7 @@ func ExecuteTerraformGenerateVarfile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print the component variables
-	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n\n", info.ComponentFromArg, info.Stack))
+	u.PrintInfo(fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':\n", info.ComponentFromArg, info.Stack))
 	err = u.PrintAsYAML(info.ComponentVarsSection)
 	if err != nil {
 		return err

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -596,17 +596,6 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (c.Ar
 				info.SubCommand2 = additionalArgsAndFlags[1]
 				twoWordsCommand = true
 			}
-			// `terraform state` commands
-			// https://www.terraform.io/cli/commands/state
-			if additionalArgsAndFlags[0] == "state" {
-				if u.SliceContainsString([]string{"list", "mv", "pull", "push", "replace-provider", "rm", "show"}, additionalArgsAndFlags[1]) {
-					info.SubCommand = "state"
-					info.SubCommand2 = additionalArgsAndFlags[1]
-					twoWordsCommand = true
-				} else {
-					return info, errors.New("'terraform state' command requires a subcommand: 'list', 'mv', 'pull', 'push', 'replace-provider', 'rm', 'show'")
-				}
-			}
 		}
 
 		if twoWordsCommand {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -579,6 +579,7 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (c.Ar
 		twoWordsCommand := false
 
 		// Handle terraform two-words commands
+		// https://www.terraform.io/cli/commands
 		if componentType == "terraform" {
 			// Handle the custom legacy command `terraform write varfile` (NOTE: use `terraform generate varfile` instead)
 			if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -159,6 +159,7 @@ func processArgsConfigAndStacks(componentType string, cmd *cobra.Command, args [
 
 	configAndStacksInfo.AdditionalArgsAndFlags = argsAndFlagsInfo.AdditionalArgsAndFlags
 	configAndStacksInfo.SubCommand = argsAndFlagsInfo.SubCommand
+	configAndStacksInfo.SubCommand2 = argsAndFlagsInfo.SubCommand2
 	configAndStacksInfo.ComponentType = componentType
 	configAndStacksInfo.ComponentFromArg = argsAndFlagsInfo.ComponentFromArg
 	configAndStacksInfo.GlobalOptions = argsAndFlagsInfo.GlobalOptions
@@ -583,11 +584,22 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (c.Ar
 		if componentType == "terraform" {
 			// Handle the custom legacy command `terraform write varfile` (NOTE: use `terraform generate varfile` instead)
 			if additionalArgsAndFlags[0] == "write" && additionalArgsAndFlags[1] == "varfile" {
-				info.SubCommand = "write varfile"
+				info.SubCommand = "write"
+				info.SubCommand2 = "varfile"
 				twoWordsCommand = true
 			}
-			if additionalArgsAndFlags[0] == "workspace" && u.SliceContainsString([]string{"list", "select", "new", "delete", "show"}, additionalArgsAndFlags[1]) {
-				info.SubCommand = "workspace " + additionalArgsAndFlags[1]
+			// `terraform workspace` commands
+			if additionalArgsAndFlags[0] == "workspace" &&
+				u.SliceContainsString([]string{"list", "select", "new", "delete", "show"}, additionalArgsAndFlags[1]) {
+				info.SubCommand = "workspace"
+				info.SubCommand2 = additionalArgsAndFlags[1]
+				twoWordsCommand = true
+			}
+			// `terraform state` commands
+			if additionalArgsAndFlags[0] == "state" &&
+				u.SliceContainsString([]string{"list", "mv", "pull", "push", "replace-provider", "rm", "show"}, additionalArgsAndFlags[1]) {
+				info.SubCommand = "state"
+				info.SubCommand2 = additionalArgsAndFlags[1]
 				twoWordsCommand = true
 			}
 		}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -589,6 +589,7 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (c.Ar
 				twoWordsCommand = true
 			}
 			// `terraform workspace` commands
+			// https://www.terraform.io/cli/commands/workspace
 			if additionalArgsAndFlags[0] == "workspace" &&
 				u.SliceContainsString([]string{"list", "select", "new", "delete", "show"}, additionalArgsAndFlags[1]) {
 				info.SubCommand = "workspace"
@@ -596,11 +597,15 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (c.Ar
 				twoWordsCommand = true
 			}
 			// `terraform state` commands
-			if additionalArgsAndFlags[0] == "state" &&
-				u.SliceContainsString([]string{"list", "mv", "pull", "push", "replace-provider", "rm", "show"}, additionalArgsAndFlags[1]) {
-				info.SubCommand = "state"
-				info.SubCommand2 = additionalArgsAndFlags[1]
-				twoWordsCommand = true
+			// https://www.terraform.io/cli/commands/state
+			if additionalArgsAndFlags[0] == "state" {
+				if u.SliceContainsString([]string{"list", "mv", "pull", "push", "replace-provider", "rm", "show"}, additionalArgsAndFlags[1]) {
+					info.SubCommand = "state"
+					info.SubCommand2 = additionalArgsAndFlags[1]
+					twoWordsCommand = true
+				} else {
+					return info, errors.New("'terraform state' command requires a subcommand: 'list', 'mv', 'pull', 'push', 'replace-provider', 'rm', 'show'")
+				}
 			}
 		}
 

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -68,6 +68,7 @@ type Context struct {
 type ArgsAndFlagsInfo struct {
 	AdditionalArgsAndFlags  []string
 	SubCommand              string
+	SubCommand2             string
 	ComponentFromArg        string
 	GlobalOptions           []string
 	TerraformDir            string
@@ -96,6 +97,7 @@ type ConfigAndStacksInfo struct {
 	FinalComponent            string
 	Command                   string
 	SubCommand                string
+	SubCommand2               string
 	ComponentSection          map[string]interface{}
 	ComponentVarsSection      map[interface{}]interface{}
 	ComponentEnvSection       map[interface{}]interface{}


### PR DESCRIPTION
## what
* Support terraform two-words commands

## why
* Support `terraform workspace <subcommand>`:
  - `terraform workspace list`
  - `terraform workspace select`
  - `terraform workspace new`
  - `terraform workspace delete`
  - `terraform workspace show`

## references
* https://www.terraform.io/cli/commands/workspace

## test
```
atmos terraform workspace list test/test-component-override-3 -s tenant1-ue2-dev
```

```
Executing command:
/usr/local/bin/terraform workspace list
  default
* test-component-override-3-workspace
```

```
atmos terraform workspace show test/test-component-override-3 -s tenant1-ue2-dev
```

```
Executing command:
/usr/local/bin/terraform workspace show
test-component-override-3-workspace
```

```
atmos terraform workspace select test/test-component-override-3 -s tenant1-ue2-dev
```

```
Executing command:
/usr/local/bin/terraform workspace show
test-component-override-3-workspace
```

```
atmos terraform workspace new test/test-component-override-3 -s tenant1-ue2-dev
```

```
Executing command:
/usr/local/bin/terraform workspace new test-component-override-3-workspace
Created and switched to workspace "test-component-override-3-workspace"!
```

