### PR TITLE
Support `{attributes}` token in the `components.helmfile.cluster_name_pattern` CLI config

### DIFF
--- a/pkg/aws/atmos.yaml
+++ b/pkg/aws/atmos.yaml
@@ -1,0 +1,66 @@
+# CLI config is loaded from the following locations (from lowest to highest priority):
+# system dir (`/usr/local/etc/atmos` on Linux, `%LOCALAPPDATA%/atmos` on Windows)
+# home dir (~/.atmos)
+# current directory
+# ENV vars
+# Command-line arguments
+#
+# It supports POSIX-style Globs for file names/paths (double-star `**` is supported)
+# https://en.wikipedia.org/wiki/Glob_(programming)
+
+# Base path for components, stacks and workflows configurations.
+# Can also be set using `ATMOS_BASE_PATH` ENV var, or `--base-path` command-line argument.
+# Supports both absolute and relative paths.
+# If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
+# are independent settings (supporting both absolute and relative paths).
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path`, `stacks.base_path` and `workflows.base_path`
+# are considered paths relative to `base_path`.
+base_path: "../../examples/complete"
+
+components:
+  terraform:
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_BASE_PATH` ENV var, or `--terraform-dir` command-line argument
+    # Supports both absolute and relative paths
+    base_path: "components/terraform"
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
+    apply_auto_approve: false
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
+    deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_INIT_RUN_RECONFIGURE` ENV var, or `--init-run-reconfigure` command-line argument
+    init_run_reconfigure: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
+    auto_generate_backend_file: false
+  helmfile:
+    # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
+    # Supports both absolute and relative paths
+    base_path: "components/helmfile"
+    # Can also be set using `ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH` ENV var
+    kubeconfig_path: "/dev/shm"
+    # Can also be set using `ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN` ENV var
+    helm_aws_profile_pattern: "{namespace}-{tenant}-gbl-{stage}-helm"
+    # Can also be set using `ATMOS_COMPONENTS_HELMFILE_CLUSTER_NAME_PATTERN` ENV var
+    cluster_name_pattern: "{namespace}-{tenant}-{environment}-{stage}-{attributes}-eks-cluster"
+
+stacks:
+  # Can also be set using `ATMOS_STACKS_BASE_PATH` ENV var, or `--config-dir` and `--stacks-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "stacks"
+  # Can also be set using `ATMOS_STACKS_INCLUDED_PATHS` ENV var (comma-separated values string)
+  included_paths:
+    - "**/*"
+  # Can also be set using `ATMOS_STACKS_EXCLUDED_PATHS` ENV var (comma-separated values string)
+  excluded_paths:
+    - "globals/**/*"
+    - "catalog/**/*"
+    - "**/*globals*"
+  # Can also be set using `ATMOS_STACKS_NAME_PATTERN` ENV var
+  name_pattern: "{tenant}-{environment}-{stage}"
+
+workflows:
+  # Can also be set using `ATMOS_WORKFLOWS_BASE_PATH` ENV var, or `--workflows-dir` command-line arguments
+  # Supports both absolute and relative paths
+  base_path: "workflows"
+
+logs:
+  verbose: false
+  colors: true

--- a/pkg/aws/aws_eks_update_kubeconfig_test.go
+++ b/pkg/aws/aws_eks_update_kubeconfig_test.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+	c "github.com/cloudposse/atmos/pkg/config"
+	u "github.com/cloudposse/atmos/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClusterNamePattern(t *testing.T) {
+	// InitConfig finds and processes `atmos.yaml` CLI config
+	err := c.InitConfig()
+	assert.Nil(t, err)
+
+	// Define variables for a component in a stack
+	componentVars := map[interface{}]interface{}{
+		"namespace":   "eg",
+		"tenant":      "plat",
+		"environment": "ue2",
+		"stage":       "dev",
+		"attributes":  []string{"blue"},
+	}
+
+	// Build `Context` from the variables
+	context := c.GetContextFromVars(componentVars)
+
+	// Build EKS cluster name using the `components.helmfile.cluster_name_pattern` config from `atmos.yaml`
+	// cluster_name_pattern: "{namespace}-{tenant}-{environment}-{stage}-{attributes}-eks-cluster"
+	clusterName := c.ReplaceContextTokens(context, c.Config.Components.Helmfile.ClusterNamePattern)
+	u.PrintInfo(fmt.Sprintf("Cluster name: %s", clusterName))
+	assert.Equal(t, "eg-plat-ue2-dev-blue-eks-cluster", clusterName)
+}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -63,6 +63,7 @@ type Context struct {
 	Region        string
 	Component     string
 	BaseComponent string
+	Attributes    []string
 }
 
 type ArgsAndFlagsInfo struct {

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -356,6 +356,10 @@ func GetContextFromVars(vars map[interface{}]interface{}) Context {
 		context.Region = region
 	}
 
+	if attributes, ok := vars["attributes"].([]string); ok {
+		context.Attributes = attributes
+	}
+
 	return context
 }
 
@@ -437,6 +441,7 @@ func ReplaceContextTokens(context Context, pattern string) string {
 		"{environment}", context.Environment,
 		"{tenant}", context.Tenant,
 		"{stage}", context.Stage,
+		"{attributes}", strings.Join(context.Attributes, "-"),
 	)
 	return r.Replace(pattern)
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1428,15 +1428,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "react-loadable": {
-          "version": "npm:@docusaurus/react-loadable@5.5.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-          "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-          "requires": {
-            "@types/react": "*",
-            "prop-types": "^15.6.2"
-          }
         }
       }
     },
@@ -7846,6 +7837,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-loadable": {
+      "version": "npm:@docusaurus/react-loadable@5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
+      }
     },
     "react-loadable-ssr-addon-v5-slorber": {
       "version": "1.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -56,7 +56,8 @@
     "remark-html": "^13.0.1",
     "remark-parse": "^8.0.3",
     "sass": "^1.44.0",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "nth-check": "^2.0.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "0.0.0-4192",


### PR DESCRIPTION
## what
* Support `{attributes}` token in the `components.helmfile.cluster_name_pattern` CLI config

## why
* Allow using `cluster_name_pattern` in the following format `{namespace}-{tenant}-{environment}-{stage}-{attributes}-eks-cluster` (note that the tokens can be defined in any order)
* When deploying multiple EKS clusters into the same AWS account and region, we can use `attributes` (`blue`, `green`, etc.) to be part of the EKS cluster names to name the clusters differently 

## test

```
// Define variables for a component in a stack
componentVars := map[interface{}]interface{}{
"namespace":   "eg",
"tenant":      "plat",
"environment": "ue2",
"stage":       "dev",
"attributes":  []string{"blue"},
}
```

```
Cluster name: eg-plat-ue2-dev-blue-eks-cluster
```
