### PR TITLE
Improve `atmos vendor pull` command. Add more vendoring examples and tests

### DIFF
--- a/examples/complete/Dockerfile
+++ b/examples/complete/Dockerfile
@@ -2,7 +2,7 @@
 ARG GEODESIC_VERSION=1.1.0
 ARG GEODESIC_OS=debian
 # atmos: https://github.com/cloudposse/atmos
-ARG ATMOS_VERSION=1.4.15
+ARG ATMOS_VERSION=1.4.17
 # Terraform: https://github.com/hashicorp/terraform/releases
 ARG TF_VERSION=1.1.9
 

--- a/examples/complete/components/terraform/infra/account-map/component.yaml
+++ b/examples/complete/components/terraform/infra/account-map/component.yaml
@@ -1,0 +1,43 @@
+# 'account-map' component vendoring config
+
+apiVersion: atmos/v1
+kind: ComponentVendorConfig
+metadata:
+  name: account-map-vendor-config
+  description: Source and mixins config for vendoring of 'vpc-flow-logs-bucket' component
+spec:
+  source:
+    # 'uri' supports all protocols (local files, Git, Mercurial, HTTP, HTTPS, Amazon S3, Google GCP),
+    # and all URL and archive formats as described in https://github.com/hashicorp/go-getter
+    # In 'uri', Golang templates are supported  https://pkg.go.dev/text/template
+    # If 'version' is provided, '{{.Version}}' will be replaced with the 'version' value before pulling the files from 'uri'
+    uri: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
+    version: 0.196.1
+    # Only include the files that match the 'included_paths' patterns
+    # If 'included_paths' is not specified, all files will be matched except those that match the patterns from 'excluded_paths'
+    # 'included_paths' support POSIX-style Globs for file names/paths (double-star `**` is supported)
+    # https://en.wikipedia.org/wiki/Glob_(programming)
+    # https://github.com/bmatcuk/doublestar#patterns
+    included_paths:
+      # include '.tf', '.tfvars' and '.md' files from the root folder
+      - "**/*.tf"
+      - "**/*.tfvars"
+      - "**/*.md"
+      # include the 'modules' folder and all sub-folders
+      # note that if you don't include the folders, the files in the folders will not be included
+      - "**/modules/**"
+      # include '.tf', '.tfvars' and '.md' files from the 'modules' folder and all sub-folders
+      - "**/modules/**/*.tf"
+      - "**/modules/**/*.tfvars"
+      - "**/modules/**/*.md"
+    # Exclude the files that match any of the 'excluded_paths' patterns
+    # Note that we are excluding 'context.tf' since a newer version of it will be downloaded using 'mixins'
+    # 'excluded_paths' support POSIX-style Globs for file names/paths (double-star `**` is supported)
+    excluded_paths: []
+
+  # mixins override files from 'source' with the same 'filename' (e.g. 'context.tf' will override 'context.tf' from the 'source')
+  # mixins are processed in the order they are declared in the list
+  mixins:
+    - uri: https://raw.githubusercontent.com/cloudposse/terraform-aws-components/{{.Version}}/modules/datadog-agent/introspection.mixin.tf
+      version: 0.196.1
+      filename: introspection.mixin.tf

--- a/examples/complete/components/terraform/infra/vpc-flow-logs-bucket/component.yaml
+++ b/examples/complete/components/terraform/infra/vpc-flow-logs-bucket/component.yaml
@@ -33,7 +33,7 @@ spec:
     # In 'uri', Golang templates are supported  https://pkg.go.dev/text/template
     # If 'version' is provided, '{{.Version}}' will be replaced with the 'version' value before pulling the files from 'uri'
     uri: github.com/cloudposse/terraform-aws-components.git//modules/vpc-flow-logs-bucket?ref={{.Version}}
-    version: 0.194.0
+    version: 0.196.1
     # Only include the files that match the 'included_paths' patterns
     # If 'included_paths' is not specified, all files will be matched except those that match the patterns from 'excluded_paths'
     # 'included_paths' support POSIX-style Globs for file names/paths (double-star `**` is supported)
@@ -56,5 +56,5 @@ spec:
     - uri: https://raw.githubusercontent.com/cloudposse/terraform-null-label/0.25.0/exports/context.tf
       filename: context.tf
     - uri: https://raw.githubusercontent.com/cloudposse/terraform-aws-components/{{.Version}}/modules/datadog-agent/introspection.mixin.tf
-      version: 0.194.0
+      version: 0.196.1
       filename: introspection.mixin.tf

--- a/pkg/vender/component_vendor_test.go
+++ b/pkg/vender/component_vendor_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 func TestVendorComponentPullCommand(t *testing.T) {
-	component := "infra/vpc-flow-logs-bucket"
-	componentType := "terraform"
-	vendorCommand := "pull"
-
 	err := c.InitConfig()
 	assert.Nil(t, err)
 
+	componentType := "terraform"
+	vendorCommand := "pull"
+
+	// Test 'infra/vpc-flow-logs-bucket' component
+	component := "infra/vpc-flow-logs-bucket"
 	componentConfig, componentPath, err := e.ReadAndProcessComponentConfigFile(component, componentType)
 	assert.Nil(t, err)
 
@@ -52,5 +53,77 @@ func TestVendorComponentPullCommand(t *testing.T) {
 	err = os.Remove(path.Join(componentPath, "variables.tf"))
 	assert.Nil(t, err)
 	err = os.Remove(path.Join(componentPath, "versions.tf"))
+	assert.Nil(t, err)
+
+	// Test 'infra/account-map' component
+	component = "infra/account-map"
+	componentConfig, componentPath, err = e.ReadAndProcessComponentConfigFile(component, componentType)
+	assert.Nil(t, err)
+
+	err = e.ExecuteComponentVendorCommandInternal(componentConfig.Spec, component, componentPath, false, vendorCommand)
+	assert.Nil(t, err)
+
+	// Check if the correct files were pulled and written to the correct folder
+	assert.FileExists(t, path.Join(componentPath, "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "default.auto.tfvars"))
+	assert.FileExists(t, path.Join(componentPath, "introspection.mixin.tf"))
+	assert.FileExists(t, path.Join(componentPath, "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "providers.tf"))
+	assert.FileExists(t, path.Join(componentPath, "README.md"))
+	assert.FileExists(t, path.Join(componentPath, "remote-state.tf"))
+	assert.FileExists(t, path.Join(componentPath, "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "versions.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
+
+	// Delete the files and folders
+	err = os.Remove(path.Join(componentPath, "context.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "default.auto.tfvars"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "introspection.mixin.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "main.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "outputs.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "providers.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "README.md"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "remote-state.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "variables.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "versions.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "iam-roles", "context.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "iam-roles", "main.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "iam-roles", "variables.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "iam-roles"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules", "roles-to-principals"))
+	assert.Nil(t, err)
+	err = os.Remove(path.Join(componentPath, "modules"))
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
## what
* Improve `atmos vendor pull` command
* Add more vendoring examples and tests

## why
* Show an example of vendoring a component with subfolders in the root folder (`account-map` with `modules` subfolder), and how to configure `included_paths`

## test vendoring a component with `modules` subfolder

```
atmos vendor pull -c infra/account-map
```

```
Including 'README.md' since it matches the '**/*.md' pattern from 'included_paths'
Including 'context.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'default.auto.tfvars' since it matches the '**/*.tfvars' pattern from 'included_paths'
Including 'main.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules' since it matches the '**/modules/**' pattern from 'included_paths'
Including 'modules/iam-roles' since it matches the '**/modules/**' pattern from 'included_paths'
Including 'modules/iam-roles/context.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/iam-roles/main.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/iam-roles/outputs.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/iam-roles/variables.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/roles-to-principals' since it matches the '**/modules/**' pattern from 'included_paths'
Including 'modules/roles-to-principals/context.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/roles-to-principals/main.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/roles-to-principals/outputs.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'modules/roles-to-principals/variables.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'outputs.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'providers.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'remote-state.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'variables.tf' since it matches the '**/*.tf' pattern from 'included_paths'
Including 'versions.tf' since it matches the '**/*.tf' pattern from 'included_paths'

Pulling the mixin 'https://raw.githubusercontent.com/cloudposse/terraform-aws-components/0.196.1/modules/datadog-agent/introspection.mixin.tf' 
for the component 'infra/account-map' 
and writing to 'examples/complete/components/terraform/infra/account-map/introspection.mixin.tf'
```

