### PR TITLE
Update `atmos workflow` command

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -24,6 +24,7 @@ func init() {
 	workflowCmd.DisableFlagParsing = false
 	workflowCmd.PersistentFlags().StringP("file", "f", "", "atmos workflow <name> -f <file>")
 	workflowCmd.PersistentFlags().Bool("dry-run", false, "atmos workflow <name> -f <file> --dry-run")
+	workflowCmd.PersistentFlags().StringP("stack", "s", "", "atmos workflow <name> -f <file> -s <stack>")
 
 	err := workflowCmd.MarkPersistentFlagRequired("file")
 	if err != nil {

--- a/examples/complete/workflows/workflow1.yaml
+++ b/examples/complete/workflows/workflow1.yaml
@@ -1,5 +1,15 @@
 workflows:
 
+  terraform-plan-all-test-components:
+    description: |
+      Run 'terraform plan' on 'test/test-component' and all its derived components.
+      The stack must be provided on the command line: atmos workflow terraform-plan-all-test-components -f workflow1 -s <stack>
+    steps:
+      - command: terraform plan test/test-component
+      - command: terraform plan test/test-component-override
+      - command: terraform plan test/test-component-override-2
+      - command: terraform plan test/test-component-override-3
+
   terraform-plan-test-component-override-2-all-stacks:
     description: Run 'terraform plan' on 'test/test-component-override-2' component in all stacks
     steps:

--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -36,6 +36,11 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	commandLineStack, err := flags.GetString("stack")
+	if err != nil {
+		return err
+	}
+
 	var workflowPath string
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile
@@ -89,7 +94,7 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = executeWorkflowSteps(workflowDefinition, dryRun)
+	err = executeWorkflowSteps(workflowDefinition, dryRun, commandLineStack)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition, dryRun bool) error {
+func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition, dryRun bool, commandLineStack string) error {
 	var steps = workflowDefinition.Steps
 
 	for _, step := range steps {
@@ -35,11 +35,16 @@ func executeWorkflowSteps(workflowDefinition c.WorkflowDefinition, dryRun bool) 
 
 			// The workflow `stack` attribute overrides the stack in the `command` (if specified)
 			// The step `stack` attribute overrides the stack in the `command` and the workflow `stack` attribute
+			// The stack defined on the command line (`atmos workflow <name> -f <file> -s <stack>`) has the highest priority,
+			// it overrides all other stacks attributes
 			if workflowStack != "" {
 				finalStack = workflowStack
 			}
 			if stepStack != "" {
 				finalStack = stepStack
+			}
+			if commandLineStack != "" {
+				finalStack = commandLineStack
 			}
 
 			if finalStack != "" {


### PR DESCRIPTION
## what
* Update `atmos workflow` command

## why
* Allow specifying the stack for workflows on the command line
* The stack defined on the command line (`atmos workflow <name> -f <file> -s <stack>`) has the highest priority, it overrides all other stacks attributes

```
  terraform-plan-all-test-components:
    description: |
      Run 'terraform plan' on 'test/test-component' and all its derived components.
      The stack must be provided on the command line: atmos workflow terraform-plan-all-test-components -f workflow1 -s <stack>
    steps:
      - command: terraform plan test/test-component
      - command: terraform plan test/test-component-override
      - command: terraform plan test/test-component-override-2
      - command: terraform plan test/test-component-override-3
```

## test

```
atmos workflow terraform-plan-all-test-components -f workflow1 -s tenant1-ue2-dev
```

```
Executing the workflow 'terraform-plan-all-test-components' from 'examples/complete/workflows/workflow1.yaml'


description: |
  Run 'terraform plan' on 'test/test-component' and all its derived components.
  The stack must be provided on the command line: atmos workflow terraform-plan-all-test-components -f workflow1 -s <stack>
steps:
- command: terraform plan test/test-component
  stack: ""
  type: ""
- command: terraform plan test/test-component-override
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-2
  stack: ""
  type: ""
- command: terraform plan test/test-component-override-3
  stack: ""
  type: ""
stack: ""

Executing workflow step: terraform plan test/test-component
Stack: tenant1-ue2-dev

Executing command:
atmos terraform plan test/test-component -s tenant1-ue2-dev

Variables for the component 'test/test-component' in the stack 'tenant1-ue2-dev':
```
