### PR TITLE
allow env vars for workflow config

### DIFF
--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -23,6 +23,12 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	
+	var configAndStacksInfo c.ConfigAndStacksInfo
+	err = c.ProcessConfig(configAndStacksInfo, false)
+	if err != nil {
+		return err
+	}
 
 	flags := cmd.Flags()
 
@@ -40,7 +46,7 @@ func ExecuteWorkflow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
+	
 	var workflowPath string
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile


### PR DESCRIPTION
## what
* add the processing of env vars to the initial startup config

## why
* all basepath config items are currently not respected when specified as environment variables.
* adding env var processing to inital config aligns with design goals



