### PR TITLE
chore: fix unnecessarily complex way of printing formatted string

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -116,9 +116,9 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options "--no-color --namespace test"
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options="--no-color --namespace=test"
 	// atmos helmfile diff echo-server -s tenant1-ue2-dev --global-options="--no-color --namespace test"
-	fmt.Println(fmt.Sprintf("Global options: %v", info.GlobalOptions))
+	fmt.Printf("Global options: %v\n", info.GlobalOptions)
 
-	fmt.Println(fmt.Sprintf("Arguments and flags: %v", info.AdditionalArgsAndFlags))
+	fmt.Printf("Arguments and flags: %v\n", info.AdditionalArgsAndFlags)
 	fmt.Println("Component: " + info.ComponentFromArg)
 	if len(info.BaseComponent) > 0 {
 		fmt.Println("Helmfile component: " + info.BaseComponent)
@@ -132,7 +132,7 @@ func ExecuteHelmfile(cmd *cobra.Command, args []string) error {
 	}
 
 	workingDir := constructHelmfileComponentWorkingDir(info)
-	fmt.Println(fmt.Sprintf("Working dir: %s\n\n", workingDir))
+	fmt.Printf("Working dir: %s\n\n", workingDir)
 
 	// Prepare arguments and flags
 	allArgsAndFlags := []string{"--state-values-file", varFile}

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -51,7 +51,7 @@ func processHelp(componentType string, command string) error {
 		}
 	} else {
 		fmt.Printf("'atmos' supports native '%s %s' command with all the options, arguments and flags.\n", componentType, command)
-		fmt.Printf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack.")
+		fmt.Printf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack.\n")
 		u.PrintInfo(fmt.Sprintf("atmos %s %s <component> -s <stack> [options]", componentType, command))
 		u.PrintInfo(fmt.Sprintf("atmos %s %s <component> --stack <stack> [options]", componentType, command))
 

--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -2,14 +2,15 @@ package exec
 
 import (
 	"fmt"
+
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 // processHelp processes help commands
 func processHelp(componentType string, command string) error {
 	if len(command) == 0 {
-		fmt.Println(fmt.Sprintf("'atmos' supports all native '%s' commands.", componentType))
-		fmt.Println(fmt.Sprintf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack."))
+		fmt.Printf("'atmos' supports all native '%s' commands.\n", componentType)
+		fmt.Printf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack.\n")
 		u.PrintInfo(fmt.Sprintf("atmos %s <command> <component> -s <stack> [options]", componentType))
 		u.PrintInfo(fmt.Sprintf("atmos %s <command> <component> --stack <stack> [options]", componentType))
 
@@ -49,8 +50,8 @@ func processHelp(componentType string, command string) error {
 			return err
 		}
 	} else {
-		fmt.Println(fmt.Sprintf("'atmos' supports native '%s %s' command with all the options, arguments and flags.", componentType, command))
-		fmt.Println(fmt.Sprintf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack."))
+		fmt.Printf("'atmos' supports native '%s %s' command with all the options, arguments and flags.\n", componentType, command)
+		fmt.Printf("In addition, 'component' and 'stack' are required in order to generate variables for the component in the stack.")
 		u.PrintInfo(fmt.Sprintf("atmos %s %s <component> -s <stack> [options]", componentType, command))
 		u.PrintInfo(fmt.Sprintf("atmos %s %s <component> --stack <stack> [options]", componentType, command))
 

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -2,11 +2,12 @@ package exec
 
 import (
 	"fmt"
-	u "github.com/cloudposse/atmos/pkg/utils"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 // ExecuteShellCommand prints and executes the provided command with args and flags
@@ -47,10 +48,10 @@ func execTerraformShellCommand(
 
 	fmt.Println()
 	u.PrintInfo("Starting a new interactive shell where you can execute all native Terraform commands (type 'exit' to go back)")
-	fmt.Println(fmt.Sprintf("Component: %s", component))
-	fmt.Println(fmt.Sprintf("Stack: %s", stack))
-	fmt.Println(fmt.Sprintf("Working directory: %s", workingDir))
-	fmt.Println(fmt.Sprintf("Terraform workspace: %s", workspaceName))
+	fmt.Printf("Component: %s\n", component)
+	fmt.Printf("Stack: %s\n", stack)
+	fmt.Printf("Working directory: %s\n", workingDir)
+	fmt.Printf("Terraform workspace: %s\n", workspaceName)
 	fmt.Println()
 	u.PrintInfo("Setting the ENV vars in the shell:\n")
 	for _, v := range componentEnvList {

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -197,11 +197,11 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	u.PrintInfo("\nCommand info:")
 	fmt.Println("Terraform binary: " + info.Command)
 	if info.SubCommand2 == "" {
-		fmt.Println(fmt.Sprintf("Terraform command: %s", info.SubCommand))
+		fmt.Printf("Terraform command: %s\n", info.SubCommand)
 	} else {
-		fmt.Println(fmt.Sprintf("Terraform command: %s %s", info.SubCommand, info.SubCommand2))
+		fmt.Printf("Terraform command: %s %s\n", info.SubCommand, info.SubCommand2)
 	}
-	fmt.Println(fmt.Sprintf("Arguments and flags: %v", info.AdditionalArgsAndFlags))
+	fmt.Printf("Arguments and flags: %v\n", info.AdditionalArgsAndFlags)
 	fmt.Println("Component: " + info.ComponentFromArg)
 	if len(info.BaseComponentPath) > 0 {
 		fmt.Println("Terraform component: " + info.BaseComponentPath)
@@ -218,7 +218,7 @@ func ExecuteTerraform(cmd *cobra.Command, args []string) error {
 	}
 
 	workingDir := constructTerraformComponentWorkingDir(info)
-	fmt.Println(fmt.Sprintf(fmt.Sprintf("Working dir: %s", workingDir)))
+	fmt.Printf("Working dir: %s\n", workingDir)
 
 	// Print ENV vars if they are found in the component's stack config
 	if len(info.ComponentEnvList) > 0 {

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -260,7 +260,7 @@ func ExecuteComponentVendorCommandInternal(
 					}
 
 					// If 'included_paths' is not provided, include all files that were not excluded
-					fmt.Printf("Including '%s'", u.TrimBasePathFromPath(tempDir+"/", src))
+					fmt.Printf("Including '%s'\n", u.TrimBasePathFromPath(tempDir+"/", src))
 					return false, nil
 				},
 

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -225,10 +225,10 @@ func ExecuteComponentVendorCommandInternal(
 							return true, err
 						} else if excludeMatch {
 							// If the file matches ANY of the 'excluded_paths' patterns, exclude the file
-							fmt.Println(fmt.Sprintf("Excluding the file '%s' since it matches the '%s' pattern from 'excluded_paths'",
+							fmt.Printf("Excluding the file '%s' since it matches the '%s' pattern from 'excluded_paths'\n",
 								trimmedSrc,
 								excludePath,
-							))
+							)
 							return true, nil
 						}
 					}
@@ -242,10 +242,10 @@ func ExecuteComponentVendorCommandInternal(
 								return true, err
 							} else if includeMatch {
 								// If the file matches ANY of the 'included_paths' patterns, include the file
-								fmt.Println(fmt.Sprintf("Including '%s' since it matches the '%s' pattern from 'included_paths'",
+								fmt.Printf("Including '%s' since it matches the '%s' pattern from 'included_paths'\n",
 									trimmedSrc,
 									includePath,
-								))
+								)
 								anyMatches = true
 								break
 							}
@@ -254,13 +254,13 @@ func ExecuteComponentVendorCommandInternal(
 						if anyMatches {
 							return false, nil
 						} else {
-							fmt.Println(fmt.Sprintf("Excluding '%s' since it does not match any pattern from 'included_paths'", trimmedSrc))
+							fmt.Printf("Excluding '%s' since it does not match any pattern from 'included_paths'\n", trimmedSrc)
 							return true, nil
 						}
 					}
 
 					// If 'included_paths' is not provided, include all files that were not excluded
-					fmt.Println(fmt.Sprintf("Including '%s'", u.TrimBasePathFromPath(tempDir+"/", src)))
+					fmt.Printf("Including '%s'", u.TrimBasePathFromPath(tempDir+"/", src))
 					return false, nil
 				},
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
 	g "github.com/cloudposse/atmos/pkg/globals"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/fatih/color"
@@ -11,10 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
 )
 
 var (
@@ -346,7 +347,7 @@ func ProcessConfigForSpacelift() error {
 func processConfigFile(path string, v *viper.Viper) error {
 	if !u.FileExists(path) {
 		if g.LogVerbose {
-			fmt.Println(fmt.Sprintf("No CLI config found in %s", path))
+			fmt.Printf("No CLI config found in %s\n", path)
 		}
 		return nil
 	}


### PR DESCRIPTION
## what
* Fix unnecessarily complex way of printing formatted string. Instead of using `fmt.Print(fmt.Sprintf(...))`, we can use `fmt.Printf(...)`.

## why
* Makes the code easier to read