### PR TITLE
Add test to show random struct key sorting in backend config

### DIFF
--- a/pkg/utils/json_utils_test.go
+++ b/pkg/utils/json_utils_test.go
@@ -1,0 +1,84 @@
+package utils_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	// "utils"
+
+	c2 "github.com/cloudposse/atmos/pkg/component"
+	c "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackendConfig(t *testing.T) {
+	var err error
+	var component string
+	var stack string
+
+	// Add atmos.yaml for test config
+	r, err := os.Open("../component/atmos.yaml")
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+	w, err := os.Create("./atmos.yaml")
+	if err != nil {
+		panic(err)
+	}
+	defer w.Close()
+	w.ReadFrom(r)
+
+	var tenant1Ue2DevTestTestComponent map[string]any
+	component = "test/test-component"
+	stack = "tenant1-ue2-dev"
+
+	tenant1Ue2DevTestTestComponent, err = c2.ProcessComponentInStack(component, stack)
+	assert.Nil(t, err)
+	assert.NotNil(t, tenant1Ue2DevTestTestComponent)
+
+	var componentBackendConfig = map[string]any{
+		"terraform": map[string]any{
+			"backend": map[string]any{
+				"s3": tenant1Ue2DevTestTestComponent["backend"],
+			},
+		},
+	}
+
+	var backendFilePath = path.Join(
+		c.Config.BasePath,
+		c.Config.Components.Terraform.BasePath,
+		"test",           // info.ComponentFolderPrefix,
+		"test-component", //  info.FinalComponent,
+		"backend.tf.json",
+	)
+
+	err = utils.WriteToFileAsJSON(backendFilePath, componentBackendConfig, 0644)
+	assert.Nil(t, err)
+
+	data, err := os.ReadFile(backendFilePath)
+	assert.Nil(t, err)
+
+	assert.Equal(t, utils.RemoveWhitespace(`{
+		"terraform": {
+		  "backend": {
+			"s3": {
+			  "encrypt": true,
+			  "key": "terraform.tfstate",
+			  "region": "us-east-1",
+			  "role_arn": null,
+			  "workspace_key_prefix": "app",
+			  "acl": "bucket-owner-full-control",
+			  "bucket": "sts-gbl-tfstate-backend",
+			  "dynamodb_table": "sts-gbl-tfstate-backend-lock"
+			}
+		  }
+		}
+	  }`), utils.RemoveWhitespace(string(data)))
+
+	// Remove config file
+	os.Remove("./atmos.yaml")
+}

--- a/pkg/utils/string_utils.go
+++ b/pkg/utils/string_utils.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"strings"
+)
+
 // UniqueStrings returns a unique subset of the string slice provided
 func UniqueStrings(input []string) []string {
 	u := make([]string, 0, len(input))
@@ -13,4 +17,14 @@ func UniqueStrings(input []string) []string {
 	}
 
 	return u
+}
+
+func RemoveWhitespace(input string) string {
+	replaceable := [...]string{"\t", "\n", " "}
+
+	for _, item := range replaceable {
+		input = strings.Replace(input, item, "", -1)
+	}
+
+	return input
 }


### PR DESCRIPTION
## what
* adding a (rough) test that demonstrates randomly changing `terraform.backend.s3` key order in backend config file generation 

## why
* We’ve noticed that backend.tf.json constantly changes the order of the keys within the s3 element. From what I can tell it’s due to go iterating over struct keys using a random order.

## references
* N/A

## test output

```
❯ make testacc TEST=github.com/cloudposse/atmos/pkg/utils
go get
go test github.com/cloudposse/atmos/pkg/utils -v  -timeout 2m
=== RUN   TestBackendConfig
    json_utils_test.go:65: 
                Error Trace:    /Users/joe/git-proj/cloudposse/atmos/pkg/utils/json_utils_test.go:65
                Error:          Not equal: 
                                expected: "{\"terraform\":{\"backend\":{\"s3\":{\"encrypt\":true,\"key\":\"terraform.tfstate\",\"region\":\"us-east-1\",\"role_arn\":null,\"workspace_key_prefix\":\"app\",\"acl\":\"bucket-owner-full-control\",\"bucket\":\"sts-gbl-tfstate-backend\",\"dynamodb_table\":\"sts-gbl-tfstate-backend-lock\"}}}}"
                                actual  : "{\"terraform\":{\"backend\":{\"s3\":{\"dynamodb_table\":\"cp-ue2-root-tfstate-lock\",\"profile\":\"cp-gb2-root-tfstate\",\"role_arn\":null,\"workspace_key_prefix\":\"test-test-component\",\"region\":\"us-east-2\",\"acl\":\"bucket-owner-full-control\",\"bucket\":\"cp-ue2-root-tfstate\",\"encrypt\":true,\"key\":\"terraform.tfstate\"}}}}"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"terraform":{"backend":{"s3":{"encrypt":true,"key":"terraform.tfstate","region":"us-east-1","role_arn":null,"workspace_key_prefix":"app","acl":"bucket-owner-full-control","bucket":"sts-gbl-tfstate-backend","dynamodb_table":"sts-gbl-tfstate-backend-lock"}}}}
                                +{"terraform":{"backend":{"s3":{"dynamodb_table":"cp-ue2-root-tfstate-lock","profile":"cp-gb2-root-tfstate","role_arn":null,"workspace_key_prefix":"test-test-component","region":"us-east-2","acl":"bucket-owner-full-control","bucket":"cp-ue2-root-tfstate","encrypt":true,"key":"terraform.tfstate"}}}}
                Test:           TestBackendConfig
--- FAIL: TestBackendConfig (0.06s)
FAIL
FAIL    github.com/cloudposse/atmos/pkg/utils   0.404s
FAIL
make: *** [testacc] Error 1

❯ make testacc TEST=github.com/cloudposse/atmos/pkg/utils
go get
go test github.com/cloudposse/atmos/pkg/utils -v  -timeout 2m
=== RUN   TestBackendConfig
    json_utils_test.go:65: 
                Error Trace:    /Users/joe/git-proj/cloudposse/atmos/pkg/utils/json_utils_test.go:65
                Error:          Not equal: 
                                expected: "{\"terraform\":{\"backend\":{\"s3\":{\"encrypt\":true,\"key\":\"terraform.tfstate\",\"region\":\"us-east-1\",\"role_arn\":null,\"workspace_key_prefix\":\"app\",\"acl\":\"bucket-owner-full-control\",\"bucket\":\"sts-gbl-tfstate-backend\",\"dynamodb_table\":\"sts-gbl-tfstate-backend-lock\"}}}}"
                                actual  : "{\"terraform\":{\"backend\":{\"s3\":{\"workspace_key_prefix\":\"test-test-component\",\"encrypt\":true,\"role_arn\":null,\"dynamodb_table\":\"cp-ue2-root-tfstate-lock\",\"key\":\"terraform.tfstate\",\"profile\":\"cp-gb2-root-tfstate\",\"region\":\"us-east-2\",\"acl\":\"bucket-owner-full-control\",\"bucket\":\"cp-ue2-root-tfstate\"}}}}"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"terraform":{"backend":{"s3":{"encrypt":true,"key":"terraform.tfstate","region":"us-east-1","role_arn":null,"workspace_key_prefix":"app","acl":"bucket-owner-full-control","bucket":"sts-gbl-tfstate-backend","dynamodb_table":"sts-gbl-tfstate-backend-lock"}}}}
                                +{"terraform":{"backend":{"s3":{"workspace_key_prefix":"test-test-component","encrypt":true,"role_arn":null,"dynamodb_table":"cp-ue2-root-tfstate-lock","key":"terraform.tfstate","profile":"cp-gb2-root-tfstate","region":"us-east-2","acl":"bucket-owner-full-control","bucket":"cp-ue2-root-tfstate"}}}}
                Test:           TestBackendConfig
--- FAIL: TestBackendConfig (0.04s)
FAIL
FAIL    github.com/cloudposse/atmos/pkg/utils   0.241s
FAIL
make: *** [testacc] Error 1
```