### PR TITLE
Update `atmos vendor pull`

### DIFF
--- a/examples/complete/Dockerfile
+++ b/examples/complete/Dockerfile
@@ -2,7 +2,7 @@
 ARG GEODESIC_VERSION=1.2.3
 ARG GEODESIC_OS=debian
 # atmos: https://github.com/cloudposse/atmos
-ARG ATMOS_VERSION=1.4.27
+ARG ATMOS_VERSION=1.4.28
 # Terraform: https://github.com/hashicorp/terraform/releases
 ARG TF_VERSION=1.2.8
 

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -352,6 +352,14 @@ func ExecuteComponentVendorCommandInternal(
 
 						// Preserve the uid and the gid of all entries
 						PreserveOwner: false,
+
+						// OnSymlink specifies what to do on symlink
+						// Override the destination file if it already exists
+						// Prevent the error:
+						// symlink components/terraform/mixins/context.tf components/terraform/infra/vpc-flow-logs-bucket/context.tf: file exists
+						OnSymlink: func(src string) cp.SymlinkAction {
+							return cp.Deep
+						},
 					}
 
 					if err = cp.Copy(tempDir, componentPath, copyOptions); err != nil {


### PR DESCRIPTION
## what
* Update `atmos vendor pull`

## why
* When pulling in mixins, override the destination file if it already exists
* Prevent the error:

```
symlink components/terraform/mixins/context.tf components/terraform/infra/vpc-flow-logs-bucket/context.tf: file exists
```

## related
* Closes https://github.com/cloudposse/atmos/issues/187

