### PR TITLE
fix: updates file_utils#FileExists to check for err (#191)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -361,7 +361,7 @@ func ProcessConfigForSpacelift() error {
 // https://medium.com/@bnprashanth256/reading-configuration-files-and-environment-variables-in-go-golang-c2607f912b63
 func processConfigFile(path string, v *viper.Viper) error {
 	if !u.FileExists(path) {
-		u.PrintInfoVerbose(fmt.Sprintf("No CLI config found in '%s'", path))
+		u.PrintInfoVerbose(fmt.Sprintf("No config file found at path '%s'.", path))
 		return nil
 	}
 

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -19,7 +19,7 @@ func IsDirectory(path string) (bool, error) {
 // FileExists checks if a file exists and is not a directory
 func FileExists(filename string) bool {
 	fileInfo, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || err != nil {
 		return false
 	}
 	return !fileInfo.IsDir()


### PR DESCRIPTION
## what
* Fixes an issue where `ATMOS_CLI_CONFIG_PATH` points to a non directory and results in a panic. 

## why
* We shouldn't panic. All is okay. This provides proper messaging and gracefully fails. 
* The error in question here that was getting skipped over by `os.IsNotExist(err)` was the following: 
	* `stat /usr/local/etc/atmos/atmos.yaml/atmos.yaml: not a directory`

## references
* #191 

