### PR TITLE
Fix `atmos` CLI config processing. Improve `logs.verbose`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
@@ -26,13 +27,23 @@ func InitCliConfig(configAndStacksInfo ConfigAndStacksInfo, verbose bool) (CliCo
 	// Command-line arguments
 
 	var cliConfig CliConfiguration
+	var err error
 
-	err := processLogsConfig(&cliConfig)
-	if err != nil {
-		return cliConfig, err
+	// Check `ATMOS_LOGS_VERBOSE` ENV var
+	// If it's set to `true`, log verbose even during the CLI config initialization
+	logVerboseEnvVar := false
+	logVerboseEnvVarFound := false
+	logVerboseEnvVarStr := os.Getenv("ATMOS_LOGS_VERBOSE")
+	if len(logVerboseEnvVarStr) > 0 {
+		u.PrintInfoVerbose(verbose, fmt.Sprintf("Found ENV var ATMOS_LOGS_VERBOSE=%s", logVerboseEnvVarStr))
+		logVerboseEnvVar, err = strconv.ParseBool(logVerboseEnvVarStr)
+		if err != nil {
+			return cliConfig, err
+		}
+		logVerboseEnvVarFound = true
 	}
 
-	var printVerbose = verbose && cliConfig.Logs.Verbose
+	var printVerbose = verbose && logVerboseEnvVarFound && logVerboseEnvVar
 
 	if printVerbose {
 		u.PrintInfo("\nSearching, processing and merging atmos CLI configurations (atmos.yaml) in the following order:")
@@ -145,6 +156,12 @@ func InitCliConfig(configAndStacksInfo ConfigAndStacksInfo, verbose bool) (CliCo
 		return cliConfig, err
 	}
 
+	// Set log verbose for the command that is being executed after the CLI config gets processed
+	// `logs.verbose` can be set in `atmos.yaml` or overridden by `ATMOS_LOGS_VERBOSE` ENV var
+	if logVerboseEnvVarFound {
+		cliConfig.Logs.Verbose = logVerboseEnvVar
+	}
+
 	// Process ENV vars
 	err = processEnvVars(&cliConfig)
 	if err != nil {
@@ -158,6 +175,7 @@ func InitCliConfig(configAndStacksInfo ConfigAndStacksInfo, verbose bool) (CliCo
 	}
 
 	// Process the base path specified in the Terraform provider (which calls into the atmos code)
+	// This overrides all other atmos base path configs (`atmos.yaml`, ENV var `ATMOS_BASE_PATH`)
 	if configAndStacksInfo.AtmosBasePath != "" {
 		cliConfig.BasePath = configAndStacksInfo.AtmosBasePath
 	}

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -356,19 +356,6 @@ func processCommandLineArgs(cliConfig *CliConfiguration, configAndStacksInfo Con
 	return nil
 }
 
-func processLogsConfig(cliConfig *CliConfiguration) error {
-	logVerbose := os.Getenv("ATMOS_LOGS_VERBOSE")
-	if len(logVerbose) > 0 {
-		u.PrintInfo(fmt.Sprintf("Found ENV var ATMOS_LOGS_VERBOSE=%s", logVerbose))
-		logVerboseBool, err := strconv.ParseBool(logVerbose)
-		if err != nil {
-			return err
-		}
-		cliConfig.Logs.Verbose = logVerboseBool
-	}
-	return nil
-}
-
 // GetContextFromVars creates a context object from the provided variables
 func GetContextFromVars(vars map[any]any) Context {
 	var context Context


### PR DESCRIPTION
## what
* Fix `atmos` CLI config processing
* Improve `logs.verbose`

## why
* Fix issues with CLI config processing introduced in https://github.com/cloudposse/atmos/pull/210
* In `Go`, a struct is passed by value to a function (the whole struct is copied), so if the function modifies any struct fields, the changes are not visible from outside of the functions
* The function `processEnvVars` was accepting the CLI config struct by value, checking the ENV var `ATMOS_BASE_PATH` and modifying the `BasePath` field - this modification was lost when the function returned resulting in the error from the `utils` provider "failed to find a match for the import ..." because the `atmos` base path was not set correctly (note that `ATMOS_BASE_PATH` ENV var is critical for the `utils` provider to work, and it's set by `geodesic` or by Spacelift scripts)
* Changing the function to accept a pointer to the struct fixed the issue (the modified fields are visible to the calling code)

