### PR TITLE
Update `atmos.yaml` initialization

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -24,7 +24,7 @@ import (
 func ExecuteVendorCommand(cmd *cobra.Command, args []string, vendorCommand string) error {
 	// InitCliConfig finds and merges CLI configurations in the following order:
 	// system dir, home dir, current dir, ENV vars, command-line arguments
-	cliConfig, err := cfg.InitCliConfig(cfg.ConfigAndStacksInfo{}, true)
+	cliConfig, err := cfg.InitCliConfig(cfg.ConfigAndStacksInfo{}, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## what
* Update `atmos.yaml` initialization

## why
* For some atmos commands (e.g. `atmos version` and `atmos vendor`), don't process `stacks` b/c `stacks` folder might not be present (e.g. during cold-start when using `atmos vendor` and `atmos version` in CI/CD systems)

