### PR TITLE
Update `atmos atlantis generate repo-config` command

### DIFF
--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -174,7 +174,11 @@ func ExecuteAtlantisGenerateRepoConfig(
 					return err
 				}
 
-				// Terraform workspace
+				// Calculate terraform workspace
+				// Base component is required to calculate terraform workspace for derived components
+				if terraformComponent != componentName {
+					context.BaseComponent = terraformComponent
+				}
 				workspace, err := BuildTerraformWorkspace(
 					stackConfigFileName,
 					cliConfig.Stacks.NamePattern,


### PR DESCRIPTION
## what
* Update `atmos atlantis generate repo-config` command

## why
* If an `atmos` component is derived from a base component, terraform workspace is calculated differently:
  - for a regular atmos component, terraform workspace is the stack name (e.g. `tenant1-ue2-prod`)
  - for a derived atmos component, terraform workspace is stack name + component name (e.g. `tenant1-ue2-prod-<component>`)

For example, for the following `vpc-2` atmos component
```yaml
  vpc-2:
    metadata:
      component: infra/vpc
```

terraform workspace in the `tenant1-ue2-prod` stack will be `tenant1-ue2-prod-vpc-2`

* This logic is used everywhere in all atmos commands (e.g. `atmos terraform apply <component> -s <stack>`). It was missing in `atmos atlantis generate repo-config` command

