### PR TITLE
Add `--format=backend-config` to `atmos terraform generate backends` command

### DIFF
--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -27,11 +27,12 @@ func init() {
 		"Backend template (the file path, file name, and file extension).\n"+
 			"Supports absolute and relative paths.\n"+
 			"Supports context tokens: {namespace}, {tenant}, {environment}, {region}, {stage}, {base-component}, {component}, {component-path}.\n"+
-			"atmos terraform generate backends --file-template {component-path}/{tenant}/{environment}-{stage}.tf.json\n"+
-			"atmos terraform generate backends --file-template {component-path}/backends/{tenant}-{environment}-{stage}.tf.json\n"+
-			"atmos terraform generate backends --file-template backends/{tenant}/{environment}/{region}/{component}.tf\n"+
+			"atmos terraform generate backends --file-template {component-path}/{tenant}/{environment}-{stage}.tf.json --format json\n"+
+			"atmos terraform generate backends --file-template {component-path}/backends/{tenant}-{environment}-{stage}.tf.json --format json\n"+
+			"atmos terraform generate backends --file-template backends/{tenant}/{environment}/{region}/{component}.tf --format hcl\n"+
 			"atmos terraform generate backends --file-template backends/{tenant}-{environment}-{stage}-{component}.tf\n"+
 			"atmos terraform generate backends --file-template /{tenant}/{stage}/{region}/{component}.tf\n"+
+			"atmos terraform generate backends --file-template backends/{tenant}-{environment}-{stage}-{component}.tfbackend --format backend-config\n"+
 			"All subdirectories in the path will be created automatically\n"+
 			"If '--file-template' flag is not specified, all backend config files will be written to the corresponding terraform component folders.",
 	)
@@ -51,8 +52,8 @@ func init() {
 	)
 
 	terraformGenerateBackendsCmd.PersistentFlags().String("format", "hcl", "Output format.\n"+
-		"Supported formats: hcl, json ('hcl' is default).\n"+
-		"atmos terraform generate backends --format=hcl|json")
+		"Supported formats: 'hcl', 'json', 'backend-config' ('hcl' is default).\n"+
+		"atmos terraform generate backends --format=hcl|json|backend-config")
 
 	terraformGenerateCmd.AddCommand(terraformGenerateBackendsCmd)
 }

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -53,8 +53,8 @@ func ExecuteTerraformGenerateBackendsCmd(cmd *cobra.Command, args []string) erro
 	if err != nil {
 		return err
 	}
-	if format != "" && format != "json" && format != "hcl" {
-		return fmt.Errorf("invalid '--format' argument '%s'. Valid values are 'hcl' and 'json", format)
+	if format != "" && format != "json" && format != "hcl" && format != "backend-config" {
+		return fmt.Errorf("invalid '--format' argument '%s'. Valid values are 'hcl', 'json', and 'backend-config'", format)
 	}
 	if format == "" {
 		format = "hcl"
@@ -211,8 +211,13 @@ func ExecuteTerraformGenerateBackends(cliConfig cfg.CliConfiguration, fileTempla
 						if err != nil {
 							return err
 						}
+					} else if format == "backend-config" {
+						err = u.WriteToFileAsHcl(backendFileAbsolutePath, backendSection, 0644)
+						if err != nil {
+							return err
+						}
 					} else {
-						return fmt.Errorf("invalid '--format' argument '%s'. Valid values are 'hcl' (default) and 'json", format)
+						return fmt.Errorf("invalid '--format' argument '%s'. Valid values are 'hcl' (default), 'json' and 'backend-config'", format)
 					}
 				}
 			}


### PR DESCRIPTION
## what
* Add `--format=backend-config` to `atmos terraform generate backends` command

## why
* Terraform supports `-backend-config` argument, which required the backend config files to have just the backend attributes without `terraform.backend` header

## references
* https://developer.hashicorp.com/terraform/language/settings/backends/configuration#file

## test

```text
atmos terraform generate backends --file-template backends/{tenant}-{environment}-{stage}-{component}.tfbackend --format backend-config --components infra/vpc

Writing backend config for the component 'infra/vpc' to file 'backends/tenant1-ue2-staging-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant1-ue2-test-1-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant1-ue2-dev-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant1-ue2-prod-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant2-ue2-staging-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant2-ue2-dev-infra-vpc.tfbackend'
Writing backend config for the component 'infra/vpc' to file 'backends/tenant2-ue2-prod-infra-vpc.tfbackend'
```

<br>

![image](https://user-images.githubusercontent.com/7356997/200154914-78c67cf6-ef66-4564-983a-efc19e5f5a2f.png)

<br>



