### PR TITLE
add shell completions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var CompletionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate completion script",
+	Long:                  "To load completions",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}


### PR DESCRIPTION
## what

* add shell completion script generation for bash, zsh, fish and powershell
* users can now run `atmos completion [bash|zsh|fish|powershell]` and atmos will output the shell completion script for that shell

## why
* so users can run `atmos [tab][tab]` and get command auto-completion

## references
* Closes #45 