### PR TITLE
Fix unwanted back-quoting in usage string

### DIFF
--- a/cmd/terraform_generate_backends.go
+++ b/cmd/terraform_generate_backends.go
@@ -47,7 +47,7 @@ func init() {
 	)
 
 	terraformGenerateBackendsCmd.PersistentFlags().String("components", "",
-		"Only generate the backend files for the specified `atmos` components (comma-separated values).\n"+
+		"Only generate the backend files for the specified 'atmos' components (comma-separated values).\n"+
 			"atmos terraform generate backends --file-template <file_template> --components <component1>,<component2>",
 	)
 

--- a/cmd/terraform_generate_varfiles.go
+++ b/cmd/terraform_generate_varfiles.go
@@ -43,7 +43,7 @@ func init() {
 	)
 
 	terraformGenerateVarfilesCmd.PersistentFlags().String("components", "",
-		"Generate Terraform `.tfvar` files only for the specified 'atmos' components (use comma-separated values to specify multiple components).\n"+
+		"Generate Terraform \".tfvar\" files only for the specified 'atmos' components (use comma-separated values to specify multiple components).\n"+
 			"atmos terraform generate varfiles --file-template <file_template> --components <component1>,<component2>",
 	)
 


### PR DESCRIPTION
## what
* Prevent, unwanted IMHO, backquoted word substitution in flag's usage message


## why
* Because these substitutions make the usage messages less understandable

## references
* For reference see https://pkg.go.dev/flag#PrintDefaults

