### PR TITLE
Typo

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "atmos",
 	Short: "Universal Tool for DevOps and Cloud Automation",
-	Long:  `'atmos'' is a universal tool for DevOps and cloud automation used for provisioning, managing and orchestrating workflows across various toolchains`,
+	Long:  `'atmos' is a universal tool for DevOps and cloud automation used for provisioning, managing and orchestrating workflows across various toolchains`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
## what
* Fix typo

## why
* Atmos' main usage message has a doubled quote.

