### PR TITLE
Allow workflow shell commands to be any (complex) shell commands

### DIFF
--- a/internal/exec/worflow.go
+++ b/internal/exec/worflow.go
@@ -101,7 +101,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = executeWorkflowSteps(workflowDefinition, dryRun, commandLineStack)
+	err = executeWorkflowSteps(workflow, workflowDefinition, dryRun, commandLineStack)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/worflow_utils.go
+++ b/internal/exec/worflow_utils.go
@@ -8,10 +8,10 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
-func executeWorkflowSteps(workflowDefinition cfg.WorkflowDefinition, dryRun bool, commandLineStack string) error {
+func executeWorkflowSteps(workflow string, workflowDefinition cfg.WorkflowDefinition, dryRun bool, commandLineStack string) error {
 	var steps = workflowDefinition.Steps
 
-	for _, step := range steps {
+	for stepIdx, step := range steps {
 		var command = strings.TrimSpace(step.Command)
 		var commandType = strings.TrimSpace(step.Type)
 
@@ -22,8 +22,8 @@ func executeWorkflowSteps(workflowDefinition cfg.WorkflowDefinition, dryRun bool
 		}
 
 		if commandType == "shell" {
-			args := strings.Fields(command)
-			if err := ExecuteShellCommand(args[0], args[1:], ".", []string{}, dryRun, true); err != nil {
+			commandName := fmt.Sprintf("%s-step-%d", workflow, stepIdx)
+			if err := ExecuteShell(command, commandName, ".", []string{}, dryRun, true); err != nil {
 				return err
 			}
 		} else if commandType == "atmos" {


### PR DESCRIPTION
## what
* With the proposed PR, a workflow command of type ` shell` could be any shell command (or script).

## why
* Because it is useful to have complex shell commands/scripts inlined in the workflow YAML definition file

## references 
* Similar to  issue #260

