### PR TITLE
Bump homebrew if build succeeds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
   homebrew:
     name: "Bump Homebrew formula"
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: mislav/bump-homebrew-formula-action@v2
         with:


### PR DESCRIPTION
## what
* Bump homebrew if build succeeds

## why
* If the build doesn't succeed, do not bump homebrew
* This came up when v1.19.0 failed and homebrew was incorrectly bumped

## references
- https://github.com/cloudposse/atmos/actions/runs/3788889725

