### PR TITLE
Avoid duplicate error message output

### DIFF
--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -24,7 +24,6 @@ func ExecuteDescribeAffectedCmd(cmd *cobra.Command, args []string) error {
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -19,7 +19,6 @@ func ExecuteDescribeStacksCmd(cmd *cobra.Command, args []string) error {
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -22,7 +22,6 @@ func ExecuteHelmfileCmd(cmd *cobra.Command, args []string) error {
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -25,7 +25,6 @@ func ExecuteTerraformCmd(cmd *cobra.Command, args []string) error {
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -36,7 +36,6 @@ func ExecuteTerraformGenerateBackendCmd(cmd *cobra.Command, args []string) error
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -20,7 +20,6 @@ func ExecuteTerraformGenerateBackendsCmd(cmd *cobra.Command, args []string) erro
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/terraform_generate_varfile.go
+++ b/internal/exec/terraform_generate_varfile.go
@@ -35,7 +35,6 @@ func ExecuteTerraformGenerateVarfileCmd(cmd *cobra.Command, args []string) error
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -20,7 +20,6 @@ func ExecuteTerraformGenerateVarfilesCmd(cmd *cobra.Command, args []string) erro
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 

--- a/internal/exec/validate_component.go
+++ b/internal/exec/validate_component.go
@@ -21,7 +21,6 @@ func ExecuteValidateComponentCmd(cmd *cobra.Command, args []string) error {
 
 	cliConfig, err := cfg.InitCliConfig(info, true)
 	if err != nil {
-		u.PrintErrorToStdError(err)
 		return err
 	}
 


### PR DESCRIPTION
## what
* The Execute*Cmd() functions do not need to print a possible error message from cfg.InitCliConfig() as their callers already do that.

## why
* The change introduced in #288 uncovered these unnecessary error message printings.

