### PR TITLE
Do not allow unknown flags when unnecessary

### DIFF
--- a/cmd/atlantis_generate.go
+++ b/cmd/atlantis_generate.go
@@ -9,7 +9,7 @@ var atlantisGenerateCmd = &cobra.Command{
 	Use:                "generate",
 	Short:              "Execute 'atlantis generate' commands",
 	Long:               "This command generates various Atlantis configurations",
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 
 func init() {

--- a/cmd/atlantis_generate_repo_config.go
+++ b/cmd/atlantis_generate_repo_config.go
@@ -11,7 +11,7 @@ var atlantisGenerateRepoConfigCmd = &cobra.Command{
 	Use:                "repo-config",
 	Short:              "Execute 'atlantis generate repo-config`",
 	Long:               "This command generates repository configuration for Atlantis",
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteAtlantisGenerateRepoConfigCmd(cmd, args)
 		if err != nil {

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -9,7 +9,7 @@ var describeCmd = &cobra.Command{
 	Use:                "describe",
 	Short:              "Execute 'describe' commands",
 	Long:               `This command shows configuration for CLI, stacks and components`,
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 
 func init() {

--- a/cmd/describe_affected.go
+++ b/cmd/describe_affected.go
@@ -12,7 +12,7 @@ var describeAffectedCmd = &cobra.Command{
 	Use:                "affected",
 	Short:              "Execute 'describe affected' command",
 	Long:               `This command produces a list of the affected Atmos components and stacks given two Git commits: atmos describe stacks [options]`,
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeAffectedCmd(cmd, args)
 		if err != nil {

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -11,7 +11,7 @@ var describeComponentCmd = &cobra.Command{
 	Use:                "component",
 	Short:              "Execute 'describe component' command",
 	Long:               `This command shows configuration for an atmos component in a stack: atmos describe component <component> -s <stack>`,
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeComponentCmd(cmd, args)
 		if err != nil {

--- a/cmd/describe_config.go
+++ b/cmd/describe_config.go
@@ -11,7 +11,7 @@ var describeConfigCmd = &cobra.Command{
 	Use:                "config",
 	Short:              "Execute 'describe config' command",
 	Long:               `This command shows the final (deep-merged) CLI configuration: atmos describe config`,
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeConfigCmd(cmd, args)
 		if err != nil {

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -11,7 +11,7 @@ var describeStacksCmd = &cobra.Command{
 	Use:                "stacks",
 	Short:              "Execute 'describe stacks' command",
 	Long:               `This command shows configuration for atmos stacks and components in the stacks: atmos describe stacks [options]`,
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := e.ExecuteDescribeStacksCmd(cmd, args)
 		if err != nil {

--- a/cmd/helmfile_generate.go
+++ b/cmd/helmfile_generate.go
@@ -9,7 +9,7 @@ var helmfileGenerateCmd = &cobra.Command{
 	Use:                "generate",
 	Short:              "Execute 'helmfile generate' commands",
 	Long:               "This command generates configurations for helmfile components",
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 
 func init() {

--- a/cmd/terraform_generate.go
+++ b/cmd/terraform_generate.go
@@ -9,7 +9,7 @@ var terraformGenerateCmd = &cobra.Command{
 	Use:                "generate",
 	Short:              "Execute 'terraform generate' commands",
 	Long:               "This command generates configurations for terraform components",
-	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
+	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 
 func init() {


### PR DESCRIPTION
## what
* Report unknown flags given to relevant commands

## why
* IMHO it causes less surprise to report unknown flags

