### PR TITLE
Update templates in stack configs

### DIFF
--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -170,7 +170,7 @@ func ProcessYAMLConfigFile(
 	}
 
 	// Process `Go` templates in the stack config file using the provided context
-	if context != nil {
+	if len(context) > 0 {
 		stackYamlConfig, err = u.ProcessTmpl(relativeFilePath, stackYamlConfig, context)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
## what
* Update templates in stack configs

## why
* If a `context` is not provided (as if using `import` with `context`), don't process `Go` templates in the imported config (templating can be used for Datadog, ArgoCD etc. w/o requiring Atmos to process them)



