### PR TITLE
Don't assume array indexes exist, check first

### DIFF
--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -1278,7 +1278,7 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (cfg.
 			} else {
 				return info, fmt.Errorf("command \"%s\" requires an argument", info.SubCommand)
 			}
-			if len(additionalArgsAndFlags) > 4 {
+			if len(additionalArgsAndFlags) > 3 {
 				info.AdditionalArgsAndFlags = additionalArgsAndFlags[3:]
 			}
 		} else {


### PR DESCRIPTION
This is the first instance I've seen us run into the issue of `atmos` simply panicking. Tracking it back I found unchecked array indexes (index assumed to exist). These checks will prevent those panics in the future and, were applicable, return a useful error message.

Pre-patch:

```
√ : [<REDACTED>] (HOST) infrastructure ⨠ atmos terraform state list -s <REDACTED>
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
github.com/cloudposse/atmos/internal/exec.processArgsAndFlags({_, _}, {_, _, _})
	/home/runner/work/atmos/atmos/internal/exec/utils.go:1259 +0x203c
github.com/cloudposse/atmos/internal/exec.processCommandLineArgs({_, _}, _, {_, _, _})
	/home/runner/work/atmos/atmos/internal/exec/utils.go:143 +0xbc
github.com/cloudposse/atmos/internal/exec.ExecuteTerraformCmd(0x40006bfd48?, {0x40000e2c40?, 0x4?, 0x1243ef0?})
	/home/runner/work/atmos/atmos/internal/exec/terraform.go:23 +0x70
github.com/cloudposse/atmos/cmd.glob..func10(0x40006bfe18?, {0x40000e2c40?, 0xfffff725f69a?, 0x40000a6b90?})
	/home/runner/work/atmos/atmos/cmd/terraform.go:16 +0x20
github.com/spf13/cobra.(*Command).execute(0x1f2fca0, {0x40000e2c40, 0x4, 0x4})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x1f2f9c0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x368
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/cloudposse/atmos/cmd.Execute(...)
	/home/runner/work/atmos/atmos/cmd/root.go:20
main.main()
	/home/runner/work/atmos/atmos/main.go:9 +0x2c
```

Post-patch:

```
√ : [<REDACTED>] (HOST) infrastructure ⨠ atmos terraform state list -s <REDACTED>
command requires an argument: state list
```