### PR TITLE
Algolia to redirect to external site when search results from external site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -124,6 +124,7 @@ const config = {
                 appId: process.env.ALGOLIA_APP_ID || '32YOERUX83',
                 apiKey: process.env.ALGOLIA_SEARCH_API_KEY || '557985309adf0e4df9dcf3cb29c61928', // this is SEARCH ONLY API key and is not sensitive information
                 indexName: process.env.ALGOLIA_INDEX_NAME || 'docs.cloudposse.com',
+                externalUrlRegex: 'docs\\.cloudposse\\.com',
                 contextualSearch: false
             },
         }),


### PR DESCRIPTION
## what

- Fixed external links in algolia search dialog.

## why

- Search results that point to an external source in the search dialog didn't actually use external host but instead relative path.

## references

- https://docusaurus.io/docs/search#connecting-algolia