### PR TITLE
Changed search index back to atmos exclusive on atmos.tools

### DIFF
--- a/.github/workflows/website-deploy-release.yml
+++ b/.github/workflows/website-deploy-release.yml
@@ -13,7 +13,7 @@ env:
   IAM_ROLE_SESSION_NAME: cloudposse-atmos-ci-deploy-release
   S3_BUCKET_NAME: cplive-plat-ue2-prod-atmos-docs-origin
   DEPLOYMENT_HOST: atmos.tools
-  ALGOLIA_INDEX_NAME: docs.cloudposse.com
+  ALGOLIA_INDEX_NAME: atmos.tools
   ALGOLIA_APP_ID: 32YOERUX83
 
 # These permissions are needed to interact with the GitHub's OIDC Token endpoint
@@ -61,6 +61,12 @@ jobs:
           aws sts get-caller-identity
           aws s3 sync . s3://${{ env.S3_BUCKET_NAME }} --delete
           aws s3 ls s3://${{ env.S3_BUCKET_NAME }} --recursive --human-readable --summarize
+
+      - name: ReIndex with Algolia
+        env:
+          ALGOLIA_SCRAPER_API_KEY: ${{ secrets.ALGOLIA_SCRAPER_API_KEY }}
+        run: |
+          ./website/algolia/reindex.sh
 
       - name: Trigger ReIndexing of atmos.tools and docs.cloudposse.com Docs
         run: |

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -123,8 +123,7 @@ const config = {
             algolia: {
                 appId: process.env.ALGOLIA_APP_ID || '32YOERUX83',
                 apiKey: process.env.ALGOLIA_SEARCH_API_KEY || '557985309adf0e4df9dcf3cb29c61928', // this is SEARCH ONLY API key and is not sensitive information
-                indexName: process.env.ALGOLIA_INDEX_NAME || 'docs.cloudposse.com',
-                externalUrlRegex: 'docs\\.cloudposse\\.com',
+                indexName: process.env.ALGOLIA_INDEX_NAME || 'atmos.tools',
                 contextualSearch: false
             },
         }),


### PR DESCRIPTION
## what

- Changed search index back to atmos exclusive on atmos.tools

## why

- on atmos.tools search dialog will contain results for atmos.tools site only
- on docs.cloudposse.com  search dialog will contain results for both atmos.tools and docs.cloudposse.com

## references
