### PR TITLE
Add `workspace` to the outputs of `atmos describe stacks` command

### DIFF
--- a/pkg/describe/describe_stacks_test.go
+++ b/pkg/describe/describe_stacks_test.go
@@ -90,3 +90,88 @@ func TestDescribeStacksWithFilter4(t *testing.T) {
 	assert.Nil(t, err)
 	t.Log(string(dependentsYaml))
 }
+
+func TestDescribeStacksWithFilter5(t *testing.T) {
+	configAndStacksInfo := schema.ConfigAndStacksInfo{}
+
+	cliConfig, err := cfg.InitCliConfig(configAndStacksInfo, true)
+	assert.Nil(t, err)
+
+	componentTypes := []string{"terraform"}
+	components := []string{"top-level-component1"}
+	sections := []string{"vars"}
+
+	stacks, err := ExecuteDescribeStacks(cliConfig, "", components, componentTypes, sections, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 7, len(stacks))
+
+	tenant1Ue2DevStack := stacks["tenant1-ue2-dev"].(map[string]any)
+	tenant1Ue2DevStackComponents := tenant1Ue2DevStack["components"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraform := tenant1Ue2DevStackComponents["terraform"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformComponent := tenant1Ue2DevStackComponentsTerraform["top-level-component1"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformComponentVars := tenant1Ue2DevStackComponentsTerraformComponent["vars"].(map[any]any)
+	tenant1Ue2DevStackComponentsTerraformComponentVarsTenant := tenant1Ue2DevStackComponentsTerraformComponentVars["tenant"].(string)
+	tenant1Ue2DevStackComponentsTerraformComponentVarsStage := tenant1Ue2DevStackComponentsTerraformComponentVars["stage"].(string)
+	tenant1Ue2DevStackComponentsTerraformComponentVarsEnvironment := tenant1Ue2DevStackComponentsTerraformComponentVars["environment"].(string)
+	assert.Equal(t, "tenant1", tenant1Ue2DevStackComponentsTerraformComponentVarsTenant)
+	assert.Equal(t, "ue2", tenant1Ue2DevStackComponentsTerraformComponentVarsEnvironment)
+	assert.Equal(t, "dev", tenant1Ue2DevStackComponentsTerraformComponentVarsStage)
+
+	stacksYaml, err := yaml.Marshal(stacks)
+	assert.Nil(t, err)
+	t.Log(string(stacksYaml))
+}
+
+func TestDescribeStacksWithFilter6(t *testing.T) {
+	configAndStacksInfo := schema.ConfigAndStacksInfo{}
+
+	cliConfig, err := cfg.InitCliConfig(configAndStacksInfo, true)
+	assert.Nil(t, err)
+
+	stack := "tenant1-ue2-dev"
+	componentTypes := []string{"terraform"}
+	components := []string{"top-level-component1"}
+	sections := []string{"workspace"}
+
+	stacks, err := ExecuteDescribeStacks(cliConfig, "tenant1-ue2-dev", components, componentTypes, sections, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(stacks))
+
+	tenant1Ue2DevStack := stacks[stack].(map[string]any)
+	tenant1Ue2DevStackComponents := tenant1Ue2DevStack["components"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraform := tenant1Ue2DevStackComponents["terraform"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformComponent := tenant1Ue2DevStackComponentsTerraform["top-level-component1"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformWorkspace := tenant1Ue2DevStackComponentsTerraformComponent["workspace"].(string)
+	assert.Equal(t, "tenant1-ue2-dev", tenant1Ue2DevStackComponentsTerraformWorkspace)
+
+	stacksYaml, err := yaml.Marshal(stacks)
+	assert.Nil(t, err)
+	t.Log(string(stacksYaml))
+}
+
+func TestDescribeStacksWithFilter7(t *testing.T) {
+	configAndStacksInfo := schema.ConfigAndStacksInfo{}
+
+	cliConfig, err := cfg.InitCliConfig(configAndStacksInfo, true)
+	assert.Nil(t, err)
+
+	stack := "tenant1-ue2-dev"
+	componentTypes := []string{"terraform"}
+	components := []string{"test/test-component-override-3"}
+	sections := []string{"workspace"}
+
+	stacks, err := ExecuteDescribeStacks(cliConfig, stack, components, componentTypes, sections, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(stacks))
+
+	tenant1Ue2DevStack := stacks[stack].(map[string]any)
+	tenant1Ue2DevStackComponents := tenant1Ue2DevStack["components"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraform := tenant1Ue2DevStackComponents["terraform"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformComponent := tenant1Ue2DevStackComponentsTerraform["test/test-component-override-3"].(map[string]any)
+	tenant1Ue2DevStackComponentsTerraformWorkspace := tenant1Ue2DevStackComponentsTerraformComponent["workspace"].(string)
+	assert.Equal(t, "test-component-override-3-workspace", tenant1Ue2DevStackComponentsTerraformWorkspace)
+
+	stacksYaml, err := yaml.Marshal(stacks)
+	assert.Nil(t, err)
+	t.Log(string(stacksYaml))
+}


### PR DESCRIPTION
## what

* Add `workspace` to the outputs of `atmos describe stacks` command

## why

* We often need to know the terraform workspace for each component (taking into account that Terraform workspaces can be overridden per component, so they are not always the same as the stack names)


## test

```yaml
tenant1-ue2-dev:
    components:
      terraform:
        
        top-level-component1:
          workspace: tenant1-ue2-dev

        test/test-component-override-3:
          workspace: test-component-override-3-workspace
```
