### PR TITLE
docs: typo in generate varfile

### DIFF
--- a/website/docs/cli/commands/terraform/terraform-generate-varfile.md
+++ b/website/docs/cli/commands/terraform/terraform-generate-varfile.md
@@ -14,7 +14,7 @@ Use this command to generate a varfile (`.tfvar` ) for an Atmos terraform [compo
 Execute the `terraform generate varfile` command like this:
 
 ```shell
-atmos terraform generate varfile <command> <component> -s <stack>
+atmos terraform generate varfile <component> -s <stack>
 ```
 
 This command generates a varfile for an Atmos terraform component in a stack.


### PR DESCRIPTION
## what

- remove stray arg in `generate varfile` subcommand

## why

- `<command>` is not an argument
