### PR TITLE
add skip lock file flag to clean command

### DIFF
--- a/internal/exec/help.go
+++ b/internal/exec/help.go
@@ -31,7 +31,7 @@ func processHelp(componentType string, command string) error {
 			u.PrintMessage(" - 'atmos terraform apply' and 'atmos terraform deploy' commands commands support '--planfile' flag to specify the path " +
 				"to a planfile. The '--planfile' flag should be used instead of the planfile argument in the native 'terraform apply <planfile>' command")
 			u.PrintMessage(" - 'atmos terraform clean' command deletes the '.terraform' folder, '.terraform.lock.hcl' lock file, " +
-				"and the previously generated 'planfile' and 'varfile' for the specified component and stack")
+				"and the previously generated 'planfile' and 'varfile' for the specified component and stack. Use --skip-lock-file flag to skip deleting the lock file.")
 			u.PrintMessage(" - 'atmos terraform workspace' command first runs 'terraform init -reconfigure', then 'terraform workspace select', " +
 				"and if the workspace was not created before, it then runs 'terraform workspace new'")
 			u.PrintMessage(" - 'atmos terraform import' command searches for 'region' in the variables for the specified component and stack, " +

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -2,11 +2,12 @@ package exec
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -14,9 +15,10 @@ import (
 )
 
 const (
-	autoApproveFlag = "-auto-approve"
-	outFlag         = "-out"
-	varFileFlag     = "-var-file"
+	autoApproveFlag           = "-auto-approve"
+	outFlag                   = "-out"
+	varFileFlag               = "-var-file"
+	skipTerraformLockFileFlag = "--skip-lock-file"
 )
 
 // ExecuteTerraformCmd parses the provided arguments and flags and executes terraform commands
@@ -81,8 +83,10 @@ func ExecuteTerraform(info schema.ConfigAndStacksInfo) error {
 			u.LogWarning(cliConfig, err.Error())
 		}
 
-		u.LogTrace(cliConfig, "Deleting '.terraform.lock.hcl' file")
-		_ = os.Remove(path.Join(componentPath, ".terraform.lock.hcl"))
+		if !u.SliceContainsString(info.AdditionalArgsAndFlags, skipTerraformLockFileFlag) {
+			u.LogTrace(cliConfig, "Deleting '.terraform.lock.hcl' file")
+			_ = os.Remove(path.Join(componentPath, ".terraform.lock.hcl"))
+		}
 
 		u.LogTrace(cliConfig, fmt.Sprintf("Deleting terraform varfile: %s\n", varFile))
 		_ = os.Remove(path.Join(componentPath, varFile))

--- a/website/docs/cli/commands/terraform/terraform-clean.md
+++ b/website/docs/cli/commands/terraform/terraform-clean.md
@@ -16,7 +16,7 @@ component in a stack.
 Execute the `terraform clean` command like this:
 
 ```shell
-atmos terraform clean <component> -s <stack>
+atmos terraform clean <component> -s <stack> [--skip-lock-file]
 ```
 
 :::tip
@@ -28,6 +28,7 @@ Run `atmos terraform clean --help` to see all the available options
 ```shell
 atmos terraform clean top-level-component1 -s tenant1-ue2-dev
 atmos terraform clean infra/vpc -s tenant1-ue2-staging
+atmos terraform clean infra/vpc -s tenant1-ue2-staging --skip-lock-file
 atmos terraform clean test/test-component -s tenant1-ue2-dev
 atmos terraform clean test/test-component-override-2 -s tenant2-ue2-prod
 atmos terraform clean test/test-component-override-3 -s tenant1-ue2-dev
@@ -36,12 +37,13 @@ atmos terraform clean test/test-component-override-3 -s tenant1-ue2-dev
 ## Arguments
 
 | Argument    | Description               | Required |
-|:------------|:--------------------------|:---------|
+| :---------- | :------------------------ | :------- |
 | `component` | Atmos terraform component | yes      |
 
 ## Flags
 
-| Flag        | Description | Alias | Required |
-|:------------|:------------|:------|:---------|
-| `--stack`   | Atmos stack | `-s`  | yes      |
-| `--dry-run` | Dry run     |       | no       |
+| Flag               | Description                       | Alias | Required |
+| :----------------- | :-------------------------------- | :---- | :------- |
+| `--stack`          | Atmos stack                       | `-s`  | yes      |
+| `--dry-run`        | Dry run                           |       | no       |
+| `--skip-lock-file` | Skip deleting .terraform.lock.hcl |       | no       |

--- a/website/docs/cli/commands/terraform/usage.mdx
+++ b/website/docs/cli/commands/terraform/usage.mdx
@@ -4,7 +4,7 @@ sidebar_label: terraform
 sidebar_class_name: command
 ---
 
-import DocCardList from '@theme/DocCardList';
+import DocCardList from "@theme/DocCardList";
 
 :::note Purpose
 Use these subcommands to interact with `terraform`.
@@ -19,7 +19,7 @@ atmos terraform <command> <component> -s <stack> [options]
 atmos terraform <command> <component> --stack <stack> [options]
 ```
 
-<br/>
+<br />
 
 :::info
 Atmos supports all `terraform` commands and options described in [Terraform CLI reference](https://www.terraform.io/cli/commands).
@@ -27,7 +27,7 @@ Atmos supports all `terraform` commands and options described in [Terraform CLI 
 In addition, the `component` argument and `stack` flag are required to generate variables and backend config for the component in the stack.
 :::
 
-<br/>
+<br />
 
 **Additions and differences from native `terraform`:**
 
@@ -53,7 +53,7 @@ In addition, the `component` argument and `stack` flag are required to generate 
   planfile
 
 - `atmos terraform clean` command deletes the `.terraform` folder, `.terraform.lock.hcl` lock file, and the previously generated `planfile`
-  and `varfile` for the specified component and stack
+  and `varfile` for the specified component and stack. Use the `--skip-lock-file` flag to skip deleting the `.terraform.lock.hcl` file.
 
 - `atmos terraform workspace` command first runs `terraform init -reconfigure`, then `terraform workspace select`, and if the workspace was not
   created before, it then runs `terraform workspace new`
@@ -72,7 +72,7 @@ In addition, the `component` argument and `stack` flag are required to generate 
 - `atmos terraform shell` command configures an environment for an Atmos component in a stack and starts a new shell allowing executing all native
   terraform commands inside the shell
 
-<br/>
+<br />
 
 :::tip
 Run `atmos terraform --help` to see all the available options
@@ -82,6 +82,7 @@ Run `atmos terraform --help` to see all the available options
 
 ```shell
 atmos terraform plan test/test-component-override-3 -s tenant1-ue2-dev
+atmos terraform plan test/test-component-override-3 -s tenant1-ue2-dev --skip-lock-file
 atmos terraform plan test/test-component-override-2 -s tenant1-ue2-dev --redirect-stderr /dev/stdout
 atmos terraform plan test/test-component-override -s tenant1-ue2-dev --redirect-stderr ./errors.txt
 
@@ -106,18 +107,18 @@ atmos terraform workspace test/test-component-override-3 -s tenant1-ue2-dev --re
 ## Arguments
 
 | Argument    | Description               | Required |
-|:------------|:--------------------------|:---------|
+| :---------- | :------------------------ | :------- |
 | `component` | Atmos terraform component | yes      |
 
 ## Flags
 
 | Flag                | Description                                                                                                                                   | Alias | Required |
-|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|:------|:---------|
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------- | :---- | :------- |
 | `--stack`           | Atmos stack                                                                                                                                   | `-s`  | yes      |
 | `--dry-run`         | Dry run                                                                                                                                       |       | no       |
 | `--redirect-stderr` | File descriptor to redirect `stderr` to.<br/>Errors can be redirected to any file or any standard file descriptor<br/>(including `/dev/null`) |       | no       |
 
-<br/>
+<br />
 
 :::note
 
@@ -127,4 +128,4 @@ All native `terraform` flags are supported
 
 ## Subcommands
 
-<DocCardList/>
+<DocCardList />


### PR DESCRIPTION
## what

Add the `--skip-lock-file` flag to the `atmos terraform clean` command

## why

For users who want to keep a stable lock file but otherwise want to clean the component directory.