### PR TITLE
Update Secret Reference to Fix Brew workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula-name: atmos
         env:
-          COMMITTER_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## what

Updating workflow to use the `GH_BOT_TOKEN` secret which has `repo` and `workflow` permissions. This is needed by the [mislav/bump-homebrew-formula-action](https://github.com/mislav/bump-homebrew-formula-action) action to:
1. Create a commit in [cloudpossebot/homebrew-core](https://github.com/cloudpossebot/homebrew-core)
2. Create a PR from [cloudpossebot/homebrew-core](https://github.com/cloudpossebot/homebrew-core) to [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core)

## why

This should fix the GH Workflows

## references

 - https://github.com/cloudpossebot/homebrew-core
 - https://github.com/Homebrew/homebrew-core
 - https://github.com/mislav/bump-homebrew-formula-action