### PR TITLE
Bugfix: `formula-path` for Promoting to homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,6 @@ jobs:
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula-name: atmos
+          formula-path: Formula/a/atmos.rb
         env:
           COMMITTER_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## what

Bugfix new error - Formula/atmos.rb could not be found.

## why

Homebrew/homebrew-core now uses folders based on alphabet such as `Formula/a/atmos.rb`. This PR uses an action parameter to fix this pathing.

## references
 - https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/atmos.rb
 - https://github.com/mislav/bump-homebrew-formula-action#action-inputs