### PR TITLE
ci: exclude dependabot from codeowner validation and auto format

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -15,7 +15,7 @@ jobs:
     # However, using a personal access token will cause events to be triggered.
     # We need that to ensure a status gets posted after the auto-format commit.
     # We also want to trigger tests if the auto-format made no changes.
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:
@@ -27,7 +27,7 @@ jobs:
 
     # Do all the formatting stuff
     - name: Auto Format
-      if: github.event.pull_request.state == 'open'
+      if: ${{ (github.event.pull_request.state == 'open') && (github.actor != 'dependabot[bot]') }}
       shell: bash
       env:
         GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
@@ -35,7 +35,7 @@ jobs:
 
     # Commit changes (if any) to the PR branch
     - name: Commit changes to the PR branch
-      if: github.event.pull_request.state == 'open'
+      if: ${{ (github.event.pull_request.state == 'open') && (github.actor != 'dependabot[bot]') }}
       shell: bash
       id: commit
       env:
@@ -74,6 +74,7 @@ jobs:
       if: >
         contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
         && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
+        && github.actor != 'dependabot[bot]'
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: cloudposse/actions

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v2
-      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
+      uses: actions/checkout@v4
+
+    # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
       name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
@@ -22,8 +23,9 @@ jobs:
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
+
     - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name != github.repository
+      if: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -13,7 +13,7 @@ jobs:
 
     # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
-      if: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) && (github.actor != 'dependabot[bot]') }}
       name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
@@ -25,7 +25,7 @@ jobs:
         github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
 
     - uses: mszostok/codeowners-validator@v0.7.1
-      if: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) && (github.actor != 'dependabot[bot]') }}
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -13,7 +13,8 @@ jobs:
 
     # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
-      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) && (github.actor != 'dependabot[bot]') }}
+      # This condition verifies that the PR repo equals the Github Repo and it's NOT dependabot
+      if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && (github.actor != 'dependabot[bot]') }}
       name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
@@ -25,6 +26,7 @@ jobs:
         github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
 
     - uses: mszostok/codeowners-validator@v0.7.1
+      # This condition verifies that the PR repo does NOT equal the Github Repo and it's NOT dependabot
       if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) && (github.actor != 'dependabot[bot]') }}
       name: "Syntax check of CODEOWNERS"
       with:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -26,8 +26,8 @@ jobs:
         github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
 
     - uses: mszostok/codeowners-validator@v0.7.1
-      # This condition verifies that the PR repo does NOT equal the Github Repo and it's NOT dependabot
-      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) && (github.actor != 'dependabot[bot]') }}
+      # This condition verifies that the PR repo does NOT equal the Github Repo
+      if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- exclude dependabot codeowner validation and auto format

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- This will make it easier for tiny dependabot PRs to be merged in without creating personal branches to correct dependencies
- The easier it is to update dependencies, the more likely they can be kept up to date

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/mszostok/codeowners-validator
- https://github.com/mszostok/codeowners-validator/issues/205
- Related PRs that are failing codeowners https://github.com/cloudposse/atmos/pulls/app%2Fdependabot
