### PR TITLE
fix: set dependabot npm to look at /website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,18 +20,18 @@ updates:
   labels:
     - dependencies
     - github-actions
-    - patch
+    - no-release
   schedule:
     interval: weekly
     day: sunday
 
 - package-ecosystem: npm
   open-pull-requests-limit: 3
-  directory: /
+  directory: /website
   labels:
     - dependencies
     - javascript
-    - patch
+    - no-release
   schedule:
     interval: weekly
     day: sunday


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix: set dependabot npm to look at /website

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- The existing dependabot prs could not rebase because it said the following and the bot said to close the PR.

> The dependabot.yml entry that created this PR has been deleted so this PR can't be rebased. Please close the PR so Dependabot can create a new one with the current dependabot.yml.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- See https://github.com/cloudposse/atmos/pull/440
- Previous PR https://github.com/cloudposse/atmos/pull/451