### PR TITLE
include some protection on the azurerm backend when global  does not …

### DIFF
--- a/pkg/stack/stack_processor.go
+++ b/pkg/stack/stack_processor.go
@@ -1002,15 +1002,18 @@ func ProcessStackConfig(
 					if componentAzurerm, componentAzurermExists := componentBackendSection["azurerm"].(map[any]any); !componentAzurermExists {
 						if _, componentAzurermKeyExists := componentAzurerm["key"].(string); !componentAzurermKeyExists {
 							azureKeyPrefixComponent := component
-							baseKeyName := ""
+							var keyName []string
 							if baseComponentName != "" {
 								azureKeyPrefixComponent = baseComponentName
 							}
 							if globalAzurerm, globalAzurermExists := globalBackendSection["azurerm"].(map[any]any); globalAzurermExists {
-								baseKeyName = globalAzurerm["key"].(string)
+								if _, globalAzurermKeyExists := globalAzurerm["key"].(string); globalAzurermKeyExists {
+									keyName = append(keyName, globalAzurerm["key"].(string))
+								}
 							}
 							componentKeyName := strings.Replace(azureKeyPrefixComponent, "/", "-", -1)
-							finalComponentBackend["key"] = fmt.Sprintf("%s/%s.terraform.tfstate", baseKeyName, componentKeyName)
+							keyName = append(keyName, fmt.Sprintf("%s.terraform.tfstate", componentKeyName))
+							finalComponentBackend["key"] = strings.Join(keyName, "/")
 
 						}
 					}


### PR DESCRIPTION
…exist

## what

When using the `azurerm` backend, the logic assumes a global `key` is set and prepends that to the component `key`. However, when it doesn't exist it causes atmos to crash.  This checks if a global `key` is set and if not, then don't prepend anything.

## why

* prevent atmos from crashing
* don't require a global `key`

## references

#95 