### PR TITLE
Update Goreleaser pipeline options to eliminate deprecation notices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --parallelism 2 --rm-dist
+          args: release --parallelism 2 --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,4 +38,4 @@ checksum:
 # draft: true
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## what

- Updates `goreleaser` workflow to eliminate deprecation notices and use updated options

## why

- The flag `--rm-dist` was deprecated, and moved to `--clean`
- Since January, `[changelog.skip](https://goreleaser.com/deprecations/#changelogskip)` changed to `disable` to conform with all other pipes

Before:

```yaml
changelog:
  skip: true
```

After:

```yaml
changelog:
  disable: true
```

## references

- [Deprecations](https://goreleaser.com/deprecations)
