### PR TITLE
Use `terraform workspace select` to select workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-TEST?=$$(go list ./... | grep -v 'vendor')
+TEST ?= $$(go list ./... | grep -v 'vendor')
 SHELL := /bin/bash
 #GOOS=darwin
-GOOS=linux
-GOARCH=amd64
+#GOOS=linux
+#GOARCH=amd64
 VERSION=test
 
 # List of targets the `readme` target should call before generating the readme
@@ -18,7 +18,7 @@ get:
 	go get
 
 build: get
-	env GOOS=${GOOS} GOARCH=${GOARCH} go build -o build/atmos -v -ldflags "-X 'github.com/cloudposse/atmos/cmd.Version=${VERSION}'"
+	env $(if $(GOOS),GOOS=$(GOOS)) $(if $(GOARCH),GOARCH=$(GOARCH)) go build -o build/atmos -v -ldflags "-X 'github.com/cloudposse/atmos/cmd.Version=${VERSION}'"
 
 version: build
 	chmod +x ./build/atmos

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -45,8 +45,9 @@ func ExecuteShellCommand(
 	} else if redirectStdError == "" {
 		cmd.Stderr = os.Stderr
 	} else {
-		f, err := os.OpenFile(redirectStdError, os.O_RDWR|os.O_CREATE, 0644)
+		f, err := os.OpenFile(redirectStdError, os.O_WRONLY|os.O_CREATE, 0644)
 		if err != nil {
+			u.LogWarning(cliConfig, err.Error())
 			return err
 		}
 

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path"
 	"strings"
 
@@ -388,6 +389,12 @@ func ExecuteTerraform(info schema.ConfigAndStacksInfo) error {
 			workspaceSelectRedirectStdErr,
 		)
 		if err != nil {
+			var osErr *osexec.ExitError
+			ok := errors.As(err, &osErr)
+			if !ok || osErr.ExitCode() != 1 {
+				// err is not a non-zero exit code or err is not exit code 1, which we are expecting
+				return err
+			}
 			err = ExecuteShellCommand(
 				cliConfig,
 				info.Command,

--- a/website/docs/core-concepts/components/terraform-workspaces.mdx
+++ b/website/docs/core-concepts/components/terraform-workspaces.mdx
@@ -35,7 +35,7 @@ Atmos automatically manages Terraform workspaces for you when you provision comp
 
 ## Terraform Workspaces in Atmos
 
-Atmos uses and automatically calculates Terraform workspaces to manage top-level stacks. By default, Atmos uses the stack
+Atmos automatically calculates Terraform workspace names and uses workspaces to manage top-level stacks. By default, Atmos uses the stack
 name as the Terraform workspace when provisioning components in the stack. For example, consider the following manifest
 for the component `vpc` in the stack `ue2-dev`:
 
@@ -134,9 +134,9 @@ When you provision the components by executing the commands:
 
 <br/>
 
-Atmos sets the [`TF_WORKSPACE`](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_workspace)
-environment variable to `ue2-dev-vpc-1` and `ue2-dev-vpc-2` respectively, and Terraform selects (or creates) different workspaces
-for the components. This is done because the same Terraform component `vpc` is used as the workspace prefix
+Atmos computes the workspace names as `ue2-dev-vpc-1` and `ue2-dev-vpc-2` respectively,
+and selects the appropriate workspace for each component (again, creating it if needed).
+This is done because the same Terraform component `vpc` is used as the workspace prefix
 (in case of [AWS S3 backend](https://developer.hashicorp.com/terraform/language/settings/backends/s3),
 folder in the S3 state bucket), and it's necessary to have different subfolders (`ue2-dev-vpc-1`
 and `ue2-dev-vpc-2` instead of just `ue2-dev`) to store the Terraform state files.

--- a/website/docs/core-concepts/components/terraform-workspaces.mdx
+++ b/website/docs/core-concepts/components/terraform-workspaces.mdx
@@ -31,8 +31,7 @@ For example, you might use separate workspaces for blue-green deployments or can
 
 To work with workspaces in Terraform, you can use commands like `terraform workspace new`, `terraform workspace select`,
 and `terraform workspace delete` to create, switch between, and delete workspaces respectively.
-Additionally, the ENV variable [`TF_WORKSPACE`](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_workspace)
-can be used to create and select Terraform workspaces.
+Atmos automatically manages Terraform workspaces for you when you provision components in a stack.
 
 ## Terraform Workspaces in Atmos
 
@@ -72,8 +71,10 @@ When you provision the `vpc` component in the stack `ue2-dev` by executing the f
 
 <br/>
 
-Atmos sets the [`TF_WORKSPACE`](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_workspace)
-ENV variable to the name of the stack `ue2-dev`, and Terraform then selects this workspace or creates it if it does not exist.
+Atmos computes the workspace name to be `ue2-dev`. Any Atmos Terraform command other than `init`, using this stack,
+will cause Atmos to select this workspace, creating it if needed. (This leaves the workspace selected as a side effect
+for subsequent Terraform commands run outside of Atmos. Atmos version 1.55 took away this side effect, but it was
+restored in version 1.69.)
 
 The exception to the default rule (using the stack name as Terraform workspace) is when we provision more than one
 instance of the same Terraform component (with the same or different settings) into the same stack by defining multiple


### PR DESCRIPTION
## what

- Use `terraform workspace select` to select the workspace when needed
- Do not ask for Read permissions for output files
- Only attempt `terraform workspace new` when `select` returns with exit code 1; report any other kind of error

## why

- Restores previous behavior, which includes fixing #574, and leaving the active workspace selected for use by `terraform` commands outside of Atmos
- Prevents users running under `atmos terraform shell` from having issues running `terraform workspace` commands or having the workspace remain selected after changing directories
- Atmos does not need Read permission on outputs, and redirected outputs may not be readable, causing unnecessary failures
- Avoid hiding unexpected errors

## discussion

While Atmos is a powerful tool and for some there is a desire to make Atmos fully capable of replacing the `terraform` CLI entirely, we are not there yet. For now, there is a need to be able to use `terraform` alongside with `atmos` in some edge cases. Also, for some, there is a desire to bypass some of Atmos' overhead when running repeated tasks (especially failing tasks) by invoking `terraform` commands directly.

The issue of selecting a Terraform "workspace" highlights the kind of difficulty one runs into when designing a solution where Atmos and Terraform can work side by side. Terraform has the concept of, for each component, a "current workspace", which is a segregated Terraform state. Cloud Posse uses a different workspace for each deployment of a component (account and region and, where the component is deployed multiple times in the same account and region, each separate deployment). 

The problem with a workspace selection is that it is stateful, modal, and mostly hidden. When you run a `terraform` command, the component it applies to is determined by the current working directory (one form of mode/state), and the workspace it uses is determined by either:

1. The most recent invocation of `terraform workspace select` in that directory
2. The value of the environment variable `TF_WORKSPACE`

with the environment variable taking precedence.

To further complicate matters, if you run `terraform workspace select foo` and the workspace `foo` has not been created, you get an error. Likewise, if you run `TF_WORKSPACE=foo terraform init -reconfigure` and the workspace `foo` does not exist, you get an error. But if you run `TF_WORKSPACE=foo terraform plan` and the workspace `foo` does not exist, it will silently and automatically be created for you (so beware of typos).

Whichever mechanism you choose, you are setting some kind of persistent state which affects what `terraform` commands affect, and it becomes easy to get lost as to what you are actually working on. Atmos handles this by always setting the state for its Terraform commands, which is admirable, and it can be more helpful to people using `terraform` directly if it helps those users manage this hidden state effectively.

Prior to Atmos version 1.55, its behavior was that if it ran any Terraform command that applied to a specific workspace (anything other than `init`), it selected the workspace, creating it if needed, and left the workspace selected. This means that if you working in the component directory, then any `terraform` commands like `terraform state show` would work on the component in the workspace of the stack you most recently used for that component. After running `atmos terraform plan <component> -s <stack>`, you could do everything else using plain Terraform commands if you wanted to (the only trick being that, for some commands, you would need to supply the `-var-file` that Atmos generated). While many users would never do things this way, in some use cases it can be particularly time saving. For example, you may want to run the same set of Terraform commands repeatedly on the same component, using different stacks, as can happen when migrating a component to a new version requires some manual steps.

As of Atmos 1.55, Atmos changed how it selects a workspace. It started using the environment variable `TF_WORKSPACE` instead of `terraform workspace select`. While this works for Atmos, it changes the behavior for running the bare `terraform` commands. No longer did Atmos set the workspace for you, nor would `atmos terraform workspace <component> -s <stack>` set the workspace for you, either. In fact, there was no longer any direct way to find out the correct workspace name to use. Your plain `terraform` commands worked on the default workspace, or whatever one was selected the last time you used an old version of Atmos.

So in summary, the change made using `terraform` harder to use, without appreciably making `atmos` easier to use. The change did eliminate a bug that was causing problems, and the consequences were not obvious (nor universally considered negative), so it was made. This PR fixes the bug a different way and restores the behavior of v1.54 and earlier.

In the long run, we are seeking ways to make these kinds of behaviors optional and easier to choose. For now, we are just reverting to the "tried-and-true" behavior to avoid further surprises.


## references

- Reverts #515 
- Fixes #574 