### PR TITLE
Update `goreleaser`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --parallelism 2 --rm-dist
+          args: release --parallelism 2 --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## what

* Update `goreleaser`

## why

* `--rm-dist` has been deprecated in favor of `--clean`
*  deprecated since 2023-01-17 (v1.15.0), removed 2024-05-26 (v2.0)

## references

* https://goreleaser.com/deprecations/?h=rm+dist#__tabbed_17_1
