### PR TITLE
Fix tag naming

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ release:
   replace_existing_artifacts: true
   mode: keep-existing
   make_latest: false
-  name_template: 'v{{.Tag}}'
+  name_template: '{{.Tag}}'
   target_commitish: "{{ .Branch }}"
 ## ----- DO NOT CHANGE ----- ##
 


### PR DESCRIPTION
## what
* Make tags be prefixed with `v`

## why
* Fix tags naming

## Reference
* DEV-2352 Atmos v1.81.0 release broke packages due to missing "v" prefix in the tag name, please fix it and let me know to create the package