### PR TITLE
Fix Codespace url

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Atmos is extensible to accommodate any tooling, including enterprise-scale Terra
 > [!TIP]
 > ### You can try out `atmos` directly in your browser using GitHub Codespaces
 >
-> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=reorg&repo=cloudposse/atmos&skip_quickstart=true) 
+> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=cloudposse/atmos&skip_quickstart=true)
 >
 > <i>Already start one? Find it [here](https://github.com/codespaces).</i>
 >
@@ -54,7 +54,7 @@ Atmos is extensible to accommodate any tooling, including enterprise-scale Terra
 
 [Atmos](https://atmos.tools) centralizes the DevOps chain and cloud automation/orchestration into a robust command-line tool,
 streamlining environments and workflows into straightforward CLI commands. Leveraging advanced hierarchical configurations,
-it efficiently orchestrates both local and CI/CD pipeline tasks, optimizing infrastructure management for engineers and cloud 
+it efficiently orchestrates both local and CI/CD pipeline tasks, optimizing infrastructure management for engineers and cloud
 architects alike. You can then run the CLI anywhere, such as locally or in CI/CD.
 
 The Atmos project consists of a command-line tool, a `Go` library, and even a terraform provider.  It provides numerous

--- a/README.yaml
+++ b/README.yaml
@@ -49,7 +49,7 @@ description: |-
   > [!TIP]
   > ### You can try out `atmos` directly in your browser using GitHub Codespaces
   >
-  > [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=reorg&repo=cloudposse/atmos&skip_quickstart=true) 
+  > [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=cloudposse/atmos&skip_quickstart=true)
   >
   > <i>Already start one? Find it [here](https://github.com/codespaces).</i>
   >
@@ -58,7 +58,7 @@ introduction: |-
 
   [Atmos](https://atmos.tools) centralizes the DevOps chain and cloud automation/orchestration into a robust command-line tool,
   streamlining environments and workflows into straightforward CLI commands. Leveraging advanced hierarchical configurations,
-  it efficiently orchestrates both local and CI/CD pipeline tasks, optimizing infrastructure management for engineers and cloud 
+  it efficiently orchestrates both local and CI/CD pipeline tasks, optimizing infrastructure management for engineers and cloud
   architects alike. You can then run the CLI anywhere, such as locally or in CI/CD.
 
   The Atmos project consists of a command-line tool, a `Go` library, and even a terraform provider.  It provides numerous
@@ -116,7 +116,7 @@ introduction: |-
     predefined templates and policies.
   - **Streamlining Deployment with Service Catalogs, Landing Zones, and Blueprints:** Provides ready-to-use templates and guidelines for
     setting up cloud environments quickly and consistently.
-  
+
   > [!TIP]
   > Don't see your use-case listed? Ask us in the [`#atmos`](https://slack.cloudposse.com) Slack channel,
   > or [join us for "Office Hours"](https://cloudposse.com/office-hours/) every week.

--- a/examples/demo-component-versions/vendor.yaml
+++ b/examples/demo-component-versions/vendor.yaml
@@ -9,13 +9,13 @@ spec:
   bases:
   - &library
     source: "github.com/cloudposse/atmos.git//examples/demo-library/{{ .Component }}?ref={{.Version}}"
-    version: "reorg"
+    version: "main"
     targets:
       - "components/terraform/{{ .Component }}/{{.Version}}"
     included_paths:
       - "**/*.tf"
       - "**/*.tfvars"
-      - "**/*.md"      
+      - "**/*.md"
     tags:
       - demo
 
@@ -25,7 +25,7 @@ spec:
 
   - &v1
     <<: *library
-    version: "reorg"
+    version: "main"
 
   sources:
   - <<: *v1
@@ -35,4 +35,7 @@ spec:
     component: "weather"
 
   - <<: *v1
+    component: "ipinfo"
+
+  - <<: *main
     component: "ipinfo"

--- a/examples/demo-component-versions/vendor.yaml
+++ b/examples/demo-component-versions/vendor.yaml
@@ -23,19 +23,17 @@ spec:
     <<: *library
     version: "main"
 
-  - &v1
-    <<: *library
-    version: "main"
+  #- &v1
+  #  <<: *library
+  #  version: "v1.83.0"
 
   sources:
-  - <<: *v1
-    component: "github/stargazers"
+  # We need to wait for the first release of the library to use this
+  #- <<: *v1
+  #  component: "github/stargazers"
 
-  - <<: *v1
-    component: "weather"
-
-  - <<: *v1
-    component: "ipinfo"
+  #- <<: *v1
+  #  component: "weather"
 
   - <<: *main
     component: "ipinfo"

--- a/examples/demo-vendoring/vendor.yaml
+++ b/examples/demo-vendoring/vendor.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - component: "github/stargazers"
       source: "github.com/cloudposse/atmos.git//examples/demo-library/{{ .Component }}?ref={{.Version}}"
-      version: "reorg"
+      version: "main"
       targets:
         - "components/terraform/{{ .Component }}/{{.Version}}"
       included_paths:
@@ -23,7 +23,7 @@ spec:
 
     - component: "weather"
       source: "github.com/cloudposse/atmos.git//examples/demo-library/{{ .Component }}?ref={{.Version}}"
-      version: "reorg"
+      version: "main"
       targets:
         - "components/terraform/{{ .Component }}/{{.Version}}"
       tags:
@@ -31,7 +31,7 @@ spec:
 
     - component: "ipinfo"
       source: "github.com/cloudposse/atmos.git//examples/demo-library/{{ .Component }}?ref={{.Version}}"
-      version: "reorg"
+      version: "main"
       targets:
         - "components/terraform/{{ .Component }}/{{.Version}}"
       tags:


### PR DESCRIPTION
## what

- Update to Codespace URL for `main` branch

## why

- It was pointed to an older `reorg` branch
