### PR TITLE
add docs with windows/scoop install instructions

### DIFF
--- a/website/docs/quick-start/install-atmos.mdx
+++ b/website/docs/quick-start/install-atmos.mdx
@@ -98,6 +98,20 @@ Atmos has native packages for macOS and every major Linux distribution. We also 
     ```
   </TabItem>
 
+  <TabItem value="scoop" label="Windows">
+
+    #### Windows via scoop.sh
+
+    On Windows, run the following command to install:
+
+    ```shell
+    scoop install atmos
+    ```
+
+    __NOTE:__ Don't have `scoop`? Install it first from https://scoop.sh/
+
+  </TabItem>
+
   <TabItem value="go" label="Go">
     #### Install with Go
 


### PR DESCRIPTION
## what

add option/documentation for installing `atmos` using scoop.sh on windows. 

```sh
scoop install atmos
```

`scoop` manifests will check GitHub releases and automatically update. no additional maintenance required for anyone 🥳. 



## why

needed an easy way for my team to install `atmos`

## references

**note:** waiting on https://github.com/ScoopInstaller/Main/pull/6011 to be merged. 
