### PR TITLE
bump http context timeout for upload to atmos pro

### DIFF
--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -209,7 +209,7 @@ func ExecuteDescribeAffectedCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		client := http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		}
 
 		resp, err := client.Do(req)


### PR DESCRIPTION
## what

Increase the maximum http timeout when uploading to atmos pro

## why

There are cases when there are a large number of stacks and a large number of workflows that this call can exceed 10 seconds