### PR TITLE
Fix docker build `ATMOS_VERSION` support `v*` tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN case ${TARGETPLATFORM} in \
         "linux/arm64") OS=linux; ARCH=arm64 ;; \
         *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
     esac && \
-    ATMOS_VERSION=${ATMOS_VERSION#v} && \
-    echo "Downloading Atmos v${ATMOS_VERSION} for ${OS}/${ARCH}" && \
-    curl -1sSLf "https://github.com/cloudposse/atmos/releases/download/v${ATMOS_VERSION}/atmos_${ATMOS_VERSION}_${OS}_${ARCH}" -o /usr/local/bin/atmos && \
+    echo "Downloading Atmos v${ATMOS_VERSION#v} for ${OS}/${ARCH}" && \
+    curl -1sSLf "https://github.com/cloudposse/atmos/releases/download/v${ATMOS_VERSION#v}/atmos_${ATMOS_VERSION#v}_${OS}_${ARCH}" -o /usr/local/bin/atmos && \
     chmod +x /usr/local/bin/atmos


### PR DESCRIPTION
## what
* Remove `v` for `ATMOS_VERSION` on docker build

## why
* Cloudposse changed the tag template policy - now the tag is always prefixed with `v`. 
The tag passed as `ATMOS_VERSION` docker build argument


## references
* https://github.com/cloudposse/atmos/actions/runs/10391667666/job/28775133282#step:3:4480

![CleanShot 2024-08-14 at 19 58 32@2x](https://github.com/user-attachments/assets/d416dc10-1e74-41f8-9f30-3a9495991f68)
