### PR TITLE
Use Latest Atmos GitHub Workflows Examples with `RemoteFile` Component

### DIFF
--- a/website/Brewfile.lock.json
+++ b/website/Brewfile.lock.json
@@ -2,45 +2,50 @@
   "entries": {
     "brew": {
       "npm": {
-        "version": "21.6.1",
+        "version": "22.8.0",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
+            "arm64_sequoia": {
+              "cellar": "/opt/homebrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:61cdabd03b53059bbdab25946e7634eea8bbdb4dace971bd2a8dfb44c7e9e5d2",
+              "sha256": "61cdabd03b53059bbdab25946e7634eea8bbdb4dace971bd2a8dfb44c7e9e5d2"
+            },
             "arm64_sonoma": {
               "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:45a17a4105e184ca536b0af538416691d99c6776e18154f4695d23ca0a51112d",
-              "sha256": "45a17a4105e184ca536b0af538416691d99c6776e18154f4695d23ca0a51112d"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:82e1cf65b77d6050ac23abc19d0f822a0e7ffc1d25cc02b98f2331011f8d32e7",
+              "sha256": "82e1cf65b77d6050ac23abc19d0f822a0e7ffc1d25cc02b98f2331011f8d32e7"
             },
             "arm64_ventura": {
               "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:f69ac27550b781f318095e0d9153401339444894dc59302624a8ffa2e9023c34",
-              "sha256": "f69ac27550b781f318095e0d9153401339444894dc59302624a8ffa2e9023c34"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:f71378244afd9391191e3aee6481d88a2b7d7ab82b4a684418487b0efd84f954",
+              "sha256": "f71378244afd9391191e3aee6481d88a2b7d7ab82b4a684418487b0efd84f954"
             },
             "arm64_monterey": {
               "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:d7deaeea8e0dad7e9118e8d4bb2bde6f6987ee87799c3a11bb897cabc7827d46",
-              "sha256": "d7deaeea8e0dad7e9118e8d4bb2bde6f6987ee87799c3a11bb897cabc7827d46"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:1269024cf87e38166c0d5fe5b0d7d29a6c39f008e06d05a0020307b38ce93d58",
+              "sha256": "1269024cf87e38166c0d5fe5b0d7d29a6c39f008e06d05a0020307b38ce93d58"
             },
             "sonoma": {
               "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:4d556f10a2ced927bd58a05310ef90c3e413cd255811b1bbc9b2c2adeb382005",
-              "sha256": "4d556f10a2ced927bd58a05310ef90c3e413cd255811b1bbc9b2c2adeb382005"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:5381453bd40679aa5ef0a3fc44762311874138e095903580fcfc90d68791385b",
+              "sha256": "5381453bd40679aa5ef0a3fc44762311874138e095903580fcfc90d68791385b"
             },
             "ventura": {
               "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:088a42c91a17a2f800bec5b57c5847117600b35039a6e228aa76de40fd19bde8",
-              "sha256": "088a42c91a17a2f800bec5b57c5847117600b35039a6e228aa76de40fd19bde8"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:6cd9dec196cd1eb38de13c334b931766178bfce17b5dc5b31a3b925df0b9cda6",
+              "sha256": "6cd9dec196cd1eb38de13c334b931766178bfce17b5dc5b31a3b925df0b9cda6"
             },
             "monterey": {
               "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:a485ad25aca8ba32579be9577a0620a830f9ce56e977c83cf7b91872210e6a2b",
-              "sha256": "a485ad25aca8ba32579be9577a0620a830f9ce56e977c83cf7b91872210e6a2b"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:0cc03d47701892cb0fd8519c4a5065a3685af25acf0a15979b1c2ac3d503f1d4",
+              "sha256": "0cc03d47701892cb0fd8519c4a5065a3685af25acf0a15979b1c2ac3d503f1d4"
             },
             "x86_64_linux": {
               "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:dda17107072d9ca46f19cc74d7d0e751431ebb9e80bb43c797f7bb6b523faa0b",
-              "sha256": "dda17107072d9ca46f19cc74d7d0e751431ebb9e80bb43c797f7bb6b523faa0b"
+              "url": "https://ghcr.io/v2/homebrew/core/node/blobs/sha256:428035db226d22f4fd8cab0302cf78107e7efea5d360b61d2892cbaa30c2bd15",
+              "sha256": "428035db226d22f4fd8cab0302cf78107e7efea5d360b61d2892cbaa30c2bd15"
             }
           }
         }
@@ -58,12 +63,12 @@
         "macOS": "12.5.1"
       },
       "sonoma": {
-        "HOMEBREW_VERSION": "4.2.7",
+        "HOMEBREW_VERSION": "4.3.20",
         "HOMEBREW_PREFIX": "/opt/homebrew",
         "Homebrew/homebrew-core": "api",
-        "CLT": "15.0.0.0.1.1694021235",
-        "Xcode": "15.1",
-        "macOS": "14.0"
+        "CLT": "15.3.0.0.1.1708646388",
+        "Xcode": "15.4",
+        "macOS": "14.4.1"
       }
     }
   }

--- a/website/docs/integrations/github-actions/affected-stacks.mdx
+++ b/website/docs/integrations/github-actions/affected-stacks.mdx
@@ -4,8 +4,8 @@ sidebar_position: 30
 sidebar_label: Affected Stacks
 description: Identify the affected stacks and components in a pull request
 ---
-import File from '@site/src/components/File'
 import Intro from '@site/src/components/Intro'
+import RemoteFile from '@site/src/components/RemoteFile'
 
 <Intro>
 The [Atmos Affected Stacks GitHub Action](https://github.com/cloudposse/github-action-atmos-affected-stacks) makes it easy identify the affected [atmos stacks](/core-concepts/stacks/) for a pull request. Use it to build a matrix so you can run other actions based on what was affected.
@@ -30,53 +30,7 @@ Atmos checks component folders for changes first, marking all related components
 
 ## Usage Example
 
-<File title=".github/workflows/atmos-terraform-plan.yaml">
-```yaml
-name: Pull Request
-on:
-  pull_request:
-    branches: [ 'main' ]
-    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
-
-jobs:
-  atmos-affected:
-    runs-on: ubuntu-latest
-    steps:
-      - id: affected
-        uses: cloudposse/github-action-atmos-affected-stacks@v3
-        with:
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-          nested-matrices-count: 1
-
-    outputs:
-      matrix: ${{ steps.affected.outputs.matrix }}
-      has-affected-stacks: ${{ steps.affected.outputs.has-affected-stacks }}
-
-  # This job is an example how to use the affected stacks with the matrix strategy
-  atmos-plan:
-    needs: ["atmos-affected"]
-    if: ${{ needs.atmos-affected.outputs.has-affected-stacks == 'true' }}
-    name: Plan ${{ matrix.stack_slug }}
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 10
-      fail-fast: false # Don't fail fast to avoid locking TF State
-      matrix: ${{ fromJson(needs.atmos-affected.outputs.matrix) }}
-    ## Avoid running the same stack in parallel mode (from different workflows)
-    concurrency:
-      group: ${{ matrix.stack_slug }}
-      cancel-in-progress: false
-    steps:
-      - name: Plan Atmos Component
-        uses: cloudposse/github-action-atmos-terraform-plan@v2
-        with:
-          component: ${{ matrix.component }}
-          stack: ${{ matrix.stack }}
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-```
-</File>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
@@ -4,8 +4,8 @@ sidebar_position: 50
 sidebar_label: Terraform Apply
 description: Run a `terraform apply` to provision changes
 ---
-import File from '@site/src/components/File'
 import Intro from '@site/src/components/Intro'
+import RemoteFile from '@site/src/components/RemoteFile'
 
 <Intro>
 Simplify provisioning Terraform entirely from within GitHub Action workflows. This action makes it very easy to apply that changes from a `terraform plan` from directly within the GitHub UI. Use this action in your workflows to apply changes to your infrastructure.
@@ -41,37 +41,7 @@ We recommend combining this action with the [`affected-stacks`](/integrations/gi
 
 :::
 
-<File title=".github/workflows/atmos-terraform-apply.yaml">
-```yaml
-name: "atmos-terraform-apply"
-
-on:
-  workflow_dispatch:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
-
-# These permissions are required for GitHub to assume roles in AWS
-permissions:
-  id-token: write
-  contents: read
-
-jobs:
-  apply:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Terraform Apply
-        uses: cloudposse/github-action-atmos-terraform-apply@v2
-        with:
-          component: "foobar"
-          stack: "plat-ue2-sandbox"
-          sha: ${{ github.sha }}          
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-```
-</File>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-apply.yaml"/>
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
@@ -43,6 +43,16 @@ We recommend combining this action with the [`affected-stacks`](/integrations/gi
 
 <RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-apply.yaml"/>
 
+:::info Why Do We have Two Workflows?
+
+GitHub Actions support 256 matrix jobs in a single workflow at most! When planning all stacks in an Atmos environment, we frequently plan more than 256 component in the stacks at a time. In order to work around this limitation by GitHub, we can add an additional layer of abstraction using reusable workflows.
+
+[256 Matrix Limitation](/integrations/github-actions/atmos-terraform-drift-detection#256-matrix-limitation)
+
+:::
+
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-apply-matrix.yaml"/>
+
 ## Requirements
 
 This action has the requirements as [Github Actions](/integrations/github-actions/). Use the same S3 Bucket, DynamoDB table, IAM Roles and config described there.

--- a/website/docs/integrations/github-actions/atmos-terraform-drift-detection.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-drift-detection.mdx
@@ -4,8 +4,8 @@ sidebar_position: 60
 sidebar_label: Terraform Drift Detection
 description: Identify drift and create GitHub Issues for remediation
 ---
-import File from '@site/src/components/File'
 import Intro from '@site/src/components/Intro'
+import RemoteFile from '@site/src/components/RemoteFile'
 
 <Intro>
 The  "Atmos Terraform Drift Detection" and "Atmos Terraform Drift Remediation" GitHub Actions provide a scalable pattern for detecting and remediating Terraform drift from within GitHub by utilizing a combination of scheduled GitHub Workflows and GitHub Issues.
@@ -91,67 +91,7 @@ We can quickly see a complete list of all drift components in the "Issues" tab i
 
 #### Usage Example
 
-<File title=".github/workflows/atmos-terraform-drfit-detection.yaml">
-```yaml
-name: 👽 Atmos Terraform Drift Detection
-
-on:
-  schedule:
-    - cron: "0 * * * *"
-
-permissions:
-  id-token: write
-  contents: write
-  issues: write
-
-jobs:
-  select-components:
-    name: Select Components
-    runs-on: ubuntu-latest
-    steps:
-      - name: Selected Components
-        id: components
-        uses: cloudposse/github-action-atmos-terraform-select-components@v2
-        with:
-          select-filter: '.settings.github.actions_enabled and .metadata.type != "abstract"'
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-    outputs:
-      stacks: ${{ steps.components.outputs.matrix }}
-      has-selected-components: ${{ steps.components.outputs.has-selected-components }}
-
-  plan-atmos-components:
-    needs: ["select-components"]
-    runs-on: ubuntu-latest
-    if: ${{ needs.select-components.outputs.has-selected-components == 'true' }}
-    name: Detect Drift (${{ matrix.name }})
-    uses: ./.github/workflows/atmos-terraform-plan-matrix.yaml
-    strategy:
-      max-parallel: 1 # This is important to avoid ddos GHA API
-      fail-fast: false # Don't fail fast to avoid locking TF State
-      matrix: ${{ fromJson(needs.select-components.outputs.stacks) }}
-    with:
-      stacks: ${{ matrix.items }}
-      sha: ${{ github.sha }}
-      drift-detection-mode-enabled: "true"
-      continue-on-error: true
-      atmos-config-path: ./rootfs/usr/local/etc/atmos/
-      atmos-version: 1.63.0
-    secrets: inherit
-
-  drift-detection:
-    needs: ["plan-atmos-components"]
-    if: always()
-    name: Reconcile issues
-    runs-on: ubuntu-latest
-    steps:
-      - name: Drift Detection
-        uses: cloudposse/github-action-atmos-terraform-drift-detection@v1
-        with:
-          max-opened-issues: '4'
-          process-all: 'true'
-```
-</File>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-detection.yaml" />
 
 #### 256 Matrix Limitation
 
@@ -207,54 +147,7 @@ Once we have an open Issue for a drifted component, we can trigger another workf
 
 #### Usage Example
 
-
-<File title=".github/workflows/atmos-terraform-drfit-remediation.yaml">
-```yaml
-name: 👽 Atmos Terraform Drift Remediation
-run-name: 👽 Atmos Terraform Drift Remediation
-
-on:
-  issues:
-    types:
-      - labeled
-      - closed
-
-permissions:
-  id-token: write
-  contents: read
-
-jobs:
-  remediate-drift:
-    runs-on: ubuntu-latest
-    name: Remediate Drift
-    if: |
-      github.event.action == 'labeled' &&
-      contains(join(github.event.issue.labels.*.name, ','), 'apply')
-    steps:
-      - name: Remediate Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          action: remediate
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-
-  discard-drift:
-    runs-on: ubuntu-latest
-    name: Discard Drift
-    if: |
-      github.event.action == 'closed' &&
-      !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
-    steps:
-      - name: Discard Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v2
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          action: discard
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-          atmos-version: 1.63.0
-```
-</File>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-drift-remediation.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-drift-remediation.mdx
@@ -4,8 +4,8 @@ sidebar_position: 60
 sidebar_label: Terraform Drift Remediation
 description: Remediate Terraform drift using IssueOps
 ---
-import File from '@site/src/components/File'
 import Intro from '@site/src/components/Intro'
+import RemoteFile from '@site/src/components/RemoteFile'
 
 <Intro>
 The  "Atmos Terraform Drift Remediation" GitHub Action provides a way for easily remediating Terraform drift and works with GitHub Issues using IssueOps.
@@ -47,50 +47,7 @@ integrations:
 
 In this example drift will be remediated when user sets label `apply` to an issue.
 
-```yaml
-name: 👽 Atmos Terraform Drift Remediation
-run-name: 👽 Atmos Terraform Drift Remediation
-
-on:
-  issues:
-    types:
-      - labeled
-      - closed
-
-permissions:
-  id-token: write
-  contents: read
-
-jobs:
-  remediate-drift:
-    runs-on: ubuntu-latest
-    name: Remediate Drift
-    if: |
-      github.event.action == 'labeled' &&
-      contains(join(github.event.issue.labels.*.name, ','), 'apply')
-    steps:
-      - name: Remediate Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          action: remediate
-          atmos-config-path: ./rootfs/usr/local/etc/atmos/
-
-  discard-drift:
-    runs-on: ubuntu-latest
-    name: Discard Drift
-    if: |
-      github.event.action == 'closed' &&
-      !contains(join(github.event.issue.labels.*.name, ','), 'remediated')
-    steps:
-      - name: Discard Drift
-        uses: cloudposse/github-action-atmos-terraform-drift-remediation@v1
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          action: discard
-          atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml    
-```
-
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-plan.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-plan.mdx
@@ -5,6 +5,7 @@ sidebar_label: Terraform Plan
 description: Run a `terraform plan` to understand the impact of changes
 ---
 import Intro from '@site/src/components/Intro'
+import RemoteFile from '@site/src/components/RemoteFile'
 
 <Intro>
 Simplify provisioning Terraform entirely from within GitHub Action workflows. This action makes it very easy to understand exactly what will happen from from the changes in a Pull Request (or any commit) by running a `terraform plan` and surfacing the output as a neatly formatted Job Summary viewable directly within the GitHub UI.
@@ -52,32 +53,17 @@ We recommend combining this action with the [`affected-stacks`](/integrations/gi
 :::
 
 
-```yaml
-  # .github/workflows/atmos-terraform-plan.yaml
-  name: "atmos-terraform-plan"
-  on:
-    pull_request:
-      types:
-        - opened
-        - synchronize
-        - reopened
-      branches:
-        - main
-  # These permissions are required for GitHub to assume roles in AWS
-  permissions:
-    id-token: write
-    contents: read
-  jobs:
-    plan:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Plan Atmos Component
-          uses: cloudposse/github-action-atmos-terraform-plan@v1
-          with:
-            component: "foobar"
-            stack: "plat-ue2-sandbox"
-            atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml
-```
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan.yaml"/>
+
+:::info Why Do We have Two Workflows?
+
+GitHub Actions support 256 matrix jobs in a single workflow at most! When planning all stacks in an Atmos environment, we frequently plan more than 256 component in the stacks at a time. In order to work around this limitation by GitHub, we can add an additional layer of abstraction using reusable workflows.
+
+[256 Matrix Limitation](/integrations/github-actions/atmos-terraform-drift-detection#256-matrix-limitation)
+
+:::
+
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan-matrix.yaml"/>
 
 with the following configuration as an example:
 

--- a/website/docs/integrations/github-actions/component-updater.mdx
+++ b/website/docs/integrations/github-actions/component-updater.mdx
@@ -5,6 +5,7 @@ sidebar_label: Component Updater
 description: Easily update your vendored components with Pull Requests
 ---
 import File from '@site/src/components/File'
+import RemoteFile from '@site/src/components/RemoteFile'
 import Intro from '@site/src/components/Intro'
 import Admonition from '@theme/Admonition';
 
@@ -32,54 +33,7 @@ Discover more details and a comprehensive list of `inputs` and `outputs` in the 
 
 ### Workflow example
 
-<File title=".github/workflows/atmos-component-updater.yaml">
-```yaml
-name: "Atmos Component Updater"
-
-on:
-  workflow_dispatch: {}
-
-  schedule:
-    - cron:  '0 8 * * *'  # Every day at 8am UTC
-
-jobs:
-  update:
-    environment: atmos
-    runs-on:
-      - "self-hosted"
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Generate a token
-        id: github-app
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.ATMOS_APP_ID }}
-          private-key: ${{ secrets.ATMOS_PRIVATE_KEY }}
-
-      - name: Update Atmos Components
-        uses: cloudposse/github-action-atmos-component-updater@v2
-        env:
-          # https://atmos.tools/cli/configuration/#environment-variables
-          ATMOS_CLI_CONFIG_PATH: ${{ github.workspace }}/rootfs/usr/local/etc/atmos/
-        with:
-          github-access-token: ${{ steps.github-app.outputs.token }}
-          log-level: INFO
-          vendoring-enabled: true
-          max-number-of-prs: 10
-
-      - name: Delete abandoned update branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@v2
-        with:
-          github_token: ${{ steps.github-app.outputs.token }}
-          last_commit_age_days: 0
-          allowed_prefixes: "component-update/"
-          dry_run: no
-```
-</File>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-components-updater.yml" />
 
 ### Requirements
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6075,8 +6075,8 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/custom-loaders": {
-      "resolved": "plugins/custom-loaders",
-      "link": true
+      "version": "0.0.0",
+      "resolved": "file:plugins/custom-loaders"
     },
     "node_modules/cytoscape": {
       "version": "3.29.2",
@@ -17664,9 +17664,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "plugins/custom-loaders": {
-      "version": "0.0.0"
     }
   }
 }

--- a/website/src/components/RemoteFile/index.tsx
+++ b/website/src/components/RemoteFile/index.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import File from '@site/src/components/File';
+import CodeBlock from '@theme/CodeBlock';
+
+const guessLanguageFromFilePath = (filePath) => {
+    if (/\.ya?ml$/i.test(filePath)) {
+        return 'yaml';
+    }   
+    if (/\.json$/i.test(filePath)) {
+        return 'json';
+    }
+    if (/\.tf$/i.test(filePath)) {
+        return 'hcl';
+    }
+    // Add more patterns as needed
+    return 'plain'; // Default to 'plain'
+  };
+
+async function fetchFileContent(url: string): Promise<string | undefined> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(`Failed to fetch the file from URL: ${url} - ${response.statusText}`);
+      return undefined;
+    }
+    return await response.text();
+  } catch (error) {
+    console.error('Error fetching the file:', error);
+    return "Error fetching the file - " + error + "\n" + url;
+  }
+}
+
+export default function RemoteFile({ source, language }) {
+  const [fileContent, setFileContent] = useState<string>('Loading...');
+
+  // Extract the filename from the URL
+  const getFileName = (url: string) => {
+    return url.substring(url.lastIndexOf('/') + 1);
+  };
+
+  const filePath = getFileName(source);
+  const guessedLanguage = language || guessLanguageFromFilePath(filePath);
+
+  useEffect(() => {
+    const loadFileContent = async () => {
+      const content = await fetchFileContent(source);
+      setFileContent(content);
+    };
+
+    loadFileContent();
+  }, [source]);
+
+  return (
+    <File title={filePath}>
+        <CodeBlock className={`language-${guessedLanguage}`}>{fileContent}</CodeBlock>
+    </File>
+  );
+}


### PR DESCRIPTION
## what
- Created the `RemoteFile` component
- Replace all hard-coded files with `RemoteFile` call

## why
- These workflows quickly get out of date. We already have these publicly available on `cloudposse/docs`, so we should fetch the latest pattern instead

## references
- [SweetOps slack thread](https://sweetops.slack.com/archives/C031919U8A0/p1725895776332059)