### PR TITLE
Fix version command in simple tutorial

### DIFF
--- a/website/docs/quick-start/simple/configure-cli.mdx
+++ b/website/docs/quick-start/simple/configure-cli.mdx
@@ -33,7 +33,7 @@ Therefore, this file should exist in the project repository alongside your Terra
 Let's ensure you've [properly installed Atmos](/install) by running the following command.
 
 ```bash
-atmos --version
+atmos version
 ```
 
 You should see something like this...


### PR DESCRIPTION
## what

- Corrects incorrect `atmos --version` command to `atmos version` in simple tutorial docs.

## why

- Documentation is incorrect.

## references

closes #704 
