### PR TITLE
Correct outdated 'myapp' references in simple tutorial

### DIFF
--- a/examples/quick-start-simple/stacks/deploy/dev.yaml
+++ b/examples/quick-start-simple/stacks/deploy/dev.yaml
@@ -6,7 +6,7 @@ import:
 
 components:
   terraform:
-    myapp:
+    station:
       vars:
         location: Stockholm
         lang: se

--- a/website/docs/quick-start/simple/provision.mdx
+++ b/website/docs/quick-start/simple/provision.mdx
@@ -21,14 +21,14 @@ After you've written your components and configured your stacks, now we're ready
 
 ## Provision Atmos Components into all Stacks
 
-Provision the `myapp` Atmos component into the stacks:
+Provision the `station` Atmos component into the stacks:
 
 ```shell
-atmos terraform apply myapp -s dev
+atmos terraform apply station -s dev
 
-atmos terraform apply myapp -s staging
+atmos terraform apply station -s staging
 
-atmos terraform apply myapp -s prod
+atmos terraform apply station -s prod
 ```
 
 Alternatively, you can execute the configured [Atmos workflow](/quick-start/advanced/create-workflows) to provision all the components in all the stacks:
@@ -42,15 +42,15 @@ atmos workflow apply-all-components -f networking
 
 Looking at the commands above, you might have a question "How does Atmos find the component in the stack and all the variables?"
 
-Let's consider what Atmos does when executing the command `atmos terraform apply myapp -s prod`:
+Let's consider what Atmos does when executing the command `atmos terraform apply station -s prod`:
 
 - Atmos uses the `stacks.name_pattern` defined in the [CLI config](/quick-start/advanced/configure-cli). In this example, we have defined a simple name based on `stacks.name_pattern: "{stage}"`. This means that the stack name is just the `stage` part of the stack name.
 
 - Atmos searches for the stack configuration file (in the `stacks` folder and all sub-folders) where `stage: prod` is defined (inline or via imports). During the search, Atmos processes all parent (top-level) config files and compares the context variables specified in the command (`-s` flag) with the context variables defined in the stack configurations, finally finding the matching stack
 
-- Atmos finds the component `myapp` in the stack, processing all the inline configs and all the imports
+- Atmos finds the component `station` in the stack, processing all the inline configs and all the imports
 
-- Atmos deep-merges all the catalog imports for the `myapp` component and then deep-merges all the variables for the component defined in all sections (global `vars`, terraform `vars`, base components `vars`, component `vars`), producing the final variables for the `myapp` component in the `prod` stack
+- Atmos deep-merges all the catalog imports for the `station` component and then deep-merges all the variables for the component defined in all sections (global `vars`, terraform `vars`, base components `vars`, component `vars`), producing the final variables for the `station` component in the `prod` stack
 
 - And lastly, Atmos writes the final deep-merged variables into a `.tfvar.json` file in the component directory and then
   executes `terraform apply -var-file ...` command

--- a/website/docs/quick-start/simple/simple.mdx
+++ b/website/docs/quick-start/simple/simple.mdx
@@ -32,7 +32,7 @@ You're about to discover [a new way to think about terraform...](/quick-start/mi
 
 **Spoiler alert** You can’t actually change the weather with Terraform, but you can certainly ask for it.
 
-We’ll [use this example](https://github.com/cloudposse/atmos/tree/main/examples/demo-stacks) to avoid relying on complicated cloud credentials, which can vary based on your organizational context and cloud provider. Instead, we want to focus on Terraform and how to utilize it effectively as a component within Atmos. Once you understand this, you’ll see how to tailor your Terraform "root modules" to work seamlessly with Atmos.
+We’ll [use this example](https://github.com/cloudposse/atmos/tree/main/examples/quick-start-simple) to avoid relying on complicated cloud credentials, which can vary based on your organizational context and cloud provider. Instead, we want to focus on Terraform and how to utilize it effectively as a component within Atmos. Once you understand this, you’ll see how to tailor your Terraform "root modules" to work seamlessly with Atmos.
 
 __NOTE:__ This tutorial is for those who prefer hands-on learning and want to create something tangible quickly.
 If you prefer to learn theory and concepts first, start with the [Core Concepts](/core-concepts).


### PR DESCRIPTION
## what

Corrects several (assuming) outdated references to a 'myapp' component rather than the correct 'station' component in the simple tutorial.

Also corrects the provided example repository hyperlink to refer to the correct weather example 'quick-start-simple' used in the tutorial rather than 'demo-stacks'

## why

Appears that the 'myapp' references were likely just missed during a refactor of the simple tutorial. Fixing them alleviates confusion/friction for new users following the tutorial. Attempting to use the examples/references as-is results in various errors as there is no 'myapp' component defined.

## references

Also closes #664 
