### PR TITLE
Fix incorrect terraform flag in simple tutorial workflow example

### DIFF
--- a/website/docs/quick-start/simple/extra-credit/create-workflows.mdx
+++ b/website/docs/quick-start/simple/extra-credit/create-workflows.mdx
@@ -65,13 +65,13 @@ workflows:
       - command: terraform plan station -s staging
       - command: terraform plan station -s prod
 
-  apply-all-components:
+  apply-all:
     description: |
       Run 'terraform apply' on all 'station' components in all stacks
     steps:
-      - command: terraform apply station -auto-apply -s dev
-      - command: terraform apply station -auto-apply -s staging
-      - command: terraform apply station -auto-apply -s prod
+      - command: terraform apply station -auto-approve -s dev
+      - command: terraform apply station -auto-approve -s staging
+      - command: terraform apply station -auto-approve -s prod
 ```
 </Step>
 


### PR DESCRIPTION
## what

Fixes inconsistencies in the simple-tutorial extra credit section on workflows that prevent successful execution when following along.

## why

As written, the tutorial results in two errors, one due to an incorrect terraform flag, and one due to a mismatch between the defined workflow name, and the provided command in the tutorial to execute it.

## references

Addresses #708 
