### PR TITLE
Add the guide to install atmos using aqua

### DIFF
--- a/website/docs/quick-start/install-atmos.mdx
+++ b/website/docs/quick-start/install-atmos.mdx
@@ -199,6 +199,7 @@ Atmos has native packages for macOS and every major Linux distribution. We also 
     #### Install with aqua
 
     [aqua](https://aquaproj.github.io/) is a CLI Version Manager.
+    aqua allows you to manage multiple versions of CLI tools, making it easy to switch between different versions of Atmos and other tools in your projects.
 
     Create `aqua.yaml` by `aqua init`:
 

--- a/website/docs/quick-start/install-atmos.mdx
+++ b/website/docs/quick-start/install-atmos.mdx
@@ -195,6 +195,28 @@ Atmos has native packages for macOS and every major Linux distribution. We also 
     __NOTE:__ Don't have `mise`? Install it first from [here](https://mise.jdx.dev/getting-started.html)
   </TabItem>
 
+  <TabItem value="aqua" label="aqua">
+    #### Install with aqua
+
+    [aqua](https://aquaproj.github.io/) is a CLI Version Manager.
+
+    Create `aqua.yaml` by `aqua init`:
+
+    ```shell
+    aqua init
+    ```
+
+    Add atmos to aqua.yaml:
+
+    ```shell
+    aqua g -i cloudposse/atmos
+    ```
+
+    Then, run `aqua install` in the same directory.
+
+    __NOTE:__ Don't have `aqua`? Install it first from [here](https://aquaproj.github.io/docs/install)
+  </TabItem>
+
   <TabItem value="source" label="From Source">
     #### Build from Source
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Add the guide to install atmos using [aqua](https://aquaproj.github.io/).

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

aqua is a CLI Version Manager written in Go.
aqua supports various tools including atmos, Terraform, Helm, Helmfile.

## Confirmation

I have launched the webserver on my laptop according to the [guide](https://github.com/cloudposse/atmos/tree/main/website#getting-started).

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/26392cf2-9c59-469c-b990-24ede390ac86">


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new installation method for Atmos using the `aqua` CLI version manager.
	- Added a dedicated tab in the installation guide for `aqua`, including instructions for setup and usage.

- **Documentation**
	- Updated the "Install Atmos" document to enhance user guidance on installation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->