### PR TITLE
feat: initial support for `.yml` and `.yaml` files for component vendoring

### DIFF
--- a/internal/exec/vendor_component_utils.go
+++ b/internal/exec/vendor_component_utils.go
@@ -52,10 +52,14 @@ func ReadAndProcessComponentVendorConfigFile(
 
 	componentConfigFile := path.Join(componentPath, cfg.ComponentVendorConfigFileName)
 	if !u.FileExists(componentConfigFile) {
-		return componentConfig, "", fmt.Errorf("component vendoring config file '%s' does not exist in the '%s' folder",
-			cfg.ComponentVendorConfigFileName,
-			componentPath,
-		)
+		componentConfigFileYML := path.Join(componentPath, "component.yml")
+		if !u.FileExists(componentConfigFileYML) {
+			return componentConfig, "", fmt.Errorf("component vendoring config file '%s' or 'component.yml' does not exist in the '%s' folder",
+				cfg.ComponentVendorConfigFileName,
+				componentPath,
+			)
+		}
+		componentConfigFile = componentConfigFileYML
 	}
 
 	componentConfigFileContent, err := os.ReadFile(componentConfigFile)
@@ -92,7 +96,6 @@ func ExecuteComponentVendorInternal(
 	componentPath string,
 	dryRun bool,
 ) error {
-
 	var tempDir string
 	var err error
 	var t *template.Template
@@ -180,7 +183,7 @@ func ExecuteComponentVendorInternal(
 				},
 			}
 
-			var tempDir2 = tempDir
+			tempDir2 := tempDir
 			if sourceIsLocalFile {
 				tempDir2 = path.Join(tempDir, filepath.Base(uri))
 			}
@@ -287,7 +290,7 @@ func ExecuteComponentVendorInternal(
 			},
 		}
 
-		var componentPath2 = componentPath
+		componentPath2 := componentPath
 		if sourceIsLocalFile {
 			if filepath.Ext(componentPath) == "" {
 				componentPath2 = path.Join(componentPath, filepath.Base(uri))


### PR DESCRIPTION
## what

- Support for `.yml` and `.yaml` when vendoring using `component.yaml`
- This change introduces a simple check into 

## alternative solutions

1. No modification of the constants, check if `component.yaml` exists before checking if `component.yml` exists

```go
	componentConfigFile := path.Join(componentPath, cfg.ComponentVendorConfigFileName)
	if !u.FileExists(componentConfigFile) {
		componentConfigFileYML := path.Join(componentPath, "component.yml")
		if !u.FileExists(componentConfigFileYML) {
			return componentConfig, "", fmt.Errorf("component vendoring config file '%s' or 'component.yml' does not exist in the '%s' folder",
				cfg.ComponentVendorConfigFileName,
				componentPath,
			)
		}
		componentConfigFile = componentConfigFileYML
	}

	componentConfigFileContent, err := os.ReadFile(componentConfigFile)
```

2. Modify constant and add helper function

```go
var possibleConfigExtensions = []string{"yaml", "yml"}

func findComponentConfigFile(basePath, fileName string, extensions []string) (string, error) {
    for _, ext := range extensions {
        configFilePath := path.Join(basePath, fmt.Sprintf("%s.%s", fileName, ext))
        if u.FileExists(configFilePath) {
            return configFilePath, nil
        }
    }
    return "", fmt.Errorf("component vendoring config file does not exist in the '%s' folder", basePath)
}

componentConfigFile, err := findComponentConfigFile(componentPath, "component", possibleConfigExtensions)
if err != nil {
    return componentConfig, "", err
}
```

## why

- The tool is strict about needing `component.yaml`, file ending for yaml files is a matter of preference and both should be accepted.

## testing

- [X] `make build`
- [ ] `atmos vendor pull -c <COMPONENT>` with `component.yaml`
- [ ] `atmos vendor pull -c <COMPONENT>` with `component.yml`
- [ ] `atmos vendor pull -c <COMPONENT>` miss `component` file

## references

- Closes the following [issue](https://github.com/cloudposse/atmos/issues/610)
