### PR TITLE
modify error handling in FindAllStackConfigsInPathsForSt

### DIFF
--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -40,9 +40,13 @@ func FindAllStackConfigsInPathsForStack(
 			// TODO: review `doublestar` library
 			matches, err = u.GetGlobMatches(pathWithExt)
 			if err != nil {
-				y, _ := u.ConvertToYAML(cliConfig)
-				return nil, nil, false, fmt.Errorf("%v\n\n\nCLI config:\n\n%v", err, y)
+				if cliConfig.Logs.Level == u.LogLevelTrace {
+					y, _ := u.ConvertToYAML(cliConfig)
+					return nil, nil, false, fmt.Errorf("%v\n\n\nCLI config:\n\n%v", err, y)
+				}
+				return nil, nil, false, err
 			}
+
 		}
 
 		// Exclude files that match any of the excludePaths
@@ -118,8 +122,11 @@ func FindAllStackConfigsInPaths(
 			// TODO: review `doublestar` library
 			matches, err = u.GetGlobMatches(pathWithExt)
 			if err != nil {
-				y, _ := u.ConvertToYAML(cliConfig)
-				return nil, nil, fmt.Errorf("%v\n\n\nCLI config:\n\n%v", err, y)
+				if cliConfig.Logs.Level == u.LogLevelTrace {
+					y, _ := u.ConvertToYAML(cliConfig)
+					return nil, nil, fmt.Errorf("%v\n\n\nCLI config:\n\n%v", err, y)
+				}
+				return nil, nil, err
 			}
 		}
 


### PR DESCRIPTION
what
This pull request introduces error handling . Key changes include adding IError interface, updating error handling to use the new IError type, and setting the log level for detailed debug information.

why
Basically break error to parts. the parts that are info to info, and those that are debug to debug

issue url
https://linear.app/cloudposse/issue/DEV-340/change-log-level-of-output-when-imports-are-not-found-to-hide-this