### PR TITLE
Refactor logging in ExecuteAtmosVendorInternal function

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -180,8 +180,8 @@ func ExecuteAtmosVendorInternal(
 	var err error
 	var uri string
 	vendorConfigFilePath := path.Dir(vendorConfigFileName)
-
-	u.LogInfo(cliConfig, fmt.Sprintf("Processing vendor config file '%s'", vendorConfigFileName))
+	tagsStr := strings.Join(tags, ", ")
+	u.LogInfo(cliConfig, fmt.Sprintf("Processing vendor config file '%s' for tags {%v}", vendorConfigFileName, tagsStr))
 
 	if len(atmosVendorSpec.Sources) == 0 && len(atmosVendorSpec.Imports) == 0 {
 		return fmt.Errorf("either 'spec.sources' or 'spec.imports' (or both) must be defined in the vendor config file '%s'", vendorConfigFileName)


### PR DESCRIPTION
## What
* Added functionality to log the specific tags being processed during `atmos vendor pull --tags demo`.
* Now, when running the command, the log will display: `Processing config file vendor.yaml for tags {demo1, demo2, demo3}`.
## Why
* This update improves visibility by explicitly showing the tags during the pull operation.
## References
* DEV-2326
* [Relevant documentation: [Link to vendor.yaml processing]](https://linear.app/cloudposse/issue/DEV-2326/pulling-only-components-for-demo-using-atmos-vendor-pull-tags-demo)
---