### PR TITLE
Dev 2331

### DIFF
--- a/examples/demo-context/atmos.yaml
+++ b/examples/demo-context/atmos.yaml
@@ -2,8 +2,7 @@ base_path: "./"
 
 schemas:
   atmos:
-    manifest: "schemas/atmos-manifest.json"
-
+    manifest: "https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json"
 # https://pkg.go.dev/text/template
 templates:
   settings:

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"io/fs"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -172,4 +173,23 @@ func IsSocket(path string) (bool, error) {
 	}
 	isSocket := fileInfo.Mode().Type() == fs.ModeSocket
 	return isSocket, nil
+}
+
+// IsURL checks if a string is a URL
+func IsURL(s string) bool {
+	url, err := url.Parse(s)
+	return err == nil && url.Scheme != "" && url.Host != ""
+}
+
+// GetFileNameFromURL extracts the file name from a URL
+func GetFileNameFromURL(rawURL string) (string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	// Extract the path from the URL
+	urlPath := parsedURL.Path
+
+	// Get the base name of the path
+	return path.Base(urlPath), nil
 }


### PR DESCRIPTION
## What
* Added support for remote schemas in `atmos` for manifest validation.
* Updated `schemas` configuration to allow referencing remote schema files, e.g.:
  ```yaml
  schemas:
    atmos:
      manifest: "stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json"
  ```
## Why
* This reduces redundancy as, in previous demos, the manifest file had to be copied multiple times. Now, it can be referenced remotely .

## References
* #DEV-2331
* [Relevant documentation: [Link to manifest schema validation docs]](https://linear.app/cloudposse/issue/DEV-2331/atmos-should-support-remote-schemas-for-manifest-validation)

---