### PR TITLE
Dev 78

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -131,9 +131,10 @@ func ReadAndProcessVendorConfigFile(cliConfig schema.CliConfiguration, vendorCon
 	}
 
 	foundVendorConfigFile := vendorConfigFile
-
 	// Look for the vendoring manifest in the current directory
-	if !u.FileExists(vendorConfigFile) {
+	foundVendorConfigFile, fileExists := u.SearchConfigFile(foundVendorConfigFile)
+
+	if !fileExists {
 		// Look for the vendoring manifest in the directory pointed to by the `base_path` setting in the `atmos.yaml`
 		pathToVendorConfig := path.Join(cliConfig.BasePath, vendorConfigFile)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -338,11 +338,12 @@ func processConfigFile(
 	path string,
 	v *viper.Viper,
 ) (bool, error) {
-	if !u.FileExists(path) {
+	// Check if the config file exists
+	configPath, fileExists := u.SearchConfigFile(path)
+	if !fileExists {
 		return false, nil
 	}
-
-	reader, err := os.Open(path)
+	reader, err := os.Open(configPath)
 	if err != nil {
 		return false, err
 	}
@@ -350,7 +351,7 @@ func processConfigFile(
 	defer func(reader *os.File) {
 		err := reader.Close()
 		if err != nil {
-			u.LogWarning(cliConfig, fmt.Sprintf("error closing file '"+path+"'. "+err.Error()))
+			u.LogWarning(cliConfig, fmt.Sprintf("error closing file '"+configPath+"'. "+err.Error()))
 		}
 	}(reader)
 

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -173,3 +173,18 @@ func IsSocket(path string) (bool, error) {
 	isSocket := fileInfo.Mode().Type() == fs.ModeSocket
 	return isSocket, nil
 }
+
+// search for a config file in the provided path with the provided extensions .yaml, .yml
+func SearchConfigFile(path string) (string, bool) {
+	// Define the possible config file extensions
+	configExtensions := []string{".yaml", ".yml"}
+	// remove extension from path
+	path = strings.TrimSuffix(path, filepath.Ext(path))
+	for _, ext := range configExtensions {
+		filePath := path + ext
+		if FileExists(filePath) {
+			return filePath, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
## what
* get atmos config and vendor file  from atmos.yaml or atmos .yml vendor.yml
* first checks if atmos.yaml exists, and if not, it checks for atmos.yml 
* If both .yaml and .yml files exist, the .yaml file is prioritized.
## why
* Both .yaml and .yml files have the same format . automatically selecting either file  .yaml and .yml exist
## references
* DEV-78
* https://linear.app/cloudposse/issue/DEV-78/have-atmos-look-for-yml-files-as-well-as-yaml-for-any-stack-file