### PR TITLE
modify InitCliConfig in ExecuteVendorPullCommand

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -29,7 +29,8 @@ func ExecuteVendorPullCommand(cmd *cobra.Command, args []string) error {
 
 	// InitCliConfig finds and merges CLI configurations in the following order:
 	// system dir, home dir, current dir, ENV vars, command-line arguments
-	cliConfig, err := cfg.InitCliConfig(info, true)
+	// vendor pull not require stack configs so we pass false to InitCliConfig
+	cliConfig, err := cfg.InitCliConfig(info, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## what
* stop process stack config when cmd atmos vendor pull
## why
* Atmos vendor should not require stack configs 
## references
* DEV-2689
* https://linear.app/cloudposse/issue/DEV-2689/atmos-vendor-should-not-require-stack-configs