### PR TITLE
Dev 2689

### DIFF
--- a/cmd/vendor_pull.go
+++ b/cmd/vendor_pull.go
@@ -15,9 +15,6 @@ var vendorPullCmd = &cobra.Command{
 	Long:               `This command executes 'atmos vendor pull' CLI commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Check Atmos configuration
-		checkAtmosConfig()
-
 		err := e.ExecuteVendorPullCmd(cmd, args)
 		if err != nil {
 			u.LogErrorAndExit(schema.CliConfiguration{}, err)

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -26,11 +26,11 @@ func ExecuteVendorPullCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
+	// check stack flag is set
+	processStacks := cmd.Flags().Changed("stack")
 	// InitCliConfig finds and merges CLI configurations in the following order:
 	// system dir, home dir, current dir, ENV vars, command-line arguments
-	// vendor pull not require stack configs so we pass false to InitCliConfig
-	cliConfig, err := cfg.InitCliConfig(info, false)
+	cliConfig, err := cfg.InitCliConfig(info, processStacks)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -29,7 +29,8 @@ func ExecuteVendorPullCommand(cmd *cobra.Command, args []string) error {
 
 	// InitCliConfig finds and merges CLI configurations in the following order:
 	// system dir, home dir, current dir, ENV vars, command-line arguments
-	cliConfig, err := cfg.InitCliConfig(info, true)
+	// vendor pull not require stack configs so we pass false to InitCliConfig
+	cliConfig, err := cfg.InitCliConfig(info, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## what
* Do not process stack configs when executing command `atmos vendor pull` and the `stack` flag is not specified

## why
* Atmos vendor should not require stack configs if the `stack` flag is not provided

## references
* DEV-2689
* https://linear.app/cloudposse/issue/DEV-2689/atmos-vendor-should-not-require-stack-configs
![image (1)](https://github.com/user-attachments/assets/90dd2304-7bae-4686-b2e2-ebe5a86faa5c)
![image (2)](https://github.com/user-attachments/assets/55509485-fa1c-47fd-b2c1-6ca2f0111375)
