### PR TITLE
Fix example demo-context

### DIFF
--- a/examples/demo-context/atmos.yaml
+++ b/examples/demo-context/atmos.yaml
@@ -26,6 +26,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
+    - "catalog/**/*"
 
   name_template: "{{.providers.context.values.product}}-{{.providers.context.values.region}}-{{.providers.context.values.environment}}"
 


### PR DESCRIPTION
## what

- Running atmos in demo-context folder causes the code to process all stack configurations, including the catalog stacks

## why

- catalogs is a abstract config file, should be excluded to avoid processing that file and output error.

## references

#DEV-2691
