### PR TITLE
improve custom command error message for missing arguments

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -167,15 +167,16 @@ func preCustomCommand(
 ) {
 	var sb strings.Builder
 	if len(args) != len(commandConfig.Arguments) {
-		sb.WriteString(fmt.Sprintf("This command needs %d argument(s):", len(commandConfig.Arguments)))
-		argName := make([]string, 0, len(commandConfig.Arguments))
-		for _, arg := range commandConfig.Arguments {
+		sb.WriteString(fmt.Sprintf("Command requires %d argument(s):\n", len(commandConfig.Arguments)))
+		for i, arg := range commandConfig.Arguments {
 			if arg.Name == "" {
 				u.LogErrorAndExit(schema.CliConfiguration{}, errors.New("invalid argument configuration: empty argument name"))
 			}
-			argName = append(argName, arg.Name)
+			sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, arg.Name))
 		}
-		sb.WriteString(fmt.Sprintf(" %s", strings.Join(argName, ", ")))
+		if len(args) > 0 {
+			sb.WriteString(fmt.Sprintf("\nReceived %d argument(s): %s", len(args), strings.Join(args, ", ")))
+		}
 		u.LogErrorAndExit(schema.CliConfiguration{}, errors.New(sb.String()))
 	}
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- improved custom command error message for missing arguments including the name of argument for better user's understanding.
## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- If a custom command expects an argument, it should say so with the arguments name.

Current: 
![image](https://github.com/user-attachments/assets/6ac35475-7852-4c56-aece-e8f6dfc3e36b)

After fix:
![image](https://github.com/user-attachments/assets/d77820d4-0401-403b-bb16-fa30a08e7d76)


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- [DEV-2324](https://linear.app/cloudposse/issue/DEV-2324/if-a-custom-command-expects-an-argument-it-should-say-so-not-give-this)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for invalid argument counts in command processing, providing clearer guidance on required arguments.

- **Bug Fixes**
	- Improved error handling for empty argument names, ensuring better logging and visibility of issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->