### PR TITLE
change PS1 to show that atmos is in the `atmos terraform shell` mode

### DIFF
--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -154,6 +154,7 @@ func execTerraformShellCommand(
 	componentEnvList = append(componentEnvList, fmt.Sprintf("TF_CLI_ARGS_import=-var-file=%s", varFile))
 	componentEnvList = append(componentEnvList, fmt.Sprintf("TF_CLI_ARGS_destroy=-var-file=%s", varFile))
 	componentEnvList = append(componentEnvList, fmt.Sprintf("TF_CLI_ARGS_console=-var-file=%s", varFile))
+	componentEnvList = append(componentEnvList, "PS1=atmos>")
 
 	u.LogDebug(cliConfig, "\nStarting a new interactive shell where you can execute all native Terraform commands (type 'exit' to go back)")
 	u.LogDebug(cliConfig, fmt.Sprintf("Component: %s\n", component))
@@ -187,7 +188,6 @@ func execTerraformShellCommand(
 			}
 			shellCommand = bashPath
 		}
-		shellCommand = shellCommand + " -l"
 	}
 
 	u.LogDebug(cliConfig, fmt.Sprintf("Starting process: %s\n", shellCommand))


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- [DEV-1899](https://linear.app/cloudposse/issue/DEV-1899/make-it-more-obvious-in-the-terminal-when-launching-the-subshell-via)
