### PR TITLE
Filter out empty results from describe stacks

### DIFF
--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -45,7 +45,7 @@ func init() {
 
 	describeStacksCmd.PersistentFlags().Bool("process-templates", true, "Enable/disable Go template processing in Atmos stack manifests when executing the command: atmos describe stacks --process-templates=false")
 
-	describeStacksCmd.PersistentFlags().Bool("include-empty-stacks", false, "Include stacks with no components in the output: atmos describe stacks --include-empty")
+	describeStacksCmd.PersistentFlags().Bool("include-empty-stacks", false, "Include stacks with no components in the output: atmos describe stacks --include-empty-stacks")
 
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -45,5 +45,7 @@ func init() {
 
 	describeStacksCmd.PersistentFlags().Bool("process-templates", true, "Enable/disable Go template processing in Atmos stack manifests when executing the command: atmos describe stacks --process-templates=false")
 
+	describeStacksCmd.PersistentFlags().Bool("include-empty-stacks", false, "Include stacks with no components in the output: atmos describe stacks --include-empty")
+
 	describeCmd.AddCommand(describeStacksCmd)
 }

--- a/internal/exec/atmos.go
+++ b/internal/exec/atmos.go
@@ -41,7 +41,7 @@ func ExecuteAtmosCmd() error {
 
 	// Get a map of stacks and components in the stacks
 	// Don't process `Go` templates in Atmos stack manifests since we just need to display the stack and component names in the TUI
-	stacksMap, err := ExecuteDescribeStacks(cliConfig, "", nil, nil, nil, false, false)
+	stacksMap, err := ExecuteDescribeStacks(cliConfig, "", nil, nil, nil, false, false, false)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -408,7 +408,7 @@ func executeDescribeAffected(
 	u.LogTrace(cliConfig, fmt.Sprintf("Current HEAD: %s", localRepoHead))
 	u.LogTrace(cliConfig, fmt.Sprintf("BASE: %s", remoteRepoHead))
 
-	currentStacks, err := ExecuteDescribeStacks(cliConfig, stack, nil, nil, nil, false, true)
+	currentStacks, err := ExecuteDescribeStacks(cliConfig, stack, nil, nil, nil, false, true, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -444,7 +444,7 @@ func executeDescribeAffected(
 		return nil, nil, nil, err
 	}
 
-	remoteStacks, err := ExecuteDescribeStacks(cliConfig, stack, nil, nil, nil, true, true)
+	remoteStacks, err := ExecuteDescribeStacks(cliConfig, stack, nil, nil, nil, true, true, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/exec/describe_dependents.go
+++ b/internal/exec/describe_dependents.go
@@ -78,7 +78,7 @@ func ExecuteDescribeDependents(
 	var ok bool
 
 	// Get all stacks with all components
-	stacks, err := ExecuteDescribeStacks(cliConfig, "", nil, nil, nil, false, true)
+	stacks, err := ExecuteDescribeStacks(cliConfig, "", nil, nil, nil, false, true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## what

This PR changes the default behavior of `atmos describe stacks` it filter empty stacks by default unless user pass the flag `--include-empty-stacks`

## why
This was causing stacks with empty results or no components/imports components to be displayed.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

DEV-1880
