### PR TITLE
WIP: Atmos needs to wrap long lines in help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/elewis787/boa"
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	e "github.com/cloudposse/atmos/internal/exec"
+	"github.com/cloudposse/atmos/internal/tui/templates"
 	tuiUtils "github.com/cloudposse/atmos/internal/tui/utils"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -107,30 +107,30 @@ func Execute() error {
 }
 
 func init() {
+	// Add template function for wrapped flag usages
+	cobra.AddTemplateFunc("wrappedFlagUsages", templates.WrappedFlagUsages)
+
 	RootCmd.PersistentFlags().String("redirect-stderr", "", "File descriptor to redirect 'stderr' to. "+
 		"Errors can be redirected to any file or any standard file descriptor (including '/dev/null'): atmos <command> --redirect-stderr /dev/stdout")
 
 	RootCmd.PersistentFlags().String("logs-level", "Info", "Logs level. Supported log levels are Trace, Debug, Info, Warning, Off. If the log level is set to Off, Atmos will not log any messages")
 	RootCmd.PersistentFlags().String("logs-file", "/dev/stdout", "The file to write Atmos logs to. Logs can be written to any file or any standard file descriptor, including '/dev/stdout', '/dev/stderr' and '/dev/null'")
 
+	// Set custom usage template
+	templates.SetCustomUsageFunc(RootCmd)
 	cobra.OnInitialize(initConfig)
 }
 
 func initConfig() {
-	styles := boa.DefaultStyles()
-	b := boa.New(boa.WithStyles(styles))
-
-	RootCmd.SetUsageFunc(b.UsageFunc)
-
 	RootCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		// Print a styled Atmos logo to the terminal
 		fmt.Println()
+
+		// Print a styled Atmos logo to the terminal
 		err := tuiUtils.PrintStyledText("ATMOS")
 		if err != nil {
 			u.LogErrorAndExit(schema.CliConfiguration{}, err)
 		}
-
-		b.HelpFunc(command, strings)
+		command.Usage()
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.30
 	github.com/lrstanley/bubblezone v0.0.0-20240914071701-b48c55a5e78e
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-policy-agent/opa v0.70.0
 	github.com/otiai10/copy v1.14.0
@@ -41,6 +42,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/zclconf/go-cty v1.15.0
+	golang.org/x/term v0.26.0
 	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/sh/v3 v3.10.0
 )
@@ -174,7 +176,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -241,8 +242,7 @@ require (
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.26.0 // indirect
-	golang.org/x/term v0.25.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1533,6 +1533,8 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1540,6 +1542,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
 golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
+golang.org/x/term v0.26.0 h1:WEQa6V3Gja/BhNxg540hBip/kkaYtRg3cxg4oXSw4AU=
+golang.org/x/term v0.26.0/go.mod h1:Si5m1o57C5nBNQo5z1iq+XDijt21BDBDp2bK0QI8e3E=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/tui/templates/help_printer.go
+++ b/internal/tui/templates/help_printer.go
@@ -1,0 +1,72 @@
+package templates
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cloudposse/atmos/internal/tui/templates/term"
+	"github.com/mitchellh/go-wordwrap"
+	"github.com/spf13/pflag"
+)
+
+const (
+	defaultOffset = 10
+	minWidth      = 80
+	flagIndent    = "    "
+)
+
+type HelpFlagPrinter struct {
+	wrapLimit uint
+	out       io.Writer
+}
+
+func NewHelpFlagPrinter(out io.Writer, wrapLimit uint) *HelpFlagPrinter {
+	if wrapLimit < minWidth {
+		wrapLimit = minWidth
+	}
+	return &HelpFlagPrinter{
+		wrapLimit: wrapLimit,
+		out:       term.NewResponsiveWriter(out),
+	}
+}
+
+func (p *HelpFlagPrinter) PrintHelpFlag(flag *pflag.Flag) {
+	var prefix strings.Builder
+	prefix.WriteString(flagIndent)
+
+	if len(flag.Shorthand) > 0 {
+		prefix.WriteString(fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name))
+	} else {
+		prefix.WriteString(fmt.Sprintf("    --%s", flag.Name))
+	}
+
+	if flag.Value.Type() != "bool" {
+		prefix.WriteString(fmt.Sprintf(" %s", flag.Value.Type()))
+	}
+
+	prefixLen := len(prefix.String())
+	descWidth := int(p.wrapLimit) - prefixLen - len(flagIndent) - 4
+
+	description := flag.Usage
+	if flag.DefValue != "" && flag.DefValue != "false" {
+		description += fmt.Sprintf(" (default %q)", flag.DefValue)
+	}
+
+	wrapped := wordwrap.WrapString(description, uint(descWidth))
+	lines := strings.Split(wrapped, "\n")
+
+	fmt.Fprintf(p.out, "%s%s%s\n",
+		prefix.String(),
+		strings.Repeat(" ", descWidth-len(lines[0])),
+		lines[0])
+
+	if len(lines) > 1 {
+		indent := strings.Repeat(" ", prefixLen+2)
+		for _, line := range lines[1:] {
+			fmt.Fprintf(p.out, "%s%s\n", indent, line)
+		}
+	}
+
+	fmt.Fprintln(p.out)
+}

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -1,0 +1,61 @@
+package templates
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+type Templater struct {
+	UsageTemplate string
+}
+
+func SetCustomUsageFunc(cmd *cobra.Command) {
+	if cmd == nil {
+		panic("nil root command")
+	}
+	t := &Templater{
+		UsageTemplate: MainUsageTemplate(),
+	}
+
+	cmd.SetUsageTemplate(t.UsageTemplate)
+}
+
+// MainUsageTemplate returns the usage template for the root command and wrap cobra flag usages to the terminal width
+func MainUsageTemplate() string {
+	return `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{wrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+}
+
+// wrappedFlagUsages returns flag usages wrapped to the terminal width
+func WrappedFlagUsages(f *pflag.FlagSet) string {
+	width := 80 // Default width
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		width = w
+	}
+	return f.FlagUsagesWrapped(width - 1)
+}

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -44,10 +44,10 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
-{{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{WrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{wrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{WrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
@@ -56,7 +56,8 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 `
 }
 
-// wrappedFlagUsages returns flag usages wrapped to the terminal width
+// WrappedFlagUsages formats the flag usage string to fit within the terminal width.
+// It attempts to detect the terminal width, falling back to 80 columns if detection fails.
 func WrappedFlagUsages(f *pflag.FlagSet) string {
 	width := 80 // Default width
 	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -44,10 +44,10 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
-{{WrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{WrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{wrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -8,19 +9,23 @@ import (
 	"golang.org/x/term"
 )
 
+// Templater handles the generation and management of command usage templates.
 type Templater struct {
 	UsageTemplate string
 }
 
-func SetCustomUsageFunc(cmd *cobra.Command) {
+// SetCustomUsageFunc configures a custom usage template for the provided cobra command.
+// It returns an error if the command is nil.
+func SetCustomUsageFunc(cmd *cobra.Command) error {
 	if cmd == nil {
-		panic("nil root command")
+		return fmt.Errorf("command cannot be nil")
 	}
 	t := &Templater{
 		UsageTemplate: MainUsageTemplate(),
 	}
 
 	cmd.SetUsageTemplate(t.UsageTemplate)
+	return nil
 }
 
 // MainUsageTemplate returns the usage template for the root command and wrap cobra flag usages to the terminal width

--- a/internal/tui/templates/term/term_writer.go
+++ b/internal/tui/templates/term/term_writer.go
@@ -1,0 +1,58 @@
+package term
+
+import (
+	"io"
+	"os"
+
+	"github.com/mitchellh/go-wordwrap"
+	"golang.org/x/term"
+)
+
+// TerminalWriter wraps an io.Writer and provides automatic line wrapping based on terminal width
+// It ensures that output text is formatted to fit within the terminal's dimensions.
+type TerminalWriter struct {
+	width  uint
+	writer io.Writer
+}
+
+func NewResponsiveWriter(w io.Writer) io.Writer {
+	file, ok := w.(*os.File)
+	if !ok {
+		return w
+	}
+
+	if !term.IsTerminal(int(file.Fd())) {
+		return w
+	}
+
+	width, _, err := term.GetSize(int(file.Fd()))
+	if err != nil {
+		return w
+	}
+
+	// Use optimal width based on terminal size
+	var limit uint
+	switch {
+	case width >= 120:
+		limit = 120
+	case width >= 100:
+		limit = 100
+	case width >= 80:
+		limit = 80
+	default:
+		limit = uint(width)
+	}
+
+	return &TerminalWriter{
+		width:  limit,
+		writer: w,
+	}
+}
+
+func (w *TerminalWriter) Write(p []byte) (int, error) {
+	if w.width == 0 {
+		return w.writer.Write(p)
+	}
+	wrapped := wordwrap.WrapString(string(p), w.width)
+	return w.writer.Write([]byte(wrapped))
+}

--- a/internal/tui/templates/term/term_writer.go
+++ b/internal/tui/templates/term/term_writer.go
@@ -53,6 +53,14 @@ func (w *TerminalWriter) Write(p []byte) (int, error) {
 	if w.width == 0 {
 		return w.writer.Write(p)
 	}
+
+	// Preserving the original length for correct return value
+	originalLen := len(p)
 	wrapped := wordwrap.WrapString(string(p), w.width)
-	return w.writer.Write([]byte(wrapped))
+	n, err := w.writer.Write([]byte(wrapped))
+	if err != nil {
+		return n, err
+	}
+	// return the original length as per io.Writer contract
+	return originalLen, nil
 }

--- a/internal/tui/templates/term/term_writer.go
+++ b/internal/tui/templates/term/term_writer.go
@@ -15,6 +15,15 @@ type TerminalWriter struct {
 	writer io.Writer
 }
 
+const (
+	maxWidth    = 120
+	mediumWidth = 100
+	minWidth    = 80
+)
+
+// NewResponsiveWriter creates a terminal-aware writer that automatically wraps text
+// based on the terminal width. If the provided writer is not a terminal or if width
+// detection fails, it will return the original writer unchanged.
 func NewResponsiveWriter(w io.Writer) io.Writer {
 	file, ok := w.(*os.File)
 	if !ok {
@@ -33,12 +42,12 @@ func NewResponsiveWriter(w io.Writer) io.Writer {
 	// Use optimal width based on terminal size
 	var limit uint
 	switch {
-	case width >= 120:
-		limit = 120
-	case width >= 100:
-		limit = 100
-	case width >= 80:
-		limit = 80
+	case width >= maxWidth:
+		limit = maxWidth
+	case width >= mediumWidth:
+		limit = mediumWidth
+	case width >= minWidth:
+		limit = minWidth
 	default:
 		limit = uint(width)
 	}


### PR DESCRIPTION
## what
- Implemented a new terminal-aware text wrapping system for CLI help output
- Added responsive width handling based on terminal size with fallback values
- Introduced custom usage template handling for consistent help text formatting
- Created dedicated terminal writer component for automatic text wrapping

## why
- Improves readability of CLI help text by ensuring content fits within terminal width
- Provides better user experience with dynamic text wrapping based on terminal size
- Standardizes help text formatting across all commands
- Fixes potential issues with text overflow in narrow terminal windows

## references

This PR is also inspired from these PR/issues bellow 
https://github.com/sigstore/cosign/pull/3011/files

https://github.com/kubernetes/kubernetes/pull/104736

Before:
![Screenshot 2024-11-09 at 16 15 26](https://github.com/user-attachments/assets/520e1cf4-18b3-48ac-9c97-82ae8bd5b5e5)
![Screenshot 2024-11-09 at 16 31 54](https://github.com/user-attachments/assets/a1ae19e9-83a0-4722-b41a-24bb5c4e7653)

After:
![Screenshot 2024-11-09 at 16 32 28](https://github.com/user-attachments/assets/ff03aee1-9478-4530-b3bd-abf262c9826c)

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
