### PR TITLE
Fix vendor pull directory creation issue

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -551,6 +551,11 @@ func ExecuteAtmosVendorInternal(
 				}
 			}
 
+			targetDir := filepath.Dir(targetPath)
+			if err := os.MkdirAll(targetDir, 0755); err != nil {
+				return fmt.Errorf("failed to create target directory '%s': %w", targetDir, err)
+			}
+
 			if err = cp.Copy(tempDir, targetPath, copyOptions); err != nil {
 				return err
 			}


### PR DESCRIPTION
## what
Added directory creation logic before copying vendored files
Fixed the "no such file or directory" error when running atmos vendor pull
Ensures target directories are created before attempting to vendor components

## why
Previously, the vendor command would fail if target directories didn't exist
Directory creation is a prerequisite for vendoring components
## references

#780 
