### PR TITLE
feat: enhance `WriteToFileAsJSON` with pretty-printing support

### DIFF
--- a/pkg/utils/json_utils.go
+++ b/pkg/utils/json_utils.go
@@ -40,11 +40,13 @@ func PrintAsJSONToFileDescriptor(cliConfig schema.CliConfiguration, data any) er
 
 // WriteToFileAsJSON converts the provided value to JSON and writes it to the specified file
 func WriteToFileAsJSON(filePath string, data any, fileMode os.FileMode) error {
-	j, err := ConvertToJSON(data)
+	// Convert data to indented JSON
+	j, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filePath, []byte(j), fileMode)
+
+	err = os.WriteFile(filePath, j, fileMode)
 	if err != nil {
 		return err
 	}
@@ -53,7 +55,7 @@ func WriteToFileAsJSON(filePath string, data any, fileMode os.FileMode) error {
 
 // ConvertToJSON converts the provided value to a JSON-encoded string
 func ConvertToJSON(data any) (string, error) {
-	var jc = jsoniter.Config{
+	jc := jsoniter.Config{
 		EscapeHTML:                    true,
 		ObjectFieldMustBeSimpleString: false,
 		SortMapKeys:                   true,
@@ -69,7 +71,7 @@ func ConvertToJSON(data any) (string, error) {
 
 // ConvertToJSONFast converts the provided value to a JSON-encoded string using 'ConfigFastest' config and json.Marshal without indents
 func ConvertToJSONFast(data any) (string, error) {
-	var jc = jsoniter.Config{
+	jc := jsoniter.Config{
 		EscapeHTML:                    false,
 		MarshalFloatWith6Digits:       true,
 		ObjectFieldMustBeSimpleString: true,
@@ -86,7 +88,7 @@ func ConvertToJSONFast(data any) (string, error) {
 
 // ConvertFromJSON converts the provided JSON-encoded string to Go data types
 func ConvertFromJSON(jsonString string) (any, error) {
-	var jc = jsoniter.Config{
+	jc := jsoniter.Config{
 		EscapeHTML:                    false,
 		MarshalFloatWith6Digits:       true,
 		ObjectFieldMustBeSimpleString: true,


### PR DESCRIPTION
## what

- Replaced the `ConvertToJSON` utility with `json.MarshalIndent` to produce formatted JSON
- Indentation is set to two spaces (" ") for consistent readability

## why

- This PR improves the WriteToFileAsJSON function by introducing pretty-printing for JSON outputs. Previously, the function serialized JSON using a compact format, which could make the resulting files harder to read. With this change, all JSON written by this function will now be formatted with indentation, making it easier for developers and users to inspect and debug the generated files

- This specifically addresses #778 , which previously rendered auto-generated backends as:

```json
{
   "terraform": {
   "backend": {
   "s3": {
   "acl": "bucket-owner-full-control",
   "bucket": "my-tfstate-bucket",
   "dynamodb_table": "some-dynamo-table",
   "encrypt": true,
   "key": "terraform.tfstate",
   "profile": "main",
   "region": "us-west-2",
   "workspace_key_prefix": "something"
}
}
}
}
```

With this addition, the output appears as:

```json
{
  "terraform": {
    "backend": {
      "s3": {
        "acl": "bucket-owner-full-control",
        "bucket": "my-tfstate-bucket",
        "dynamodb_table": "some-dynamo-table",
        "encrypt": true,
        "key": "terraform.tfstate",
        "profile": "main",
        "region": "us-west-2",
        "workspace_key_prefix": "something"
      }
    }
  }
}
```

## references

- [Stack Overflow](https://stackoverflow.com/questions/19038598/how-can-i-pretty-print-json-using-go)
