### PR TITLE
handle empty stack yaml file configuration

### DIFF
--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -199,6 +199,10 @@ func ProcessYAMLConfigFile(
 			return nil, nil, nil, err
 		}
 	}
+	if stackYamlConfig == "" {
+		return map[string]any{}, map[string]map[string]any{}, map[string]any{}, nil
+
+	}
 
 	stackManifestTemplatesProcessed := stackYamlConfig
 	stackManifestTemplatesErrorMessage := ""
@@ -1874,7 +1878,7 @@ func CreateComponentStackMap(
 func GetFileContent(filePath string) (string, error) {
 	existingContent, found := getFileContentSyncMap.Load(filePath)
 	if found && existingContent != nil {
-		return fmt.Sprintf("%s", existingContent), nil
+		return "", nil
 	}
 
 	content, err := os.ReadFile(filePath)


### PR DESCRIPTION
## what
handle empty stack yaml file configuration

## why
Atmos Validate Should Not Error on Empty Files

## references
before fix : atmos validate stacks 
https://linear.app/cloudposse/issue/DEV-2362/atmos-validate-should-not-error-on-empty-files
![2024-11-17 12_41_16-Window](https://github.com/user-attachments/assets/a3dd6986-ecc5-493a-8443-a8f9505e8df5)
after :
![2024-11-17 12_42_18-Window](https://github.com/user-attachments/assets/b39c938b-3694-4a8d-9b91-b1c74d41ab16)

