### PR TITLE
Added  Support for Automatic Templated File Search for Atmos Imports

### DIFF
--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -368,8 +368,33 @@ func ProcessYAMLConfigFile(
 		impWithExt := imp
 		ext := filepath.Ext(imp)
 		if ext == "" {
-			ext = cfg.DefaultStackConfigFileExtension
-			impWithExt = imp + ext
+			extensions := []string{
+				".yaml",
+				".yml",
+				".yaml.tmpl",
+				".yml.tmpl",
+			}
+
+			found := false
+			for _, extension := range extensions {
+				testPath := path.Join(basePath, imp+extension)
+				if _, err := os.Stat(testPath); err == nil {
+					impWithExt = imp + extension
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				// Default to .yaml if no file is found
+				impWithExt = imp + cfg.DefaultStackConfigFileExtension
+			}
+		} else if ext == ".yaml" || ext == ".yml" {
+			// Check if there's a template version of this file
+			templatePath := impWithExt + ".tmpl"
+			if _, err := os.Stat(path.Join(basePath, templatePath)); err == nil {
+				impWithExt = templatePath
+			}
 		}
 
 		impWithExtPath := path.Join(basePath, impWithExt)

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -30,7 +30,6 @@ func FindAllStackConfigsInPathsForStack(
 
 		ext := filepath.Ext(p)
 		if ext == "" {
-			// If no extension, try both regular and template extensions
 			patterns = []string{
 				p + DefaultStackConfigFileExtension,
 				p + DefaultStackConfigFileExtension + ".tmpl",
@@ -129,7 +128,6 @@ func FindAllStackConfigsInPaths(
 
 		ext := filepath.Ext(p)
 		if ext == "" {
-			// If no extension, try both regular and template extensions
 			patterns = []string{
 				p + DefaultStackConfigFileExtension,
 				p + DefaultStackConfigFileExtension + ".tmpl",
@@ -694,7 +692,6 @@ func SearchConfigFile(configPath string, cliConfig schema.CliConfiguration) (str
 	dir := filepath.Dir(configPath)
 	base := filepath.Base(configPath)
 
-	// Read directory once for better performance
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", fmt.Errorf("error reading directory %s: %v", dir, err)

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -39,8 +39,13 @@ func FileOrDirExists(filename string) bool {
 
 // IsYaml checks if the file has YAML extension (does not check file schema, nor validates the file)
 func IsYaml(file string) bool {
-	yamlExtensions := []string{".yaml", ".yml"}
+	yamlExtensions := []string{".yaml", ".yml", ".yaml.tmpl", ".yml.tmpl"}
 	ext := filepath.Ext(file)
+	if ext == ".tmpl" {
+		// For .tmpl files, we check if the full extension is .yaml.tmpl or .yml.tmpl
+		baseExt := filepath.Ext(strings.TrimSuffix(file, ext))
+		ext = baseExt + ext
+	}
 	return SliceContainsString(yamlExtensions, ext)
 }
 
@@ -180,12 +185,12 @@ func IsSocket(path string) (bool, error) {
 // If the path has a file extension, it checks if the file exists.
 // If the path does not have a file extension, it checks for the existence of the file with the provided path and the possible config file extensions
 func SearchConfigFile(path string) (string, bool) {
-	// check if the provided has a file extension
+	// check if the provided path has a file extension
 	if filepath.Ext(path) != "" {
 		return path, FileExists(path)
 	}
 	// Define the possible config file extensions
-	configExtensions := []string{".yaml", ".yml"}
+	configExtensions := []string{".yaml", ".yml", ".yaml.tmpl", ".yml.tmpl"}
 	for _, ext := range configExtensions {
 		filePath := path + ext
 		if FileExists(filePath) {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Implementing automatic detection and import of templated files (.yaml.tmpl or .yml.tmpl) in Atmos
- Adding fallback to regular .yaml or .yml files when templated versions aren't found
- Simplifying import configuration by removing the need to explicitly specify .tmpl extensions
- Maintaining backward compatibility with existing import configurations

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Improves developer experience by reducing manual configuration overhead

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
