### PR TITLE
Dynamic width terminal calculation for help

### DIFF
--- a/internal/tui/templates/help_printer.go
+++ b/internal/tui/templates/help_printer.go
@@ -30,6 +30,7 @@ func NewHelpFlagPrinter(out io.Writer, wrapLimit uint, flags *pflag.FlagSet) *He
 	if flags == nil {
 		panic("flag set cannot be nil")
 	}
+
 	if wrapLimit < minWidth {
 		wrapLimit = minWidth
 	}
@@ -89,6 +90,15 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *pflag.Flag) {
 		}
 	}
 
+	availWidth := int(p.wrapLimit) - p.maxFlagLen - 4
+	if availWidth < minDescWidth {
+		if _, err := fmt.Fprintf(p.out, "%s\n", flagName); err != nil {
+			return
+		}
+		flagName = strings.Repeat(" ", p.maxFlagLen)
+		availWidth = int(p.wrapLimit) - 4
+	}
+
 	flagSection := fmt.Sprintf("%-*s", p.maxFlagLen, flagName)
 	descIndent := p.maxFlagLen + 4
 
@@ -97,12 +107,7 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *pflag.Flag) {
 		description = fmt.Sprintf("%s (default %q)", description, flag.DefValue)
 	}
 
-	descWidth := int(p.wrapLimit) - descIndent
-	if descWidth < minDescWidth {
-		descWidth = minDescWidth
-	}
-
-	wrapped := wordwrap.WrapString(description, uint(descWidth))
+	wrapped := wordwrap.WrapString(description, uint(availWidth))
 	lines := strings.Split(wrapped, "\n")
 
 	if _, err := fmt.Fprintf(p.out, "%-*s%s\n", descIndent, flagSection, lines[0]); err != nil {


### PR DESCRIPTION
## what

Help should detect proper screen width

## why

Terminal Width should be dynamic calculated when the user prints help menu

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
