### PR TITLE
Update the help descriptions for commands

### DIFF
--- a/cmd/atlantis.go
+++ b/cmd/atlantis.go
@@ -7,7 +7,7 @@ import (
 // atlantisCmd executes Atlantis commands
 var atlantisCmd = &cobra.Command{
 	Use:                "atlantis",
-	Short:              "Execute 'atlantis' commands",
+	Short:              "Generate and manage Atlantis configurations",
 	Long:               `This command executes Atlantis integration commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -7,7 +7,7 @@ import (
 // awsCmd executes 'aws' CLI commands
 var awsCmd = &cobra.Command{
 	Use:                "aws",
-	Short:              "Execute 'aws' commands",
+	Short:              "Run AWS-specific commands for interacting with cloud resources",
 	Long:               `This command executes 'aws' CLI commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -11,7 +11,7 @@ import (
 
 var completionCmd = &cobra.Command{
 	Use:                   "completion [bash|zsh|fish|powershell]",
-	Short:                 "Generate completion script for Bash, Zsh, Fish and PowerShell",
+	Short:                 "Generate autocompletion scripts for Bash, Zsh, Fish, and PowerShell",
 	Long:                  "This command generates completion scripts for Bash, Zsh, Fish and PowerShell",
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -7,7 +7,7 @@ import (
 // describeCmd describes configuration for stacks and components
 var describeCmd = &cobra.Command{
 	Use:                "describe",
-	Short:              "Execute 'describe' commands",
+	Short:              "Show details about Atmos configurations and components",
 	Long:               `This command shows configuration for CLI, stacks and components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -22,7 +22,7 @@ const atmosDocsURL = "https://atmos.tools"
 // docsCmd opens the Atmos docs and can display component documentation
 var docsCmd = &cobra.Command{
 	Use:                "docs",
-	Short:              "Open the Atmos docs or display component documentation",
+	Short:              "Open Atmos documentation or display component-specific docs",
 	Long:               `This command opens the Atmos docs or displays the documentation for a specified Atmos component.`,
 	Example:            "atmos docs vpc",
 	Args:               cobra.MaximumNArgs(1),

--- a/cmd/helmfile.go
+++ b/cmd/helmfile.go
@@ -16,7 +16,7 @@ import (
 var helmfileCmd = &cobra.Command{
 	Use:                "helmfile",
 	Aliases:            []string{"hf"},
-	Short:              "Execute 'helmfile' commands",
+	Short:              "Manage Helmfile-based Kubernetes deployments",
 	Long:               `This command runs Helmfile commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,9 +6,10 @@ import (
 
 // listCmd commands list stacks and components
 var listCmd = &cobra.Command{
-	Use:                "list",
-	Short:              "Execute 'list' commands",
-	Long:               `This command lists stacks and components`,
+	Use:   "list",
+	Short: "List available stacks and components",
+	Long: `The 'list' command retrieves and displays a list of all stacks and components within the environment.
+	It provides an overview of the current resources, making it easier to manage and navigate your infrastructure.`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 

--- a/cmd/pro.go
+++ b/cmd/pro.go
@@ -7,7 +7,7 @@ import (
 // proCmd executes 'atmos pro' CLI commands
 var proCmd = &cobra.Command{
 	Use:                "pro",
-	Short:              "Execute 'pro' commands",
+	Short:              "Access premium features integrated with app.cloudposse.com",
 	Long:               `This command executes 'atmos pro' CLI commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -16,7 +16,7 @@ import (
 var terraformCmd = &cobra.Command{
 	Use:                "terraform",
 	Aliases:            []string{"tf"},
-	Short:              "Execute Terraform commands",
+	Short:              "Execute Terraform commands (e.g., plan, apply, destroy) using Atmos stack configurations",
 	Long:               `This command executes Terraform commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -7,7 +7,7 @@ import (
 // validateCmd commands validate stacks and components
 var validateCmd = &cobra.Command{
 	Use:                "validate",
-	Short:              "Execute 'validate' commands",
+	Short:              "Validate configurations against OPA policies and JSON schemas",
 	Long:               `This command validates stacks and components`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -7,7 +7,7 @@ import (
 // vendorCmd executes 'atmos vendor' CLI commands
 var vendorCmd = &cobra.Command{
 	Use:                "vendor",
-	Short:              "Execute 'vendor' commands",
+	Short:              "Manage external dependencies for components or stacks",
 	Long:               `This command executes 'atmos vendor' CLI commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:     "version",
-	Short:   "Print the CLI version",
+	Short:   "Show the installed Atmos CLI version and check for updates",
 	Long:    `This command prints the CLI version`,
 	Example: "atmos version",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -11,7 +11,7 @@ import (
 // workflowCmd executes a workflow
 var workflowCmd = &cobra.Command{
 	Use:   "workflow",
-	Short: "Execute a workflow",
+	Short: "Run automated workflows for infrastructure and operations",
 	Long:  `This command executes a workflow: atmos workflow <name> -f <file>`,
 	Example: "atmos workflow\n" +
 		"atmos workflow <name> -f <file>\n" +


### PR DESCRIPTION
issue: https://linear.app/cloudposse/issue/DEV-2823/atmos-commands-should-describe-what-they-do
parent issue: https://linear.app/cloudposse/issue/DEV-2740/atmos-help-should-show-meaningful-descriptions-of-commands

## what

We have updated the help strings of the commands

## why
Previously the help descriptions metioned a cyclic description. 
Example:
![image](https://github.com/user-attachments/assets/533e82b7-2aaa-4ce0-9e71-36387aa53ef6)
So we had to improve the descriptions.
## references
issue: https://linear.app/cloudposse/issue/DEV-2823/atmos-commands-should-describe-what-they-do
parent issue: https://linear.app/cloudposse/issue/DEV-2740/atmos-help-should-show-meaningful-descriptions-of-commands