### PR TITLE
Append new lines to end of json files before writing

### DIFF
--- a/pkg/utils/json_utils.go
+++ b/pkg/utils/json_utils.go
@@ -51,6 +51,11 @@ func WriteToFileAsJSON(filePath string, data any, fileMode os.FileMode) error {
 		return err
 	}
 
+	// Ensure that the JSON content ends with a newline
+	if len(indentedJSON) == 0 || indentedJSON[len(indentedJSON)-1] != '\n' {
+		indentedJSON = append(indentedJSON, '\n')
+	}
+
 	err = os.WriteFile(filePath, indentedJSON, fileMode)
 	if err != nil {
 		return err


### PR DESCRIPTION
## what
It's common for linters and pre-commit hooks to expect new lines at the end of files.
In the case of the pretty-printed json (used for the creation of the backend.tf.json files) these objects are now properly indented, but still lacking the new line at the end of the file.

This PR addresses this by checking that the file is either empty OR that the last object by length isn't already a new line, and appends it.
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why
Better support for linting and pre-comming standards.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
