### PR TITLE
Exclude abstract components from list

### DIFF
--- a/internal/exec/atmos.go
+++ b/internal/exec/atmos.go
@@ -51,7 +51,7 @@ func ExecuteAtmosCmd() error {
 		if v2, ok := v.(map[string]any); ok {
 			if v3, ok := v2["components"].(map[string]any); ok {
 				if v4, ok := v3["terraform"].(map[string]any); ok {
-					return k, lo.Keys(v4)
+					return k, FilterAbstractComponents(v4)
 				}
 				// TODO: process 'helmfile' components and stacks.
 				// This will require checking the list of commands and filtering the stacks and components depending on the selected command.

--- a/internal/exec/describe_component.go
+++ b/internal/exec/describe_component.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -82,4 +83,22 @@ func ExecuteDescribeComponent(
 	}
 
 	return configAndStacksInfo.ComponentSection, nil
+}
+
+// FilterAbstractComponents This function removes abstract components and returns the list of components
+func FilterAbstractComponents(componentsMap map[string]any) []string {
+	components := make([]string, 0)
+	for _, k := range lo.Keys(componentsMap) {
+		if v5, ok := componentsMap[k].(map[string]any); ok {
+			if v6, ok := v5["metadata"].(map[string]any); ok {
+				if v7, ok := v6["type"]; ok {
+					if v7 == "abstract" {
+						continue
+					}
+				}
+			}
+		}
+		components = append(components, k)
+	}
+	return components
 }


### PR DESCRIPTION
issue: https://linear.app/cloudposse/issue/DEV-2808/atmos-tui-should-not-include-abstract-components

## what

We want to exclude abstract components from the UI list

## why
currently we show all the components in the Atmos UI.
i agree we don't need to show the abstract components to execute the commands like atmos terraform plan/apply, but they can be used in the commands like atmos describe component
we'll probably disable the abstract components in the UI


## references
https://sweetops.slack.com/archives/C031919U8A0/p1733161390410539
