### PR TITLE
Add support for atlantis version

### DIFF
--- a/cmd/atlantis.go
+++ b/cmd/atlantis.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/cloudposse/atmos/internal/exec"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,9 @@ var atlantisCmd = &cobra.Command{
 	Short:              "Execute 'atlantis' commands",
 	Long:               `This command executes Atlantis integration commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
+	Run: func(cmd *cobra.Command, args []string) {
+		exec.ExecuteAtlantis(cmd, args)
+	},
 }
 
 func init() {

--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -17,6 +17,20 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
+// ExecuteAtlantis executes atlantis command
+func ExecuteAtlantis(cmd *cobra.Command, args []string) error {
+	info, err := ProcessCommandLineArgs("atlantis", cmd, args, nil)
+	if err != nil {
+		return err
+	}
+
+	cliConfig, err := cfg.InitCliConfig(info, true)
+	if err != nil {
+		return err
+	}
+	return ExecuteShellCommand(cliConfig, "atlantis", args, "", nil, false, "")
+}
+
 // ExecuteAtlantisGenerateRepoConfigCmd executes 'atlantis generate repo-config' command
 func ExecuteAtlantisGenerateRepoConfigCmd(cmd *cobra.Command, args []string) error {
 	info, err := ProcessCommandLineArgs("", cmd, args, nil)

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -661,21 +661,20 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (sche
 	var indexesToRemove []int
 
 	// For commands like `atmos terraform clean` and `atmos terraform plan`, show the command help
-	if len(inputArgsAndFlags) == 1 {
+	if len(inputArgsAndFlags) == 1 && inputArgsAndFlags[0] != "version" {
 		info.SubCommand = inputArgsAndFlags[0]
 		info.NeedHelp = true
+		return info, nil
+	}
+
+	// For version commands `atmos terraform version` or `atmos atlantis version`
+	if len(inputArgsAndFlags) == 1 && inputArgsAndFlags[0] == "version" {
+		info.SubCommand = inputArgsAndFlags[0]
 		return info, nil
 	}
 
 	// https://github.com/roboll/helmfile#cli-reference
 	var globalOptionsFlagIndex int
-
-	// For commands like `atmos terraform clean` and `atmos terraform plan`, show the command help
-	if len(inputArgsAndFlags) == 1 {
-		info.SubCommand = inputArgsAndFlags[0]
-		info.NeedHelp = true
-		return info, nil
-	}
 
 	for i, arg := range inputArgsAndFlags {
 		if arg == cfg.GlobalOptionsFlag {


### PR DESCRIPTION
## what
We are adding support for atlantis version

## why
We say atmos supports all native atlantis commands, yet we do not support `atmos atlantis version`

## references

issue: https://linear.app/cloudposse/issue/DEV-2839/atmos-atlantis-version-does-not-work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command execution functionality for the Atlantis command.
	- Added a wrapper function for executing the Atlantis command with improved argument handling.

- **Bug Fixes**
	- Refined logic for handling command-line arguments, particularly for the "version" command.

- **Documentation**
	- Updated comments for clarity regarding command-line argument processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->