### PR TITLE
Add support for helmfile version command

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -54,6 +54,10 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 		return nil
 	}
 
+	if info.SubCommand == "version" {
+		return ExecuteShellCommand(cliConfig, "helmfile", []string{info.SubCommand}, "", nil, false, info.RedirectStdErr)
+	}
+
 	info, err = ProcessStacks(cliConfig, info, true, true)
 	if err != nil {
 		return err

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -661,21 +661,18 @@ func processArgsAndFlags(componentType string, inputArgsAndFlags []string) (sche
 	var indexesToRemove []int
 
 	// For commands like `atmos terraform clean` and `atmos terraform plan`, show the command help
-	if len(inputArgsAndFlags) == 1 {
+	if len(inputArgsAndFlags) == 1 && inputArgsAndFlags[0] != "version" {
 		info.SubCommand = inputArgsAndFlags[0]
 		info.NeedHelp = true
+		return info, nil
+	}
+	if len(inputArgsAndFlags) == 1 && inputArgsAndFlags[0] == "version" {
+		info.SubCommand = inputArgsAndFlags[0]
 		return info, nil
 	}
 
 	// https://github.com/roboll/helmfile#cli-reference
 	var globalOptionsFlagIndex int
-
-	// For commands like `atmos terraform clean` and `atmos terraform plan`, show the command help
-	if len(inputArgsAndFlags) == 1 {
-		info.SubCommand = inputArgsAndFlags[0]
-		info.NeedHelp = true
-		return info, nil
-	}
 
 	for i, arg := range inputArgsAndFlags {
 		if arg == cfg.GlobalOptionsFlag {


### PR DESCRIPTION

## what

* Support for `atmos helmfile version` command

Currently:
![image](https://github.com/user-attachments/assets/37a1ea53-e330-47d9-92dc-03c57d71d336)

After this pr:
![image](https://github.com/user-attachments/assets/28148e12-fdf9-437a-b88b-33b98490dd03)


## why
We say atmos supports all native terraform commands, yet we do not support atmos helmfile version

## references
issue: https://linear.app/cloudposse/issue/DEV-2844/atmos-helmfile-version-does-not-work
conversation: https://sweetops.slack.com/archives/D08447GN7JA/p1734006016227039?thread_ts=1734002589.248629&cid=D08447GN7JA
