### PR TITLE
Fix terraform plan file should not be deleted

### DIFF
--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -478,7 +478,7 @@ func ExecuteTerraform(info schema.ConfigAndStacksInfo) error {
 	}
 
 	// Clean up
-	if info.SubCommand != "plan" && info.PlanFile == "" {
+	if info.SubCommand != "plan" && info.SubCommand != "show" && info.PlanFile == "" {
 		planFilePath := constructTerraformComponentPlanfilePath(cliConfig, info)
 		_ = os.Remove(planFilePath)
 	}


### PR DESCRIPTION
issue: https://linear.app/cloudposse/issue/DEV-2825/atmos-terraform-show-deletes-planfile

## what

* Stop deleting planfile after terraform show

## why
We should not delete the terraform plan file if the user uses show to check his results.

# Test

Steps:
1. `cd examples/quick-start-simple`
2. `../../build/atmos terraform plan -s dev station`
3.  `../../build/atmos terraform show -s dev station --json dev-station.planfile --skip-init`

Verified if the file `./examples/quick-start-simple/components/terraform/weather/dev-station.planfile` still exists.

Before this change: deleted

After this change: present

## references

issue: https://linear.app/cloudposse/issue/DEV-2825/atmos-terraform-show-deletes-planfile

conversation: https://sweetops.slack.com/archives/C031919U8A0/p1733924783112799
