### PR TITLE
Replace path.Join with filepath.Join

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -403,13 +403,13 @@ func printMessageForMissingAtmosConfig(cliConfig schema.CliConfiguration) {
 		u.PrintMessageInColor("atmos.yaml", c1)
 		fmt.Println(" CLI config file was not found.")
 		fmt.Print("\nThe default Atmos stacks directory is set to ")
-		u.PrintMessageInColor(path.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath), c1)
+		u.PrintMessageInColor(filepath.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath), c1)
 		fmt.Println(",\nbut the directory does not exist in the current path.")
 	} else {
 		// If Atmos found an `atmos.yaml` config file, but it defines invalid paths to Atmos stacks and components
 		u.PrintMessageInColor("atmos.yaml", c1)
 		fmt.Print(" CLI config file specifies the directory for Atmos stacks as ")
-		u.PrintMessageInColor(path.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath), c1)
+		u.PrintMessageInColor(filepath.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath), c1)
 		fmt.Println(",\nbut the directory does not exist.")
 	}
 

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/charmbracelet/glamour"
@@ -59,7 +59,7 @@ var docsCmd = &cobra.Command{
 			}
 
 			// Construct the full path to the Terraform component by combining the Atmos base path, Terraform base path, and component name
-			componentPath := path.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, info.Component)
+			componentPath := filepath.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, info.Component)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil {
 				u.LogErrorAndExit(schema.CliConfiguration{}, err)
@@ -68,7 +68,7 @@ var docsCmd = &cobra.Command{
 				u.LogErrorAndExit(schema.CliConfiguration{}, fmt.Errorf("Component '%s' not found in path: '%s'", info.Component, componentPath))
 			}
 
-			readmePath := path.Join(componentPath, "README.md")
+			readmePath := filepath.Join(componentPath, "README.md")
 			if _, err := os.Stat(readmePath); err != nil {
 				if os.IsNotExist(err) {
 					u.LogErrorAndExit(schema.CliConfiguration{}, fmt.Errorf("No README found for component: %s", info.Component))

--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -339,7 +338,7 @@ func ExecuteAtlantisGenerateRepoConfig(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					cliConfig.BasePath,
 					cliConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -2,10 +2,11 @@ package exec
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"path"
-	"strings"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -157,11 +158,11 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 
 		configAndStacksInfo.ComponentType = "terraform"
 		configAndStacksInfo, err = ProcessStacks(cliConfig, configAndStacksInfo, true, true)
-		shellCommandWorkingDir = path.Join(cliConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+		shellCommandWorkingDir = filepath.Join(cliConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 		if err != nil {
 			configAndStacksInfo.ComponentType = "helmfile"
 			configAndStacksInfo, err = ProcessStacks(cliConfig, configAndStacksInfo, true, true)
-			shellCommandWorkingDir = path.Join(cliConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+			shellCommandWorkingDir = filepath.Join(cliConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 			if err != nil {
 				return err
 			}

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -432,12 +432,12 @@ func executeDescribeAffected(
 	}
 
 	// Update paths to point to the cloned remote repo dir
-	cliConfig.StacksBaseAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, cliConfig.Stacks.BasePath)
-	cliConfig.TerraformDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, cliConfig.Components.Terraform.BasePath)
-	cliConfig.HelmfileDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, cliConfig.Components.Helmfile.BasePath)
+	cliConfig.StacksBaseAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, cliConfig.Stacks.BasePath)
+	cliConfig.TerraformDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, cliConfig.Components.Terraform.BasePath)
+	cliConfig.HelmfileDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, cliConfig.Components.Helmfile.BasePath)
 
 	cliConfig.StackConfigFilesAbsolutePaths, err = u.JoinAbsolutePathWithPaths(
-		path.Join(remoteRepoFileSystemPath, basePath, cliConfig.Stacks.BasePath),
+		filepath.Join(remoteRepoFileSystemPath, basePath, cliConfig.Stacks.BasePath),
 		cliConfig.StackConfigFilesRelativePaths,
 	)
 	if err != nil {
@@ -1182,9 +1182,9 @@ func isComponentFolderChanged(
 
 	switch componentType {
 	case "terraform":
-		componentPath = path.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, component)
+		componentPath = filepath.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, component)
 	case "helmfile":
-		componentPath = path.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath, component)
+		componentPath = filepath.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath, component)
 	}
 
 	componentPathAbs, err := filepath.Abs(componentPath)
@@ -1220,7 +1220,7 @@ func areTerraformComponentModulesChanged(
 	changedFiles []string,
 ) (bool, error) {
 
-	componentPath := path.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, component)
+	componentPath := filepath.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, component)
 
 	componentPathAbs, err := filepath.Abs(componentPath)
 	if err != nil {
@@ -1241,7 +1241,7 @@ func areTerraformComponentModulesChanged(
 				continue
 			}
 
-			modulePath := path.Join(path.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
+			modulePath := filepath.Join(path.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
 
 			modulePathAbs, err := filepath.Abs(modulePath)
 			if err != nil {

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -5,7 +5,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -74,20 +74,20 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 	}
 
 	// Check if the component exists as a helmfile component
-	componentPath := path.Join(cliConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
+	componentPath := filepath.Join(cliConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
 	componentPathExists, err := u.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {
 		return fmt.Errorf("'%s' points to the Helmfile component '%s', but it does not exist in '%s'",
 			info.ComponentFromArg,
 			info.FinalComponent,
-			path.Join(cliConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
+			filepath.Join(cliConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
 		)
 	}
 
 	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract {
 		return fmt.Errorf("abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"by 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component))
+			"by 'metadata.type: abstract' attribute", filepath.Join(info.ComponentFolderPrefix, info.Component))
 	}
 
 	// Print component variables
@@ -192,7 +192,7 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 		u.LogDebug(cliConfig, "Stack: "+info.StackFromArg)
 	} else {
 		u.LogDebug(cliConfig, "Stack: "+info.StackFromArg)
-		u.LogDebug(cliConfig, "Stack path: "+path.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath, info.Stack))
+		u.LogDebug(cliConfig, "Stack path: "+filepath.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath, info.Stack))
 	}
 
 	workingDir := constructHelmfileComponentWorkingDir(cliConfig, info)

--- a/internal/exec/oci_utils.go
+++ b/internal/exec/oci_utils.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -30,7 +30,7 @@ func processOciImage(cliConfig schema.CliConfiguration, imageName string, destDi
 	defer removeTempDir(cliConfig, tempDir)
 
 	// Temp tarball file name
-	tempTarFileName := path.Join(tempDir, uuid.New().String()) + ".tar"
+	tempTarFileName := filepath.Join(tempDir, uuid.New().String()) + ".tar"
 
 	// Get the image reference from the OCI registry
 	ref, err := name.ParseReference(imageName)
@@ -91,7 +91,7 @@ func processOciImage(cliConfig schema.CliConfiguration, imageName string, destDi
 
 	// Extract the layers into the destination directory
 	for _, l := range manifest.Layers {
-		layerPath := path.Join(tempDir, l)
+		layerPath := filepath.Join(tempDir, l)
 
 		err = extractTarball(cliConfig, layerPath, destDir)
 		if err != nil {

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -357,7 +357,7 @@ func ProcessYAMLConfigFile(
 
 			found := false
 			for _, extension := range extensions {
-				testPath := path.Join(basePath, imp+extension)
+				testPath := filepath.Join(basePath, imp+extension)
 				if _, err := os.Stat(testPath); err == nil {
 					impWithExt = imp + extension
 					found = true
@@ -372,12 +372,12 @@ func ProcessYAMLConfigFile(
 		} else if ext == u.YamlFileExtension || ext == u.YmlFileExtension {
 			// Check if there's a template version of this file
 			templatePath := impWithExt + u.TemplateExtension
-			if _, err := os.Stat(path.Join(basePath, templatePath)); err == nil {
+			if _, err := os.Stat(filepath.Join(basePath, templatePath)); err == nil {
 				impWithExt = templatePath
 			}
 		}
 
-		impWithExtPath := path.Join(basePath, impWithExt)
+		impWithExtPath := filepath.Join(basePath, impWithExt)
 
 		if impWithExtPath == filePath {
 			errorMessage := fmt.Sprintf("invalid import in the manifest '%s'\nThe file imports itself in '%s'",
@@ -2180,7 +2180,7 @@ func ProcessBaseComponentConfig(
 		if checkBaseComponentExists {
 			// Check if the base component exists as Terraform/Helmfile component
 			// If it does exist, don't throw errors if it is not defined in YAML config
-			componentPath := path.Join(componentBasePath, baseComponent)
+			componentPath := filepath.Join(componentBasePath, baseComponent)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil || !componentPathExists {
 				return errors.New("The component '" + component + "' inherits from the base component '" +

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -163,9 +163,9 @@ func BuildComponentPath(
 
 	if stackComponentSection, ok := componentSectionMap[cfg.ComponentSectionName].(string); ok {
 		if componentType == "terraform" {
-			componentPath = path.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, stackComponentSection)
+			componentPath = filepath.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath, stackComponentSection)
 		} else if componentType == "helmfile" {
-			componentPath = path.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath, stackComponentSection)
+			componentPath = filepath.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath, stackComponentSection)
 		}
 	}
 

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -75,7 +75,7 @@ func ExecuteTerraformGenerateBackendCmd(cmd *cobra.Command, args []string) error
 	}
 
 	// Write backend config to file
-	var backendFilePath = path.Join(
+	var backendFilePath = filepath.Join(
 		cliConfig.BasePath,
 		cliConfig.Components.Terraform.BasePath,
 		info.ComponentFolderPrefix,

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -161,7 +160,7 @@ func ExecuteTerraformGenerateBackends(
 				}
 
 				// Path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					cliConfig.BasePath,
 					cliConfig.Components.Terraform.BasePath,
 					terraformComponent,
@@ -291,7 +290,7 @@ func ExecuteTerraformGenerateBackends(
 
 						processedTerraformComponents[terraformComponent] = terraformComponent
 
-						backendFilePath = path.Join(
+						backendFilePath = filepath.Join(
 							terraformComponentPath,
 							"backend.tf",
 						)

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -160,7 +159,7 @@ func ExecuteTerraformGenerateVarfiles(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					cliConfig.BasePath,
 					cliConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -88,7 +87,7 @@ func execTerraformOutput(cliConfig schema.CliConfiguration, component string, st
 
 		// Auto-generate backend file
 		if cliConfig.Components.Terraform.AutoGenerateBackendFile {
-			backendFileName := path.Join(componentPath, "backend.tf.json")
+			backendFileName := filepath.Join(componentPath, "backend.tf.json")
 
 			u.LogTrace(cliConfig, "\nWriting the backend config to file:")
 			u.LogTrace(cliConfig, backendFileName)
@@ -121,7 +120,7 @@ func execTerraformOutput(cliConfig schema.CliConfiguration, component string, st
 		providersSection, ok := sections["providers"].(map[string]any)
 
 		if ok && len(providersSection) > 0 {
-			providerOverrideFileName := path.Join(componentPath, "providers_override.tf.json")
+			providerOverrideFileName := filepath.Join(componentPath, "providers_override.tf.json")
 
 			u.LogTrace(cliConfig, "\nWriting the provider overrides to file:")
 			u.LogTrace(cliConfig, providerOverrideFileName)

--- a/internal/exec/validate_component.go
+++ b/internal/exec/validate_component.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -197,11 +197,11 @@ func validateComponentInternal(
 		switch schemaType {
 		case "jsonschema":
 			{
-				filePath = path.Join(cliConfig.BasePath, cliConfig.Schemas.JsonSchema.BasePath, schemaPath)
+				filePath = filepath.Join(cliConfig.BasePath, cliConfig.Schemas.JsonSchema.BasePath, schemaPath)
 			}
 		case "opa":
 			{
-				filePath = path.Join(cliConfig.BasePath, cliConfig.Schemas.Opa.BasePath, schemaPath)
+				filePath = filepath.Join(cliConfig.BasePath, cliConfig.Schemas.Opa.BasePath, schemaPath)
 			}
 		}
 
@@ -228,7 +228,7 @@ func validateComponentInternal(
 		}
 	case "opa":
 		{
-			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(path.Join(cliConfig.BasePath, cliConfig.Schemas.Opa.BasePath), modulePaths)
+			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(filepath.Join(cliConfig.BasePath, cliConfig.Schemas.Opa.BasePath), modulePaths)
 			if err != nil {
 				return false, err
 			}

--- a/internal/exec/validate_stacks.go
+++ b/internal/exec/validate_stacks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -91,7 +91,7 @@ func ValidateStacks(cliConfig schema.CliConfiguration) error {
 		u.LogTrace(cliConfig, fmt.Sprintf("The Atmos JSON Schema file is not configured. Using the default schema '%s'", atmosManifestDefault))
 	}
 
-	atmosManifestJsonSchemaFileAbsPath := path.Join(cliConfig.BasePath, cliConfig.Schemas.Atmos.Manifest)
+	atmosManifestJsonSchemaFileAbsPath := filepath.Join(cliConfig.BasePath, cliConfig.Schemas.Atmos.Manifest)
 
 	if u.FileExists(cliConfig.Schemas.Atmos.Manifest) {
 		atmosManifestJsonSchemaFilePath = cliConfig.Schemas.Atmos.Manifest
@@ -131,7 +131,7 @@ func ValidateStacks(cliConfig schema.CliConfiguration) error {
 	}
 
 	u.LogDebug(cliConfig, fmt.Sprintf("Validating all YAML files in the '%s' folder and all subfolders (excluding template files)\n",
-		path.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath)))
+		filepath.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath)))
 
 	for _, filePath := range stackConfigFilesAbsolutePaths {
 		stackConfig, importsConfig, _, _, _, err := ProcessYAMLConfigFile(
@@ -376,7 +376,7 @@ func downloadSchemaFromURL(manifestURL string) (string, error) {
 	if err != nil || fileName == "" {
 		return "", fmt.Errorf("failed to get the file name from the URL '%s': %w", manifestURL, err)
 	}
-	atmosManifestJsonSchemaFilePath := path.Join(tempDir, fileName)
+	atmosManifestJsonSchemaFilePath := filepath.Join(tempDir, fileName)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	client := &getter.Client{

--- a/internal/exec/vendor_component_utils.go
+++ b/internal/exec/vendor_component_utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -27,7 +26,7 @@ func findComponentConfigFile(basePath, fileName string) (string, error) {
 	componentConfigExtensions := []string{"yaml", "yml"}
 
 	for _, ext := range componentConfigExtensions {
-		configFilePath := path.Join(basePath, fmt.Sprintf("%s.%s", fileName, ext))
+		configFilePath := filepath.Join(basePath, fmt.Sprintf("%s.%s", fileName, ext))
 		if u.FileExists(configFilePath) {
 			return configFilePath, nil
 		}
@@ -52,7 +51,7 @@ func ReadAndProcessComponentVendorConfigFile(
 		return componentConfig, "", fmt.Errorf("type '%s' is not supported. Valid types are 'terraform' and 'helmfile'", componentType)
 	}
 
-	componentPath := path.Join(cliConfig.BasePath, componentBasePath, component)
+	componentPath := filepath.Join(cliConfig.BasePath, componentBasePath, component)
 
 	dirExists, err := u.IsDirectory(componentPath)
 	if err != nil {
@@ -191,7 +190,7 @@ func ExecuteComponentVendorInternal(
 
 			tempDir2 := tempDir
 			if sourceIsLocalFile {
-				tempDir2 = path.Join(tempDir, filepath.Base(uri))
+				tempDir2 = filepath.Join(tempDir, filepath.Base(uri))
 			}
 
 			if err = cp.Copy(uri, tempDir2, copyOptions); err != nil {
@@ -207,7 +206,7 @@ func ExecuteComponentVendorInternal(
 			// - https://github.com/hashicorp/go-getter?tab=readme-ov-file#subdirectories
 			// We add the `uri` to the already created `tempDir` so it does not exist to allow `go-getter` to create
 			// and correctly initialize it
-			tempDir = path.Join(tempDir, filepath.Base(uri))
+			tempDir = filepath.Join(tempDir, filepath.Base(uri))
 
 			client := &getter.Client{
 				Ctx: context.Background(),
@@ -299,7 +298,7 @@ func ExecuteComponentVendorInternal(
 		componentPath2 := componentPath
 		if sourceIsLocalFile {
 			if filepath.Ext(componentPath) == "" {
-				componentPath2 = path.Join(componentPath, filepath.Base(uri))
+				componentPath2 = filepath.Join(componentPath, filepath.Base(uri))
 			}
 		}
 
@@ -357,7 +356,7 @@ func ExecuteComponentVendorInternal(
 				"Pulling the mixin '%s' for the component '%s' into '%s'\n",
 				uri,
 				component,
-				path.Join(componentPath, mixin.Filename),
+				filepath.Join(componentPath, mixin.Filename),
 			))
 
 			if !dryRun {
@@ -370,7 +369,7 @@ func ExecuteComponentVendorInternal(
 				if !useOciScheme {
 					client := &getter.Client{
 						Ctx:  context.Background(),
-						Dst:  path.Join(tempDir, mixin.Filename),
+						Dst:  filepath.Join(tempDir, mixin.Filename),
 						Src:  uri,
 						Mode: getter.ClientModeFile,
 					}

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -149,7 +149,7 @@ func ReadAndProcessVendorConfigFile(
 
 		if !fileExists {
 			// Look for the vendoring manifest in the directory pointed to by the `base_path` setting in `atmos.yaml`
-			pathToVendorConfig := path.Join(cliConfig.BasePath, vendorConfigFile)
+			pathToVendorConfig := filepath.Join(cliConfig.BasePath, vendorConfigFile)
 
 			if !u.FileExists(pathToVendorConfig) {
 				vendorConfigFileExists = false
@@ -392,7 +392,7 @@ func ExecuteAtmosVendorInternal(
 				return err
 			}
 
-			targetPath := path.Join(vendorConfigFilePath, target)
+			targetPath := filepath.Join(vendorConfigFilePath, target)
 
 			if s.Component != "" {
 				u.LogInfo(cliConfig, fmt.Sprintf("Pulling sources for the component '%s' from '%s' into '%s'",
@@ -441,7 +441,7 @@ func ExecuteAtmosVendorInternal(
 				}
 
 				if sourceIsLocalFile {
-					tempDir = path.Join(tempDir, filepath.Base(uri))
+					tempDir = filepath.Join(tempDir, filepath.Base(uri))
 				}
 
 				if err = cp.Copy(uri, tempDir, copyOptions); err != nil {
@@ -457,7 +457,7 @@ func ExecuteAtmosVendorInternal(
 				// - https://github.com/hashicorp/go-getter?tab=readme-ov-file#subdirectories
 				// We add the `uri` to the already created `tempDir` so it does not exist to allow `go-getter` to create
 				// and correctly initialize it
-				tempDir = path.Join(tempDir, filepath.Base(uri))
+				tempDir = filepath.Join(tempDir, filepath.Base(uri))
 
 				client := &getter.Client{
 					Ctx: context.Background(),
@@ -548,7 +548,7 @@ func ExecuteAtmosVendorInternal(
 
 			if sourceIsLocalFile {
 				if filepath.Ext(targetPath) == "" {
-					targetPath = path.Join(targetPath, filepath.Base(uri))
+					targetPath = filepath.Join(targetPath, filepath.Base(uri))
 				}
 			}
 

--- a/internal/exec/workflow.go
+++ b/internal/exec/workflow.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -80,7 +79,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile
 	} else {
-		workflowPath = path.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath, workflowFile)
+		workflowPath = filepath.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath, workflowFile)
 	}
 
 	// If the workflow file is specified without an extension, use the default extension

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -147,7 +146,7 @@ func ExecuteDescribeWorkflows(
 	if u.IsPathAbsolute(cliConfig.Workflows.BasePath) {
 		workflowsDir = cliConfig.Workflows.BasePath
 	} else {
-		workflowsDir = path.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath)
+		workflowsDir = filepath.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath)
 	}
 
 	isDirectory, err := u.IsDirectory(workflowsDir)
@@ -164,9 +163,9 @@ func ExecuteDescribeWorkflows(
 	for _, f := range files {
 		var workflowPath string
 		if u.IsPathAbsolute(cliConfig.Workflows.BasePath) {
-			workflowPath = path.Join(cliConfig.Workflows.BasePath, f)
+			workflowPath = filepath.Join(cliConfig.Workflows.BasePath, f)
 		} else {
-			workflowPath = path.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath, f)
+			workflowPath = filepath.Join(cliConfig.BasePath, cliConfig.Workflows.BasePath, f)
 		}
 
 		fileContent, err := os.ReadFile(workflowPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 
@@ -126,7 +125,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	if len(configFilePath1) > 0 {
-		configFile1 := path.Join(configFilePath1, CliConfigFileName)
+		configFile1 := filepath.Join(configFilePath1, CliConfigFileName)
 		found, err = processConfigFile(cliConfig, configFile1, v)
 		if err != nil {
 			return cliConfig, err
@@ -141,7 +140,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return cliConfig, err
 	}
-	configFile2 := path.Join(configFilePath2, ".atmos", CliConfigFileName)
+	configFile2 := filepath.Join(configFilePath2, ".atmos", CliConfigFileName)
 	found, err = processConfigFile(cliConfig, configFile2, v)
 	if err != nil {
 		return cliConfig, err
@@ -155,7 +154,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return cliConfig, err
 	}
-	configFile3 := path.Join(configFilePath3, CliConfigFileName)
+	configFile3 := filepath.Join(configFilePath3, CliConfigFileName)
 	found, err = processConfigFile(cliConfig, configFile3, v)
 	if err != nil {
 		return cliConfig, err
@@ -168,7 +167,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	configFilePath4 := os.Getenv("ATMOS_CLI_CONFIG_PATH")
 	if len(configFilePath4) > 0 {
 		u.LogTrace(cliConfig, fmt.Sprintf("Found ENV var ATMOS_CLI_CONFIG_PATH=%s", configFilePath4))
-		configFile4 := path.Join(configFilePath4, CliConfigFileName)
+		configFile4 := filepath.Join(configFilePath4, CliConfigFileName)
 		found, err = processConfigFile(cliConfig, configFile4, v)
 		if err != nil {
 			return cliConfig, err
@@ -182,7 +181,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if configAndStacksInfo.AtmosCliConfigPath != "" {
 		configFilePath5 := configAndStacksInfo.AtmosCliConfigPath
 		if len(configFilePath5) > 0 {
-			configFile5 := path.Join(configFilePath5, CliConfigFileName)
+			configFile5 := filepath.Join(configFilePath5, CliConfigFileName)
 			found, err = processConfigFile(cliConfig, configFile5, v)
 			if err != nil {
 				return cliConfig, err
@@ -258,7 +257,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	// Convert stacks base path to absolute path
-	stacksBasePath := path.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath)
+	stacksBasePath := filepath.Join(cliConfig.BasePath, cliConfig.Stacks.BasePath)
 	stacksBaseAbsPath, err := filepath.Abs(stacksBasePath)
 	if err != nil {
 		return cliConfig, err
@@ -280,7 +279,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	cliConfig.ExcludeStackAbsolutePaths = excludeStackAbsPaths
 
 	// Convert terraform dir to absolute path
-	terraformBasePath := path.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath)
+	terraformBasePath := filepath.Join(cliConfig.BasePath, cliConfig.Components.Terraform.BasePath)
 	terraformDirAbsPath, err := filepath.Abs(terraformBasePath)
 	if err != nil {
 		return cliConfig, err
@@ -288,7 +287,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	cliConfig.TerraformDirAbsolutePath = terraformDirAbsPath
 
 	// Convert helmfile dir to absolute path
-	helmfileBasePath := path.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath)
+	helmfileBasePath := filepath.Join(cliConfig.BasePath, cliConfig.Components.Helmfile.BasePath)
 	helmfileDirAbsPath, err := filepath.Abs(helmfileBasePath)
 	if err != nil {
 		return cliConfig, err

--- a/pkg/generate/terraform_generate_varfiles_test.go
+++ b/pkg/generate/terraform_generate_varfiles_test.go
@@ -2,7 +2,7 @@ package generate
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -28,7 +28,7 @@ func TestTerraformGenerateVarfiles(t *testing.T) {
 
 	var stacks []string
 	var components []string
-	filePattern := path.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
+	filePattern := filepath.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
 	format := "hcl"
 
 	err = e.ExecuteTerraformGenerateVarfiles(cliConfig, filePattern, format, stacks, components)

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -69,7 +69,7 @@ func JoinAbsolutePathWithPaths(basePath string, paths []string) ([]string, error
 	res := []string{}
 
 	for _, p := range paths {
-		res = append(res, path.Join(basePath, p))
+		res = append(res, filepath.Join(basePath, p))
 	}
 
 	return res, nil
@@ -93,7 +93,7 @@ func JoinAbsolutePathWithPath(basePath string, providedPath string) (string, err
 	}
 
 	// Join the base path with the provided path
-	joinedPath := path.Join(basePath, providedPath)
+	joinedPath := filepath.Join(basePath, providedPath)
 
 	// If the joined path is an absolute path and exists in the file system, return it
 	if filepath.IsAbs(joinedPath) {

--- a/pkg/utils/glob_utils.go
+++ b/pkg/utils/glob_utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -36,7 +36,7 @@ func GetGlobMatches(pattern string) ([]string, error) {
 
 	var fullMatches []string
 	for _, match := range matches {
-		fullMatches = append(fullMatches, path.Join(base, match))
+		fullMatches = append(fullMatches, filepath.Join(base, match))
 	}
 
 	getGlobMatchesSyncMap.Store(pattern, strings.Join(fullMatches, ","))

--- a/pkg/vender/component_vendor_test.go
+++ b/pkg/vender/component_vendor_test.go
@@ -2,7 +2,7 @@ package vender
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,12 +29,12 @@ func TestVendorComponentPullCommand(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check if the correct files were pulled and written to the correct folder
-	assert.FileExists(t, path.Join(componentPath, "context.tf"))
-	assert.FileExists(t, path.Join(componentPath, "main.tf"))
-	assert.FileExists(t, path.Join(componentPath, "outputs.tf"))
-	assert.FileExists(t, path.Join(componentPath, "providers.tf"))
-	assert.FileExists(t, path.Join(componentPath, "variables.tf"))
-	assert.FileExists(t, path.Join(componentPath, "versions.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "context.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "main.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "outputs.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "providers.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "variables.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "versions.tf"))
 
 	// Test 'infra/account-map' component
 	component = "infra/account-map"
@@ -45,43 +45,43 @@ func TestVendorComponentPullCommand(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check if the correct files were pulled and written to the correct folder
-	assert.FileExists(t, path.Join(componentPath, "context.tf"))
-	assert.FileExists(t, path.Join(componentPath, "dynamic-roles.tf"))
-	assert.FileExists(t, path.Join(componentPath, "main.tf"))
-	assert.FileExists(t, path.Join(componentPath, "outputs.tf"))
-	assert.FileExists(t, path.Join(componentPath, "providers.tf"))
-	assert.FileExists(t, path.Join(componentPath, "README.md"))
-	assert.FileExists(t, path.Join(componentPath, "remote-state.tf"))
-	assert.FileExists(t, path.Join(componentPath, "variables.tf"))
-	assert.FileExists(t, path.Join(componentPath, "versions.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "context.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "main.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "variables.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
-	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "context.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "dynamic-roles.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "main.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "outputs.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "providers.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "README.md"))
+	assert.FileExists(t, filepath.Join(componentPath, "remote-state.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "variables.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "versions.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "context.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "main.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "variables.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
+	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
 
 	// Delete the files and folders
-	err = os.Remove(path.Join(componentPath, "context.tf"))
+	err = os.Remove(filepath.Join(componentPath, "context.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "dynamic-roles.tf"))
+	err = os.Remove(filepath.Join(componentPath, "dynamic-roles.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "main.tf"))
+	err = os.Remove(filepath.Join(componentPath, "main.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "outputs.tf"))
+	err = os.Remove(filepath.Join(componentPath, "outputs.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "providers.tf"))
+	err = os.Remove(filepath.Join(componentPath, "providers.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "README.md"))
+	err = os.Remove(filepath.Join(componentPath, "README.md"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "remote-state.tf"))
+	err = os.Remove(filepath.Join(componentPath, "remote-state.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "variables.tf"))
+	err = os.Remove(filepath.Join(componentPath, "variables.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(path.Join(componentPath, "versions.tf"))
+	err = os.Remove(filepath.Join(componentPath, "versions.tf"))
 	assert.Nil(t, err)
-	err = os.RemoveAll(path.Join(componentPath, "modules"))
+	err = os.RemoveAll(filepath.Join(componentPath, "modules"))
 	assert.Nil(t, err)
 }

--- a/pkg/vender/vendor_config_test.go
+++ b/pkg/vender/vendor_config_test.go
@@ -4,7 +4,7 @@ package vender
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestVendorConfigScenarios(t *testing.T) {
 	cliConfig.Logs.Level = "Trace"
 
 	// Setup test component directory
-	componentPath := path.Join(testDir, "components", "terraform", "myapp")
+	componentPath := filepath.Join(testDir, "components", "terraform", "myapp")
 	err := os.MkdirAll(componentPath, 0755)
 	assert.Nil(t, err)
 
@@ -47,7 +47,7 @@ spec:
       included_paths:
         - "**/*.tf"
 `
-		vendorYamlPath := path.Join(testDir, "vendor.yaml")
+		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
 		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
 		assert.Nil(t, err)
 
@@ -84,7 +84,7 @@ spec:
     uri: github.com/cloudposse/terraform-null-label.git//exports?ref={{.Version}}
     version: 0.25.0
 `
-		componentYamlPath := path.Join(componentPath, "component.yaml")
+		componentYamlPath := filepath.Join(componentPath, "component.yaml")
 		err := os.WriteFile(componentYamlPath, []byte(componentYaml), 0644)
 		assert.Nil(t, err)
 
@@ -102,7 +102,7 @@ spec:
 	// Test Case 3: Neither vendor.yaml nor component.yaml exists
 	t.Run("no vendor.yaml or component.yaml", func(t *testing.T) {
 		// Test vendoring with component flag
-		vendorYamlPath := path.Join(testDir, "vendor.yaml")
+		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
 		_, exists, _, err := e.ReadAndProcessVendorConfigFile(cliConfig, vendorYamlPath)
 		assert.Nil(t, err)
 		assert.False(t, exists)
@@ -126,7 +126,7 @@ spec:
       source: github.com/cloudposse/terraform-null-label.git//exports?ref={{.Version}}
       version: 0.25.0
 `
-		vendorYamlPath := path.Join(testDir, "vendor.yaml")
+		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
 		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
 		assert.Nil(t, err)
 


### PR DESCRIPTION

## What

- Replaced all instances of `path.Join` with `filepath.Join` in the codebase.
- Updated imports to use the `path/filepath` package instead of `path`.

## Why

- **Cross-platform compatibility**: `path.Join` does not respect platform-specific path separators, causing potential issues on non-Unix systems (e.g., Windows).
- **Correct usage**: `filepath.Join` is designed for working with filesystem paths, ensuring semantic correctness.
- Ensures the codebase adheres to Go best practices for handling file paths.

## References

- [Go Documentation on `filepath.Join`](https://pkg.go.dev/path/filepath#Join)
- Internal discussion about cross-platform issues caused by `path.Join`.
- Example StackOverflow explanation: [path.Join vs filepath.Join](https://stackoverflow.com/questions/29559878/path-join-vs-filepath-join-in-go).
- issue: https://linear.app/cloudposse/issue/DEV-2817/replace-pathjoin-with-filepathjoin-in-atmos-code
