### PR TITLE
Fix panic on atmos terraform providers lock

### DIFF
--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -319,6 +319,7 @@ func ProcessStacks(
 			configAndStacksInfo.ComponentType,
 			configAndStacksInfo.ComponentFromArg,
 		)
+
 		if err != nil {
 			return configAndStacksInfo, err
 		}
@@ -432,6 +433,10 @@ func ProcessStacks(
 		} else {
 			configAndStacksInfo = foundConfigAndStacksInfo
 		}
+	}
+
+	if configAndStacksInfo.ComponentSection == nil {
+		configAndStacksInfo.ComponentSection = make(map[string]any)
 	}
 
 	// Add imports


### PR DESCRIPTION
## what

The following command `atmos terraform providers lock foo --stack bar` resulted in a panic message like this. 

![before](https://github.com/user-attachments/assets/64257485-020b-4e83-8985-59904bef2504)

and after

![after](https://github.com/user-attachments/assets/10949cca-c5b5-4ac7-8d60-fa1eaa68631e)

## why

The panic shouldn't be shown instead the case with the map/nil values should be handled properly. 

## references

Link to the ticket - [https://linear.app/cloudposse/issue/DEV-2767/panic-on-atmos-terraform-providers-lock](url)
