### PR TITLE
Support `GITHUB_TOKEN` for HTTP Requests to github.com

### DIFF
--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -1934,15 +1934,16 @@ func GetFileContent(filePath string) (string, error) {
 	parsedURL, err := url.Parse(filePath) // Parse the URL
 	if err != nil {
 		u.LogInfo(schema.AtmosConfiguration{}, fmt.Sprintf("Filepath is local: %s", filePath))
-	}
-	if parsedURL.Host == "github.com" && parsedURL.Scheme == "https" {
-		u.LogDebug(schema.AtmosConfiguration{}, fmt.Sprintf("Fetching GitHub source: %s", filePath))
-		fileContents, err := u.DownloadFileFromGitHub(filePath)
-		if err != nil {
-			return "", fmt.Errorf("failed to download GitHub file: %w", err)
+	} else {
+		if parsedURL.Host == "github.com" && parsedURL.Scheme == "https" {
+			u.LogDebug(schema.AtmosConfiguration{}, fmt.Sprintf("Fetching GitHub source: %s", filePath))
+			fileContents, err := u.DownloadFileFromGitHub(filePath)
+			if err != nil {
+				return "", fmt.Errorf("failed to download GitHub file: %w", err)
+			}
+			getFileContentSyncMap.Store(filePath, fileContents)
+			return string(fileContents), nil
 		}
-		getFileContentSyncMap.Store(filePath, fileContents)
-		return string(fileContents), nil
 	}
 
 	content, err := os.ReadFile(filePath)

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -1933,8 +1933,7 @@ func GetFileContent(filePath string) (string, error) {
 	//Check if its Github remote URL to single file
 	parsedURL, err := url.Parse(filePath) // Parse the URL
 	if err != nil {
-		u.LogWarning(schema.AtmosConfiguration{}, fmt.Sprintf("Failed to parse the URL: %s", filePath))
-		return "", nil
+		u.LogInfo(schema.AtmosConfiguration{}, fmt.Sprintf("Filepath is local: %s", filePath))
 	}
 	if parsedURL.Host == "github.com" && parsedURL.Scheme == "https" {
 		u.LogDebug(schema.AtmosConfiguration{}, fmt.Sprintf("Fetching GitHub source: %s", filePath))

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -1931,7 +1930,8 @@ func GetFileContent(filePath string) (string, error) {
 	}
 
 	//Check if its Github remote URL to single file
-	parsedURL, err := url.Parse(filePath) // Parse the URL
+	// Shoudl be decommised as the direct hook into map does not work
+	/*parsedURL, err := url.Parse(filePath) // Parse the URL
 	if err != nil {
 		u.LogInfo(schema.AtmosConfiguration{}, fmt.Sprintf("Filepath is local: %s", filePath))
 	} else {
@@ -1945,7 +1945,7 @@ func GetFileContent(filePath string) (string, error) {
 			return string(fileContents), nil
 		}
 	}
-
+	*/
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -21,6 +21,7 @@ var (
 	commonFlags = []string{
 		"--stack",
 		"-s",
+		"--folder",
 		cfg.DryRunFlag,
 		cfg.SkipInitFlag,
 		cfg.KubeConfigConfigFlag,

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -375,19 +375,23 @@ func ExecuteAtmosVendorInternal(
 
 		// Handle GitHub source
 		if isGitHubSource {
-			u.LogDebug(atmosConfig, fmt.Sprintf("Fetching GitHub source: %s", uri))
-			fileContents, err := u.DownloadFileFromGitHub(uri)
-			if err != nil {
-				return fmt.Errorf("failed to download GitHub file: %w", err)
+			if dryRun {
+				u.LogInfo(atmosConfig, fmt.Sprintf("Dry run: Fetching GitHub source: %s", uri))
+			} else {
+				u.LogDebug(atmosConfig, fmt.Sprintf("Fetching GitHub source: %s", uri))
+				fileContents, err := u.DownloadFileFromGitHub(uri)
+				if err != nil {
+					return fmt.Errorf("failed to download GitHub file: %w", err)
+				}
+				// Save the downloaded file to the existing tempDir
+				tempGitHubFile := filepath.Join(tempDir, filepath.Base(uri))
+				err = os.WriteFile(tempGitHubFile, fileContents, os.ModePerm)
+				if err != nil {
+					return fmt.Errorf("failed to save GitHub file to temp location: %w", err)
+				}
+				// Update the URI to point to the saved file in the temp directory
+				uri = tempGitHubFile
 			}
-			// Save the downloaded file to the existing tempDir
-			tempGitHubFile := filepath.Join(tempDir, filepath.Base(uri))
-			err = os.WriteFile(tempGitHubFile, fileContents, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to save GitHub file to temp location: %w", err)
-			}
-			// Update the URI to point to the saved file in the temp directory
-			uri = tempGitHubFile
 		}
 
 		// Determine package type

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -242,3 +242,27 @@ func GetFileNameFromURL(rawURL string) (string, error) {
 	}
 	return fileName, nil
 }
+
+// ParseGitHubURL parses a GitHub URL and returns the owner, repo, file path and branch
+func ParseGitHubURL(rawURL string) (owner, repo, filePath, branch string, err error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if !strings.Contains(parsedURL.Host, "github.com") {
+		return "", "", "", "", fmt.Errorf("URL is not a GitHub URL")
+	}
+
+	pathParts := strings.Split(strings.Trim(parsedURL.Path, "/"), "/")
+	if len(pathParts) < 4 || pathParts[2] != "blob" {
+		return "", "", "", "", fmt.Errorf("URL format not supported. Expected: /owner/repo/blob/branch/filepath")
+	}
+
+	owner = pathParts[0]
+	repo = pathParts[1]
+	branch = pathParts[3]
+	filePath = strings.Join(pathParts[4:], "/")
+
+	return owner, repo, filePath, branch, nil
+}

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -263,3 +263,12 @@ func ParseGitHubURL(rawURL string) (owner, repo, filePath, branch string, err er
 
 	return owner, repo, filePath, branch, nil
 }
+
+// ParseFilenameFromURL extracts the file name from a URL
+func ParseFilenameFromURL(url string) string {
+	parts := strings.Split(url, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1] // e.g. "dev.yaml"
+}

--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -82,4 +83,13 @@ func DownloadFileFromGitHub(rawURL string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+// IsGithubURL checks if a URL is a valid GitHub URL.
+func IsGithubURL(rawURL string) bool {
+	parsedURL, err := url.Parse(rawURL)
+	if err == nil && parsedURL.Host == "github.com" && parsedURL.Scheme == "https" {
+		return true
+	}
+	return false
 }

--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -2,6 +2,10 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/google/go-github/v59/github"
@@ -27,4 +31,39 @@ func GetLatestGitHubRepoRelease(owner string, repo string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// ParseGitHubURL parses a GitHub URL and returns the owner, repo, file path and branch
+func DownloadFileFromGitHub(rawURL string) ([]byte, error) {
+	owner, repo, filePath, branch, err := ParseGitHubURL(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub URL: %w", err)
+	}
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s", owner, repo, filePath, branch)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+githubToken)
+	req.Header.Set("Accept", "application/vnd.github.v3.raw")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download file: %s", resp.Status)
+	}
+
+	return io.ReadAll(resp.Body)
 }

--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -77,7 +77,8 @@ func DownloadFileFromGitHub(rawURL string) ([]byte, error) {
 	}
 	data, err := base64.StdEncoding.DecodeString(content)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode file content: %w", err)
+		// fallback to raw content
+		data = []byte(content)
 	}
 
 	return data, nil

--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -2,68 +2,83 @@ package utils
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/google/go-github/v59/github"
+	"golang.org/x/oauth2"
 )
 
-// GetLatestGitHubRepoRelease returns the latest release tag for a GitHub repository
-func GetLatestGitHubRepoRelease(owner string, repo string) (string, error) {
-	opt := &github.ListOptions{Page: 1, PerPage: 1}
-	client := github.NewClient(nil)
+// newGitHubClient creates a new GitHub client. If a token is provided, it returns an authenticated client;
+// otherwise, it returns an unauthenticated client.
+func newGitHubClient(ctx context.Context) *github.Client {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return github.NewClient(nil)
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	// Token found, create an authenticated client
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	return github.NewClient(tc)
+}
+
+// GetLatestGitHubRepoRelease returns the latest release tag for a GitHub repository.
+func GetLatestGitHubRepoRelease(owner string, repo string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+
+	client := newGitHubClient(ctx)
+	opt := &github.ListOptions{Page: 1, PerPage: 1}
 
 	releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, opt)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to list releases: %w", err)
 	}
 
-	if len(releases) > 0 {
-		latestRelease := releases[0]
-		latestReleaseTag := *latestRelease.TagName
-		return latestReleaseTag, nil
+	if len(releases) > 0 && releases[0].TagName != nil {
+		return *releases[0].TagName, nil
 	}
 
 	return "", nil
 }
 
-// ParseGitHubURL parses a GitHub URL and returns the owner, repo, file path and branch
+// DownloadFileFromGitHub downloads a file from a GitHub repository using the GitHub API.
 func DownloadFileFromGitHub(rawURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	owner, repo, filePath, branch, err := ParseGitHubURL(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse GitHub URL: %w", err)
 	}
 
-	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
-	}
+	client := newGitHubClient(ctx)
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s", owner, repo, filePath, branch)
-	req, err := http.NewRequest("GET", apiURL, nil)
+	// Get the file content
+	opt := &github.RepositoryContentGetOptions{Ref: branch}
+	fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, filePath, opt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to get file content from GitHub: %w", err)
+	}
+	if fileContent == nil {
+		return nil, fmt.Errorf("no content returned for the requested file")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+githubToken)
-	req.Header.Set("Accept", "application/vnd.github.v3.raw")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	// Decode the base64 encoded content
+	content, err := fileContent.GetContent()
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform request: %w", err)
+		return nil, fmt.Errorf("failed to get file content: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download file: %s", resp.Status)
+	data, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode file content: %w", err)
 	}
 
-	return io.ReadAll(resp.Body)
+	return data, nil
 }


### PR DESCRIPTION
## what

This PR contains the code that checks if GITHUB_TOKEN env variable is set, and if it does, the requests to github.com are done with the provided token. 

The following functionality was added :

- vendoring - done 
- check for the latest atmos version  - done
- read atmos.yaml from remote sources - done, mdx docs are not updated yet (subject to the scope sign off)
- import stack configs from remote sources - done

## why

Bypass github ratelimts and allow access to the files in the private repos. 

## Testing

### atmos.yaml local vs. remote

This testcase is based on the green update box that's shown depedning on the settings from the atmos.yaml file. 
The local atmos yaml version has this defaulted to 1 h (see section A below), i.e. if one runs the version command in less than a hour the update box isn't shown (sections B and C at the screenshot below). 
![atmos_yaml_test_no_box_as_per_local_file_setting](https://github.com/user-attachments/assets/b26466b3-4e9a-4b61-bfa3-a3a23d4b5ff1)

Then a slightly adjusted version of atmos.yaml (see section D below, the timeout is set to a smaller value vs 1000 ms in the original local file above, i.e. if applied correctly the greenbox should be shown every time a version command is run)
![new_atmos_yaml_in_remove_private_repo](https://github.com/user-attachments/assets/b3c5d52e-3e82-469e-852c-b2f79b1aef31)

Since GITHUB_TOKEN isn't yet set, the private repo isn't available.

![bad_credentials](https://github.com/user-attachments/assets/d86e55ec-3eb0-4f6a-8d96-c7329481f672)


Then ATMOS_REMOTE_CONFIG_URL and GITHUB_TOKEN env variables are set (see section E below),
and in section F the version command is run twice and the greenbox is shown everytime (i.e. the updated timeout setting from the remote repo is respected)

![atmos_read_config_from_remote_after_token_seetting](https://github.com/user-attachments/assets/2588aaba-9a1e-461e-adfb-1830f75e4d08)

NB. This test case also covers the version command that honors GITHUB_TOKEN value too. 

### remote vendoring

Make sure that GITHUB_TOKEN variable is empty brefore running this test. 
In the vendoring example, a new component is added. The component is located in the private repo, it is a standard vendor.yaml from demo-vendoring example with the following extra section (shown in section A at the screenshot below)

`
- component: "CoonectorDescribed"
      source: "https://github.com/analitikasi/CoonectorDescribed/blob/main/README.md"
      version: "main"
      targets:
        - "components/docs/{{ .Component }}/{{ .Version}}"
      tags:
      - demo
      - github
`

![private_repo_isn't_accebile_without_a_token](https://github.com/user-attachments/assets/5f4659bf-42ab-4e3c-8def-796c7a162d7f)

Then vednor pull command is run that fails as the repo is private (see section B at the screenshot above).
Also there were no files added to components folder (refer to section C at the screenshot above)

Then the token variable is assigned as per section D at the screenshot below

![successfully_retrieved_a_file_from_github_repo](https://github.com/user-attachments/assets/776247d5-2f48-4f64-ac8c-b0acd9b65e09)

The command succesfully completes (see section E) and the file from the private repo is downloaded into the specified locaion (F)

### local stacks vs remote stacks

The test is based on quick start simple example, i.e. first it is run with local stacks on (shows weather for stockholm), then is it run with a remote stack (boston). There's a new flag added for remote stack uploading to specify the folder where it should land once downloaded. E.g. 

`./../../atmos terraform apply station -s https://github.com/analitikasi/CoonectorDescribed/blob/main/quick-start-simple/stacks/deploy/dev.yaml --folder ./stacks/deploy`

Here is the local stack file from the sample
![local_stack_view](https://github.com/user-attachments/assets/a3bacb22-dbd1-472f-aa49-38f1d87b26c2)

Here is the output when run with local stack

![local_stack_sample](https://github.com/user-attachments/assets/c058751f-fd11-4dd6-98c7-1416fb1617b0)

After that, a remote stack is checked, it is located in a private repo and looks like this (note it says Boston unlike the value from the local stack so it is possible to differenciate local vs remote stacks)

![remote_stack_boston](https://github.com/user-attachments/assets/b0c1ef9a-b2ae-4c00-9ea0-1b9e07e3bfd7)

and since GITHUB_TOKEN variable isn't set it results in 404 error:

![token_not_set_404_error](https://github.com/user-attachments/assets/0ad75b0e-4cc3-4b49-9e31-2bc14de015a8)

If the token is set, the output looks like this 

![remote_stack_successfully_loaded](https://github.com/user-attachments/assets/486c80be-0c29-478f-87ce-ada722f2ccb4)

Please note that the new flag was introduced to specify the location where the remote stacks have to be downloaded to. 

## references

Link to ticket - [https://linear.app/cloudposse/issue/DEV-2778/atmos-should-support-github-token-for-http-requests-to-githubcom](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to download files directly from GitHub repositories.
	- Added a new method to parse GitHub URLs for better handling of repository details.
	- Added a `--folder` flag to specify the download location for stack files.
	- Enhanced configuration management to support loading remote configurations from GitHub URLs.
- **Bug Fixes**
	- Improved error handling for GitHub source detection and file downloads.
	- Enhanced feedback for missing required fields in vendor configurations.
- **Tests**
	- Added a new test case to validate vendor execution with a GitHub token, enhancing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->