### PR TITLE
Fix Mocks for Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,42 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
+      - name: Add GNU tar to PATH (significantly faster than windows tar)
+        if: matrix.flavor.target == 'windows'
+        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
+
+      - name: Download build artifacts for ${{ matrix.flavor.target }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ matrix.flavor.target }}
+          path: ${{ github.workspace }}
+
+      - name: Add build artifacts directory to PATH for linux or macos
+        if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
+        run: |
+          echo "${{ github.workspace }}" >> $GITHUB_PATH
+          chmod +x "${{ github.workspace }}/atmos"
+
+      - name: Add build artifacts directory to PATH for windows
+        if: matrix.flavor.target == 'windows'
+        run: |
+          echo "${{ github.workspace }}" >> $Env:GITHUB_PATH
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Check atmos.exe integrity
+        if: matrix.flavor.target == 'windows'
+        shell: pwsh
+        run: |
+          Write-Output "PATH=$Env:PATH"
+          Write-Output "PATHEXT=$Env:PATHEXT"
+          Get-ChildItem "${{ github.workspace }}"
+          Get-Command "${{ github.workspace }}\atmos.exe"
+          atmos version
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -296,13 +332,13 @@ jobs:
           name: build-artifacts-${{ matrix.flavor.target }}
           path: ${{ github.workspace }}
 
-      - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
+      - name: Add build artifacts directory to PATH for linux or macos
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: |
           echo "${{ github.workspace }}" >> $GITHUB_PATH
           chmod +x "${{ github.workspace }}/atmos"
 
-      - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
+      - name: Add build artifacts directory to PATH for windows
         if: matrix.flavor.target == 'windows'
         run: |
           echo "${{ github.workspace }}" >> $Env:GITHUB_PATH
@@ -312,7 +348,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
+      - name: Run tests in ${{ matrix.demo-folder }} for ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: |
@@ -328,7 +364,7 @@ jobs:
           Get-Command "${{ github.workspace }}\atmos.exe"
           atmos version
 
-      - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
+      - name: Run tests in ${{ matrix.demo-folder }} for ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}
         if: matrix.flavor.target == 'windows'
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,12 @@ jobs:
 
       - name: Add build artifacts directory to PATH for windows
         if: matrix.flavor.target == 'windows'
+        shell: pwsh
         run: |
+          $atmosPath = Join-Path ${{ github.workspace }} "atmos.exe"
+          if (-not (Test-Path $atmosPath)) {
+            throw "atmos.exe not found at: $atmosPath"
+          }
           echo "${{ github.workspace }}" >> $Env:GITHUB_PATH
 
       - uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> "${{env.GITHUB_PATH}}"
+        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -288,7 +288,7 @@ jobs:
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> "${{env.GITHUB_PATH}}"
+        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
 
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
@@ -297,13 +297,15 @@ jobs:
           path: ${{ github.workspace }}
 
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
-        run: |
-          ls "${{ github.workspace }}"
-          echo "${{ github.workspace }}" >> "${{env.GITHUB_PATH}}"
-
-      - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
-        run: chmod +x "${{ github.workspace }}/atmos"
+        run: |
+          echo "${{ github.workspace }}" >> $GITHUB_PATH
+          chmod +x "${{ github.workspace }}/atmos
+
+      - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
+        if: matrix.flavor.target == 'windows'
+        run: |
+          echo "${{ github.workspace }}" >> $Env:GITHUB_PATH
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -329,8 +331,9 @@ jobs:
       - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}
         if: matrix.flavor.target == 'windows'
+        shell: pwsh
         run: |
-          "${{ github.workspace }}\atmos.exe" test
+          ${{ github.workspace }}\atmos.exe test
 
   # run other demo tests
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,15 +279,19 @@ jobs:
 
     timeout-minutes: 20
     steps:
+      - name: Determine build artifacts path
+        id: determine-path
+        run: echo "artifact_path=${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}" >> $GITHUB_ENV
+
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts-${{ matrix.flavor.target }}
-          path: ${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}
+          path: ${{ env.artifact_path }}
 
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
         run: |
-          echo "${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}" >> $GITHUB_PATH
+          echo "${{ env.artifact_path }}" >> $GITHUB_PATH
 
       - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> "$GITHUB_PATH"
+        run: echo "C:\Program Files\Git\usr\bin" >> "${{env.GITHUB_PATH}}"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -288,7 +288,7 @@ jobs:
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
+        run: echo "C:\Program Files\Git\usr\bin" >> "${{env.GITHUB_PATH}}"
 
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
@@ -299,7 +299,7 @@ jobs:
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
         run: |
           ls "${{ github.workspace }}"
-          echo "${{ github.workspace }}" >> "$GITHUB_PATH"
+          echo "${{ github.workspace }}" >> "${{env.GITHUB_PATH}}"
 
       - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
@@ -318,10 +318,13 @@ jobs:
 
       - name: Check atmos.exe integrity
         if: matrix.flavor.target == 'windows'
+        shell: pwsh
         run: |
-          echo $PATH
-          dir "${{ github.workspace }}"
+          Write-Output "PATH=$Env:PATH"
+          Write-Output "PATHEXT=$Env:PATHEXT"
+          Get-ChildItem "${{ github.workspace }}"
           Get-Command "${{ github.workspace }}\atmos.exe"
+          .\atmos.exe version
 
       - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,14 +326,14 @@ jobs:
           Write-Output "PATHEXT=$Env:PATHEXT"
           Get-ChildItem "${{ github.workspace }}"
           Get-Command "${{ github.workspace }}\atmos.exe"
-          .\atmos.exe version
+          atmos version
 
       - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}
         if: matrix.flavor.target == 'windows'
         shell: pwsh
         run: |
-          ${{ github.workspace }}\atmos.exe test
+          atmos test
 
   # run other demo tests
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,6 +286,7 @@ jobs:
           path: /usr/local/bin
 
       - name: Set execute permissions on atmos
+        if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: chmod +x /usr/local/bin/atmos
 
       - name: Check out code into the Go module directory
@@ -296,10 +297,17 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run tests for ${{ matrix.demo-folder }}
+      - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
+        working-directory: examples/${{ matrix.demo-folder }}
+        if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: |
-          cd examples/${{ matrix.demo-folder }}
           atmos test
+
+      - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
+        working-directory: examples/${{ matrix.demo-folder }}
+        if: matrix.flavor.target == 'windows'
+        run: |
+          atmos.exe test
 
   # run other demo tests
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,7 +386,7 @@ jobs:
             --minimum-failure-severity=warning
             --recursive
             --config=${{ github.workspace }}/examples/.tflint.hcl
-          fail_on_error: true
+          fail_level: error
 
   # run other demo tests
   validate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,6 +282,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
+      - name: Add GNU tar to PATH (significantly faster than windows tar)
+        if: matrix.flavor.target == 'windows'
+        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
+
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,7 @@ jobs:
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: |
           echo "${{ github.workspace }}" >> $GITHUB_PATH
-          chmod +x "${{ github.workspace }}/atmos
+          chmod +x "${{ github.workspace }}/atmos"
 
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
           - { os: windows-latest, target: windows }
           - { os: macos-latest, target: macos }
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.flavor.os }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,13 +279,17 @@ jobs:
 
     timeout-minutes: 20
     steps:
-      - name: Download build artifacts
+      - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts-${{ matrix.flavor.target }}
-          path: /usr/local/bin
+          path: ${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}
 
-      - name: Set execute permissions on atmos
+      - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
+        run: |
+          echo "${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}" >> $GITHUB_PATH
+
+      - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
         run: chmod +x /usr/local/bin/atmos
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,11 +316,18 @@ jobs:
         run: |
           atmos test
 
+      - name: Check atmos.exe integrity
+        if: matrix.flavor.target == 'windows'
+        run: |
+          echo $PATH
+          dir "${{ github.workspace }}"
+          Get-Command "${{ github.workspace }}\atmos.exe"
+
       - name: Run tests for ${{ matrix.demo-folder }} with ${{ matrix.flavor.target }}
         working-directory: examples/${{ matrix.demo-folder }}
         if: matrix.flavor.target == 'windows'
         run: |
-          atmos.exe test
+          "${{ github.workspace }}\atmos.exe" test
 
   # run other demo tests
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
         run: echo "Building on ${{ matrix.os }}"
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
-        if: matrix.flavor.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
+        if: matrix.target == 'windows'
+        run: echo "C:\Program Files\Git\usr\bin" >> "$GITHUB_PATH"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,13 +79,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            target: linux
-          - os: windows-latest
-            target: windows
-          - os: macos-latest
-            target: macos
+        flavor:
+          - { os: ubuntu-latest, target: linux }
+          - { os: windows-latest, target: windows }
+          - { os: macos-latest, target: macos }
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
         run: |
           ls "${{ github.workspace }}"
-          echo "${{ github.workspace }}" >> $GITHUB_PATH
+          echo "${{ github.workspace }}" >> "$GITHUB_PATH"
 
       - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,26 +279,23 @@ jobs:
 
     timeout-minutes: 20
     steps:
-      - name: Determine build artifacts path
-        id: determine-path
-        run: echo "artifact_path=${{ matrix.flavor.target == 'windows' && 'D:\\a\\_temp' || '/usr/local/bin' }}" >> $GITHUB_ENV
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts-${{ matrix.flavor.target }}
-          path: ${{ env.artifact_path }}
+          path: ${{ github.workspace }}
 
       - name: Add build artifacts directory to PATH for ${{ matrix.flavor.target }}
         run: |
-          echo "${{ env.artifact_path }}" >> $GITHUB_PATH
+          ls "${{ github.workspace }}"
+          echo "${{ github.workspace }}" >> $GITHUB_PATH
 
       - name: Set execute permissions on atmos for ${{ matrix.flavor.target }}
         if: matrix.flavor.target == 'linux' || matrix.flavor.target == 'macos'
-        run: chmod +x /usr/local/bin/atmos
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        run: chmod +x "${{ github.workspace }}/atmos"
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Build
         run: echo "Building on ${{ matrix.os }}"
 
+      - name: Add GNU tar to PATH (significantly faster than windows tar)
+        if: matrix.flavor.target == 'windows'
+        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -1,0 +1,184 @@
+package tests
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Expectation struct {
+	Stdout       []string            `yaml:"stdout"`
+	Stderr       []string            `yaml:"stderr"`
+	ExitCode     int                 `yaml:"exit_code"`
+	FileExists   []string            `yaml:"file_exists"`
+	FileContains map[string][]string `yaml:"file_contains"`
+}
+
+type TestCase struct {
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Enabled     bool              `yaml:"enabled"`
+	Workdir     string            `yaml:"workdir"`
+	Command     string            `yaml:"command"`
+	Args        []string          `yaml:"args"`
+	Env         map[string]string `yaml:"env"`
+	Expect      Expectation       `yaml:"expect"`
+}
+
+type TestSuite struct {
+	Tests []TestCase `yaml:"tests"`
+}
+
+func loadTestSuite(filePath string) (*TestSuite, error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var suite TestSuite
+	err = yaml.Unmarshal(data, &suite)
+	if err != nil {
+		return nil, err
+	}
+
+	return &suite, nil
+}
+
+func TestCLICommands(t *testing.T) {
+	// Capture the starting working directory
+	startingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get the current working directory: %v", err)
+	}
+
+	testSuite, err := loadTestSuite("test_cases.yaml")
+	if err != nil {
+		t.Fatalf("Failed to load test suite: %v", err)
+	}
+
+	for _, tc := range testSuite.Tests {
+
+		if !tc.Enabled {
+			t.Logf("Skipping disabled test: %s", tc.Name)
+			continue
+		}
+
+		t.Run(tc.Name, func(t *testing.T) {
+			defer func() {
+				// Change back to the original working directory after the test
+				if err := os.Chdir(startingDir); err != nil {
+					t.Fatalf("Failed to change back to the starting directory: %v", err)
+				}
+			}()
+
+			// Change to the specified working directory
+			if tc.Workdir != "" {
+				err := os.Chdir(tc.Workdir)
+				if err != nil {
+					t.Fatalf("Failed to change directory to %q: %v", tc.Workdir, err)
+				}
+			}
+
+			// Prepare the command
+			cmd := exec.Command(tc.Command, tc.Args...)
+
+			// Set environment variables
+			envVars := os.Environ()
+			for key, value := range tc.Env {
+				envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
+			}
+			cmd.Env = envVars
+
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			// Run the command
+			err := cmd.Run()
+
+			// Validate exit code
+			exitCode := 0
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					exitCode = exitErr.ExitCode()
+				}
+			}
+			if exitCode != tc.Expect.ExitCode {
+				t.Errorf("Description: %s", tc.Description)
+				t.Errorf("Reason: Expected exit code %d, got %d", tc.Expect.ExitCode, exitCode)
+			}
+
+			// Validate stdout
+			if !verifyOutput(stdout.String(), tc.Expect.Stdout) {
+				t.Errorf("Description: %s", tc.Description)
+				t.Errorf("Reason: Stdout did not match expected patterns.")
+				t.Errorf("Output: %q", stdout.String())
+			}
+
+			// Validate stderr
+			if !verifyOutput(stderr.String(), tc.Expect.Stderr) {
+				t.Errorf("Description: %s", tc.Description)
+				t.Errorf("Reason: Stderr did not match expected patterns.")
+				t.Errorf("Output: %q", stderr.String())
+			}
+
+			// Validate file existence
+			if !verifyFileExists(tc.Expect.FileExists) {
+				t.Errorf("Description: %s", tc.Description)
+			}
+
+			// Validate file contents
+			if !verifyFileContains(tc.Expect.FileContains) {
+				t.Errorf("Description: %s", tc.Description)
+			}
+		})
+	}
+}
+
+func verifyOutput(output string, patterns []string) bool {
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return false
+		}
+		if !re.MatchString(output) {
+			return false
+		}
+	}
+	return true
+}
+
+func verifyFileExists(files []string) bool {
+	for _, file := range files {
+		if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+	}
+	return true
+}
+
+func verifyFileContains(filePatterns map[string][]string) bool {
+	for file, patterns := range filePatterns {
+		content, err := ioutil.ReadFile(file)
+		if err != nil {
+			return false
+		}
+		for _, pattern := range patterns {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return false
+			}
+			if !re.Match(content) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/tests/test_cases.yaml
+++ b/tests/test_cases.yaml
@@ -1,4 +1,16 @@
 tests:
+  - name: "which atmos"
+    enabled: true
+    description: "Ensure atmos CLI is installed and we're using the one that was built."
+    workdir: "../"
+    command: "which"
+    args:
+      - "atmos"
+    expect:
+      stdout:
+        - '(build[/\\]atmos|atmos[/\\]atmos)'
+      exit_code: 0
+
   - name: "atmos"
     enabled: true
     description: "Verify atmos CLI reports missing stacks directory."
@@ -47,7 +59,7 @@ tests:
       - "version"
     expect:
       stdout:
-        - '👽 Atmos \d+\.\d+\.\d+ on [a-z]+/[a-z0-9]+'
+        - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
       stderr: []
       exit_code: 0
 
@@ -61,7 +73,7 @@ tests:
       - "--check"
     expect:
       stdout:
-        - '👽 Atmos \d+\.\d+\.\d+ on [a-z]+/[a-z0-9]+'
+        - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
       stderr: []
       exit_code: 0
 
@@ -125,7 +137,7 @@ tests:
       - "yaml"
     expect:
       stdout:
-        - 'append_user_agent: Atmos/\d+\.\d+\.\d+ \(Cloud Posse; \+https:\/\/atmos\.tools\)'
+        - 'append_user_agent: Atmos/(\d+\.\d+\.\d+|test) \(Cloud Posse; \+https:\/\/atmos\.tools\)'
       exit_code: 0
 
   - name: atmos describe config
@@ -138,5 +150,5 @@ tests:
       - "config"
     expect:
       stdout:
-        - '"append_user_agent": "Atmos/\d+\.\d+\.\d+ \(Cloud Posse; \+https:\/\/atmos\.tools\)"'
+        - '"append_user_agent": "Atmos/(\d+\.\d+\.\d+|test) \(Cloud Posse; \+https:\/\/atmos\.tools\)"'
       exit_code: 0

--- a/tests/test_cases.yaml
+++ b/tests/test_cases.yaml
@@ -1,0 +1,142 @@
+tests:
+  - name: "atmos"
+    enabled: true
+    description: "Verify atmos CLI reports missing stacks directory."
+    workdir: "../"
+    command: "atmos"
+    expect:
+      stdout:
+        - "atmos.yaml CLI config file specifies the directory for Atmos stacks as stacks,"
+        - "but the directory does not exist."
+      exit: 0
+
+  - name: atmos --help
+    enabled: true
+    description: "Ensure atmos CLI help command lists available commands."
+    workdir: "../examples/demo-stacks"
+    command: "atmos"
+    args:
+      - "--help"
+    expect:
+      stdout:
+        - "Available Commands:"
+        - "\\batlantis\\b"
+        - "\\baws\\b"
+        - "\\bcompletion\\b"
+        - "\\bdescribe\\b"
+        - "\\bdocs\\b"
+        - "\\bhelmfile\\b"
+        - "\\bhelp\\b"
+        - "\\blist\\b"
+        - "\\bpro\\b"
+        - "\\bterraform\\b"
+        - "\\bvalidate\\b"
+        - "\\bvendor\\b"
+        - "\\bversion\\b"
+        - "\\bworkflow\\b"
+        - "Flags:"
+        - "for more information about a command"
+      exit_code: 0
+
+  - name: atmos version
+    enabled: true
+    description: "Check that atmos version command outputs version details."
+    workdir: "../examples/demo-stacks"
+    command: "atmos"
+    args:
+      - "version"
+    expect:
+      stdout:
+        - '👽 Atmos \d+\.\d+\.\d+ on [a-z]+/[a-z0-9]+'
+      stderr: []
+      exit_code: 0
+
+  - name: atmos version --check
+    enabled: true
+    description: "Verify atmos version --check command functions correctly."
+    workdir: "../examples/demo-stacks"
+    command: "atmos"
+    args:
+      - "version"
+      - "--check"
+    expect:
+      stdout:
+        - '👽 Atmos \d+\.\d+\.\d+ on [a-z]+/[a-z0-9]+'
+      stderr: []
+      exit_code: 0
+
+  - name: atmos docs
+    enabled: false
+    description: "Ensure atmos docs command executes without errors."
+    workdir: "../"
+    command: "atmos"
+    args:
+      - "docs"
+    expect:
+      exit_code: 0
+
+  - name: atmos docs myapp
+    enabled: true
+    description: "Validate atmos docs command outputs documentation for a specific component."
+    workdir: "../examples/demo-stacks/"
+    command: "atmos"
+    args:
+      - "docs"
+      - "myapp"
+    expect:
+      stdout:
+        - "Example Terraform Weather Component"
+      exit_code: 0
+
+  - name: atmos non-existent
+    enabled: true
+    description: "Ensure atmos CLI returns an error for a non-existent command."
+    workdir: "../"
+    command: "atmos"
+    args:
+      - "non-existent"
+    expect:
+      stderr:
+        - 'unknown command "non-existent" for "atmos"'
+      exit_code: 1
+
+  - name: atmos terraform non-existent
+    enabled: false
+    description: "Ensure atmos CLI returns an error for a non-existent command."
+    workdir: "../"
+    command: "atmos"
+    args:
+      - "terraform"
+      - "non-existent"
+    expect:
+      stderr:
+        - 'unknown command "non-existent" for "atmos"'
+      exit_code: 1
+
+  - name: atmos describe config -f yaml
+    enabled: true
+    description: "Ensure atmos CLI outputs the Atmos configuration in YAML."
+    workdir: "../examples/demo-stacks/"
+    command: "atmos"
+    args:
+      - "describe"
+      - "config"
+      - "-f"
+      - "yaml"
+    expect:
+      stdout:
+        - 'append_user_agent: Atmos/\d+\.\d+\.\d+ \(Cloud Posse; \+https:\/\/atmos\.tools\)'
+      exit_code: 0
+
+  - name: atmos describe config
+    enabled: true
+    description: "Ensure atmos CLI outputs the Atmos configuration in JSON."
+    workdir: "../examples/demo-stacks/"
+    command: "atmos"
+    args:
+      - "describe"
+      - "config"
+    expect:
+      stdout:
+        - '"append_user_agent": "Atmos/\d+\.\d+\.\d+ \(Cloud Posse; \+https:\/\/atmos\.tools\)"'
+      exit_code: 0

--- a/tests/test_cases.yaml
+++ b/tests/test_cases.yaml
@@ -8,7 +8,7 @@ tests:
       stdout:
         - "atmos.yaml CLI config file specifies the directory for Atmos stacks as stacks,"
         - "but the directory does not exist."
-      exit: 0
+      exit_code: 0
 
   - name: atmos --help
     enabled: true

--- a/tests/test_cases.yaml
+++ b/tests/test_cases.yaml
@@ -9,6 +9,8 @@ tests:
     expect:
       stdout:
         - '(build[/\\]atmos|atmos[/\\]atmos)'
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: "atmos"
@@ -20,6 +22,8 @@ tests:
       stdout:
         - "atmos.yaml CLI config file specifies the directory for Atmos stacks as stacks,"
         - "but the directory does not exist."
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos --help
@@ -48,6 +52,8 @@ tests:
         - "\\bworkflow\\b"
         - "Flags:"
         - "for more information about a command"
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos version
@@ -60,7 +66,8 @@ tests:
     expect:
       stdout:
         - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
-      stderr: []
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos version --check
@@ -74,7 +81,8 @@ tests:
     expect:
       stdout:
         - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
-      stderr: []
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos docs
@@ -86,6 +94,8 @@ tests:
       - "docs"
     expect:
       exit_code: 0
+      stderr:
+        - "^$"
 
   - name: atmos docs myapp
     enabled: true
@@ -98,6 +108,8 @@ tests:
     expect:
       stdout:
         - "Example Terraform Weather Component"
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos non-existent
@@ -138,6 +150,8 @@ tests:
     expect:
       stdout:
         - 'append_user_agent: Atmos/(\d+\.\d+\.\d+|test) \(Cloud Posse; \+https:\/\/atmos\.tools\)'
+      stderr:
+        - "^$"
       exit_code: 0
 
   - name: atmos describe config
@@ -151,4 +165,6 @@ tests:
     expect:
       stdout:
         - '"append_user_agent": "Atmos/(\d+\.\d+\.\d+|test) \(Cloud Posse; \+https:\/\/atmos\.tools\)"'
+      stderr:
+        - "^$"
       exit_code: 0


### PR DESCRIPTION
## what
- Run commands depending on the flavor of OS
- Add e2e smoke tests to verify commands work

## why
- Windows behaves differently from Linux/macOS
- #875 introduced windows testing
- Catch certain cases when we have no unit tests for CLI behaviors (tests for condition @mcalhoun encountered with an infinite loop in `atmos version`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive testing framework for the CLI commands.
	- Added a series of test cases for various functionalities of the `atmos` CLI, including error handling and command outputs.

- **Bug Fixes**
	- Improved conditional execution of tests based on operating system.
	- Enhanced clarity in test execution step names.

- **Chores**
	- Updated testing workflow to differentiate commands for Windows, Linux, and macOS.
	- Added steps to set the build artifacts directory in the PATH for both Linux/macOS and Windows targets.
	- Refined the process for downloading build artifacts with OS-specific naming.
	- Added GNU tar to PATH for improved build efficiency on Windows targets.
	- Restructured jobs to utilize a matrix strategy for better organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->