### PR TITLE
Revert "Replace path.Join with filepath.Join (#856)"

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -404,7 +405,7 @@ func printMessageForMissingAtmosConfig(atmosConfig schema.AtmosConfiguration) {
 		u.PrintMessageInColor("atmos.yaml", c1)
 		fmt.Println(" CLI config file was not found.")
 		fmt.Print("\nThe default Atmos stacks directory is set to ")
-		u.PrintMessageInColor(filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath), c1)
+		u.PrintMessageInColor(path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath), c1)
 		fmt.Println(",\nbut the directory does not exist in the current path.")
 	} else {
 		// If Atmos found an `atmos.yaml` config file, but it defines invalid paths to Atmos stacks and components

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"path"
 	"runtime"
 
 	"github.com/charmbracelet/glamour"
@@ -59,7 +59,7 @@ var docsCmd = &cobra.Command{
 			}
 
 			// Construct the full path to the Terraform component by combining the Atmos base path, Terraform base path, and component name
-			componentPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, info.Component)
+			componentPath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, info.Component)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil {
 				u.LogErrorAndExit(schema.AtmosConfiguration{}, err)
@@ -68,7 +68,7 @@ var docsCmd = &cobra.Command{
 				u.LogErrorAndExit(schema.AtmosConfiguration{}, fmt.Errorf("Component '%s' not found in path: '%s'", info.Component, componentPath))
 			}
 
-			readmePath := filepath.Join(componentPath, "README.md")
+			readmePath := path.Join(componentPath, "README.md")
 			if _, err := os.Stat(readmePath); err != nil {
 				if os.IsNotExist(err) {
 					u.LogErrorAndExit(schema.AtmosConfiguration{}, fmt.Errorf("No README found for component: %s", info.Component))

--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -338,7 +339,7 @@ func ExecuteAtlantisGenerateRepoConfig(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := filepath.Join(
+				terraformComponentPath := path.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -158,11 +158,11 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 
 		configAndStacksInfo.ComponentType = "terraform"
 		configAndStacksInfo, err = ProcessStacks(atmosConfig, configAndStacksInfo, true, true)
-		shellCommandWorkingDir = filepath.Join(atmosConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+		shellCommandWorkingDir = path.Join(atmosConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 		if err != nil {
 			configAndStacksInfo.ComponentType = "helmfile"
 			configAndStacksInfo, err = ProcessStacks(atmosConfig, configAndStacksInfo, true, true)
-			shellCommandWorkingDir = filepath.Join(atmosConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+			shellCommandWorkingDir = path.Join(atmosConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 			if err != nil {
 				return err
 			}

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -432,13 +432,13 @@ func executeDescribeAffected(
 	}
 
 	// Update paths to point to the cloned remote repo dir
-	atmosConfig.StacksBaseAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath)
-	atmosConfig.TerraformDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Terraform.BasePath)
-	atmosConfig.HelmfileDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Helmfile.BasePath)
+	atmosConfig.StacksBaseAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath)
+	atmosConfig.TerraformDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Terraform.BasePath)
+	atmosConfig.HelmfileDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Helmfile.BasePath)
 
 	atmosConfig.StackConfigFilesAbsolutePaths, err = u.JoinAbsolutePathWithPaths(
 		filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath),
-		atmosConfig.StackConfigFilesRelativePaths,
+		cliConfig.StackConfigFilesRelativePaths,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -1182,9 +1182,9 @@ func isComponentFolderChanged(
 
 	switch componentType {
 	case "terraform":
-		componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
+		componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
 	case "helmfile":
-		componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, component)
+		componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, component)
 	}
 
 	componentPathAbs, err := filepath.Abs(componentPath)
@@ -1220,7 +1220,7 @@ func areTerraformComponentModulesChanged(
 	changedFiles []string,
 ) (bool, error) {
 
-	componentPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
+	componentPath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
 
 	componentPathAbs, err := filepath.Abs(componentPath)
 	if err != nil {
@@ -1241,7 +1241,7 @@ func areTerraformComponentModulesChanged(
 				continue
 			}
 
-			modulePath := filepath.Join(path.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
+			modulePath := path.Join(path.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
 
 			modulePathAbs, err := filepath.Abs(modulePath)
 			if err != nil {

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -5,7 +5,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -78,20 +78,20 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 	}
 
 	// Check if the component exists as a helmfile component
-	componentPath := filepath.Join(atmosConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
+	componentPath := path.Join(atmosConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
 	componentPathExists, err := u.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {
 		return fmt.Errorf("'%s' points to the Helmfile component '%s', but it does not exist in '%s'",
 			info.ComponentFromArg,
 			info.FinalComponent,
-			filepath.Join(atmosConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
+			path.Join(atmosConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
 		)
 	}
 
 	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract {
 		return fmt.Errorf("abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"by 'metadata.type: abstract' attribute", filepath.Join(info.ComponentFolderPrefix, info.Component))
+			"by 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component))
 	}
 
 	// Print component variables
@@ -196,7 +196,7 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 		u.LogDebug(atmosConfig, "Stack: "+info.StackFromArg)
 	} else {
 		u.LogDebug(atmosConfig, "Stack: "+info.StackFromArg)
-		u.LogDebug(atmosConfig, "Stack path: "+filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath, info.Stack))
+		u.LogDebug(atmosConfig, "Stack path: "+path.Join(cliConfig.BasePath, atmosConfig.Stacks.BasePath, info.Stack))
 	}
 
 	workingDir := constructHelmfileComponentWorkingDir(atmosConfig, info)

--- a/internal/exec/oci_utils.go
+++ b/internal/exec/oci_utils.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -30,7 +30,7 @@ func processOciImage(atmosConfig schema.AtmosConfiguration, imageName string, de
 	defer removeTempDir(atmosConfig, tempDir)
 
 	// Temp tarball file name
-	tempTarFileName := filepath.Join(tempDir, uuid.New().String()) + ".tar"
+	tempTarFileName := path.Join(tempDir, uuid.New().String()) + ".tar"
 
 	// Get the image reference from the OCI registry
 	ref, err := name.ParseReference(imageName)
@@ -91,7 +91,7 @@ func processOciImage(atmosConfig schema.AtmosConfiguration, imageName string, de
 
 	// Extract the layers into the destination directory
 	for _, l := range manifest.Layers {
-		layerPath := filepath.Join(tempDir, l)
+		layerPath := path.Join(tempDir, l)
 
 		err = extractTarball(atmosConfig, layerPath, destDir)
 		if err != nil {

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -357,7 +357,7 @@ func ProcessYAMLConfigFile(
 
 			found := false
 			for _, extension := range extensions {
-				testPath := filepath.Join(basePath, imp+extension)
+				testPath := path.Join(basePath, imp+extension)
 				if _, err := os.Stat(testPath); err == nil {
 					impWithExt = imp + extension
 					found = true
@@ -372,12 +372,12 @@ func ProcessYAMLConfigFile(
 		} else if ext == u.YamlFileExtension || ext == u.YmlFileExtension {
 			// Check if there's a template version of this file
 			templatePath := impWithExt + u.TemplateExtension
-			if _, err := os.Stat(filepath.Join(basePath, templatePath)); err == nil {
+			if _, err := os.Stat(path.Join(basePath, templatePath)); err == nil {
 				impWithExt = templatePath
 			}
 		}
 
-		impWithExtPath := filepath.Join(basePath, impWithExt)
+		impWithExtPath := path.Join(basePath, impWithExt)
 
 		if impWithExtPath == filePath {
 			errorMessage := fmt.Sprintf("invalid import in the manifest '%s'\nThe file imports itself in '%s'",
@@ -2180,7 +2180,7 @@ func ProcessBaseComponentConfig(
 		if checkBaseComponentExists {
 			// Check if the base component exists as Terraform/Helmfile component
 			// If it does exist, don't throw errors if it is not defined in YAML config
-			componentPath := filepath.Join(componentBasePath, baseComponent)
+			componentPath := path.Join(componentBasePath, baseComponent)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil || !componentPathExists {
 				return errors.New("The component '" + component + "' inherits from the base component '" +

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -164,9 +164,9 @@ func BuildComponentPath(
 
 	if stackComponentSection, ok := componentSectionMap[cfg.ComponentSectionName].(string); ok {
 		if componentType == "terraform" {
-			componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, stackComponentSection)
+			componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, stackComponentSection)
 		} else if componentType == "helmfile" {
-			componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, stackComponentSection)
+			componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, stackComponentSection)
 		}
 	}
 

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -75,7 +75,7 @@ func ExecuteTerraformGenerateBackendCmd(cmd *cobra.Command, args []string) error
 	}
 
 	// Write backend config to file
-	var backendFilePath = filepath.Join(
+	var backendFilePath = path.Join(
 		atmosConfig.BasePath,
 		atmosConfig.Components.Terraform.BasePath,
 		info.ComponentFolderPrefix,

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -160,7 +161,7 @@ func ExecuteTerraformGenerateBackends(
 				}
 
 				// Path to the terraform component
-				terraformComponentPath := filepath.Join(
+				terraformComponentPath := path.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,
@@ -290,7 +291,7 @@ func ExecuteTerraformGenerateBackends(
 
 						processedTerraformComponents[terraformComponent] = terraformComponent
 
-						backendFilePath = filepath.Join(
+						backendFilePath = path.Join(
 							terraformComponentPath,
 							"backend.tf",
 						)

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -159,7 +160,7 @@ func ExecuteTerraformGenerateVarfiles(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := filepath.Join(
+				terraformComponentPath := path.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -87,7 +88,7 @@ func execTerraformOutput(atmosConfig schema.AtmosConfiguration, component string
 
 		// Auto-generate backend file
 		if atmosConfig.Components.Terraform.AutoGenerateBackendFile {
-			backendFileName := filepath.Join(componentPath, "backend.tf.json")
+			backendFileName := path.Join(componentPath, "backend.tf.json")
 
 			u.LogTrace(atmosConfig, "\nWriting the backend config to file:")
 			u.LogTrace(atmosConfig, backendFileName)
@@ -120,7 +121,7 @@ func execTerraformOutput(atmosConfig schema.AtmosConfiguration, component string
 		providersSection, ok := sections["providers"].(map[string]any)
 
 		if ok && len(providersSection) > 0 {
-			providerOverrideFileName := filepath.Join(componentPath, "providers_override.tf.json")
+			providerOverrideFileName := path.Join(componentPath, "providers_override.tf.json")
 
 			u.LogTrace(atmosConfig, "\nWriting the provider overrides to file:")
 			u.LogTrace(atmosConfig, providerOverrideFileName)

--- a/internal/exec/validate_component.go
+++ b/internal/exec/validate_component.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -197,11 +197,11 @@ func validateComponentInternal(
 		switch schemaType {
 		case "jsonschema":
 			{
-				filePath = filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.JsonSchema.BasePath, schemaPath)
+				filePath = path.Join(atmosConfig.BasePath, atmosConfig.Schemas.JsonSchema.BasePath, schemaPath)
 			}
 		case "opa":
 			{
-				filePath = filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath, schemaPath)
+				filePath = path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath, schemaPath)
 			}
 		}
 
@@ -228,7 +228,7 @@ func validateComponentInternal(
 		}
 	case "opa":
 		{
-			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath), modulePaths)
+			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath), modulePaths)
 			if err != nil {
 				return false, err
 			}

--- a/internal/exec/validate_stacks.go
+++ b/internal/exec/validate_stacks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
+	"path"
 	"reflect"
 	"strings"
 	"time"
@@ -91,7 +91,7 @@ func ValidateStacks(atmosConfig schema.AtmosConfiguration) error {
 		u.LogTrace(atmosConfig, fmt.Sprintf("The Atmos JSON Schema file is not configured. Using the default schema '%s'", atmosManifestDefault))
 	}
 
-	atmosManifestJsonSchemaFileAbsPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Atmos.Manifest)
+	atmosManifestJsonSchemaFileAbsPath := path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Atmos.Manifest)
 
 	if u.FileExists(atmosConfig.Schemas.Atmos.Manifest) {
 		atmosManifestJsonSchemaFilePath = atmosConfig.Schemas.Atmos.Manifest
@@ -131,7 +131,7 @@ func ValidateStacks(atmosConfig schema.AtmosConfiguration) error {
 	}
 
 	u.LogDebug(atmosConfig, fmt.Sprintf("Validating all YAML files in the '%s' folder and all subfolders (excluding template files)\n",
-		filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)))
+		path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)))
 
 	for _, filePath := range stackConfigFilesAbsolutePaths {
 		stackConfig, importsConfig, _, _, _, err := ProcessYAMLConfigFile(
@@ -376,7 +376,7 @@ func downloadSchemaFromURL(manifestURL string) (string, error) {
 	if err != nil || fileName == "" {
 		return "", fmt.Errorf("failed to get the file name from the URL '%s': %w", manifestURL, err)
 	}
-	atmosManifestJsonSchemaFilePath := filepath.Join(tempDir, fileName)
+	atmosManifestJsonSchemaFilePath := path.Join(tempDir, fileName)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	client := &getter.Client{

--- a/internal/exec/vendor_component_utils.go
+++ b/internal/exec/vendor_component_utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -25,7 +26,7 @@ func findComponentConfigFile(basePath, fileName string) (string, error) {
 	componentConfigExtensions := []string{"yaml", "yml"}
 
 	for _, ext := range componentConfigExtensions {
-		configFilePath := filepath.Join(basePath, fmt.Sprintf("%s.%s", fileName, ext))
+		configFilePath := path.Join(basePath, fmt.Sprintf("%s.%s", fileName, ext))
 		if u.FileExists(configFilePath) {
 			return configFilePath, nil
 		}
@@ -50,7 +51,7 @@ func ReadAndProcessComponentVendorConfigFile(
 		return componentConfig, "", fmt.Errorf("type '%s' is not supported. Valid types are 'terraform' and 'helmfile'", componentType)
 	}
 
-	componentPath := filepath.Join(atmosConfig.BasePath, componentBasePath, component)
+	componentPath := path.Join(atmosConfig.BasePath, componentBasePath, component)
 
 	dirExists, err := u.IsDirectory(componentPath)
 	if err != nil {

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -164,7 +165,7 @@ func ReadAndProcessVendorConfigFile(
 
 		if !fileExists {
 			// Look for the vendoring manifest in the directory pointed to by the `base_path` setting in `atmos.yaml`
-			pathToVendorConfig := filepath.Join(atmosConfig.BasePath, vendorConfigFile)
+			pathToVendorConfig := path.Join(atmosConfig.BasePath, vendorConfigFile)
 			foundVendorConfigFile, fileExists = u.SearchConfigFile(pathToVendorConfig)
 
 			if !fileExists {

--- a/internal/exec/workflow.go
+++ b/internal/exec/workflow.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -79,7 +80,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile
 	} else {
-		workflowPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, workflowFile)
+		workflowPath = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, workflowFile)
 	}
 
 	// If the workflow file is specified without an extension, use the default extension

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -146,7 +147,7 @@ func ExecuteDescribeWorkflows(
 	if u.IsPathAbsolute(atmosConfig.Workflows.BasePath) {
 		workflowsDir = atmosConfig.Workflows.BasePath
 	} else {
-		workflowsDir = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath)
+		workflowsDir = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath)
 	}
 
 	isDirectory, err := u.IsDirectory(workflowsDir)
@@ -163,9 +164,9 @@ func ExecuteDescribeWorkflows(
 	for _, f := range files {
 		var workflowPath string
 		if u.IsPathAbsolute(atmosConfig.Workflows.BasePath) {
-			workflowPath = filepath.Join(atmosConfig.Workflows.BasePath, f)
+			workflowPath = path.Join(atmosConfig.Workflows.BasePath, f)
 		} else {
-			workflowPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, f)
+			workflowPath = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, f)
 		}
 
 		fileContent, err := os.ReadFile(workflowPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 
@@ -132,7 +133,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	if len(configFilePath1) > 0 {
-		configFile1 := filepath.Join(configFilePath1, CliConfigFileName)
+		configFile1 := path.Join(configFilePath1, CliConfigFileName)
 		found, err = processConfigFile(atmosConfig, configFile1, v)
 		if err != nil {
 			return atmosConfig, err
@@ -147,7 +148,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return atmosConfig, err
 	}
-	configFile2 := filepath.Join(configFilePath2, ".atmos", CliConfigFileName)
+	configFile2 := path.Join(configFilePath2, ".atmos", CliConfigFileName)
 	found, err = processConfigFile(atmosConfig, configFile2, v)
 	if err != nil {
 		return atmosConfig, err
@@ -161,7 +162,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return atmosConfig, err
 	}
-	configFile3 := filepath.Join(configFilePath3, CliConfigFileName)
+	configFile3 := path.Join(configFilePath3, CliConfigFileName)
 	found, err = processConfigFile(atmosConfig, configFile3, v)
 	if err != nil {
 		return atmosConfig, err
@@ -174,7 +175,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	configFilePath4 := os.Getenv("ATMOS_CLI_CONFIG_PATH")
 	if len(configFilePath4) > 0 {
 		u.LogTrace(atmosConfig, fmt.Sprintf("Found ENV var ATMOS_CLI_CONFIG_PATH=%s", configFilePath4))
-		configFile4 := filepath.Join(configFilePath4, CliConfigFileName)
+		configFile4 := path.Join(configFilePath4, CliConfigFileName)
 		found, err = processConfigFile(atmosConfig, configFile4, v)
 		if err != nil {
 			return atmosConfig, err
@@ -188,7 +189,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if configAndStacksInfo.AtmosCliConfigPath != "" {
 		configFilePath5 := configAndStacksInfo.AtmosCliConfigPath
 		if len(configFilePath5) > 0 {
-			configFile5 := filepath.Join(configFilePath5, CliConfigFileName)
+			configFile5 := path.Join(configFilePath5, CliConfigFileName)
 			found, err = processConfigFile(atmosConfig, configFile5, v)
 			if err != nil {
 				return atmosConfig, err
@@ -270,7 +271,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	// Convert stacks base path to absolute path
-	stacksBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)
+	stacksBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)
 	stacksBaseAbsPath, err := filepath.Abs(stacksBasePath)
 	if err != nil {
 		return atmosConfig, err
@@ -292,7 +293,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	atmosConfig.ExcludeStackAbsolutePaths = excludeStackAbsPaths
 
 	// Convert terraform dir to absolute path
-	terraformBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath)
+	terraformBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath)
 	terraformDirAbsPath, err := filepath.Abs(terraformBasePath)
 	if err != nil {
 		return atmosConfig, err
@@ -300,7 +301,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	atmosConfig.TerraformDirAbsolutePath = terraformDirAbsPath
 
 	// Convert helmfile dir to absolute path
-	helmfileBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath)
+	helmfileBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath)
 	helmfileDirAbsPath, err := filepath.Abs(helmfileBasePath)
 	if err != nil {
 		return atmosConfig, err

--- a/pkg/generate/terraform_generate_varfiles_test.go
+++ b/pkg/generate/terraform_generate_varfiles_test.go
@@ -2,7 +2,7 @@ package generate
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 	"strconv"
 	"testing"
 	"time"
@@ -28,7 +28,7 @@ func TestTerraformGenerateVarfiles(t *testing.T) {
 
 	var stacks []string
 	var components []string
-	filePattern := filepath.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
+	filePattern := path.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
 	format := "hcl"
 
 	err = e.ExecuteTerraformGenerateVarfiles(atmosConfig, filePattern, format, stacks, components)

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -69,7 +69,7 @@ func JoinAbsolutePathWithPaths(basePath string, paths []string) ([]string, error
 	res := []string{}
 
 	for _, p := range paths {
-		res = append(res, filepath.Join(basePath, p))
+		res = append(res, path.Join(basePath, p))
 	}
 
 	return res, nil
@@ -93,7 +93,7 @@ func JoinAbsolutePathWithPath(basePath string, providedPath string) (string, err
 	}
 
 	// Join the base path with the provided path
-	joinedPath := filepath.Join(basePath, providedPath)
+	joinedPath := path.Join(basePath, providedPath)
 
 	// If the joined path is an absolute path and exists in the file system, return it
 	if filepath.IsAbs(joinedPath) {

--- a/pkg/utils/glob_utils.go
+++ b/pkg/utils/glob_utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -36,7 +36,7 @@ func GetGlobMatches(pattern string) ([]string, error) {
 
 	var fullMatches []string
 	for _, match := range matches {
-		fullMatches = append(fullMatches, filepath.Join(base, match))
+		fullMatches = append(fullMatches, path.Join(base, match))
 	}
 
 	getGlobMatchesSyncMap.Store(pattern, strings.Join(fullMatches, ","))

--- a/pkg/vender/component_vendor_test.go
+++ b/pkg/vender/component_vendor_test.go
@@ -2,7 +2,7 @@ package vender
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,12 +29,12 @@ func TestVendorComponentPullCommand(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check if the correct files were pulled and written to the correct folder
-	assert.FileExists(t, filepath.Join(componentPath, "context.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "main.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "outputs.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "providers.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "variables.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "versions.tf"))
+	assert.FileExists(t, path.Join(componentPath, "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "providers.tf"))
+	assert.FileExists(t, path.Join(componentPath, "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "versions.tf"))
 
 	// Test 'infra/account-map' component
 	component = "infra/account-map"
@@ -45,43 +45,43 @@ func TestVendorComponentPullCommand(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check if the correct files were pulled and written to the correct folder
-	assert.FileExists(t, filepath.Join(componentPath, "context.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "dynamic-roles.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "main.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "outputs.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "providers.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "README.md"))
-	assert.FileExists(t, filepath.Join(componentPath, "remote-state.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "variables.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "versions.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "context.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "main.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "iam-roles", "variables.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
-	assert.FileExists(t, filepath.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "dynamic-roles.tf"))
+	assert.FileExists(t, path.Join(componentPath, "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "providers.tf"))
+	assert.FileExists(t, path.Join(componentPath, "README.md"))
+	assert.FileExists(t, path.Join(componentPath, "remote-state.tf"))
+	assert.FileExists(t, path.Join(componentPath, "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "versions.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "iam-roles", "variables.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "context.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "main.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "outputs.tf"))
+	assert.FileExists(t, path.Join(componentPath, "modules", "roles-to-principals", "variables.tf"))
 
 	// Delete the files and folders
-	err = os.Remove(filepath.Join(componentPath, "context.tf"))
+	err = os.Remove(path.Join(componentPath, "context.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "dynamic-roles.tf"))
+	err = os.Remove(path.Join(componentPath, "dynamic-roles.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "main.tf"))
+	err = os.Remove(path.Join(componentPath, "main.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "outputs.tf"))
+	err = os.Remove(path.Join(componentPath, "outputs.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "providers.tf"))
+	err = os.Remove(path.Join(componentPath, "providers.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "README.md"))
+	err = os.Remove(path.Join(componentPath, "README.md"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "remote-state.tf"))
+	err = os.Remove(path.Join(componentPath, "remote-state.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "variables.tf"))
+	err = os.Remove(path.Join(componentPath, "variables.tf"))
 	assert.Nil(t, err)
-	err = os.Remove(filepath.Join(componentPath, "versions.tf"))
+	err = os.Remove(path.Join(componentPath, "versions.tf"))
 	assert.Nil(t, err)
-	err = os.RemoveAll(filepath.Join(componentPath, "modules"))
+	err = os.RemoveAll(path.Join(componentPath, "modules"))
 	assert.Nil(t, err)
 }

--- a/pkg/vender/vendor_config_test.go
+++ b/pkg/vender/vendor_config_test.go
@@ -4,7 +4,7 @@ package vender
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestVendorConfigScenarios(t *testing.T) {
 	atmosConfig.Logs.Level = "Trace"
 
 	// Setup test component directory
-	componentPath := filepath.Join(testDir, "components", "terraform", "myapp")
+	componentPath := path.Join(testDir, "components", "terraform", "myapp")
 	err := os.MkdirAll(componentPath, 0755)
 	assert.Nil(t, err)
 
@@ -47,7 +47,7 @@ spec:
       included_paths:
         - "**/*.tf"
 `
-		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
+		vendorYamlPath := path.Join(testDir, "vendor.yaml")
 		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
 		assert.Nil(t, err)
 
@@ -84,7 +84,7 @@ spec:
     uri: github.com/cloudposse/terraform-null-label.git//exports?ref={{.Version}}
     version: 0.25.0
 `
-		componentYamlPath := filepath.Join(componentPath, "component.yaml")
+		componentYamlPath := path.Join(componentPath, "component.yaml")
 		err := os.WriteFile(componentYamlPath, []byte(componentYaml), 0644)
 		assert.Nil(t, err)
 
@@ -102,7 +102,7 @@ spec:
 	// Test Case 3: Neither vendor.yaml nor component.yaml exists
 	t.Run("no vendor.yaml or component.yaml", func(t *testing.T) {
 		// Test vendoring with component flag
-		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
+		vendorYamlPath := path.Join(testDir, "vendor.yaml")
 		_, exists, _, err := e.ReadAndProcessVendorConfigFile(atmosConfig, vendorYamlPath, true)
 		assert.Nil(t, err)
 		assert.False(t, exists)
@@ -126,7 +126,7 @@ spec:
       source: github.com/cloudposse/terraform-null-label.git//exports?ref={{.Version}}
       version: 0.25.0
 `
-		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
+		vendorYamlPath := path.Join(testDir, "vendor.yaml")
 		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
 		assert.Nil(t, err)
 


### PR DESCRIPTION
This reverts commit 2051592cf9615ebe333a0fd01468d39c8e77de3c.

## what
- Manual revert of #856

## why
- It broke too many things that were are to debug, and we lacked tests to catch the situation. 
- We've added windows tests in, and should revisit this.
  - #877 
  - #875 