### PR TITLE
Fix invalid command should not show terraform help

### DIFF
--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
@@ -16,7 +18,7 @@ var terraformCmd = &cobra.Command{
 	Short:              "Execute Terraform commands",
 	Long:               `This command executes Terraform commands`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: true},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check Atmos configuration
 		//checkAtmosConfig()
 
@@ -35,9 +37,14 @@ var terraformCmd = &cobra.Command{
 
 		// Exit on help
 		if info.NeedHelp {
+			if info.SubCommand != "" {
+				fmt.Printf(`Error: Unknkown command %q for %q`+"\n", args[0], cmd.CommandPath())
+				fmt.Printf(`Run '%s --help' for usage`+"\n", cmd.CommandPath())
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
 			// Check for the latest Atmos release on GitHub and print update message
 			CheckForAtmosUpdateAndPrintMessage(atmosConfig)
-			return
+			return nil
 		}
 		// Check Atmos configuration
 		checkAtmosConfig()
@@ -46,6 +53,7 @@ var terraformCmd = &cobra.Command{
 		if err != nil {
 			u.LogErrorAndExit(schema.AtmosConfiguration{}, err)
 		}
+		return nil
 	},
 }
 


### PR DESCRIPTION
issue: https://linear.app/cloudposse/issue/DEV-2894/atmos-terraform-asdfasdf-should-show-error-message-instead-of-help

## what

* We will now show error message if the command is invalid like:
![image](https://github.com/user-attachments/assets/28205bb4-e247-485d-9014-4328328e3746)

* After https://github.com/cloudposse/atmos/pull/857 we would be getting rid of the help content that is seen above the error.
This would then look like:
![image](https://github.com/user-attachments/assets/5df8c01e-94a0-4385-88ba-41e84bf6d132)


## why

* Currently if customer executes invalid command we get the following help screen:
![image](https://github.com/user-attachments/assets/30c5d20f-41f3-484f-bd44-d322e8b7b3a5)
This was not consistent with 
![image](https://github.com/user-attachments/assets/9c6b604d-68ca-48e3-b3d4-405056fa579e)

## references

* https://linear.app/cloudposse/issue/DEV-2894/atmos-terraform-asdfasdf-should-show-error-message-instead-of-help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for the `terraformCmd` command, providing clearer feedback for command usage.
  
- **Bug Fixes**
	- Improved consistency in command execution return values to ensure proper error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->