### PR TITLE
Trigger workflows from github actions bot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,1 +1,38 @@
 extends: .github
+
+shared:
+  # Automated pull requests from bot users
+  is_a_bot: &is_a_bot
+    - or:
+        - "author=github-actions[bot]"
+
+  # Default branches
+  is_default_branch: &is_default_branch
+    - and:
+        - "base=main"
+        - "base=master"
+
+  # It's not closed or merged
+  is_open: &is_open
+    - and:
+        - -merged
+        - -closed
+
+pull_request_rules:
+  - name: Trigger workflow dispatch on PR synchronized by github-actions[bot]
+    conditions:
+      - and: *is_a_bot
+      - and: *is_open
+      - and: *is_default_branch
+
+    actions:
+      comment:
+        message: |
+          Triggering the workflow dispatch for preview build...
+      github_actions:
+        workflow:
+          dispatch:
+            - workflow: website-preview-build.yml
+              ref: "{{ pull_request.head.ref }}"
+            - workflow: test.yml
+              ref: "{{ pull_request.head.ref }}"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,7 @@ shared:
 
   # Default branches
   is_default_branch: &is_default_branch
-    - and:
+    - or:
         - "base=main"
         - "base=master"
 


### PR DESCRIPTION
## what
- Call workflow dispatch to build previews and run tests

## why
- Automated PRs from `github-actions[bot]` will not trigger workflows (by design) unless a PAT is used
- This approach doesn't require introcing a PAT and leverages mergify instead

## tests
- Demo #886 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated handling for pull requests, including conditions for bot authors, default branches, and open status.
	- Added a new rule to trigger a workflow dispatch when a pull request is synchronized by the GitHub Actions bot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->