### PR TITLE
Add editorconfig-checker to atmos cli

### DIFF
--- a/cmd/editor_config.go
+++ b/cmd/editor_config.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	er "github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/validation"
+	"github.com/spf13/cobra"
+)
+
+var (
+	editorConfigVersion   = "v3.0.0"
+	defaultConfigFilePath = ".ecrc"
+	currentConfig         *config.Config
+	cliConfig             config.Config
+	configFilePath        string
+	tmpExclude            string
+)
+
+var editorConfigCmd *cobra.Command = &cobra.Command{
+	Use:   "editorconfig-checker",
+	Short: "EditorConfig Checker CLI",
+	Long:  "A command-line tool to check your files against the EditorConfig rules",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		initializeConfig()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		runMainLogic()
+	},
+}
+
+// initializeConfig breaks the initialization cycle by separating the config setup
+func initializeConfig() {
+	if configFilePath == "" {
+		configFilePath = defaultConfigFilePath
+	}
+
+	var err error
+	currentConfig, err = config.NewConfig(configFilePath)
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	_ = currentConfig.Parse()
+
+	if tmpExclude != "" {
+		currentConfig.Exclude = append(currentConfig.Exclude, tmpExclude)
+	}
+
+	currentConfig.Merge(cliConfig)
+}
+
+// runMainLogic contains the main logic
+func runMainLogic() {
+	config := *currentConfig
+	config.Logger.Debug(config.GetAsString())
+	config.Logger.Verbose("Exclude Regexp: %s", config.GetExcludesAsRegularExpression())
+
+	if utils.FileExists(config.Path) && config.Version != "" && config.Version != editorConfigVersion {
+		config.Logger.Error("Version from config file is not the same as the version of the binary")
+		config.Logger.Error("Binary: %s, Config: %s", editorConfigVersion, config.Version)
+		os.Exit(1)
+	}
+
+	if handleReturnableFlags(config) {
+		return
+	}
+
+	filePaths, err := files.GetFiles(config)
+	if err != nil {
+		config.Logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	if config.DryRun {
+		for _, file := range filePaths {
+			config.Logger.Output(file)
+		}
+		os.Exit(0)
+	}
+
+	errors := validation.ProcessValidation(filePaths, config)
+	errorCount := er.GetErrorCount(errors)
+
+	if errorCount != 0 {
+		er.PrintErrors(errors, config)
+		config.Logger.Error(fmt.Sprintf("\n%d errors found", errorCount))
+		os.Exit(1)
+	}
+
+	config.Logger.Verbose("%d files checked", len(filePaths))
+}
+
+// handleReturnableFlags handles early termination flags
+func handleReturnableFlags(config config.Config) bool {
+	if config.ShowVersion {
+		config.Logger.Output(editorConfigVersion)
+		return true
+	}
+	if config.Help {
+		config.Logger.Output("USAGE:")
+		return true
+	}
+	return false
+}
+
+// addPersistentFlags adds flags to the root command
+func addPersistentFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&configFilePath, "config", "", "Path to the configuration file")
+	cmd.PersistentFlags().StringVar(&tmpExclude, "exclude", "", "Regex to exclude files from checking")
+	cmd.PersistentFlags().BoolVar(&cliConfig.IgnoreDefaults, "ignore-defaults", false, "Ignore default excludes")
+	cmd.PersistentFlags().BoolVar(&cliConfig.DryRun, "dry-run", false, "Show which files would be checked")
+	cmd.PersistentFlags().BoolVar(&cliConfig.ShowVersion, "version", false, "Print the version number")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Help, "help", false, "Print help information")
+	cmd.PersistentFlags().StringVar(&cliConfig.Format, "format", "default", "Specify the output format: default, gcc")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Verbose, "verbose", false, "Print debugging information")
+	cmd.PersistentFlags().BoolVar(&cliConfig.NoColor, "no-color", false, "Don't print colors")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.TrimTrailingWhitespace, "disable-trim-trailing-whitespace", false, "Disable trailing whitespace check")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.EndOfLine, "disable-end-of-line", false, "Disable end-of-line check")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.InsertFinalNewline, "disable-insert-final-newline", false, "Disable final newline check")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.Indentation, "disable-indentation", false, "Disable indentation check")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.IndentSize, "disable-indent-size", false, "Disable indent size check")
+	cmd.PersistentFlags().BoolVar(&cliConfig.Disable.MaxLineLength, "disable-max-line-length", false, "Disable max line length check")
+}
+
+func init() {
+	// Add flags
+	addPersistentFlags(editorConfigCmd)
+	// Add command
+	validateCmd.AddCommand(editorConfigCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/charmbracelet/log v0.4.0
+	github.com/editorconfig-checker/editorconfig-checker/v3 v3.0.3
 	github.com/elewis787/boa v0.1.2
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.12.0
@@ -95,6 +96,7 @@ require (
 	github.com/aws/smithy-go v1.22.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/baulk/chardet v0.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 // indirect
@@ -122,10 +124,12 @@ require (
 	github.com/docker/libkv v0.2.2-0.20180912205406-458977154600 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
+	github.com/editorconfig/editorconfig-core-go/v2 v2.6.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -385,6 +385,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/baulk/chardet v0.1.0 h1:6/r5nPMikB9OG1Njs10VfVHZTDMFH6BdybHPISpfUVA=
+github.com/baulk/chardet v0.1.0/go.mod h1:0ibN6068qswel5Hv54U7GNJUU57njfzPJrLIq7Y8xas=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -513,6 +515,10 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad h1:Qk76DOWdOp+GlyDKBAG3Klr9cn7N+LcYc82AZ2S7+cA=
 github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad/go.mod h1:mPKfmRa823oBIgl2r20LeMSpTAteW5j7FLkc0vjmzyQ=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/editorconfig-checker/editorconfig-checker/v3 v3.0.3 h1:WO9Yd7/KjfGDYUeSBsGKh+Uj+K+/oTnJ3elDQ7Oq7yU=
+github.com/editorconfig-checker/editorconfig-checker/v3 v3.0.3/go.mod h1:9mvpU+I3xMoU+l0vNtR98SUX/AsoAhBCntntRtNIu3Y=
+github.com/editorconfig/editorconfig-core-go/v2 v2.6.2 h1:dKG8sc7n321deIVRcQtwlMNoBEra7j0qQ8RwxO8RN0w=
+github.com/editorconfig/editorconfig-core-go/v2 v2.6.2/go.mod h1:7dvD3GCm7eBw53xZ/lsiq72LqobdMg3ITbMBxnmJmqY=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elewis787/boa v0.1.2 h1:xNKWJ9X2MWbLSLLOA31N4l1Jdec9FZSkbTvXy3C8rw4=
@@ -553,6 +559,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
+github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=


### PR DESCRIPTION
issue: https://linear.app/cloudposse/issue/DEV-2836/implement-atmos-validate-editorconfig

## what
* Added functionality to atmos validate to validate against the .editorconfig file if it is defined.
* Integrated the editorconfig-checker library to perform the validation.
* Modified the validation process to support OPA/JSON schema validation alongside the new .editorconfig validation.

## why

* The change ensures that the .editorconfig file is validated, which helps maintain consistency in code formatting across teams.
* By incorporating editorconfig-checker, the validation process becomes more comprehensive, ensuring that both OPA/JSON schemas and editor configuration are correct.
* This update was made to improve development workflow by catching formatting issues early during the validation process.


## references

* https://github.com/editorconfig-checker/editorconfig-checker
* https://linear.app/cloudposse/issue/DEV-2836/implement-atmos-validate-editorconfig
