### PR TITLE
replace path with filepath

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -405,7 +404,8 @@ func printMessageForMissingAtmosConfig(atmosConfig schema.AtmosConfiguration) {
 		u.PrintMessageInColor("atmos.yaml", c1)
 		fmt.Println(" CLI config file was not found.")
 		fmt.Print("\nThe default Atmos stacks directory is set to ")
-		u.PrintMessageInColor(path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath), c1)
+
+		u.PrintMessageInColor(filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath), c1)
 		fmt.Println(",\nbut the directory does not exist in the current path.")
 	} else {
 		// If Atmos found an `atmos.yaml` config file, but it defines invalid paths to Atmos stacks and components

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/charmbracelet/glamour"
@@ -59,7 +59,7 @@ var docsCmd = &cobra.Command{
 			}
 
 			// Construct the full path to the Terraform component by combining the Atmos base path, Terraform base path, and component name
-			componentPath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, info.Component)
+			componentPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, info.Component)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil {
 				u.LogErrorAndExit(schema.AtmosConfiguration{}, err)
@@ -68,7 +68,7 @@ var docsCmd = &cobra.Command{
 				u.LogErrorAndExit(schema.AtmosConfiguration{}, fmt.Errorf("Component '%s' not found in path: '%s'", info.Component, componentPath))
 			}
 
-			readmePath := path.Join(componentPath, "README.md")
+			readmePath := filepath.Join(componentPath, "README.md")
 			if _, err := os.Stat(readmePath); err != nil {
 				if os.IsNotExist(err) {
 					u.LogErrorAndExit(schema.AtmosConfiguration{}, fmt.Errorf("No README found for component: %s", info.Component))

--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -339,7 +338,7 @@ func ExecuteAtlantisGenerateRepoConfig(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -158,11 +158,11 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 
 		configAndStacksInfo.ComponentType = "terraform"
 		configAndStacksInfo, err = ProcessStacks(atmosConfig, configAndStacksInfo, true, true)
-		shellCommandWorkingDir = path.Join(atmosConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+		shellCommandWorkingDir = filepath.Join(atmosConfig.TerraformDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 		if err != nil {
 			configAndStacksInfo.ComponentType = "helmfile"
 			configAndStacksInfo, err = ProcessStacks(atmosConfig, configAndStacksInfo, true, true)
-			shellCommandWorkingDir = path.Join(atmosConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
+			shellCommandWorkingDir = filepath.Join(atmosConfig.HelmfileDirAbsolutePath, configAndStacksInfo.ComponentFolderPrefix, configAndStacksInfo.FinalComponent)
 			if err != nil {
 				return err
 			}

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -424,7 +423,7 @@ func executeDescribeAffected(
 	// Absolute base path can be set in the `base_path` attribute in `atmos.yaml`, or using the ENV var `ATMOS_BASE_PATH` (as it's done in `geodesic`)
 	// If the `atmos` base path is absolute, find the relative path between the local repo path and the `atmos` base path.
 	// This relative path (the difference) is then used below to join with the remote (cloned) target repo path.
-	if path.IsAbs(basePath) {
+	if filepath.IsAbs(basePath) {
 		basePath, err = filepath.Rel(localRepoFileSystemPathAbs, basePath)
 		if err != nil {
 			return nil, nil, nil, err
@@ -432,9 +431,9 @@ func executeDescribeAffected(
 	}
 
 	// Update paths to point to the cloned remote repo dir
-	atmosConfig.StacksBaseAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath)
-	atmosConfig.TerraformDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Terraform.BasePath)
-	atmosConfig.HelmfileDirAbsolutePath = path.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Helmfile.BasePath)
+	atmosConfig.StacksBaseAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath)
+	atmosConfig.TerraformDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Terraform.BasePath)
+	atmosConfig.HelmfileDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Components.Helmfile.BasePath)
 
 	atmosConfig.StackConfigFilesAbsolutePaths, err = u.JoinAbsolutePathWithPaths(
 		filepath.Join(remoteRepoFileSystemPath, basePath, atmosConfig.Stacks.BasePath),
@@ -1182,9 +1181,9 @@ func isComponentFolderChanged(
 
 	switch componentType {
 	case "terraform":
-		componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
+		componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
 	case "helmfile":
-		componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, component)
+		componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, component)
 	}
 
 	componentPathAbs, err := filepath.Abs(componentPath)
@@ -1220,7 +1219,7 @@ func areTerraformComponentModulesChanged(
 	changedFiles []string,
 ) (bool, error) {
 
-	componentPath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
+	componentPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, component)
 
 	componentPathAbs, err := filepath.Abs(componentPath)
 	if err != nil {
@@ -1241,7 +1240,7 @@ func areTerraformComponentModulesChanged(
 				continue
 			}
 
-			modulePath := path.Join(path.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
+			modulePath := filepath.Join(filepath.Dir(moduleConfig.Pos.Filename), moduleConfig.Source)
 
 			modulePathAbs, err := filepath.Abs(modulePath)
 			if err != nil {

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -5,7 +5,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -78,20 +78,20 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 	}
 
 	// Check if the component exists as a helmfile component
-	componentPath := path.Join(atmosConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
+	componentPath := filepath.Join(atmosConfig.HelmfileDirAbsolutePath, info.ComponentFolderPrefix, info.FinalComponent)
 	componentPathExists, err := u.IsDirectory(componentPath)
 	if err != nil || !componentPathExists {
 		return fmt.Errorf("'%s' points to the Helmfile component '%s', but it does not exist in '%s'",
 			info.ComponentFromArg,
 			info.FinalComponent,
-			path.Join(atmosConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
+			filepath.Join(atmosConfig.Components.Helmfile.BasePath, info.ComponentFolderPrefix),
 		)
 	}
 
 	// Check if the component is allowed to be provisioned (`metadata.type` attribute)
 	if (info.SubCommand == "sync" || info.SubCommand == "apply" || info.SubCommand == "deploy") && info.ComponentIsAbstract {
 		return fmt.Errorf("abstract component '%s' cannot be provisioned since it's explicitly prohibited from being deployed "+
-			"by 'metadata.type: abstract' attribute", path.Join(info.ComponentFolderPrefix, info.Component))
+			"by 'metadata.type: abstract' attribute", filepath.Join(info.ComponentFolderPrefix, info.Component))
 	}
 
 	// Print component variables
@@ -196,7 +196,7 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 		u.LogDebug(atmosConfig, "Stack: "+info.StackFromArg)
 	} else {
 		u.LogDebug(atmosConfig, "Stack: "+info.StackFromArg)
-		u.LogDebug(atmosConfig, "Stack path: "+path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath, info.Stack))
+		u.LogDebug(atmosConfig, "Stack path: "+filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath, info.Stack))
 	}
 
 	workingDir := constructHelmfileComponentWorkingDir(atmosConfig, info)

--- a/internal/exec/oci_utils.go
+++ b/internal/exec/oci_utils.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -30,7 +30,7 @@ func processOciImage(atmosConfig schema.AtmosConfiguration, imageName string, de
 	defer removeTempDir(atmosConfig, tempDir)
 
 	// Temp tarball file name
-	tempTarFileName := path.Join(tempDir, uuid.New().String()) + ".tar"
+	tempTarFileName := filepath.Join(tempDir, uuid.New().String()) + ".tar"
 
 	// Get the image reference from the OCI registry
 	ref, err := name.ParseReference(imageName)
@@ -91,7 +91,7 @@ func processOciImage(atmosConfig schema.AtmosConfiguration, imageName string, de
 
 	// Extract the layers into the destination directory
 	for _, l := range manifest.Layers {
-		layerPath := path.Join(tempDir, l)
+		layerPath := filepath.Join(tempDir, l)
 
 		err = extractTarball(atmosConfig, layerPath, destDir)
 		if err != nil {

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -60,7 +59,7 @@ func ProcessYAMLConfigFiles(
 
 			stackBasePath := stacksBasePath
 			if len(stackBasePath) < 1 {
-				stackBasePath = path.Dir(p)
+				stackBasePath = filepath.Dir(p)
 			}
 
 			stackFileName := strings.TrimSuffix(
@@ -357,7 +356,7 @@ func ProcessYAMLConfigFile(
 
 			found := false
 			for _, extension := range extensions {
-				testPath := path.Join(basePath, imp+extension)
+				testPath := filepath.Join(basePath, imp+extension)
 				if _, err := os.Stat(testPath); err == nil {
 					impWithExt = imp + extension
 					found = true
@@ -372,12 +371,12 @@ func ProcessYAMLConfigFile(
 		} else if ext == u.YamlFileExtension || ext == u.YmlFileExtension {
 			// Check if there's a template version of this file
 			templatePath := impWithExt + u.TemplateExtension
-			if _, err := os.Stat(path.Join(basePath, templatePath)); err == nil {
+			if _, err := os.Stat(filepath.Join(basePath, templatePath)); err == nil {
 				impWithExt = templatePath
 			}
 		}
 
-		impWithExtPath := path.Join(basePath, impWithExt)
+		impWithExtPath := filepath.Join(basePath, impWithExt)
 
 		if impWithExtPath == filePath {
 			errorMessage := fmt.Sprintf("invalid import in the manifest '%s'\nThe file imports itself in '%s'",
@@ -1826,7 +1825,7 @@ func CreateComponentStackMap(
 	componentStackMap["terraform"] = map[string][]string{}
 	componentStackMap["helmfile"] = map[string][]string{}
 
-	dir := path.Dir(filePath)
+	dir := filepath.Dir(filePath)
 
 	err := filepath.Walk(dir,
 		func(p string, info os.FileInfo, err error) error {
@@ -2180,7 +2179,7 @@ func ProcessBaseComponentConfig(
 		if checkBaseComponentExists {
 			// Check if the base component exists as Terraform/Helmfile component
 			// If it does exist, don't throw errors if it is not defined in YAML config
-			componentPath := path.Join(componentBasePath, baseComponent)
+			componentPath := filepath.Join(componentBasePath, baseComponent)
 			componentPathExists, err := u.IsDirectory(componentPath)
 			if err != nil || !componentPathExists {
 				return errors.New("The component '" + component + "' inherits from the base component '" +

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -164,9 +164,9 @@ func BuildComponentPath(
 
 	if stackComponentSection, ok := componentSectionMap[cfg.ComponentSectionName].(string); ok {
 		if componentType == "terraform" {
-			componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, stackComponentSection)
+			componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath, stackComponentSection)
 		} else if componentType == "helmfile" {
-			componentPath = path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, stackComponentSection)
+			componentPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath, stackComponentSection)
 		}
 	}
 

--- a/internal/exec/terraform_generate_backend.go
+++ b/internal/exec/terraform_generate_backend.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -75,7 +75,7 @@ func ExecuteTerraformGenerateBackendCmd(cmd *cobra.Command, args []string) error
 	}
 
 	// Write backend config to file
-	var backendFilePath = path.Join(
+	var backendFilePath = filepath.Join(
 		atmosConfig.BasePath,
 		atmosConfig.Components.Terraform.BasePath,
 		info.ComponentFolderPrefix,

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -161,7 +160,7 @@ func ExecuteTerraformGenerateBackends(
 				}
 
 				// Path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,
@@ -291,7 +290,7 @@ func ExecuteTerraformGenerateBackends(
 
 						processedTerraformComponents[terraformComponent] = terraformComponent
 
-						backendFilePath = path.Join(
+						backendFilePath = filepath.Join(
 							terraformComponentPath,
 							"backend.tf",
 						)

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -160,7 +159,7 @@ func ExecuteTerraformGenerateVarfiles(
 				}
 
 				// Absolute path to the terraform component
-				terraformComponentPath := path.Join(
+				terraformComponentPath := filepath.Join(
 					atmosConfig.BasePath,
 					atmosConfig.Components.Terraform.BasePath,
 					terraformComponent,

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -88,7 +87,7 @@ func execTerraformOutput(atmosConfig schema.AtmosConfiguration, component string
 
 		// Auto-generate backend file
 		if atmosConfig.Components.Terraform.AutoGenerateBackendFile {
-			backendFileName := path.Join(componentPath, "backend.tf.json")
+			backendFileName := filepath.Join(componentPath, "backend.tf.json")
 
 			u.LogTrace(atmosConfig, "\nWriting the backend config to file:")
 			u.LogTrace(atmosConfig, backendFileName)
@@ -121,7 +120,7 @@ func execTerraformOutput(atmosConfig schema.AtmosConfiguration, component string
 		providersSection, ok := sections["providers"].(map[string]any)
 
 		if ok && len(providersSection) > 0 {
-			providerOverrideFileName := path.Join(componentPath, "providers_override.tf.json")
+			providerOverrideFileName := filepath.Join(componentPath, "providers_override.tf.json")
 
 			u.LogTrace(atmosConfig, "\nWriting the provider overrides to file:")
 			u.LogTrace(atmosConfig, providerOverrideFileName)

--- a/internal/exec/validate_component.go
+++ b/internal/exec/validate_component.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -197,11 +197,11 @@ func validateComponentInternal(
 		switch schemaType {
 		case "jsonschema":
 			{
-				filePath = path.Join(atmosConfig.BasePath, atmosConfig.Schemas.JsonSchema.BasePath, schemaPath)
+				filePath = filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.JsonSchema.BasePath, schemaPath)
 			}
 		case "opa":
 			{
-				filePath = path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath, schemaPath)
+				filePath = filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath, schemaPath)
 			}
 		}
 
@@ -228,7 +228,7 @@ func validateComponentInternal(
 		}
 	case "opa":
 		{
-			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath), modulePaths)
+			modulePathsAbsolute, err := u.JoinAbsolutePathWithPaths(filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Opa.BasePath), modulePaths)
 			if err != nil {
 				return false, err
 			}

--- a/internal/exec/validate_stacks.go
+++ b/internal/exec/validate_stacks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -91,7 +91,7 @@ func ValidateStacks(atmosConfig schema.AtmosConfiguration) error {
 		u.LogTrace(atmosConfig, fmt.Sprintf("The Atmos JSON Schema file is not configured. Using the default schema '%s'", atmosManifestDefault))
 	}
 
-	atmosManifestJsonSchemaFileAbsPath := path.Join(atmosConfig.BasePath, atmosConfig.Schemas.Atmos.Manifest)
+	atmosManifestJsonSchemaFileAbsPath := filepath.Join(atmosConfig.BasePath, atmosConfig.Schemas.Atmos.Manifest)
 
 	if u.FileExists(atmosConfig.Schemas.Atmos.Manifest) {
 		atmosManifestJsonSchemaFilePath = atmosConfig.Schemas.Atmos.Manifest
@@ -131,7 +131,7 @@ func ValidateStacks(atmosConfig schema.AtmosConfiguration) error {
 	}
 
 	u.LogDebug(atmosConfig, fmt.Sprintf("Validating all YAML files in the '%s' folder and all subfolders (excluding template files)\n",
-		path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)))
+		filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)))
 
 	for _, filePath := range stackConfigFilesAbsolutePaths {
 		stackConfig, importsConfig, _, _, _, err := ProcessYAMLConfigFile(
@@ -376,7 +376,7 @@ func downloadSchemaFromURL(manifestURL string) (string, error) {
 	if err != nil || fileName == "" {
 		return "", fmt.Errorf("failed to get the file name from the URL '%s': %w", manifestURL, err)
 	}
-	atmosManifestJsonSchemaFilePath := path.Join(tempDir, fileName)
+	atmosManifestJsonSchemaFilePath := filepath.Join(tempDir, fileName)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	client := &getter.Client{

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -167,7 +166,7 @@ func ReadAndProcessVendorConfigFile(
 
 		if !fileExists {
 			// Look for the vendoring manifest in the directory pointed to by the `base_path` setting in `atmos.yaml`
-			pathToVendorConfig := path.Join(atmosConfig.BasePath, vendorConfigFile)
+			pathToVendorConfig := filepath.Join(atmosConfig.BasePath, vendorConfigFile)
 			foundVendorConfigFile, fileExists = u.SearchConfigFile(pathToVendorConfig)
 
 			if !fileExists {

--- a/internal/exec/workflow.go
+++ b/internal/exec/workflow.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -80,7 +79,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 	if u.IsPathAbsolute(workflowFile) {
 		workflowPath = workflowFile
 	} else {
-		workflowPath = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, workflowFile)
+		workflowPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, workflowFile)
 	}
 
 	// If the workflow file is specified without an extension, use the default extension

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -147,7 +146,7 @@ func ExecuteDescribeWorkflows(
 	if u.IsPathAbsolute(atmosConfig.Workflows.BasePath) {
 		workflowsDir = atmosConfig.Workflows.BasePath
 	} else {
-		workflowsDir = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath)
+		workflowsDir = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath)
 	}
 
 	isDirectory, err := u.IsDirectory(workflowsDir)
@@ -164,9 +163,9 @@ func ExecuteDescribeWorkflows(
 	for _, f := range files {
 		var workflowPath string
 		if u.IsPathAbsolute(atmosConfig.Workflows.BasePath) {
-			workflowPath = path.Join(atmosConfig.Workflows.BasePath, f)
+			workflowPath = filepath.Join(atmosConfig.Workflows.BasePath, f)
 		} else {
-			workflowPath = path.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, f)
+			workflowPath = filepath.Join(atmosConfig.BasePath, atmosConfig.Workflows.BasePath, f)
 		}
 
 		fileContent, err := os.ReadFile(workflowPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 
@@ -133,7 +132,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	if len(configFilePath1) > 0 {
-		configFile1 := path.Join(configFilePath1, CliConfigFileName)
+		configFile1 := filepath.Join(configFilePath1, CliConfigFileName)
 		found, err = processConfigFile(atmosConfig, configFile1, v)
 		if err != nil {
 			return atmosConfig, err
@@ -148,7 +147,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return atmosConfig, err
 	}
-	configFile2 := path.Join(configFilePath2, ".atmos", CliConfigFileName)
+	configFile2 := filepath.Join(configFilePath2, ".atmos", CliConfigFileName)
 	found, err = processConfigFile(atmosConfig, configFile2, v)
 	if err != nil {
 		return atmosConfig, err
@@ -162,7 +161,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if err != nil {
 		return atmosConfig, err
 	}
-	configFile3 := path.Join(configFilePath3, CliConfigFileName)
+	configFile3 := filepath.Join(configFilePath3, CliConfigFileName)
 	found, err = processConfigFile(atmosConfig, configFile3, v)
 	if err != nil {
 		return atmosConfig, err
@@ -175,7 +174,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	configFilePath4 := os.Getenv("ATMOS_CLI_CONFIG_PATH")
 	if len(configFilePath4) > 0 {
 		u.LogTrace(atmosConfig, fmt.Sprintf("Found ENV var ATMOS_CLI_CONFIG_PATH=%s", configFilePath4))
-		configFile4 := path.Join(configFilePath4, CliConfigFileName)
+		configFile4 := filepath.Join(configFilePath4, CliConfigFileName)
 		found, err = processConfigFile(atmosConfig, configFile4, v)
 		if err != nil {
 			return atmosConfig, err
@@ -189,7 +188,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	if configAndStacksInfo.AtmosCliConfigPath != "" {
 		configFilePath5 := configAndStacksInfo.AtmosCliConfigPath
 		if len(configFilePath5) > 0 {
-			configFile5 := path.Join(configFilePath5, CliConfigFileName)
+			configFile5 := filepath.Join(configFilePath5, CliConfigFileName)
 			found, err = processConfigFile(atmosConfig, configFile5, v)
 			if err != nil {
 				return atmosConfig, err
@@ -271,7 +270,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	// Convert stacks base path to absolute path
-	stacksBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)
+	stacksBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Stacks.BasePath)
 	stacksBaseAbsPath, err := filepath.Abs(stacksBasePath)
 	if err != nil {
 		return atmosConfig, err
@@ -293,7 +292,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	atmosConfig.ExcludeStackAbsolutePaths = excludeStackAbsPaths
 
 	// Convert terraform dir to absolute path
-	terraformBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath)
+	terraformBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Terraform.BasePath)
 	terraformDirAbsPath, err := filepath.Abs(terraformBasePath)
 	if err != nil {
 		return atmosConfig, err
@@ -301,7 +300,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	atmosConfig.TerraformDirAbsolutePath = terraformDirAbsPath
 
 	// Convert helmfile dir to absolute path
-	helmfileBasePath := path.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath)
+	helmfileBasePath := filepath.Join(atmosConfig.BasePath, atmosConfig.Components.Helmfile.BasePath)
 	helmfileDirAbsPath, err := filepath.Abs(helmfileBasePath)
 	if err != nil {
 		return atmosConfig, err

--- a/pkg/generate/terraform_generate_varfiles_test.go
+++ b/pkg/generate/terraform_generate_varfiles_test.go
@@ -2,7 +2,7 @@ package generate
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -28,7 +28,7 @@ func TestTerraformGenerateVarfiles(t *testing.T) {
 
 	var stacks []string
 	var components []string
-	filePattern := path.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
+	filePattern := filepath.Join(tempDir, "varfiles/{tenant}-{environment}-{stage}-{component}.tfvars")
 	format := "hcl"
 
 	err = e.ExecuteTerraformGenerateVarfiles(atmosConfig, filePattern, format, stacks, components)

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -69,7 +68,7 @@ func JoinAbsolutePathWithPaths(basePath string, paths []string) ([]string, error
 	res := []string{}
 
 	for _, p := range paths {
-		res = append(res, path.Join(basePath, p))
+		res = append(res, filepath.Join(basePath, p))
 	}
 
 	return res, nil
@@ -93,7 +92,7 @@ func JoinAbsolutePathWithPath(basePath string, providedPath string) (string, err
 	}
 
 	// Join the base path with the provided path
-	joinedPath := path.Join(basePath, providedPath)
+	joinedPath := filepath.Join(basePath, providedPath)
 
 	// If the joined path is an absolute path and exists in the file system, return it
 	if filepath.IsAbs(joinedPath) {
@@ -133,7 +132,7 @@ func EnsureDir(fileName string) error {
 // SliceOfPathsContainsPath checks if a slice of file paths contains a path
 func SliceOfPathsContainsPath(paths []string, checkPath string) bool {
 	for _, v := range paths {
-		dir := path.Dir(v)
+		dir := filepath.Dir(v)
 		if dir == checkPath {
 			return true
 		}
@@ -236,7 +235,7 @@ func GetFileNameFromURL(rawURL string) (string, error) {
 	urlPath := parsedURL.Path
 
 	// Get the base name of the path
-	fileName := path.Base(urlPath)
+	fileName := filepath.Base(urlPath)
 	if fileName == "/" || fileName == "." {
 		return "", fmt.Errorf("unable to extract filename from URL: %s", rawURL)
 	}

--- a/pkg/utils/glob_utils.go
+++ b/pkg/utils/glob_utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -36,7 +36,7 @@ func GetGlobMatches(pattern string) ([]string, error) {
 
 	var fullMatches []string
 	for _, match := range matches {
-		fullMatches = append(fullMatches, path.Join(base, match))
+		fullMatches = append(fullMatches, filepath.Join(base, match))
 	}
 
 	getGlobMatchesSyncMap.Store(pattern, strings.Join(fullMatches, ","))


### PR DESCRIPTION
## replace path with filepath 
## why 
Problem: Different operating systems use different path separators (/ on Unix-based systems like Linux and macOS, and \ on Windows).
filepath package automatically handles these differences, making  code platform-independent. It abstracts the underlying file system separator, so we don't have to worry about whether you're running on Windows or Unix-based systems
## references
- DEV-2817
