### PR TITLE
Default value for demo argument should not cause an error

### DIFF
--- a/examples/demo-custom-command/atmos.yaml
+++ b/examples/demo-custom-command/atmos.yaml
@@ -57,6 +57,18 @@ commands:
     steps:
       - curl -s https://api.github.com/repos/{{ .Arguments.repo }} | jq -r .stargazers_count
 
+# # Use positional arguments with default values
+- name: greet
+  description: "Displays a personalized greeting. Defaults to 'John Doe' if no name is provided."
+  arguments:
+    - name: name
+      description: >-
+          Enter your name as an argument
+      required: true
+      default: John Doe
+  steps:
+    - "echo Hello, {{ .Arguments.name }}"
+
 # Use flags
 - name: weather
   description: This command fetches the weather

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -343,6 +343,8 @@ type Command struct {
 type CommandArgument struct {
 	Name        string `yaml:"name" json:"name" mapstructure:"name"`
 	Description string `yaml:"description" json:"description" mapstructure:"description"`
+	Required    bool   `yaml:"required" json:"required" mapstructure:"required"`
+	Default     string `yaml:"default" json:"default" mapstructure:"default"`
 }
 
 type CommandFlag struct {

--- a/website/docs/core-concepts/custom-commands/custom-commands.mdx
+++ b/website/docs/core-concepts/custom-commands/custom-commands.mdx
@@ -39,18 +39,21 @@ atmos hello
 
 ## Positional Arguments
 
-Atmos also can support positional arguments. Arguments do not support default values and are required if defined.
-
-If we add the following to `atmos.yaml`, will introduce a new `hello` command that accepts one `name` argument.
+Atmos also can support positional arguments. If a positional argument is required but not provided by the user, 
+the command will fail—unless you define a default in your config. 
+If we add the following to `atmos.yaml`, will introduce a new `greet` command that accepts one `name` argument,
+but uses a default of "John Doe" if none is provided:. 
 
 ```yaml
 # subcommands
 commands:
-  - name: hello
+  - name: greet
     description: This command says hello to the provided name
     arguments:
       - name: name
         description: Name to greet
+        required: true
+        default: John Doe
     steps:
       - "echo Hello {{ .Arguments.name }}!"
 ```
@@ -58,7 +61,12 @@ commands:
 We can run this example like this:
 
 ```shell
-atmos hello world
+atmos greet Alice
+```
+or defaulting to "John Doe"
+
+```shell
+atmos greet
 ```
 
 ## Passing Flags


### PR DESCRIPTION
## what

The task is was "If a default is provided for a custom command, and required is true, then it shouldn't error."

### before
![before](https://github.com/user-attachments/assets/fb58069d-e092-4a95-a0ac-d5a199136dde)

### a custom cli-command is defined
![custom_cli_command](https://github.com/user-attachments/assets/ff959eac-ef13-4b54-8df6-fc9866d8321d)

### after 
![after](https://github.com/user-attachments/assets/dcdc3e2d-2b3b-4162-98b3-efc36f35693f)


## why

Provide a deafult value in atmos.yaml for a custom CLI command, so it doesn't error out (before it did). 

## references

Link to the ticket - [https://linear.app/cloudposse/issue/DEV-2327/default-value-for-demo-argument-should-not-cause-an-error](url)
