### PR TITLE
feat: Support Component Lock with `metadata.locked`

### DIFF
--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -94,6 +94,16 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 			"by 'metadata.type: abstract' attribute", filepath.Join(info.ComponentFolderPrefix, info.Component))
 	}
 
+	// Check if the component is locked (`metadata.locked` is set to true)
+	if info.ComponentIsLocked {
+		// Allow read-only commands, block modification commands
+		switch info.SubCommand {
+		case "sync", "apply", "deploy", "delete", "destroy", "secrets":
+			return fmt.Errorf("component '%s' is locked and cannot be modified (metadata.locked = true)",
+				filepath.Join(info.ComponentFolderPrefix, info.Component))
+		}
+	}
+
 	// Print component variables
 	u.LogDebug(atmosConfig, fmt.Sprintf("\nVariables for the component '%s' in the stack '%s':", info.ComponentFromArg, info.Stack))
 

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -55,14 +55,15 @@ func BuildTerraformWorkspace(atmosConfig schema.AtmosConfiguration, configAndSta
 }
 
 // ProcessComponentMetadata processes component metadata and returns a base component (if any) and whether
-// the component is real or abstract and whether the component is disabled or not
+// the component is real or abstract and whether the component is disabled or not and whether the component is locked
 func ProcessComponentMetadata(
 	component string,
 	componentSection map[string]any,
-) (map[string]any, string, bool, bool) {
+) (map[string]any, string, bool, bool, bool) {
 	baseComponentName := ""
 	componentIsAbstract := false
 	componentIsEnabled := true
+	componentIsLocked := false
 	var componentMetadata map[string]any
 
 	// Find base component in the `component` attribute
@@ -82,6 +83,11 @@ func ProcessComponentMetadata(
 				componentIsEnabled = false
 			}
 		}
+		if lockedValue, exists := componentMetadata["locked"]; exists {
+			if locked, ok := lockedValue.(bool); ok && locked {
+				componentIsLocked = true
+			}
+		}
 		// Find base component in the `metadata.component` attribute
 		// `metadata.component` overrides `component`
 		if componentMetadataComponent, componentMetadataComponentExists := componentMetadata[cfg.ComponentSectionName].(string); componentMetadataComponentExists {
@@ -94,7 +100,7 @@ func ProcessComponentMetadata(
 		baseComponentName = ""
 	}
 
-	return componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled
+	return componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled, componentIsLocked
 }
 
 // BuildDependentStackNameFromDependsOnLegacy builds the dependent stack name from "settings.spacelift.depends_on" config

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -122,6 +122,16 @@ func ExecuteTerraform(info schema.ConfigAndStacksInfo) error {
 			"by 'metadata.type: abstract' attribute", filepath.Join(info.ComponentFolderPrefix, info.Component))
 	}
 
+	// Check if the component is locked (`metadata.locked` is set to true)
+	if info.ComponentIsLocked {
+		// Allow read-only commands, block modification commands
+		switch info.SubCommand {
+		case "apply", "deploy", "destroy", "import", "state", "taint", "untaint":
+			return fmt.Errorf("component '%s' is locked and cannot be modified (metadata.locked = true)",
+				filepath.Join(info.ComponentFolderPrefix, info.Component))
+		}
+	}
+
 	if info.SubCommand == "clean" {
 		err := handleCleanSubCommand(info, componentPath, atmosConfig)
 		if err != nil {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -130,8 +130,9 @@ func ProcessComponentConfig(
 	}
 
 	// Process component metadata and find a base component (if any) and whether the component is real or abstract
-	componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled := ProcessComponentMetadata(component, componentSection)
+	componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled, componentIsLocked := ProcessComponentMetadata(component, componentSection)
 	configAndStacksInfo.ComponentIsEnabled = componentIsEnabled
+	configAndStacksInfo.ComponentIsLocked = componentIsLocked
 
 	// Remove the ENV vars that are set to `null` in the `env` section.
 	// Setting an ENV var to `null` in stack config has the effect of unsetting it
@@ -599,9 +600,10 @@ func ProcessStacks(
 	configAndStacksInfo.ComponentEnvList = u.ConvertEnvVars(configAndStacksInfo.ComponentEnvSection)
 
 	// Process component metadata
-	_, baseComponentName, _, componentIsEnabled := ProcessComponentMetadata(configAndStacksInfo.ComponentFromArg, configAndStacksInfo.ComponentSection)
+	_, baseComponentName, _, componentIsEnabled, componentIsLocked := ProcessComponentMetadata(configAndStacksInfo.ComponentFromArg, configAndStacksInfo.ComponentSection)
 	configAndStacksInfo.BaseComponentPath = baseComponentName
 	configAndStacksInfo.ComponentIsEnabled = componentIsEnabled
+	configAndStacksInfo.ComponentIsLocked = componentIsLocked
 
 	// Process component path and name
 	configAndStacksInfo.ComponentFolderPrefix = ""

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -231,6 +231,7 @@ type ConfigAndStacksInfo struct {
 	NeedHelp                      bool
 	ComponentIsAbstract           bool
 	ComponentIsEnabled            bool
+	ComponentIsLocked             bool
 	ComponentMetadataSection      AtmosSectionMapType
 	TerraformWorkspace            string
 	JsonSchemaDir                 string

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -172,7 +172,7 @@ func TransformStackConfigToSpaceliftStacks(
 					}
 
 					// Process component metadata and find a base component (if any) and whether the component is real or abstract
-					componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled := e.ProcessComponentMetadata(component, componentMap)
+					componentMetadata, baseComponentName, componentIsAbstract, componentIsEnabled, _ := e.ProcessComponentMetadata(component, componentMap)
 
 					if componentIsAbstract || !componentIsEnabled {
 						continue

--- a/website/docs/core-concepts/stacks/define-components.mdx
+++ b/website/docs/core-concepts/stacks/define-components.mdx
@@ -234,3 +234,26 @@ components:
         name: primary-vpc
 ```
 Using the `metadata.enabled` flag makes it easy to ensure that only the intended components are active in each environment.
+
+### Locking Components with `metadata.locked`
+
+The `metadata.locked` parameter prevents changes to a component while still allowing read operations. When a component is locked, operations that would modify infrastructure (like `terraform apply`) are blocked, while read-only operations (like `terraform plan`) remain available. By default, components are unlocked. Setting `metadata.locked` to `true` prevents any change operations.
+
+:::info Note
+Locking a component does not affect the Terraform state. It's intended as a way to communicate intention and prevent accidental changes to sensitive or critical infrastructure.
+:::
+
+**Example**:
+```yaml
+# Lock a production database component to prevent accidental changes
+components:
+  terraform:
+    rds:
+      metadata:
+        type: real
+        locked: true
+      vars:
+        name: production-database
+```
+
+Using the `metadata.locked` flag helps protect critical infrastructure from unintended modifications while still allowing teams to inspect and review the configuration.


### PR DESCRIPTION
## what
- Added support for `metadata.locked` with components

```yaml
# Lock a production database component to prevent accidental changes
components:
  terraform:
    rds:
      metadata:
        type: real
        locked: true
      vars:
        name: production-database
```

## why
- The `metadata.locked` parameter prevents changes to a component while still allowing read operations. When a component is locked, operations that would modify infrastructure (like `terraform apply`) are blocked, while read-only operations (like `terraform plan`) remain available. By default, components are unlocked. Setting `metadata.locked` to `true` prevents any change operations.

## references
- DEV-2849