### PR TITLE
Support GITHUB_TOKEN for HTTP Requests to github.com for version command

### DIFF
--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -2,18 +2,38 @@ package utils
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/google/go-github/v59/github"
+	"golang.org/x/oauth2"
 )
+
+// newGitHubClient creates a new GitHub client. If a token is provided, it returns an authenticated client;
+// otherwise, it returns an unauthenticated client.
+func newGitHubClient(ctx context.Context) *github.Client {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return github.NewClient(nil)
+	}
+
+	// Token found, create an authenticated client
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	return github.NewClient(tc)
+}
 
 // GetLatestGitHubRepoRelease returns the latest release tag for a GitHub repository
 func GetLatestGitHubRepoRelease(owner string, repo string) (string, error) {
 	opt := &github.ListOptions{Page: 1, PerPage: 1}
-	client := github.NewClient(nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
+
+	client := newGitHubClient(ctx)
 
 	releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, opt)
 	if err != nil {


### PR DESCRIPTION
## what

After the internal discussion and descoping of [this PR](https://github.com/cloudposse/atmos/pull/871) the only part left is the support of the github token for the version command. The code checks if the token is set (e.g. via an env var) and if it is, the requests are done using the token. In case no token is provided, the requests to github are made without it. 

## why

Bypass github ratelimits for non-auth requests (use a token instead)

## references

- DEV-2778 (1 part out of 4 initially requested)
