### PR TITLE
update eol settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 [*]
 insert_final_newline = true
+end_of_line = lf
 
 # Override for Makefile
 [{Makefile,makefile,GNUmakefile}]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+* text eol=lf
 docs linguist-documentation=true
 website/src/components/screengrabs/**.html linguist-generated=true


### PR DESCRIPTION
## what

Ensure the EOL for files in this repo are always `lf` regardless of platform the user is developing on (windows, mac, linux)

## why

Ensure consistency and avoid diffs being shown solely for line endings.

## references

#896 