### PR TITLE
Tweak `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
-* text eol=lf
+# Always check-out / check-in files with LF line endings.
+* text=auto eol=lf
+
 docs linguist-documentation=true
-website/src/components/screengrabs/**/*.html linguist-generated=true binary
+
+# Screengrabs are binary HTML files that are automatically generated
+website/src/components/Screengrabs/**/*.html linguist-generated=true binary
 
 # Mark binary files to prevent normalization
 *.png binary


### PR DESCRIPTION
## what
- Use same setting for text as in the kubernetes project
- Fix type on path (for case-sensitive filesystems)

## why
- Seeing odd behavior from `goreleaser` that only affects the Screengrabs. Won't know if this fixes it until we merge.

## references
- #928 
- #929 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitattributes` configuration to improve line ending handling
	- Modified file path for screengrab HTML files with corrected directory casing
	- Added clarifying comments about file type and line ending management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->