### PR TITLE
[Vendor] Print error message when an error occurs during installation of the last vendored component

### DIFF
--- a/internal/exec/vendor_model.go
+++ b/internal/exec/vendor_model.go
@@ -162,7 +162,7 @@ func (m *modelVendor) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			version := grayColor.Render(version)
 			return m, tea.Sequence(
-				tea.Printf("%s %s %s", mark, pkg.name, version),
+				tea.Printf("%s %s %s %s", mark, pkg.name, version, errMsg),
 				tea.Quit,
 			)
 		}


### PR DESCRIPTION
## what
Adds an error message to the output of `atmos vendor pull` for the last component in a vendor manifest

## references
closes #935