### PR TITLE
fix vendor pull error message

### DIFF
--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -181,7 +181,7 @@ func ReadAndProcessVendorConfigFile(
 	// Check if it's a directory
 	fileInfo, err := os.Stat(foundVendorConfigFile)
 	if err != nil {
-		return vendorConfig, false, "", err
+		return vendorConfig, false, "", fmt.Errorf("Vendoring is not configured. To set up vendoring please see https://atmos.tools/core-concepts/vendor/")
 	}
 
 	var configFiles []string

--- a/tests/test-cases/vendor-test.yaml
+++ b/tests/test-cases/vendor-test.yaml
@@ -1,0 +1,13 @@
+tests:
+  - name: atmos vendor pull
+    enabled: true
+    description: ""
+    workdir: "../"
+    command: "atmos"
+    args:
+      - "vendor"
+      - "pull"
+    expect:
+      stderr:
+        - "Vendoring is not configured. To set up vendoring please see https://atmos.tools/core-concepts/vendor/"
+      exit_code: 1


### PR DESCRIPTION
## what
* New error message for vendor pull when config does not exist
![image](https://github.com/user-attachments/assets/9f34c4b6-a01f-47c8-92ed-2329374e19ed)

## why

* Old error message was not helpful
![image](https://github.com/user-attachments/assets/27212640-5d37-4c1a-8e16-ec58822eb4b5)


## references
* https://linear.app/cloudposse/issue/DEV-2931/atmos-vendor-pull-prints-unhelpful-error-for-non-existant