### PR TITLE
Skipping disabled components on atmos describe afffected

### DIFF
--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -553,6 +553,12 @@ func findAffected(
 										continue
 									}
 								}
+								// Skip disabled components
+								if enabled, ok := metadataSection["enabled"].(bool); ok {
+									if !enabled {
+										continue
+									}
+								}
 								// Check `metadata` section
 								if !isEqual(remoteStacks, stackName, "terraform", componentName, metadataSection, "metadata") {
 									affected := schema.Affected{
@@ -790,6 +796,12 @@ func findAffected(
 								// Skip abstract components
 								if metadataType, ok := metadataSection["type"].(string); ok {
 									if metadataType == "abstract" {
+										continue
+									}
+								}
+								// Skip disabled components
+								if enabled, ok := metadataSection["enabled"].(bool); ok {
+									if !enabled {
 										continue
 									}
 								}

--- a/pkg/describe/describe_affected_test.go
+++ b/pkg/describe/describe_affected_test.go
@@ -77,3 +77,36 @@ func TestDescribeAffectedWithTargetRepoPath(t *testing.T) {
 
 	t.Log(fmt.Sprintf("\nAffected components and stacks:\n%v", affectedYaml))
 }
+
+func TestDescribeAffectedFiltersDisabledComponents(t *testing.T) {
+	configAndStacksInfo := schema.ConfigAndStacksInfo{}
+
+	atmosConfig, err := cfg.InitCliConfig(configAndStacksInfo, true)
+	assert.Nil(t, err)
+
+	// Set the base path to the test fixtures directory
+	atmosConfig.BasePath = "./tests/fixtures/scenarios/complete"
+
+	// Point to the same local repository
+	repoPath := "../../"
+
+	affected, _, _, _, err := e.ExecuteDescribeAffectedWithTargetRepoPath(
+		atmosConfig,
+		repoPath,
+		true,
+		true,
+		true,
+		"tenant1-ue2-test-1", // Use a specific stack that has disabled components
+	)
+	assert.Nil(t, err)
+
+	// Convert to YAML for logging
+	affectedYaml, err := u.ConvertToYAML(affected)
+	assert.Nil(t, err)
+	t.Log(fmt.Sprintf("\nAffected components and stacks:\n%v", affectedYaml))
+
+	// Verify that no disabled components are in the affected list
+	for _, a := range affected {
+		assert.NotEqual(t, "disabled-component", a.Component, "Disabled component should not be included in affected list")
+	}
+}

--- a/tests/fixtures/scenarios/complete/stacks/orgs/cp/tenant1/ue2/test-1.yaml
+++ b/tests/fixtures/scenarios/complete/stacks/orgs/cp/tenant1/ue2/test-1.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+vars:
+  tenant: "tenant1"
+  environment: "ue2"
+  stage: "test"
+
+components:
+  terraform:
+    disabled-component:
+      metadata:
+        type: real
+        enabled: false
+        component: "test/test-component"
+      vars:
+        enabled: false
+        name: "disabled-component"


### PR DESCRIPTION
## what

- Added filtering of disabled components in `atmos describe affected` command
- Added test case `TestDescribeAffectedFiltersDisabledComponents` to verify disabled components filtering
- Updated test fixtures to include a disabled component test case

## why

- Components marked with `metadata.enabled: false` should be excluded from the affected components list
- Improves accuracy of the `describe affected` command by only showing components that would actually be processed

