### PR TITLE
feat(DEV-2936): Spinner for `!terraform.output`

### DIFF
--- a/internal/exec/spinner_utils.go
+++ b/internal/exec/spinner_utils.go
@@ -1,0 +1,39 @@
+package exec
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type modelSpinner struct {
+	spinner spinner.Model
+	message string
+}
+
+func (m modelSpinner) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m modelSpinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		default:
+			return m, nil
+		}
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	default:
+		return m, nil
+	}
+}
+
+func (m modelSpinner) View() string {
+	return fmt.Sprintf("\r%s %s", m.spinner.View(), m.message)
+}

--- a/internal/exec/yaml_func_terraform_output.go
+++ b/internal/exec/yaml_func_terraform_output.go
@@ -25,7 +25,8 @@ func processTagTerraformOutput(
 	var stack string
 	var output string
 
-	// Split the string into slices based on any whitespace
+	// Split the string into slices based on any whitespace (one or more spaces, tabs, or newlines),
+	// while also ignoring leading and trailing whitespace
 	parts := strings.Fields(str)
 	partsLen := len(parts)
 

--- a/internal/exec/yaml_func_terraform_output.go
+++ b/internal/exec/yaml_func_terraform_output.go
@@ -25,8 +25,7 @@ func processTagTerraformOutput(
 	var stack string
 	var output string
 
-	// Split the string into slices based on any whitespace (one or more spaces, tabs, or newlines),
-	// while also ignoring leading and trailing whitespace
+	// Split the string into slices based on any whitespace
 	parts := strings.Fields(str)
 	partsLen := len(parts)
 

--- a/tests/fixtures/scenarios/atmos-functions/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-functions/atmos.yaml
@@ -1,0 +1,21 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "../../components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+  
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_pattern: "{stage}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info

--- a/tests/fixtures/scenarios/atmos-functions/stacks/catalog/component-1.yaml
+++ b/tests/fixtures/scenarios/atmos-functions/stacks/catalog/component-1.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+components:
+  # This is a mocked component that will only be used to gather output
+  terraform:
+    component-1:
+      metadata:
+        component: myapp
+      vars:
+        location: Los Angeles
+        lang: en
+        format: ''
+        options: '0'
+        units: m

--- a/tests/fixtures/scenarios/atmos-functions/stacks/deploy/nonprod.yaml
+++ b/tests/fixtures/scenarios/atmos-functions/stacks/deploy/nonprod.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+vars:
+  stage: nonprod
+
+import:
+  - catalog/component-1
+
+components:
+  terraform:
+    # We want to test passing and reading multiple terraform outputs to component with atmos functions
+    component-2:
+      metadata:
+        component: myapp
+        inherits:
+          - component-1
+    component-3:
+      metadata:
+        component: myapp
+        inherits:
+          - component-1
+    component-4:
+      metadata:
+        component: myapp
+      vars:
+        location: !terraform.output component-1 location
+        lang: !terraform.output component-2 lang
+        format: ''
+        options: '0'
+        units: !terraform.output component-3 units

--- a/tests/fixtures/scenarios/atmos-functions/stacks/workflows/terraform-output.yaml
+++ b/tests/fixtures/scenarios/atmos-functions/stacks/workflows/terraform-output.yaml
@@ -1,0 +1,8 @@
+workflows:
+  deploy:
+    description: Test terraform.output function
+    steps:
+      - command: terraform deploy component-1 -s nonprod
+      - command: terraform deploy component-2 -s nonprod
+      - command: terraform deploy component-3 -s nonprod
+      - command: terraform deploy component-4 -s nonprod

--- a/tests/test-cases/atmos-functions.yaml
+++ b/tests/test-cases/atmos-functions.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: terraform output function
+    enabled: true
+    description: "Ensure the !terraform.output function works."
+    workdir: "fixtures/scenarios/atmos-functions/"
+    command: "atmos"
+    args:
+       - "workflow"
+       - "deploy"
+       - "-f"
+       - "terraform-output"
+    expect:
+      stdout:
+        - "Fetching Terraform output component-1 nonprod location"
+        - "Fetching Terraform output component-2 nonprod lang"
+        - "Fetching Terraform output component-3 nonprod units"
+      exit_code: 0


### PR DESCRIPTION
## what
- Created a charmbracelet spinner when loading terraform output with `!terraform.output`
- Centralized spinner model in `terraform_outputs_model.go`
- Added success/failure indicators for terraform output operations
- Improved user feedback during terraform output operations

## why
- Provides visual feedback during potentially long-running terraform output operations
- Maintains consistency with other Atmos operations (like vendoring) that use spinners
- Improves user experience by clearly indicating:
  - When an operation is in progress
  - When an operation succeeds (✓)
  - When an operation fails (✗)
- Makes it clear which component and stack is being queried for outputs

## references
- DEV-2936
- Related to existing spinner implementation in vendor commands, #367 