### PR TITLE
Fix typo Atoms -> Atmos

### DIFF
--- a/website/docs/quick-start/advanced/configure-cli.mdx
+++ b/website/docs/quick-start/advanced/configure-cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure Atmos CLI
 sidebar_position: 4
-sidebar_label: Configure Atoms CLI
+sidebar_label: Configure Atmos CLI
 ---
 import File from '@site/src/components/File'
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in the sidebar label for the "Configure Atmos CLI" documentation page, correcting "Atoms" to "Atmos"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->