### PR TITLE
Remove Broken Link to Schema

### DIFF
--- a/website/docs/cli/schemas.mdx
+++ b/website/docs/cli/schemas.mdx
@@ -33,7 +33,7 @@ command line by executing the command [`atmos validate stacks`](/cli/commands/va
 For this to work, configure the following:
 
 - Add the [Atmos Manifest JSON Schema](pathname:///schemas/atmos/atmos-manifest/1.0/atmos-manifest.json) to your repository, for example
-  in  [`stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json`](https://github.com/cloudposse/atmos/blob/master/examples/quick-start-advanced/stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json)
+  in `stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json`
 
 - Configure the following section in the `atmos.yaml` [CLI config file](/cli/configuration)
 

--- a/website/docs/cli/schemas.mdx
+++ b/website/docs/cli/schemas.mdx
@@ -32,8 +32,8 @@ command line by executing the command [`atmos validate stacks`](/cli/commands/va
 
 For this to work, configure the following:
 
-- Add the [Atmos Manifest JSON Schema](pathname:///schemas/atmos/atmos-manifest/1.0/atmos-manifest.json) to your repository, for example
-  in `stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json`
+- Add the _optional_ [Atmos Manifest JSON Schema](pathname:///schemas/atmos/atmos-manifest/1.0/atmos-manifest.json) to your repository, for example
+  in `stacks/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json`. If not specified, Atmos will default to the [schema](pathname:///schemas/atmos/atmos-manifest/1.0/atmos-manifest.json) corresponding to the currently installed version of Atmos.
 
 - Configure the following section in the `atmos.yaml` [CLI config file](/cli/configuration)
 


### PR DESCRIPTION
The file originally linked to was in github under `examples/` but now is located under `website/`

The current path is `/website/static/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json`, but I'm not sure if this doc should actually link to it there so I removed it pending any discussion here in this PR.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Clarified that the Atmos Manifest JSON Schema is optional in the repository setup.
	- Minor formatting adjustment for consistency by removing extra whitespace in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->