### PR TITLE
chore: disable CGO in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL := /bin/bash
 #GOARCH=amd64
 VERSION=test
 
+export CGO_ENABLED=0
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Disable CGO in Makefile.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

By default CGO is enabled.
In .goreleaser.yml, CGO is disabled.

https://github.com/cloudposse/atmos/blob/255a05a295c20e29c979f575bcf9cb405e68f745/.goreleaser.yml#L8-L11

Enabling CGO causes problemds like that. https://github.com/cloudposse/atmos/issues/926#issuecomment-2623465765

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
