### PR TITLE
Disable Build Harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,10 @@ SHELL := /bin/bash
 VERSION=test
 
 export CGO_ENABLED=0
-# List of targets the `readme` target should call before generating the readme
-export README_DEPS ?= docs/targets.md
 
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-## Lint terraform code
-lint:
-	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate
+readme:
+	@echo "README.md generation temporarily disabled."
+	@exit 0
 
 get:
 	go get


### PR DESCRIPTION
## what
- Remove build-harness injection
- Add a placeholder for `readme` target

## why
- README generation is really the only use-case we have for the build-harness in this repo
- We're ripping that out and going to start doing native README generation with atmos
- Build Harness initialization started getting flakey 

## references
- #934 
- https://github.com/cloudposse/atmos/pull/991#issuecomment-2625732873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily disabled README generation
	- Removed linting process from build workflow
	- Simplified Makefile configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->