### PR TITLE
try fixing windows performance on gha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
         run: echo "Building on ${{ matrix.os }}"
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
-        if: matrix.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
+        if: matrix.os == 'windows'
+        run: echo 'C:\Program Files\Git\usr\bin'>>"%GITHUB_PATH%"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -86,12 +86,12 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.flavor.os }}
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
+        run: echo 'C:\Program Files\Git\usr\bin'>>"%GITHUB_PATH%"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4
@@ -335,12 +335,12 @@ jobs:
 
     timeout-minutes: 20
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows'
-        run: echo "C:\Program Files\Git\usr\bin" >> $Env:GITHUB_PATH
+        run: echo 'C:\Program Files\Git\usr\bin'>>"%GITHUB_PATH%"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
       - name: Download build artifacts for ${{ matrix.flavor.target }}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## what
- Fixed Windows path handling in GitHub Actions workflows
- Reordered workflow steps to ensure GNU tar is available before checkout
- Updated the syntax for setting GitHub path on Windows environments

## why
- Previous Windows path syntax using `$Env:GITHUB_PATH` was causing failures
- Using `"%GITHUB_PATH%"` provides better compatibility with Windows command prompt
- Moving the GNU tar path addition before checkout ensures faster artifact handling

## references
- Related to GitHub Actions Windows environment path handling: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path