### PR TITLE
allow user to specify default value when using store

### DIFF
--- a/internal/exec/yaml_func_store.go
+++ b/internal/exec/yaml_func_store.go
@@ -11,35 +11,11 @@ import (
 )
 
 type params struct {
-	storeName string
-	stack     string
-	component string
-	key       string
-}
-
-func getParams(input string, currentStack string) (params, error) {
-	parts := strings.Split(input, " ")
-
-	partsLength := len(parts)
-	if partsLength != 3 && partsLength != 4 {
-		return params{}, fmt.Errorf("invalid Atmos Store YAML function execution:: %s\ninvalid parameters: store_name, {stack}, component, key", input)
-	}
-
-	retParams := params{storeName: strings.TrimSpace(parts[0])}
-
-	if partsLength == 4 {
-		retParams.stack = strings.TrimSpace(parts[1])
-		retParams.component = strings.TrimSpace(parts[2])
-		retParams.key = strings.TrimSpace(parts[3])
-	} else if partsLength == 3 {
-		retParams.stack = currentStack
-		retParams.component = strings.TrimSpace(parts[1])
-		retParams.key = strings.TrimSpace(parts[2])
-	} else {
-		return params{}, fmt.Errorf("invalid Atmos Store YAML function execution:: %s\ninvalid parameters: store_name, {stack}, component, key", input)
-	}
-
-	return retParams, nil
+	storeName    string
+	stack        string
+	component    string
+	key          string
+	defaultValue *string
 }
 
 func processTagStore(atmosConfig schema.AtmosConfiguration, input string, currentStack string) any {
@@ -50,20 +26,58 @@ func processTagStore(atmosConfig schema.AtmosConfiguration, input string, curren
 		u.LogErrorAndExit(err)
 	}
 
-	params, err := getParams(str, currentStack)
-	if err != nil {
-		u.LogErrorAndExit(err)
+	// Split the input on the pipe symbol to separate the store parameters and default value
+	parts := strings.Split(str, "|")
+	storePart := strings.TrimSpace(parts[0])
+
+	var defaultValue *string
+	if len(parts) > 1 {
+		// Expecting the format: default <value>
+		defaultParts := strings.Fields(strings.TrimSpace(parts[1]))
+		if len(defaultParts) != 2 || defaultParts[0] != "default" {
+			log.Error(fmt.Sprintf("invalid default value format in: %s", str))
+			return fmt.Sprintf("invalid default value format in: %s", str)
+		}
+		val := strings.Trim(defaultParts[1], `"'`) // Remove surrounding quotes if present
+		defaultValue = &val
 	}
 
-	store := atmosConfig.Stores[params.storeName]
+	// Process the main store part
+	storeParts := strings.Fields(storePart)
+	partsLength := len(storeParts)
+	if partsLength != 3 && partsLength != 4 {
+		return fmt.Sprintf("invalid Atmos Store YAML function execution:: %s\ninvalid parameters: store_name, {stack}, component, key", input)
+	}
+
+	retParams := params{
+		storeName:    strings.TrimSpace(storeParts[0]),
+		defaultValue: defaultValue,
+	}
+
+	if partsLength == 4 {
+		retParams.stack = strings.TrimSpace(storeParts[1])
+		retParams.component = strings.TrimSpace(storeParts[2])
+		retParams.key = strings.TrimSpace(storeParts[3])
+	} else if partsLength == 3 {
+		retParams.stack = currentStack
+		retParams.component = strings.TrimSpace(storeParts[1])
+		retParams.key = strings.TrimSpace(storeParts[2])
+	}
+
+	// Retrieve the store from atmosConfig
+	store := atmosConfig.Stores[retParams.storeName]
 
 	if store == nil {
-		u.LogErrorAndExit(fmt.Errorf("invalid Atmos Store YAML function execution:: %s\nstore '%s' not found", input, params.storeName))
+		u.LogErrorAndExit(fmt.Errorf("invalid Atmos Store YAML function execution:: %s\nstore '%s' not found", input, retParams.storeName))
 	}
 
-	value, err := store.Get(params.stack, params.component, params.key)
+	// Retrieve the value from the store
+	value, err := store.Get(retParams.stack, retParams.component, retParams.key)
 	if err != nil {
-		u.LogErrorAndExit(fmt.Errorf("an error occurred while looking up key %s in stack %s and component %s from store %s\n%v", params.key, params.stack, params.component, params.storeName, err))
+		if retParams.defaultValue != nil {
+			return *retParams.defaultValue
+		}
+		u.LogErrorAndExit(fmt.Errorf("failed to get key: %s", err))
 	}
 
 	return value

--- a/internal/exec/yaml_func_store_test.go
+++ b/internal/exec/yaml_func_store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessTagStore(t *testing.T) {
@@ -36,8 +37,8 @@ func TestProcessTagStore(t *testing.T) {
 	}
 
 	// Populate the store with some data
-		require.NoError(t, redisStore.Set("dev", "vpc", "cidr", "10.0.0.0/16"))
-		require.NoError(t, redisStore.Set("prod", "vpc", "cidr", "172.16.0.0/16"))
+	require.NoError(t, redisStore.Set("dev", "vpc", "cidr", "10.0.0.0/16"))
+	require.NoError(t, redisStore.Set("prod", "vpc", "cidr", "172.16.0.0/16"))
 
 	tests := []struct {
 		name         string

--- a/internal/exec/yaml_func_store_test.go
+++ b/internal/exec/yaml_func_store_test.go
@@ -36,8 +36,8 @@ func TestProcessTagStore(t *testing.T) {
 	}
 
 	// Populate the store with some data
-	redisStore.Set("dev", "vpc", "cidr", "10.0.0.0/16")
-	redisStore.Set("prod", "vpc", "cidr", "172.16.0.0/16")
+		require.NoError(t, redisStore.Set("dev", "vpc", "cidr", "10.0.0.0/16"))
+		require.NoError(t, redisStore.Set("prod", "vpc", "cidr", "172.16.0.0/16"))
 
 	tests := []struct {
 		name         string

--- a/website/docs/core-concepts/stacks/yaml-functions/store.mdx
+++ b/website/docs/core-concepts/stacks/yaml-functions/store.mdx
@@ -9,13 +9,13 @@ import Intro from '@site/src/components/Intro'
 import Terminal from '@site/src/components/Terminal'
 
 <Intro>
-The `!store` YAML function allows reading the values from a remote [store](/core-concepts/projects/configuration/stores) (e.g. SSM Parameter Store, Artifactory, etc.)
+The `!store` YAML function allows reading the values from a remote [store](/core-concepts/projects/configuration/stores) (e.g. SSM Parameter Store, Artifactory, Redis, etc.)
 into Atmos stack manifests.
 </Intro>
 
 ## Usage
 
-The `!store` function can be called with either two or three parameters:
+The `!store` function can be called with either two or three parameters, and optionally a default value:
 
 ```yaml
   # Get the `key` from the store of a `component` in the current stack
@@ -23,6 +23,9 @@ The `!store` function can be called with either two or three parameters:
 
   # Get the `key` from the store of a `component` in a different stack
   !store <component> <stack> <key>
+
+  # Get the `key` from the store of a `component` in a different stack, with a default value
+  !store <component> <stack> <key> | default <default_value>
 ```
 
 ## Arguments
@@ -36,6 +39,9 @@ The `!store` function can be called with either two or three parameters:
 
   <dt>`key`</dt>
   <dd>The key to read from the store</dd>
+
+  <dt>`default_value`</dt>
+  <dd>(optional) The default value to return if the key is not found in the store</dd>
 </dl>
 
 


### PR DESCRIPTION
## what

- Added support for default values in the `!store` YAML function using the pipe (`|`) syntax
- Added comprehensive test coverage for the store function, including default value scenarios
- Updated documentation to reflect the new default value functionality

## why

- Provides a fallback mechanism when store values are not found, preventing errors
- Improves user experience by allowing graceful handling of missing values
- Makes the store function more resilient and flexible in different environments
- Support cold-start scenarios where components the target component depends on haven't been provisioned yet

## references

- Related to store functionality described in `/core-concepts/projects/configuration/stores`
- Implements similar default value patterns found in other YAML processors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional default value for YAML store lookups, allowing a fallback when a key is not found.
  - Enhanced parameter parsing and error handling for a smoother user experience.
- **Tests**
  - Added comprehensive tests to cover diverse lookup scenarios and default value usage.
- **Documentation**
  - Updated the YAML store function guide to include details on the new default value parameter and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->