### PR TITLE
fix: Log to stderr per default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,7 +183,7 @@ func init() {
 		"Errors can be redirected to any file or any standard file descriptor (including '/dev/null'): atmos <command> --redirect-stderr /dev/stdout")
 
 	RootCmd.PersistentFlags().String("logs-level", "Info", "Logs level. Supported log levels are Trace, Debug, Info, Warning, Off. If the log level is set to Off, Atmos will not log any messages")
-	RootCmd.PersistentFlags().String("logs-file", "/dev/stdout", "The file to write Atmos logs to. Logs can be written to any file or any standard file descriptor, including '/dev/stdout', '/dev/stderr' and '/dev/null'")
+	RootCmd.PersistentFlags().String("logs-file", "/dev/stderr", "The file to write Atmos logs to. Logs can be written to any file or any standard file descriptor, including '/dev/stdout', '/dev/stderr' and '/dev/null'")
 
 	// Set custom usage template
 	err := templates.SetCustomUsageFunc(RootCmd)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,7 +75,7 @@ var (
 			BasePath: "stacks/workflows",
 		},
 		Logs: schema.Logs{
-			File:  "/dev/stdout",
+			File:  "/dev/stderr",
 			Level: "Info",
 		},
 		Schemas: schema.Schemas{


### PR DESCRIPTION
## what

- Sync the default value for `logs.file` with the one shipped in `atmos.yaml`.

## why

- `atmos` behaves different without an `atmos.yaml` file than with the one shipped per default.
- It avoids the logging bug in #1026.

## references

- Works around (but does not fix #1026).
