### PR TITLE
properly handle stdout, stderr, and null

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,7 +75,7 @@ var (
 			BasePath: "stacks/workflows",
 		},
 		Logs: schema.Logs{
-			File:  "/dev/stdout",
+			File:  "/dev/stderr",
 			Level: "Info",
 		},
 		Schemas: schema.Schemas{


### PR DESCRIPTION
## what
* handle `/dev/stderr`, `/dev/stdout`, and `/dev/null` with charmbracelet logger.