### PR TITLE
Consider the website as documentation, not programming

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 # Always check-out / check-in files with LF line endings.
 * text=auto eol=lf
 
-docs linguist-documentation=true
+docs/** linguist-documentation
+website/** linguist-documentation
 
 # Screengrabs are binary HTML files that are automatically generated
 website/src/components/Screengrabs/**/*.html linguist-generated=true binary


### PR DESCRIPTION
## what

- Mark the website source as documentation, not programming

## why

- Atmos is a tool written in `go`
- The website is documentation, written in MDX and JavaScript, supporting the tool
- Language statistics should reflect the tool, not the documentation

