### PR TITLE
add doubble dash args support for custom command

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -73,7 +73,8 @@ func processCustomCommands(
 					executeCustomCommand(atmosConfig, cmd, args, parentCommand, commandConfig)
 				},
 			}
-
+			// TODO: we need to update this post https://github.com/cloudposse/atmos/pull/959 gets merged
+			customCommand.PersistentFlags().Bool("", false, "Use double dashes to separate Atmos-specific options from native arguments and flags for the command.")
 			// Process and add flags to the command
 			for _, flag := range commandConfig.Flags {
 				if flag.Type == "bool" {
@@ -270,7 +271,7 @@ func executeCustomCommand(
 	commandConfig *schema.Command,
 ) {
 	var err error
-
+	args, doubleDashArgs := handleArgsAfterDoubleDash(args, os.Args)
 	if commandConfig.Verbose {
 		atmosConfig.Logs.Level = u.LogLevelTrace
 	}
@@ -311,8 +312,9 @@ func executeCustomCommand(
 
 		// Prepare template data
 		data := map[string]any{
-			"Arguments": argumentsData,
-			"Flags":     flagsData,
+			"Arguments":  argumentsData,
+			"Flags":      flagsData,
+			"NativeArgs": doubleDashArgs,
 		}
 
 		// If the custom command defines 'component_config' section with 'component' and 'stack' attributes,
@@ -405,6 +407,32 @@ func executeCustomCommand(
 			u.LogErrorAndExit(err)
 		}
 	}
+}
+
+func handleArgsAfterDoubleDash(args []string, osArgs []string) ([]string, string) {
+	doubleDashIndex := lo.IndexOf(osArgs, "--")
+	mainArgs := args
+	doubleDashString := ""
+	if doubleDashIndex > 0 {
+		mainArgs = lo.Slice(osArgs, 0, doubleDashIndex)
+		doubleDashString = strings.Join(lo.Slice(osArgs, doubleDashIndex+1, len(osArgs)), " ")
+		result := []string{}
+		lookup := make(map[string]bool)
+
+		// Populate a lookup map for quick existence check
+		for _, val := range mainArgs {
+			lookup[val] = true
+		}
+
+		// Iterate over leftArr and collect matching elements in order
+		for _, val := range args {
+			if lookup[val] {
+				result = append(result, val)
+			}
+		}
+		mainArgs = result
+	}
+	return mainArgs, doubleDashString
 }
 
 // cloneCommand clones a custom command config into a new struct


### PR DESCRIPTION
## Why draft?
* Add documentation for this new feature
* Add test cases for this functionality.

## what

* We would add support for double dash argument in custom command. So from now on, customer can easily use ` {{ .NativeArgs }}` in template to get the commands as is after the `--` 

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
* Currently we do not have a defined way of passing all the native commands of a step that might require native args like we do for terraform cli.
* this will help users know how to use double dash to get the native args of a step.

## references

* [DEV-112](https://linear.app/cloudposse/issue/DEV-112/add-support-for-double-dash-in-atmos-custom-commands)