### PR TITLE
create logging defaults

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,9 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	v.SetDefault("components.terraform.append_user_agent", fmt.Sprintf("Atmos/%s (Cloud Posse; +https://atmos.tools)", version.Version))
 	v.SetDefault("settings.inject_github_token", true)
 
+	v.SetDefault("logs.file", "/dev/stderr")
+	v.SetDefault("logs.level", "Info")
+
 	// Process config in system folder
 	configFilePath1 := ""
 
@@ -377,11 +380,13 @@ func processConfigFile(
 	path string,
 	v *viper.Viper,
 ) (bool, error) {
+
 	// Check if the config file exists
 	configPath, fileExists := u.SearchConfigFile(path)
 	if !fileExists {
 		return false, nil
 	}
+
 	reader, err := os.Open(configPath)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## what

Add sane defaults for logging when not provided via `atmos.yaml` or args

## why

To ensure logging still works, even if not specified in config.