### PR TITLE
fix custom commands should not need stacks

### DIFF
--- a/examples/demo-custom-command/atmos.yaml
+++ b/examples/demo-custom-command/atmos.yaml
@@ -1,25 +1,5 @@
 base_path: "./"
 
-components:
-  terraform:
-    base_path: "components/terraform"
-    apply_auto_approve: false
-    deploy_run_init: true
-    init_run_reconfigure: true
-    auto_generate_backend_file: false
-  
-stacks:
-  base_path: "stacks"
-  included_paths:
-    - "deploy/**/*"
-  excluded_paths:
-    - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
-logs:
-  file: "/dev/stderr"
-  level: Info
-
 # Custom CLI commands
 
 # No arguments or flags are required

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -287,7 +287,7 @@ func InitCliConfig(configAndStacksInfo schema.ConfigAndStacksInfo, processStacks
 	}
 
 	// Check config
-	err = checkConfig(atmosConfig)
+	err = checkConfig(atmosConfig, processStacks)
 	if err != nil {
 		return atmosConfig, err
 	}

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -391,12 +391,12 @@ func processEnvVars(atmosConfig *schema.AtmosConfiguration) error {
 	return nil
 }
 
-func checkConfig(atmosConfig schema.AtmosConfiguration) error {
-	if len(atmosConfig.Stacks.BasePath) < 1 {
+func checkConfig(atmosConfig schema.AtmosConfiguration, isProcessStack bool) error {
+	if isProcessStack && len(atmosConfig.Stacks.BasePath) < 1 {
 		return errors.New("stack base path must be provided in 'stacks.base_path' config or ATMOS_STACKS_BASE_PATH' ENV variable")
 	}
 
-	if len(atmosConfig.Stacks.IncludedPaths) < 1 {
+	if isProcessStack && len(atmosConfig.Stacks.IncludedPaths) < 1 {
 		return errors.New("at least one path must be provided in 'stacks.included_paths' config or ATMOS_STACKS_INCLUDED_PATHS' ENV variable")
 	}
 


### PR DESCRIPTION
## what

* We should not require custom commands to have `stacks.base_path` and `stacks.included_paths`  in atmos config.

## why

* Custom commands may or may not be using components and stacks data.

## references

* [DEV-3041](https://linear.app/cloudposse/issue/DEV-3041/bug-fix-custom-commands-require-stacksbase-path-and-stacksincluded)