### PR TITLE
Fix mergify dispatch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,7 +28,7 @@ pull_request_rules:
     actions:
       comment:
         message: |
-          Triggering the workflow dispatch for preview build...
+          Triggering the workflow dispatch for tests & preview build on `{{ head }}`...
       github_actions:
         workflow:
           dispatch:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,6 +33,6 @@ pull_request_rules:
         workflow:
           dispatch:
             - workflow: website-preview-build.yml
-              ref: "{{ pull_request.head.ref }}"
+              ref: "{{ head }}"
             - workflow: test.yml
-              ref: "{{ pull_request.head.ref }}"
+              ref: "{{ head }}"


### PR DESCRIPTION
## what
- Incorrect specification of head ref


## why
- Mergify doesn't really explain how to do it.
- Based on the example of how `{{ author }}` works, there's no `pull_request` prefix https://docs.mergify.com/workflow/actions/github_actions/#examples
- Based on the documentation here, it suggests the key is just `head` https://docs.mergify.com/configuration/data-types/#template

## Documented Example

Based on the documentation, 
> The dynamic_workflow.yaml takes the [template](https://docs.mergify.com/configuration/data-types#template) input author.

This implies that everything under `data-types` can be used as a Jinja template variable. Since `author` works (at least based on their example), `head` should as well.

```
pull_request_rules:
  - name: Dispatch GitHub Actions
    conditions:
      - label = dispatch
    actions:
      github_actions:
        workflow:
          dispatch:
            - workflow: foo_workflow.yaml
            - workflow: hello_world_workflow.yaml
              inputs:
                name: steve
                age: 42
            - workflow: dynamic_workflow.yaml
              inputs:
                author: "{{ author }}"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced clarity in automation settings by updating messages for preview builds and testing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->