### PR TITLE
fix exit code for each exec command

### DIFF
--- a/pkg/utils/markdown_utils.go
+++ b/pkg/utils/markdown_utils.go
@@ -3,8 +3,10 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime/debug"
 
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -66,6 +68,13 @@ func PrintfErrorMarkdown(format string, a ...interface{}) {
 
 func PrintErrorMarkdownAndExit(title string, err error, suggestion string) {
 	PrintErrorMarkdown(title, err, suggestion)
+
+	// Find the executed command's exit code from the error
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		os.Exit(exitError.ExitCode())
+	}
+
 	os.Exit(1)
 }
 


### PR DESCRIPTION
## Draft reason
* Adding a Test case so that this is not missed ever
## what

* The change ensures consistency between the exit code of the CLI and the exit code of the program being executed. 
 
## why


* Improved User Experience: It provides more accurate feedback to the user, reflecting the success or failure of the desired program.

* Better Integration with Other Tools: Many CI/CD systems, monitoring tools, or scripts rely on exit codes to determine whether a task has succeeded or failed. Matching the exit codes allows seamless integration with existing workflows.

* Debugging and Troubleshooting: By matching exit codes, users and developers can more easily trace issues and understand which program (or specific execution) caused the failure.

* This change helps ensure the CLI behaves more predictably and conforms to standard practices for handling exit codes.

## references
* https://github.com/cloudposse/atmos/issues/1064
