### PR TITLE
Add shared configuration for RunsOn GHA runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,2 @@
+# See https://runs-on.com/configuration/repo-config/
+_extends: .github


### PR DESCRIPTION
## what

- Add shared configuration for RunsOn GHA runners

## why

- Allow use of simple runner configuration labels like "large"

## references

- https://runs-on.com/configuration/repo-config/
- https://github.com/cloudposse/.github/pull/139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined our automation workflow settings to promote consistency and reduce redundant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->