### PR TITLE
Enhance Atmos CLI: Add Support for Custom Base Path and Config Paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -251,7 +251,9 @@ func init() {
 
 	RootCmd.PersistentFlags().String("logs-level", "Info", "Logs level. Supported log levels are Trace, Debug, Info, Warning, Off. If the log level is set to Off, Atmos will not log any messages")
 	RootCmd.PersistentFlags().String("logs-file", "/dev/stderr", "The file to write Atmos logs to. Logs can be written to any file or any standard file descriptor, including '/dev/stdout', '/dev/stderr' and '/dev/null'")
-
+	RootCmd.PersistentFlags().String("base-path", "", "Base path for Atmos project")
+	RootCmd.PersistentFlags().StringSlice("config", []string{}, "Paths to configuration file")
+	RootCmd.PersistentFlags().StringSlice("config-path", []string{}, "Path to configuration directory")
 	// Set custom usage template
 	err := templates.SetCustomUsageFunc(RootCmd)
 	if err != nil {

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -205,6 +205,18 @@ func ProcessCommandLineArgs(
 		return configAndStacksInfo, err
 	}
 
+	configAndStacksInfo.BasePath, err = cmd.Flags().GetString("base-path")
+	if err != nil {
+		return configAndStacksInfo, err
+	}
+	configAndStacksInfo.AtmosConfigFilesFromArg, err = cmd.Flags().GetStringSlice("config")
+	if err != nil {
+		return configAndStacksInfo, err
+	}
+	configAndStacksInfo.AtmosConfigDirsFromArg, err = cmd.Flags().GetStringSlice("config-path")
+	if err != nil {
+		return configAndStacksInfo, err
+	}
 	finalAdditionalArgsAndFlags := argsAndFlagsInfo.AdditionalArgsAndFlags
 	if len(additionalArgsAndFlags) > 0 {
 		finalAdditionalArgsAndFlags = append(finalAdditionalArgsAndFlags, additionalArgsAndFlags...)
@@ -216,7 +228,6 @@ func ProcessCommandLineArgs(
 	configAndStacksInfo.ComponentType = componentType
 	configAndStacksInfo.ComponentFromArg = argsAndFlagsInfo.ComponentFromArg
 	configAndStacksInfo.GlobalOptions = argsAndFlagsInfo.GlobalOptions
-	configAndStacksInfo.BasePath = argsAndFlagsInfo.BasePath
 	configAndStacksInfo.TerraformCommand = argsAndFlagsInfo.TerraformCommand
 	configAndStacksInfo.TerraformDir = argsAndFlagsInfo.TerraformDir
 	configAndStacksInfo.HelmfileCommand = argsAndFlagsInfo.HelmfileCommand

--- a/pkg/config/atmos.yaml
+++ b/pkg/config/atmos.yaml
@@ -1,0 +1,8 @@
+logs:
+  # Can also be set using 'ATMOS_LOGS_FILE' ENV var, or '--logs-file' command-line argument
+  # File or standard file descriptor to write logs to
+  # Logs can be written to any file or any standard file descriptor, including `/dev/stdout`, `/dev/stderr` and `/dev/null`
+  file: "/dev/stderr"
+  # Supported log levels: Trace, Debug, Info, Warning, Off
+  # Can also be set using 'ATMOS_LOGS_LEVEL' ENV var, or '--logs-level' command-line argument
+  level: Info

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -1,7 +1,9 @@
 package config
 
 const (
-	CliConfigFileName       = "atmos"
+	CliConfigFileName    = "atmos"
+	DotCliConfigFileName = ".atmos"
+
 	SystemDirConfigFilePath = "/usr/local/etc/atmos"
 	WindowsAppDataEnvVar    = "LOCALAPPDATA"
 

--- a/pkg/config/load_config_args.go
+++ b/pkg/config/load_config_args.go
@@ -19,18 +19,20 @@ var (
 // loadConfigFromCLIArgs handles the loading of configurations provided via --config-path.
 func loadConfigFromCLIArgs(v *viper.Viper, configAndStacksInfo *schema.ConfigAndStacksInfo, atmosConfig *schema.AtmosConfiguration) error {
 	log.Debug("loading config from command line arguments")
+
 	configFilesArgs := configAndStacksInfo.AtmosConfigFilesFromArg
 	configDirsArgs := configAndStacksInfo.AtmosConfigDirsFromArg
 	var configPaths []string
-	//merge all config from --config files
+
+	// Merge all config from --config files
 	if len(configFilesArgs) > 0 {
-		err := mergeFiles(v, configFilesArgs)
-		if err != nil {
+		if err := mergeFiles(v, configFilesArgs); err != nil {
 			return err
 		}
 		configPaths = append(configPaths, configFilesArgs...)
 	}
-	// merge config from -config-path directors
+
+	// Merge config from --config-path directories
 	if len(configDirsArgs) > 0 {
 		paths, err := mergeConfigFromDirectories(v, configDirsArgs)
 		if err != nil {
@@ -39,15 +41,16 @@ func loadConfigFromCLIArgs(v *viper.Viper, configAndStacksInfo *schema.ConfigAnd
 		configPaths = append(configPaths, paths...)
 	}
 
-	// check if any config files were found from command line arguments
+	// Check if any config files were found from command line arguments
 	if len(configPaths) == 0 {
 		log.Debug("no config files found from command line arguments")
 		return ErrAtmosArgConfigNotFound
 	}
-	err := v.Unmarshal(atmosConfig)
-	if err != nil {
+
+	if err := v.Unmarshal(atmosConfig); err != nil {
 		return err
 	}
+
 	atmosConfig.CliConfigPath = connectPaths(configPaths)
 	return nil
 }

--- a/pkg/config/load_config_args.go
+++ b/pkg/config/load_config_args.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"errors"
+	"os"
+
+	log "github.com/charmbracelet/log"
+	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/spf13/viper"
+)
+
+var (
+	ErrExpectedDirOrPattern   = errors.New("--config-path expected directory found file")
+	ErrFileNotFound           = errors.New("file not found")
+	ErrExpectedFile           = errors.New("--config expected file found directory")
+	ErrAtmosArgConfigNotFound = errors.New("atmos configuration not found")
+)
+
+// loadConfigFromCLIArgs handles the loading of configurations provided via --config-path.
+func loadConfigFromCLIArgs(v *viper.Viper, configAndStacksInfo *schema.ConfigAndStacksInfo, atmosConfig *schema.AtmosConfiguration) error {
+	log.Debug("loading config from command line arguments")
+	configFilesArgs := configAndStacksInfo.AtmosConfigFilesFromArg
+	configDirsArgs := configAndStacksInfo.AtmosConfigDirsFromArg
+	var configPaths []string
+	//merge all config from --config files
+	if len(configFilesArgs) > 0 {
+		err := mergeFiles(v, configFilesArgs)
+		if err != nil {
+			return err
+		}
+		configPaths = append(configPaths, configFilesArgs...)
+	}
+	// merge config from -config-path directors
+	if len(configDirsArgs) > 0 {
+		paths, err := mergeConfigFromDirectories(v, configDirsArgs)
+		if err != nil {
+			return err
+		}
+		configPaths = append(configPaths, paths...)
+	}
+
+	// check if any config files were found from command line arguments
+	if len(configPaths) == 0 {
+		log.Debug("no config files found from command line arguments")
+		return ErrAtmosArgConfigNotFound
+	}
+	err := v.Unmarshal(atmosConfig)
+	if err != nil {
+		return err
+	}
+	atmosConfig.CliConfigPath = connectPaths(configPaths)
+	return nil
+}
+
+// mergeFiles merges config files from the provided paths.
+func mergeFiles(v *viper.Viper, configFilePaths []string) error {
+	err := validatedIsFiles(configFilePaths)
+	if err != nil {
+		return err
+	}
+	for _, configPath := range configFilePaths {
+		err := mergeConfigFile(configPath, v)
+		if err != nil {
+			log.Debug("error loading config file", "path", configPath, "error", err)
+			return err
+		}
+		log.Debug("config file merged", "path", configPath)
+		if err := mergeDefaultImports(configPath, v); err != nil {
+			log.Debug("error process imports", "path", configPath, "error", err)
+		}
+		if err := mergeImports(v); err != nil {
+			log.Debug("error process imports", "file", configPath, "error", err)
+		}
+	}
+	return nil
+}
+
+// mergeConfigFromDirectories merges config files from the provided directories.
+func mergeConfigFromDirectories(v *viper.Viper, dirPaths []string) ([]string, error) {
+	if err := validatedIsDirs(dirPaths); err != nil {
+		return nil, err
+	}
+	var configPaths []string
+	for _, confDirPath := range dirPaths {
+		err := mergeConfig(v, confDirPath, CliConfigFileName, true)
+		if err != nil {
+			log.Debug("Failed to find atmos config", "path", confDirPath, "error", err)
+			switch err.(type) {
+			case viper.ConfigFileNotFoundError:
+				log.Debug("Failed to found atmos config", "file", v.ConfigFileUsed())
+			default:
+				return nil, err
+			}
+		}
+		if err == nil {
+			log.Debug("atmos config file merged", "path", v.ConfigFileUsed())
+			configPaths = append(configPaths, confDirPath)
+			continue
+		}
+		err = mergeConfig(v, confDirPath, DotCliConfigFileName, true)
+		if err != nil {
+			log.Debug("Failed to found .atmos config", "path", confDirPath, "error", err)
+			return nil, ErrAtmosArgConfigNotFound
+		}
+		log.Debug(".atmos config file merged", "path", v.ConfigFileUsed())
+		configPaths = append(configPaths, confDirPath)
+
+	}
+
+	return configPaths, nil
+}
+func validatedIsDirs(dirPaths []string) error {
+	for _, dirPath := range dirPaths {
+		stat, err := os.Stat(dirPath)
+		if err != nil {
+			log.Debug("--config-path directory not found", "path", dirPath)
+			return err
+		}
+		if !stat.IsDir() {
+			log.Debug("--config-path expected directory found file", "path", dirPath)
+			return ErrAtmosDIrConfigNotFound
+		}
+	}
+	return nil
+}
+func validatedIsFiles(files []string) error {
+	for _, filePath := range files {
+		stat, err := os.Stat(filePath)
+		if err != nil {
+			log.Debug("--config file not found", "path", filePath)
+			return ErrFileNotFound
+		}
+		if stat.IsDir() {
+			log.Debug("--config expected file found directors", "path", filePath)
+			return ErrExpectedFile
+		}
+	}
+	return nil
+}
+func connectPaths(paths []string) string {
+	if len(paths) == 1 {
+		return paths[0]
+	}
+	var result string
+	for _, path := range paths {
+		result += path + ";"
+	}
+	return result
+
+}

--- a/pkg/config/load_config_args.go
+++ b/pkg/config/load_config_args.go
@@ -107,11 +107,10 @@ func mergeConfigFromDirectories(v *viper.Viper, dirPaths []string) ([]string, er
 		}
 		log.Debug(".atmos config file merged", "path", v.ConfigFileUsed())
 		configPaths = append(configPaths, confDirPath)
-
 	}
-
 	return configPaths, nil
 }
+
 func validatedIsDirs(dirPaths []string) error {
 	for _, dirPath := range dirPaths {
 		stat, err := os.Stat(dirPath)
@@ -126,6 +125,7 @@ func validatedIsDirs(dirPaths []string) error {
 	}
 	return nil
 }
+
 func validatedIsFiles(files []string) error {
 	for _, filePath := range files {
 		stat, err := os.Stat(filePath)
@@ -140,6 +140,7 @@ func validatedIsFiles(files []string) error {
 	}
 	return nil
 }
+
 func connectPaths(paths []string) string {
 	if len(paths) == 1 {
 		return paths[0]
@@ -149,5 +150,4 @@ func connectPaths(paths []string) string {
 		result += path + ";"
 	}
 	return result
-
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -293,6 +293,8 @@ type ConfigAndStacksInfo struct {
 	LogsFile                      string
 	SettingsListMergeStrategy     string
 	Query                         string
+	AtmosConfigFilesFromArg       []string
+	AtmosConfigDirsFromArg        []string
 }
 
 // Workflows


### PR DESCRIPTION
## what
*Add global command-line flags (--base-path, --config, and --config-path) to the Atmos CLI tool.
## why
The changes allow users to specify:
- Base path for the Atmos project (--base-path).
- Specific configuration files (--config).
- Configuration directories (--config-path).

## references
- DEV-2790
