### PR TITLE
fix formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -500,7 +500,7 @@ jobs:
       - name: Lint with golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
-          filter_mode: "added"
+          filter_mode: "diff_context"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   release:

--- a/cmd/helmfile_apply.go
+++ b/cmd/helmfile_apply.go
@@ -5,13 +5,15 @@ import (
 )
 
 // Command: atmos helmfile apply
-var helmfileApplyShort = "Apply changes to align the actual state of Helm releases with the desired state."
-var helmfileApplyLong = `This command reconciles the actual state of Helm releases in the cluster with the desired state
+var (
+	helmfileApplyShort = "Apply changes to align the actual state of Helm releases with the desired state."
+	helmfileApplyLong  = `This command reconciles the actual state of Helm releases in the cluster with the desired state
 defined in your configurations by applying the necessary changes.
 
 Example usage:
   atmos helmfile apply echo-server -s tenant1-ue2-dev
   atmos helmfile apply echo-server -s tenant1-ue2-dev --redirect-stderr /dev/stdout`
+)
 
 // helmfileApplyCmd represents the base command for all helmfile sub-commands
 var helmfileApplyCmd = &cobra.Command{

--- a/cmd/helmfile_destroy.go
+++ b/cmd/helmfile_destroy.go
@@ -3,13 +3,15 @@ package cmd
 import "github.com/spf13/cobra"
 
 // Command: atmos helmfile destroy
-var helmfileDestroyShort = "Destroy the Helm releases for the specified stack."
-var helmfileDestroyLong = `This command removes the specified Helm releases from the cluster, ensuring a clean state for
+var (
+	helmfileDestroyShort = "Destroy the Helm releases for the specified stack."
+	helmfileDestroyLong  = `This command removes the specified Helm releases from the cluster, ensuring a clean state for
 the given stack.
 
 Example usage:
   atmos helmfile destroy echo-server --stack=tenant1-ue2-dev
   atmos helmfile destroy echo-server --stack=tenant1-ue2-dev --redirect-stderr /dev/stdout`
+)
 
 // helmfileDestroyCmd represents the base command for all helmfile sub-commands
 var helmfileDestroyCmd = &cobra.Command{

--- a/cmd/helmfile_diff.go
+++ b/cmd/helmfile_diff.go
@@ -5,13 +5,15 @@ import (
 )
 
 // Command: atmos helmfile diff
-var helmfileDiffShort = "Show differences between the desired and actual state of Helm releases."
-var helmfileDiffLong = `This command calculates and displays the differences between the desired state of Helm releases
+var (
+	helmfileDiffShort = "Show differences between the desired and actual state of Helm releases."
+	helmfileDiffLong  = `This command calculates and displays the differences between the desired state of Helm releases
 defined in your configurations and the actual state deployed in the cluster.
 
 Example usage:
   atmos helmfile diff echo-server -s tenant1-ue2-dev
   atmos helmfile diff echo-server -s tenant1-ue2-dev --redirect-stderr /dev/null`
+)
 
 // helmfileDiffCmd represents the base command for all helmfile sub-commands
 var helmfileDiffCmd = &cobra.Command{

--- a/cmd/helmfile_sync.go
+++ b/cmd/helmfile_sync.go
@@ -3,13 +3,15 @@ package cmd
 import "github.com/spf13/cobra"
 
 // Command: atmos helmfile sync
-var helmfileSyncShort = "Synchronize the state of Helm releases with the desired state without making changes."
-var helmfileSyncLong = `This command ensures that the actual state of Helm releases in the cluster matches the desired
+var (
+	helmfileSyncShort = "Synchronize the state of Helm releases with the desired state without making changes."
+	helmfileSyncLong  = `This command ensures that the actual state of Helm releases in the cluster matches the desired
 state defined in your configurations without performing destructive actions.
 
 Example usage:
   atmos helmfile sync echo-server --stack tenant1-ue2-dev
   atmos helmfile sync echo-server --stack tenant1-ue2-dev --redirect-stderr ./errors.txt`
+)
 
 // helmfileSyncCmd represents the base command for all helmfile sub-commands
 var helmfileSyncCmd = &cobra.Command{

--- a/internal/exec/atlantis_utils.go
+++ b/internal/exec/atlantis_utils.go
@@ -15,7 +15,6 @@ func BuildAtlantisProjectNameFromComponentConfig(
 	atmosConfig schema.AtmosConfiguration,
 	configAndStacksInfo schema.ConfigAndStacksInfo,
 ) (string, error) {
-
 	var atlantisProjectTemplate schema.AtlantisProjectConfig
 	var atlantisProjectName string
 

--- a/internal/exec/config_sources_utils.go
+++ b/internal/exec/config_sources_utils.go
@@ -76,7 +76,6 @@ func processSectionValueInStacks(
 	subsection string,
 	value string,
 ) schema.ConfigSourcesStackDependencies {
-
 	result := schema.ConfigSourcesStackDependencies{}
 
 	// Process the value for the component in the stack
@@ -231,7 +230,6 @@ func processComponentSectionValueInStack(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result
@@ -327,7 +325,6 @@ func processComponentTypeSectionValueInStack(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result
@@ -402,7 +399,6 @@ func processGlobalSectionValueInStack(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result
@@ -468,7 +464,6 @@ func processComponentSectionValueInStackImports(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result
@@ -578,7 +573,6 @@ func processComponentTypeSectionValueInStackImports(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result
@@ -667,7 +661,6 @@ func processGlobalSectionValueInStackImports(
 	subsection string,
 	value string,
 ) *schema.ConfigSourcesStackDependencies {
-
 	rawStackConfig, ok := rawStackConfigs[stackFile]
 	if !ok {
 		return result

--- a/internal/exec/describe_workflows.go
+++ b/internal/exec/describe_workflows.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+
 	u "github.com/cloudposse/atmos/pkg/utils"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"

--- a/internal/exec/pro.go
+++ b/internal/exec/pro.go
@@ -115,7 +115,6 @@ func parseUnlockCliArgs(cmd *cobra.Command, args []string) (ProUnlockCmdArgs, er
 	}
 
 	return result, nil
-
 }
 
 // ExecuteProLockCommand executes `atmos pro lock` command

--- a/internal/exec/spacelift_utils.go
+++ b/internal/exec/spacelift_utils.go
@@ -86,7 +86,6 @@ func BuildSpaceliftStackNameFromComponentConfig(
 	atmosConfig schema.AtmosConfiguration,
 	configAndStacksInfo schema.ConfigAndStacksInfo,
 ) (string, error) {
-
 	var spaceliftStackName string
 	var spaceliftSettingsSection map[string]any
 	var contextPrefix string

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -82,7 +82,6 @@ func ProcessYAMLConfigFiles(
 				map[string]any{},
 				"",
 			)
-
 			if err != nil {
 				errorResult = err
 				return
@@ -181,7 +180,6 @@ func ProcessYAMLConfigFile(
 	finalHelmfileOverrides := map[string]any{}
 
 	stackYamlConfig, err := GetFileContent(filePath)
-
 	// If the file does not exist (`err != nil`), and `ignoreMissingFiles = true`, don't return the error.
 	//
 	// `ignoreMissingFiles = true` is used when executing `atmos describe affected` command.
@@ -535,7 +533,6 @@ func ProcessStackConfig(
 	importsConfig map[string]map[string]any,
 	checkBaseComponentExists bool,
 ) (map[string]any, error) {
-
 	stackName := strings.TrimSuffix(
 		strings.TrimSuffix(
 			u.TrimBasePathFromPath(stacksBasePath+"/", stack),
@@ -1640,8 +1637,8 @@ func FindComponentStacks(
 	componentType string,
 	component string,
 	baseComponent string,
-	componentStackMap map[string]map[string][]string) ([]string, error) {
-
+	componentStackMap map[string]map[string][]string,
+) ([]string, error) {
 	var stacks []string
 
 	if componentStackConfig, componentStackConfigExists := componentStackMap[componentType]; componentStackConfigExists {
@@ -1675,8 +1672,8 @@ func FindComponentDependenciesLegacy(
 	componentType string,
 	component string,
 	baseComponents []string,
-	stackImports map[string]map[string]any) ([]string, error) {
-
+	stackImports map[string]map[string]any,
+) ([]string, error) {
 	var deps []string
 
 	sectionsToCheck := []string{
@@ -1854,7 +1851,6 @@ func CreateComponentStackMap(
 	helmfileComponentsBasePath string,
 	filePath string,
 ) (map[string]map[string][]string, error) {
-
 	stackComponentMap := map[string]map[string][]string{}
 	stackComponentMap["terraform"] = map[string][]string{}
 	stackComponentMap["helmfile"] = map[string][]string{}
@@ -1938,7 +1934,6 @@ func CreateComponentStackMap(
 
 			return nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -1987,7 +1982,6 @@ func ProcessBaseComponentConfig(
 	checkBaseComponentExists bool,
 	baseComponents *[]string,
 ) error {
-
 	if component == baseComponent {
 		return nil
 	}
@@ -2039,7 +2033,6 @@ func ProcessBaseComponentConfig(
 				checkBaseComponentExists,
 				baseComponents,
 			)
-
 			if err != nil {
 				return err
 			}
@@ -2250,7 +2243,6 @@ func FindComponentsDerivedFromBaseComponents(
 	allComponents map[string]any,
 	baseComponents []string,
 ) ([]string, error) {
-
 	res := []string{}
 
 	for component, compSection := range allComponents {

--- a/internal/exec/validate_utils.go
+++ b/internal/exec/validate_utils.go
@@ -72,7 +72,6 @@ func ValidateWithOpa(
 	modulePaths []string,
 	timeoutSeconds int,
 ) (bool, error) {
-
 	// Set timeout for schema validation
 	if timeoutSeconds == 0 {
 		timeoutSeconds = 20

--- a/internal/exec/vendor.go
+++ b/internal/exec/vendor.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/list/list_workflows_test.go
+++ b/pkg/list/list_workflows_test.go
@@ -68,7 +68,7 @@ func TestListWorkflows(t *testing.T) {
 
 	// Create workflow directory structure
 	workflowsDir := filepath.Join(tmpDir, "stacks", "workflows")
-	err = os.MkdirAll(workflowsDir, 0755)
+	err = os.MkdirAll(workflowsDir, 0o755)
 	require.NoError(t, err)
 
 	// Create atmos.yaml with workflow configuration
@@ -81,7 +81,7 @@ stacks:
 workflows:
   base_path: "stacks/workflows"
 `
-	err = os.WriteFile(filepath.Join(tmpDir, "atmos.yaml"), []byte(atmosConfig), 0644)
+	err = os.WriteFile(filepath.Join(tmpDir, "atmos.yaml"), []byte(atmosConfig), 0o644)
 	require.NoError(t, err)
 
 	// Create an empty workflow file
@@ -92,7 +92,7 @@ workflows:
 	}
 	emptyWorkflowBytes, err := yaml.Marshal(emptyWorkflow)
 	require.NoError(t, err)
-	err = os.WriteFile(emptyWorkflowFile, emptyWorkflowBytes, 0644)
+	err = os.WriteFile(emptyWorkflowFile, emptyWorkflowBytes, 0o644)
 	require.NoError(t, err)
 
 	// Create a networking workflow file
@@ -110,7 +110,7 @@ workflows:
 	}
 	networkingWorkflowBytes, err := yaml.Marshal(networkingWorkflow)
 	require.NoError(t, err)
-	err = os.WriteFile(networkingWorkflowFile, networkingWorkflowBytes, 0644)
+	err = os.WriteFile(networkingWorkflowFile, networkingWorkflowBytes, 0o644)
 	require.NoError(t, err)
 
 	// Create a validation workflow file
@@ -128,7 +128,7 @@ workflows:
 	}
 	validationWorkflowBytes, err := yaml.Marshal(validationWorkflow)
 	require.NoError(t, err)
-	err = os.WriteFile(validationWorkflowFile, validationWorkflowBytes, 0644)
+	err = os.WriteFile(validationWorkflowFile, validationWorkflowBytes, 0o644)
 	require.NoError(t, err)
 
 	// Change to the temporary directory for testing
@@ -302,7 +302,7 @@ func TestListWorkflowsWithFile(t *testing.T) {
 	}
 	testWorkflowBytes, err := yaml.Marshal(testWorkflow)
 	require.NoError(t, err)
-	err = os.WriteFile(testWorkflowFile, testWorkflowBytes, 0644)
+	err = os.WriteFile(testWorkflowFile, testWorkflowBytes, 0o644)
 	require.NoError(t, err)
 
 	listConfig := schema.ListConfig{

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -174,7 +174,6 @@ func (c *AtmosProAPIClient) UnlockStack(dto UnlockStackRequest) (UnlockStackResp
 
 	// Unmarshal the JSON response into the struct
 	err = json.Unmarshal(body, &responseData)
-
 	if err != nil {
 		return UnlockStackResponse{}, fmt.Errorf("error unmarshaling JSON: %s", err)
 	}

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -14,7 +14,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 	processImports := true
 	stackConfigPathTemplate := "stacks/%s.yaml"
 
-	var spaceliftStacks, err = CreateSpaceliftStacks(
+	spaceliftStacks, err := CreateSpaceliftStacks(
 		"",
 		"",
 		"",
@@ -123,7 +123,7 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 	processImports := true
 	stackConfigPathTemplate := "stacks/%s.yaml"
 
-	var spaceliftStacks, err = CreateSpaceliftStacks(
+	spaceliftStacks, err := CreateSpaceliftStacks(
 		stacksBasePath,
 		terraformComponentsBasePath,
 		helmfileComponentsBasePath,

--- a/pkg/stack/stack_processor_test.go
+++ b/pkg/stack/stack_processor_test.go
@@ -38,7 +38,7 @@ func TestStackProcessor(t *testing.T) {
 		},
 	}
 
-	var listResult, mapResult, _, err = ProcessYAMLConfigFiles(
+	listResult, mapResult, _, err := ProcessYAMLConfigFiles(
 		atmosConfig,
 		stacksBasePath,
 		terraformComponentsBasePath,

--- a/pkg/store/artifactory_store_test.go
+++ b/pkg/store/artifactory_store_test.go
@@ -22,7 +22,6 @@ func (m *MockArtifactoryClient) DownloadFiles(params ...services.DownloadParams)
 	totalDownloaded := args.Int(0)
 	totalFailed := args.Int(1)
 	err := args.Error(2)
-
 	// First check: if there's an error, return immediately
 	if err != nil {
 		return totalDownloaded, totalFailed, err
@@ -42,13 +41,13 @@ func (m *MockArtifactoryClient) DownloadFiles(params ...services.DownloadParams)
 	targetDir := params[0].Target
 	filename := filepath.Base(params[0].Pattern)
 
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		return 0, 0, err
 	}
 
 	data := []byte(`{"test":"value"}`)
 	fullPath := filepath.Join(targetDir, filename)
-	if err := os.WriteFile(fullPath, data, 0644); err != nil {
+	if err := os.WriteFile(fullPath, data, 0o644); err != nil {
 		return 0, 0, err
 	}
 

--- a/pkg/utils/glob_utils.go
+++ b/pkg/utils/glob_utils.go
@@ -10,9 +10,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-var (
-	getGlobMatchesSyncMap = sync.Map{}
-)
+var getGlobMatchesSyncMap = sync.Map{}
 
 // GetGlobMatches tries to read and return the Glob matches content from the sync map if it exists in the map,
 // otherwise it finds and returns all files matching the pattern, stores the files in the map and returns the files

--- a/pkg/utils/highlight_utils.go
+++ b/pkg/utils/highlight_utils.go
@@ -2,11 +2,10 @@ package utils
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
-
-	"encoding/json"
 
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters"

--- a/pkg/utils/version_utils.go
+++ b/pkg/utils/version_utils.go
@@ -18,7 +18,8 @@ func PrintMessageToUpgradeToAtmosLatestRelease(latestVersion string) {
 			theme.Styles.VersionNumber.Render(version.Version),
 			theme.Styles.NewVersion.Render(latestVersion)))
 
-	links := []string{lipgloss.NewStyle().Render(fmt.Sprintf("Atmos Releases: %s", theme.Styles.Link.Render("https://github.com/cloudposse/atmos/releases"))),
+	links := []string{
+		lipgloss.NewStyle().Render(fmt.Sprintf("Atmos Releases: %s", theme.Styles.Link.Render("https://github.com/cloudposse/atmos/releases"))),
 		lipgloss.NewStyle().Render(fmt.Sprintf("Install Atmos: %s", theme.Styles.Link.Render("https://atmos.tools/install"))),
 	}
 

--- a/pkg/vender/vendor_config_test.go
+++ b/pkg/vender/vendor_config_test.go
@@ -4,7 +4,6 @@ package vender
 
 import (
 	"os"
-
 	"path/filepath"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestVendorConfigScenarios(t *testing.T) {
 
 	// Setup test component directory
 	componentPath := filepath.Join(testDir, "components", "terraform", "myapp")
-	err := os.MkdirAll(componentPath, 0755)
+	err := os.MkdirAll(componentPath, 0o755)
 	assert.Nil(t, err)
 
 	// Test Case 1: vendor.yaml exists and component is defined in it
@@ -49,7 +48,7 @@ spec:
         - "**/*.tf"
 `
 		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
-		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
+		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0o644)
 		assert.Nil(t, err)
 
 		// Test vendoring with component flag
@@ -86,7 +85,7 @@ spec:
     version: 0.25.0
 `
 		componentYamlPath := filepath.Join(componentPath, "component.yaml")
-		err := os.WriteFile(componentYamlPath, []byte(componentYaml), 0644)
+		err := os.WriteFile(componentYamlPath, []byte(componentYaml), 0o644)
 		assert.Nil(t, err)
 
 		// Test component vendoring
@@ -128,7 +127,7 @@ spec:
       version: 0.25.0
 `
 		vendorYamlPath := filepath.Join(testDir, "vendor.yaml")
-		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0644)
+		err := os.WriteFile(vendorYamlPath, []byte(vendorYaml), 0o644)
 		assert.Nil(t, err)
 
 		// Test vendoring without component flag


### PR DESCRIPTION
## what

Fix the formatting of files that don't match the `gofumpt` format

## why

These files are getting included in linting on other PRs, even when people aren't changing them because the CI process runs `gofumpt` and commits the files back to the repo. Those files then become part of the `diff` that is linted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced CLI command help texts to offer clearer, more detailed usage instructions and descriptions for various commands.

- **Chores**
  - Applied internal cleanup and formatting improvements, including the restructuring of variable declarations and updates to file permission syntax, to streamline code structure and maintain consistency without altering command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->