### PR TITLE
change golangci reporter to github-check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -501,6 +501,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           filter_mode: "diff_context"
+          reporter: github-check
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   release:


### PR DESCRIPTION
## what
- Change reporter to `github-check`

## why
- `github-status` (default) results in duplicate status checks