### PR TITLE
Warn on Excessive Function Returns & `//nolint` Usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,7 @@ linters-settings:
       - name: function-length
         arguments: [50, 60] # Max lines per function
       - name: function-result-limit
+        severity: warning
         arguments: [2] # Functions should return at most 2 values; use objects for better readability and maintainability.
       - name: cognitive-complexity
         arguments: [25] # Max cognitive complexity

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - misspell # Detect spelling mistakes
     - nestif # Detect deeply nested if statements
     - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
+    - nolintlint # Check for nolint comments
     - revive # Fast, configurable linter
     - rowserrcheck # Check that rows are closed
     - staticcheck # Perform static analysis
@@ -96,6 +97,8 @@ linters-settings:
             skipBlankLines: true
       - name: function-length
         arguments: [50, 60] # Max lines per function
+      - name: function-result-limit
+        arguments: [2] # Functions should return at most 2 values; use objects for better readability and maintainability.
       - name: cognitive-complexity
         arguments: [25] # Max cognitive complexity
       - name: cyclomatic


### PR DESCRIPTION
## What
- Warn when functions return more than 2 values (we should be returning objects).
- Warn when using lint ignore (`//nolint`), so that we draw attention to it.

## Why
- Objects have named properties, making it easier to understand what everything is. We've seen functions returning 7+ values, which is impractical and error-prone.
- Many times when `//nolint` is used, there’s a better way to address the issue:
  - The lint rule might be too strict.
  - The developer might not realize there's a straightforward solution that avoids ignoring the rule.
  - The rule may have been misunderstood.
  - The ignore might have been intended as temporary but was never revisited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal code quality checks to promote cleaner code practices.
  - Introduced stricter guidelines for function signatures to ensure improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->