### PR TITLE
Downgrade Lint Errors to Warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -502,7 +502,7 @@ jobs:
         id: golangci
         with:
           filter_mode: "diff_context"
-          reporter: github-check
+          reporter: github-annotations
           github_token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - bodyclose # Check that HTTP response body is closed
     - cyclop # Check cyclomatic complexity
-    - err113 # Detects the use of the deprecated context.Done() method
+    - err113 # Enforces best practices for error handling, specifically around comparing errors.
     - errcheck # Check that errors are handled
     - forbidigo # Forbid specific function calls
     - funlen # Enforce function length limits
@@ -98,7 +98,6 @@ linters-settings:
       - name: function-length
         arguments: [50, 60] # Max lines per function
       - name: function-result-limit
-        severity: warning
         arguments: [2] # Functions should return at most 2 values; use objects for better readability and maintainability.
       - name: cognitive-complexity
         arguments: [25] # Max cognitive complexity
@@ -162,6 +161,21 @@ linters-settings:
   nestif:
     # Minimal complexity of if statements to report.
     min-complexity: 4
+
+severity:
+  default-severity: error
+  case-sensitive: true
+  rules:
+    # Downgrade severity for specific linters until we increase the code quality
+    # to avoid overwhelming PRs with too many required changes.
+    - linters:
+        - function-length
+        - function-result-limit
+        - nestif
+        - cognitive-complexity
+        - cyclomatic
+        - nolintlint
+      severity: warning
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## What
- Downgrade some common lint errors to warnings.

## Why
- Strict enforcement significantly increase scope on some PRs
- We need incremental improvements to code quality rather than blocking progress.
- Warnings should still be addressed, but they shouldn't block PR merges, if necessary
- Instead of lowering the bar, we keep the bar high informing developers of best practices.