### PR TITLE
Change the level and severity of `function-result-limit`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,8 @@ linters-settings:
       - name: function-length
         arguments: [50, 60] # Max lines per function
       - name: function-result-limit
-        arguments: [2] # Functions should return at most 2 values; use objects for better readability and maintainability.
+        severity: warning
+        arguments: [3] # Functions should return at most 2 values; use objects for better readability and maintainability
       - name: cognitive-complexity
         arguments: [25] # Max cognitive complexity
       - name: cyclomatic


### PR DESCRIPTION
## what
- Change severity from error to warning
- Increase limit to 3 from 2

## why
- 2 is a bit extreme, many functions return 3-4 arguments.
- 3 return arguments is still intelligible (according to @osterman) ;)
- We should set the guidelines but not enforce it yet as an error since many existing functions return way more than this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted internal settings to allow increased flexibility in function outputs while reducing the alert level for designs that previously exceeded limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->