### PR TITLE
Fork go-homedir into Atmos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,7 @@ linters-settings:
         arguments:
           - maxLitCount: "3"
             allowStrs: '""'
-            allowInts: "0,1,2,3,4"
+            allowInts: "0,1,2,3,4,5,6,7"
             allowFloats: "0.0,0.,1.0,1.,2.0,2."
       - name: argument-limit
         arguments: [5] # Max arguments per function

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,7 @@ linters-settings:
         arguments:
           - maxLitCount: "3"
             allowStrs: '""'
-            allowInts: "0,1,2,3,4,5,6,7"
+            allowInts: "0,1,2,3,4"
             allowFloats: "0.0,0.,1.0,1.,2.0,2."
       - name: argument-limit
         arguments: [5] # Max arguments per function

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/kubescape/go-git-url v0.0.30
 	github.com/lrstanley/bubblezone v0.0.0-20250301021021-ab7b445e9861
 	github.com/mikefarah/yq/v4 v4.45.1
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/muesli/termenv v0.16.0
@@ -221,6 +220,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cloudposse/atmos/pkg/config/go-homedir"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 

--- a/pkg/config/go-homedir/ATTRIBUTIONS.md
+++ b/pkg/config/go-homedir/ATTRIBUTIONS.md
@@ -1,0 +1,6 @@
+# Attributions
+
+This repository is a fork of [go-homedir](https://github.com/mitchellh/go-homedir) by [Mitchell Hashimoto](https://github.com/mitchellh).
+
+The original project is licensed under the MIT License.  
+For details, see the [LICENSE](./LICENSE) file.

--- a/pkg/config/go-homedir/LICENSE
+++ b/pkg/config/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pkg/config/go-homedir/README.md
+++ b/pkg/config/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/pkg/config/go-homedir/homedir.go
+++ b/pkg/config/go-homedir/homedir.go
@@ -1,0 +1,167 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+// Reset clears the cache, forcing the next call to Dir to re-detect
+// the home directory. This generally never has to be called, but can be
+// useful in tests if you're modifying the home directory via the HOME
+// env var or something.
+func Reset() {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	homedirCache = ""
+}
+
+func dirUnix() (string, error) {
+	homeEnv := "HOME"
+	if runtime.GOOS == "plan9" {
+		// On plan9, env vars are lowercase.
+		homeEnv = "home"
+	}
+
+	// First prefer the HOME environmental variable
+	if home := os.Getenv(homeEnv); home != "" {
+		return home, nil
+	}
+
+	var stdout bytes.Buffer
+
+	// If that fails, try OS specific commands
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err == nil {
+			result := strings.TrimSpace(stdout.String())
+			if result != "" {
+				return result, nil
+			}
+		}
+	} else {
+		cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+			if err != exec.ErrNotFound {
+				return "", err
+			}
+		} else {
+			if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+				// username:password:uid:gid:gecos:home:shell
+				passwdParts := strings.SplitN(passwd, ":", 7)
+				if len(passwdParts) > 5 {
+					return passwdParts[5], nil
+				}
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd := exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// Prefer standard environment variable USERPROFILE
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/pkg/config/go-homedir/homedir.go
+++ b/pkg/config/go-homedir/homedir.go
@@ -16,8 +16,10 @@ import (
 // by default.
 var DisableCache bool
 
-var homedirCache string
-var cacheLock sync.RWMutex
+var (
+	homedirCache string
+	cacheLock    sync.RWMutex
+)
 
 // Dir returns the home directory for the executing user.
 //

--- a/pkg/config/go-homedir/homedir.go
+++ b/pkg/config/go-homedir/homedir.go
@@ -24,6 +24,11 @@ var (
 	ErrHomeDrivePathBlank  = errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
 )
 
+const (
+	passwdFieldCount   = 7
+	passwdHomeDirIndex = 5
+)
+
 // Dir returns the home directory for the executing user.
 //
 // This uses an OS-specific method for discovering the home directory.
@@ -173,9 +178,9 @@ func getUnixHomeDir() (string, error) {
 	}
 
 	// username:password:uid:gid:gecos:home:shell
-	passwdParts := strings.SplitN(passwd, ":", 7)
-	if len(passwdParts) > 5 {
-		return passwdParts[5], nil
+	passwdParts := strings.SplitN(passwd, ":", passwdFieldCount)
+	if len(passwdParts) > passwdHomeDirIndex {
+		return passwdParts[passwdHomeDirIndex], nil
 	}
 	return "", nil
 }

--- a/pkg/config/go-homedir/homedir_test.go
+++ b/pkg/config/go-homedir/homedir_test.go
@@ -1,0 +1,129 @@
+package homedir
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func patchEnv(key, value string) func() {
+	bck := os.Getenv(key)
+	deferFunc := func() {
+		os.Setenv(key, bck)
+	}
+
+	if value != "" {
+		os.Setenv(key, value)
+	} else {
+		os.Unsetenv(key)
+	}
+
+	return deferFunc
+}
+
+func BenchmarkDir(b *testing.B) {
+	// We do this for any "warmups"
+	for i := 0; i < 10; i++ {
+		Dir()
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Dir()
+	}
+}
+
+func TestDir(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "")()
+	dir, err = Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+			"/foo",
+			"/foo",
+			false,
+		},
+
+		{
+			"~/foo",
+			filepath.Join(u.HomeDir, "foo"),
+			false,
+		},
+
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
+
+		{
+			"~foo/foo",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := Expand(tc.Input)
+		if (err != nil) != tc.Err {
+			t.Fatalf("Input: %#v\n\nErr: %s", tc.Input, err)
+		}
+
+		if actual != tc.Output {
+			t.Fatalf("Input: %#v\n\nOutput: %#v", tc.Input, actual)
+		}
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "/custom/path/")()
+	expected := filepath.Join("/", "custom", "path", "foo/bar")
+	actual, err := Expand("~/foo/bar")
+
+	if err != nil {
+		t.Errorf("No error is expected, got: %v", err)
+	} else if actual != expected {
+		t.Errorf("Expected: %v; actual: %v", expected, actual)
+	}
+}

--- a/pkg/config/go-homedir/homedir_test.go
+++ b/pkg/config/go-homedir/homedir_test.go
@@ -118,7 +118,7 @@ func TestExpand(t *testing.T) {
 	DisableCache = true
 	defer func() { DisableCache = false }()
 	defer patchEnv("HOME", "/custom/path/")()
-	expected := filepath.Join("/", "custom", "path", "foo/bar")
+	expected := filepath.Join(string(filepath.Separator), "custom", "path", "foo", string(filepath.Separator), "bar")
 	actual, err := Expand("~/foo/bar")
 
 	if err != nil {


### PR DESCRIPTION
## what
- Forked [mitchellh/go-homedir](https://github.com/mitchellh/go-homedir) into the Atmos organization.
- Added a LICENSE file to ensure compliance with the original repository's licensing terms.
- Created an ATTRIBUTIONS.md file to credit the original author.
- Updated references in Atmos to use the new forked repository instead of the original
## why

- Homedir is abandoned https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc
- No blessed fork exists
- Ensures maintainability and control over the `go-homedir` package within the Atmos

## references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced home directory functionality now reliably retrieves and expands user paths, ensuring seamless cross-platform support.
  - Updated dependency management improves overall module handling.
  
- **Documentation**
  - Added comprehensive usage guidance, attributions, and licensing details for the new home directory library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->