### PR TITLE
Lint check for dogsleds and duplicated code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters:
   enable:
     - bodyclose # Check that HTTP response body is closed
     - cyclop # Check cyclomatic complexity
+    - dogsled # Check for assignments with too many blank identifiers
+    - dupl # Check for duplicated code
     - err113 # Enforces best practices for error handling, specifically around comparing errors.
     - errcheck # Check that errors are handled
     - forbidigo # Forbid specific function calls
@@ -36,6 +38,14 @@ linters:
     - whitespace # Check for leading whitespace
 
 linters-settings:
+  dogsled:
+    # Checks assignments with too many blank identifiers.
+    # Default: 2
+    max-blank-identifiers: 3
+
+  dupl:
+    threshold: 150 # Tokens count to trigger issue.
+
   funlen:
     lines: 60 # Maximum number of lines per function
     statements: 40 # Maximum number of statements per function


### PR DESCRIPTION
## What  
- Raise errors on **dogsledding**: 
  ```go
  _, _, isActive, err := getUserData() // Too many unused return values
  ```
- Raise errors on **duplicate code** 

## Why  
- Too many return values; should use structs.  
- Identifies repeated logic that should be refactored. 

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal code quality measures by updating static analysis rules to better identify redundant code patterns and potential assignment issues. These adjustments contribute to improved long-term maintainability and robustness of the software without affecting the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->