### PR TITLE
Fix snapshots extra slashes 

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -15,7 +15,6 @@
 # are independent settings (supporting both absolute and relative paths).
 # If 'base_path' is provided, 'components.terraform.base_path', 'components.helmfile.base_path', 'stacks.base_path' and 'workflows.base_path'
 # are considered paths relative to 'base_path'.
-base_path: ""
 
 vendor:
   # Path to vendor configuration file or directory containing vendor files
@@ -231,7 +230,6 @@ commands:
 
 # Integrations
 integrations:
-
   # Atlantis integration
   # https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
   atlantis:
@@ -357,17 +355,17 @@ settings:
 
   # Terminal settings for displaying content
   terminal:
-    max_width: 120          # Maximum width for terminal output
-    pager: true             # Pager setting for all terminal output
-    colors: true            # Enable colored output
-    unicode: true           # Use unicode characters
+    max_width: 120 # Maximum width for terminal output
+    pager: true # Pager setting for all terminal output
+    colors: true # Enable colored output
+    unicode: true # Use unicode characters
 
     syntax_highlighting:
       enabled: true
-      formatter: terminal   # Output formatter (e.g., terminal, html)
-      theme: dracula        # Highlighting theme
-      line_numbers: true    # Display line numbers
-      wrap: false           # Wrap long lines
+      formatter: terminal # Output formatter (e.g., terminal, html)
+      theme: dracula # Highlighting theme
+      line_numbers: true # Display line numbers
+      wrap: false # Wrap long lines
 
   # Markdown element styling
   markdown:
@@ -394,4 +392,3 @@ version:
     enabled: true
     timeout: 1000 # ms
     frequency: 1h
-

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -393,3 +393,4 @@ version:
     enabled: true
     timeout: 1000 # ms
     frequency: 1h
+

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -230,6 +230,7 @@ commands:
 
 # Integrations
 integrations:
+
   # Atlantis integration
   # https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
   atlantis:
@@ -355,17 +356,17 @@ settings:
 
   # Terminal settings for displaying content
   terminal:
-    max_width: 120 # Maximum width for terminal output
-    pager: true # Pager setting for all terminal output
-    colors: true # Enable colored output
-    unicode: true # Use unicode characters
+    max_width: 120          # Maximum width for terminal output
+    pager: true             # Pager setting for all terminal output
+    colors: true            # Enable colored output
+    unicode: true           # Use unicode characters
 
     syntax_highlighting:
       enabled: true
-      formatter: terminal # Output formatter (e.g., terminal, html)
-      theme: dracula # Highlighting theme
-      line_numbers: true # Display line numbers
-      wrap: false # Wrap long lines
+      formatter: terminal   # Output formatter (e.g., terminal, html)
+      theme: dracula        # Highlighting theme
+      line_numbers: true    # Display line numbers
+      wrap: false           # Wrap long lines
 
   # Markdown element styling
   markdown:

--- a/tests/cli_terraform_test.go
+++ b/tests/cli_terraform_test.go
@@ -172,3 +172,42 @@ func runTerraformCleanCommand(t *testing.T, binaryPath string, args ...string) {
 		t.Fatalf("Failed to run terraform clean: %v", stderr.String())
 	}
 }
+func TestCollapseExtraSlashesHandlesOnlySlashes(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// Basic cases with only slashes
+		{"///", "/"},
+		{"/", "/"},
+		{"//", "/"},
+		{"", ""},
+
+		// Relative paths
+		{"..//path", "../path"},
+		{"/path//to//file", "/path/to/file"},
+		{"./../path", "./../path"}, // No change expected
+
+		// Protocol handling
+		{"https://", "https://"},
+		{"http://", "http://"},
+		{"http://example.com//path//", "http://example.com/path/"},
+		{"https:////example.com", "https://example.com"}, // Normalize after protocol
+		{"http:/example.com", "http://example.com"},      // Fix missing slashes after protocol
+
+		// Complex URLs
+		{"http://example.com:8080//api//v1", "http://example.com:8080/api/v1"},
+		{"http://user:pass@example.com//path", "http://user:pass@example.com/path"},
+
+		// Edge cases for trimming
+		{"http:////example.com", "http://example.com"}, // Extra slashes after protocol
+		{"http:///path", "http://path"},                // Implicit empty authority
+	}
+
+	for _, tc := range testCases {
+		result := collapseExtraSlashes(tc.input)
+		if result != tc.expected {
+			t.Errorf("collapseExtraSlashes(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
+	}
+}

--- a/tests/cli_terraform_test.go
+++ b/tests/cli_terraform_test.go
@@ -172,6 +172,7 @@ func runTerraformCleanCommand(t *testing.T, binaryPath string, args ...string) {
 		t.Fatalf("Failed to run terraform clean: %v", stderr.String())
 	}
 }
+
 func TestCollapseExtraSlashesHandlesOnlySlashes(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -248,7 +248,24 @@ func isCIEnvironment() bool {
 
 // collapseExtraSlashes replaces multiple consecutive slashes with a single slash.
 func collapseExtraSlashes(s string) string {
-	return regexp.MustCompile("/+").ReplaceAllString(s, "/")
+	// Normalize the protocol to have exactly two slashes after http: or https:
+	protocolRegex := regexp.MustCompile(`(?i)(https?):/*`)
+	s = protocolRegex.ReplaceAllString(s, "$1://")
+
+	// Split into protocol and the rest of the URL
+	parts := regexp.MustCompile(`(?i)^(https?://)(.*)$`).FindStringSubmatch(s)
+	if len(parts) == 3 {
+		protocol := parts[1]
+		rest := parts[2]
+		// Collapse multiple slashes in the rest part
+		rest = regexp.MustCompile(`/+`).ReplaceAllString(rest, "/")
+		// Remove any leading slashes after the protocol to avoid triple slashes
+		rest = strings.TrimLeft(rest, "/")
+		return protocol + rest
+	}
+
+	// If no protocol, collapse all slashes
+	return regexp.MustCompile(`/+`).ReplaceAllString(s, "/")
 }
 
 // sanitizeOutput replaces occurrences of the repository's absolute path in the output


### PR DESCRIPTION
## what
-  Improved collapseExtraSlashes to normalize URLs by collapsing redundant slashes while preserving http:// and https:// structure.
- Remove ` base_path` empty value from atmos.yaml

## why
- Ensures valid URL formatting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Revised configuration settings by removing the `base_path` key for improved simplicity.

- **Bug Fixes**
	- Enhanced URL normalization to correctly handle extra consecutive slashes, ensuring proper protocol formatting and robust handling of various URL patterns.

- **Tests**
	- Added a new test function to validate the behavior of the URL normalization process with various input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->