### PR TITLE
Improve yq utils to handle nil config pointers

### DIFF
--- a/pkg/utils/yq_utils.go
+++ b/pkg/utils/yq_utils.go
@@ -31,14 +31,21 @@ func (n logBackend) IsEnabledFor(level logging.Level, s string) bool {
 	return false
 }
 
-func EvaluateYqExpression(atmosConfig *schema.AtmosConfiguration, data any, yq string) (any, error) {
-	// Use the `yqlib` default (chatty) logger only when Atmos Logs Level is set to `Trace`
-	// Otherwise, use the no-op logging backend
-	if atmosConfig.Logs.Level != LogLevelTrace {
+// configureYqLogger configures the yq logger based on Atmos configuration.
+// If atmosConfig is nil or log level is not Trace, use a no-op logging backend.
+func configureYqLogger(atmosConfig *schema.AtmosConfiguration) {
+	// Only use the default (chatty) logger when atmosConfig is not nil and log level is Trace
+	// In all other cases, use the no-op logging backend
+	if atmosConfig == nil || atmosConfig.Logs.Level != LogLevelTrace {
 		logger := yqlib.GetLogger()
 		backend := logBackend{}
 		logger.SetBackend(backend)
 	}
+}
+
+func EvaluateYqExpression(atmosConfig *schema.AtmosConfiguration, data any, yq string) (any, error) {
+	// Configure the yq logger based on Atmos configuration
+	configureYqLogger(atmosConfig)
 
 	evaluator := yqlib.NewStringEvaluator()
 


### PR DESCRIPTION
## what

Added handling for nil configuration pointers in the YQ expression evaluation utilities.

## why

When `atmosConfig` is passed as nil to `EvaluateYqExpression()`, it would panic with a nil pointer dereference when trying to access `atmosConfig.Logs.Level`. This happens in scenarios where the configuration hasn't been loaded yet or when the function is called from contexts where configuration isn't available.

## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced YAML expression evaluation to gracefully handle absent configurations, preventing unexpected errors and ensuring reliable, consistent results.
  - Updated default logging behavior improves stability during expression processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->