### PR TITLE
Update dry run for atmos vendor pull to support ssh + detailed SCP urls alignment v2

### DIFF
--- a/website/docs/cli/commands/vendor/vendor-pull.mdx
+++ b/website/docs/cli/commands/vendor/vendor-pull.mdx
@@ -108,6 +108,124 @@ The following config can be used to download the `vpc` component from an AWS pub
       version: "latest"
   ```
 
+## Vendoring from SSH
+
+Atmos supports SSH for accessing non-public Git repositories, which is convenient for local development. Atmos will use any installed SSH keys automatically. 
+
+:::tip  
+In automated systems like GitHub Actions, we recommend sticking with the `https://` scheme for vendoring. Atmos will automatically inject the `GITHUB_TOKEN`.  
+:::
+
+There are two primary ways to specify an SSH source.
+
+### SCP-style Sources
+
+Atmos supports traditional SCP-style sources, which use a colon to separate the host from the repository, like this:
+
+```shell
+git::git@github.com:cloudposse/terraform-null-label.git?ref={{.Version}}
+```
+
+Atmos rewrites this URL to the following format:
+
+```shell
+git::ssh://git@github.com/cloudposse/terraform-null-label.git?depth=1&ref={{.Version}}
+```
+
+If no username is supplied and the host is `github.com`, Atmos automatically injects the default username `git`.
+
+### Explicit SSH Sources
+
+When the `ssh://` scheme is explicitly specified, the URL is used as provided, and no rewriting occurs.
+
+For example:
+
+```shell
+git::ssh://git@github.com/cloudposse/terraform-null-label.git?ref={{ .Version }}
+```
+
+
+### Important Notes
+
+- The following URL is **invalid** because `go-getter` misinterprets `github.com:` as a URL scheme (like `http:` or `git:`), causing a parsing error:
+  ```shell
+  github.com:cloudposse/terraform-null-label.git?ref={{ .Version }}
+  ```
+
+- When a URL has no scheme, Atmos defaults to **HTTPS** and injects credentials if available.
+  ```shell
+  github.com/cloudposse/terraform-null-label.git?ref={{ .Version }}
+  ```
+
+## Git over HTTPS Vendoring
+
+Atmos supports vendoring components using **Git over HTTPS**.
+
+For example:
+```
+github.com/cloudposse/terraform-null-label.git?ref={{ .Version }}
+```
+is automatically resolved as:
+```
+git::https://github.com/cloudposse/terraform-null-label.git?depth=1&ref={{ .Version }}
+```
+
+## Authentication & Token Usage for HTTPS
+
+Atmos prioritizes authentication credentials based on predefined environment variables. The priority order for each provider is:
+
+### GitHub
+<dl>
+ <dt>`ATMOS_GITHUB_TOKEN`</dt>
+ <dd>Bearer token for GitHub API requests, enabling authentication for private repositories and higher rate limits.</dd>
+
+ <dt>`GITHUB_TOKEN`</dt>
+ <dd>Used as a fallback if `ATMOS_GITHUB_TOKEN` is not set.</dd>
+</dl>
+
+**Default Username for HTTPS:** `x-access-token`
+
+### Bitbucket
+<dl>
+ <dt>`ATMOS_BITBUCKET_TOKEN`</dt>
+ <dd>Bitbucket app password for API requests; used to avoid rate limits. When both `ATMOS_BITBUCKET_TOKEN` and `BITBUCKET_TOKEN` are defined, the former prevails.</dd>
+
+ <dt>`BITBUCKET_TOKEN`</dt>
+ <dd>Used as a fallback when `ATMOS_BITBUCKET_TOKEN` is not set.</dd>
+
+ <dt>`ATMOS_BITBUCKET_USERNAME`</dt>
+ <dd>Bitbucket username for authentication. Takes precedence over `BITBUCKET_USERNAME`.</dd>
+
+ <dt>`BITBUCKET_USERNAME`</dt>
+ <dd>Used as a fallback when `ATMOS_BITBUCKET_USERNAME` is not set. Bitbucket requires a valid username and does not accept dummy values like `x-access-token`.</dd>
+</dl>
+
+### GitLab
+<dl>
+ <dt>`ATMOS_GITLAB_TOKEN`</dt>
+ <dd>Personal Access Token (PAT) for GitLab authentication. Takes precedence over `GITLAB_TOKEN`.</dd>
+
+ <dt>`GITLAB_TOKEN`</dt>
+ <dd>Used as a fallback if `ATMOS_GITLAB_TOKEN` is not set.</dd>
+</dl>
+
+**Default Username for HTTPS:** `"oauth2"`
+
+## How HTTPS URLs Are Resolved
+
+When resolving Git sources, Atmos follows these rules:
+
+1. If a **full HTTPS URL** is provided (`git::https://github.com/...`), it is used as-is. No token data is injected, even if environment variables are set.
+2. If a **repository name** is provided without a scheme (`github.com/org/repo.git`), it defaults to `https://`, and if a token is set, it is injected into the URL.
+3. If a **username and repository name** are provided in SCP format (`git@github.com:org/repo.git`), it is rewritten as an SSH URL.
+
+
+:::note
+For more details on configuration, refer to [Atmos Configuration](/cli/configuration).
+ 
+:::
+
+
 :::tip
 Run `atmos vendor pull --help` to see all the available options
 :::

--- a/website/docs/cli/configuration/configuration.mdx
+++ b/website/docs/cli/configuration/configuration.mdx
@@ -678,6 +678,9 @@ setting `ATMOS_STACKS_BASE_PATH` to a path in `/localhost` to your local develop
 | ATMOS_SETTINGS_LIST_MERGE_STRATEGY                    | settings.list_merge_strategy                    | Specifies how lists are merged in Atmos stack manifests. The following strategies are supported: `replace`, `append`, `merge`                                                                                                |
 | ATMOS_VERSION_CHECK_ENABLED                           | version.check.enabled                           | Enable/disable Atmos version checks for updates to the newest release                                                                                                                                                        |
 | ATMOS_GITHUB_TOKEN                                    | N/A                                             | Bearer token for GitHub API requests, enabling authentication for private repositories and higher rate limits                                                                                                                |
+| ATMOS_BITBUCKET_TOKEN                                 | N/A                                             | App password for Bitbucket API requests is set to avoid rate limits. Unauthenticated Requests are limited to 60 requests per hour across all API resources.                                                                  |
+| ATMOS_BITBUCKET_USERNAME                              | N/A                                             | Username for Bitbucket authentication. Takes precedence over BITBUCKET_USERNAME.                                                                                                                                             |
+| ATMOS_GITLAB_TOKEN                                    | N/A                                             | Personal Access Token (PAT) for GitLab authentication. Unauthenticated users are limited to 6 requests per minute per IP address for certain endpoints, while authenticated users have higher thresholds.                    |
 
 ### Context
 
@@ -691,8 +694,8 @@ configuration, Atmos may set the following environment variables in the spawned 
 |:------------------------|:-------------------------------------------------------------------------------------------------------|
 | ATMOS_COMPONENT         | The name of the active component                                                                       |
 | ATMOS_SHELL_WORKING_DIR | The directory from which native commands should be run                                                 |
-| ATMOS_SHLVL | The depth of Atmos shell nesting. When present, it indicates that the shell has been spawned by Atmos. |
+| ATMOS_SHLVL             | The depth of Atmos shell nesting. When present, it indicates that the shell has been spawned by Atmos. |
 | ATMOS_STACK             | The name of the active stack                                                                           |
-| ATMOS_TERRAFORM_WORKSPACE | The name of the Terraform workspace in which Terraform comamnds should be run                          |
+| ATMOS_TERRAFORM_WORKSPACE | The name of the Terraform workspace in which Terraform comamnds should be run                        |
 | PS1                     | When a custom shell prompt has been configured in Atmos, the prompt will be set via `PS1`              |
 | TF_CLI_ARGS_*           | Terraform CLI arguments to be passed to Terraform commands                                             |


### PR DESCRIPTION
## what

This is a copy of #1076 that got too big and had issues with codecov results upload. 

This PR upgrades the output of dry run mode for vendor pull command. 
After the change is applied, the dry run mode shows 
1) details on the SCP-style links converion,
2) Injected tokens
3) urls being vendored in a santized format 
yet there's no actual files download. 

### Before ( component vendoring dry-run output)
![component_vendoring_dry_run_before](https://github.com/user-attachments/assets/f6c918ae-7ec1-4622-bf8b-c9713c7b7816)
### After ( component vendoring dry-run output)
![component vendoring dry run after](https://github.com/user-attachments/assets/83bc2e6c-d37b-4c38-8cee-8c83189765db)
### component.yaml,  refer to the respective test case for details
![comonent yaml](https://github.com/user-attachments/assets/1469ed8b-e870-4f34-a042-3889c0efe816)



### Before ( generic vendoring dry-run output)
![generic_vendoring_dry_run_before](https://github.com/user-attachments/assets/db2ec262-2c28-4c06-8a8e-e3049df7e59e)
### After ( generic vendoring dry-run output)
![generic_vendoring_after](https://github.com/user-attachments/assets/358240ae-f855-4dfb-ad79-ed8d588a9fe0)
### vendor.yaml, refer to the respective test case for detaails
![generic vendor yaml](https://github.com/user-attachments/assets/c998abc1-1860-46fb-abe6-1e8c00617b4d)


## why
Received [feedback](https://github.com/cloudposse/atmos/pull/1061#issuecomment-2660950484) from in the parent PR

## references
Copy of  #1076
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new sections detailing how to use SSH and HTTPS for vendoring private Git repositories, including practical examples and URL handling tips.
	- Updated configuration documentation with new environment variables for Bitbucket and GitLab authentication, clarifying token usage and addressing API request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->