### PR TITLE
Add Announcements Blog

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -157,6 +157,11 @@ const config = {
                         position: 'left',
                         to: '/community'
                     },
+                    {
+                        label: 'Blog',
+                        position: 'left',
+                        to: '/blog'
+                    },
                     // Algolia search configuration
                     {
                         type: 'search',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -103,6 +103,10 @@ const config = {
                 },
                 blog: {
                     showReadingTime: true,
+                    postsPerPage: 10,
+                    blogTitle: 'Atmos Changelog',
+                    blogDescription: 'Release notes for Atmos',
+                    include: ['**/*.{md,mdx}'],
                     editUrl: ({versionDocsDirPath, docPath, locale}) => {
                         return `https://github.com/cloudposse/atmos/edit/master/website/${versionDocsDirPath}/${docPath}`;
                     },


### PR DESCRIPTION
## what
- Provide an area for announcements

## why
- A lot is changing in atmos and following releases is difficult to get the big picture