### PR TITLE
update config to be an array of string for editorconfig

### DIFF
--- a/cmd/validate_editorconfig.go
+++ b/cmd/validate_editorconfig.go
@@ -24,7 +24,7 @@ var (
 	initEditorConfig       bool
 	currentConfig          *config.Config
 	cliConfig              config.Config
-	configFilePath         string
+	configFilePaths        []string
 	tmpExclude             string
 	format                 string
 )
@@ -50,10 +50,10 @@ func initializeConfig(cmd *cobra.Command) {
 	replaceAtmosConfigInConfig(cmd, atmosConfig)
 
 	configPaths := []string{}
-	if configFilePath == "" {
+	if len(configFilePaths) == 0 {
 		configPaths = append(configPaths, defaultConfigFileNames[:]...)
 	} else {
-		configPaths = append(configPaths, configFilePath)
+		configPaths = append(configPaths, configFilePaths...)
 	}
 
 	currentConfig = config.NewConfig(configPaths)
@@ -75,8 +75,8 @@ func initializeConfig(cmd *cobra.Command) {
 }
 
 func replaceAtmosConfigInConfig(cmd *cobra.Command, atmosConfig schema.AtmosConfiguration) {
-	if !cmd.Flags().Changed("config") && atmosConfig.Validate.EditorConfig.ConfigFilePath != "" {
-		configFilePath = atmosConfig.Validate.EditorConfig.ConfigFilePath
+	if !cmd.Flags().Changed("config") && len(atmosConfig.Validate.EditorConfig.ConfigFilePaths) > 0 {
+		configFilePaths = atmosConfig.Validate.EditorConfig.ConfigFilePaths
 	}
 	if !cmd.Flags().Changed("exclude") && len(atmosConfig.Validate.EditorConfig.Exclude) > 0 {
 		tmpExclude = strings.Join(atmosConfig.Validate.EditorConfig.Exclude, ",")
@@ -179,7 +179,7 @@ func checkVersion(config config.Config) error {
 
 // addPersistentFlags adds flags to the root command
 func addPersistentFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&configFilePath, "config", "", "Path to the configuration file")
+	cmd.PersistentFlags().StringSliceVar(&configFilePaths, "config", []string{}, "Path to the configuration file")
 	cmd.PersistentFlags().StringVar(&tmpExclude, "exclude", "", "Regex to exclude files from checking")
 	cmd.PersistentFlags().BoolVar(&initEditorConfig, "init", false, "creates an initial configuration")
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -170,13 +170,13 @@ type Validate struct {
 }
 
 type EditorConfig struct {
-	IgnoreDefaults bool     `yaml:"ignore_defaults,omitempty" json:"ignore_defaults,omitempty" mapstructure:"ignore_defaults"`
-	DryRun         bool     `yaml:"dry_run,omitempty" json:"dry_run,omitempty" mapstructure:"dry_run"`
-	Format         string   `yaml:"format,omitempty" json:"format,omitempty" mapstructure:"format"`
-	Color          bool     `yaml:"color,omitempty" json:"color,omitempty" mapstructure:"color"`
-	ConfigFilePath string   `yaml:"config_file_path,omitempty" json:"config_file_path,omitempty" mapstructure:"config_file_path"`
-	Exclude        []string `yaml:"exclude,omitempty" json:"exclude,omitempty" mapstructure:"exclude"`
-	Init           bool     `yaml:"init,omitempty" json:"init,omitempty" mapstructure:"init"`
+	IgnoreDefaults  bool     `yaml:"ignore_defaults,omitempty" json:"ignore_defaults,omitempty" mapstructure:"ignore_defaults"`
+	DryRun          bool     `yaml:"dry_run,omitempty" json:"dry_run,omitempty" mapstructure:"dry_run"`
+	Format          string   `yaml:"format,omitempty" json:"format,omitempty" mapstructure:"format"`
+	Color           bool     `yaml:"color,omitempty" json:"color,omitempty" mapstructure:"color"`
+	ConfigFilePaths []string `yaml:"config_file_path,omitempty" json:"config_file_path,omitempty" mapstructure:"config_file_path"`
+	Exclude         []string `yaml:"exclude,omitempty" json:"exclude,omitempty" mapstructure:"exclude"`
+	Init            bool     `yaml:"init,omitempty" json:"init,omitempty" mapstructure:"init"`
 
 	DisableEndOfLine              bool `yaml:"disable_end_of_line,omitempty" json:"disable_end_of_line,omitempty" mapstructure:"disable_end_of_line"`
 	DisableInsertFinalNewline     bool `yaml:"disable_insert_final_newline,omitempty" json:"disable_insert_final_newline,omitempty" mapstructure:"disable_insert_final_newline"`


### PR DESCRIPTION
## what

* We are supporting config flag as a string array for validate editorconfig

## why

* We want to be consistent with our config flag. With pr https://github.com/cloudposse/atmos/pull/1091 `config` would be an array of string at the root. And this should be reflected in `validate editorconfig`


## references

* [DEV-3111](https://linear.app/cloudposse/issue/DEV-3111/update-the-config-flag-in-editorconfig)