### PR TITLE
 Fix bug related to loading and merging atmos configurations files

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -237,4 +238,43 @@ func changeWorkingDir(t *testing.T, dir string) {
 
 	err = os.Chdir(dir)
 	require.NoError(t, err, "Failed to change working directory")
+}
+func TestMergeConfig_ConfigFileNotFound(t *testing.T) {
+	tempDir := t.TempDir() // Empty directory, no config file
+
+	v := viper.New()
+	err := mergeConfig(v, tempDir, true)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Config File \"atmos\" Not Found")
+
+}
+func TestMergeConfig_MultipleConfigFilesMerge(t *testing.T) {
+	tempDir := t.TempDir()
+	content := `
+base_path: ./
+vendor:  
+  base_path: "./test-vendor.yaml"
+logs:
+  file: /dev/stderr
+  level: Debug`
+	createConfigFile(t, tempDir, "atmos.yaml", content)
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := mergeConfig(v, tempDir, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "./", v.GetString("base_path"))
+	content2 := `
+base_path: ./test
+vendor:  
+  base_path: "./test2-vendor.yaml"
+`
+	tempDir2 := t.TempDir()
+	createConfigFile(t, tempDir2, "atmos.yml", content2)
+	err = mergeConfig(v, tempDir2, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "./test", v.GetString("base_path"))
+	assert.Equal(t, "./test2-vendor.yaml", v.GetString("vendor.base_path"))
+	assert.Equal(t, "Debug", v.GetString("logs.level"))
+	assert.Equal(t, filepath.Join(tempDir2, "atmos.yml"), v.ConfigFileUsed())
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -239,6 +239,7 @@ func changeWorkingDir(t *testing.T, dir string) {
 	err = os.Chdir(dir)
 	require.NoError(t, err, "Failed to change working directory")
 }
+
 func TestMergeConfig_ConfigFileNotFound(t *testing.T) {
 	tempDir := t.TempDir() // Empty directory, no config file
 
@@ -247,8 +248,8 @@ func TestMergeConfig_ConfigFileNotFound(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Config File \"atmos\" Not Found")
-
 }
+
 func TestMergeConfig_MultipleConfigFilesMerge(t *testing.T) {
 	tempDir := t.TempDir()
 	content := `

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -200,13 +200,23 @@ func readAtmosConfigCli(v *viper.Viper, atmosCliConfigPath string) error {
 
 // mergeConfig merge config from a specified path directory and process imports. Return error if config file does not exist.
 func mergeConfig(v *viper.Viper, path string, processImports bool) error {
-	v.AddConfigPath(path)
-	v.SetConfigName(CliConfigFileName)
+	// Create a temporary Viper instance to isolate this configuration load
+	tempViper := viper.New()
+	tempViper.AddConfigPath(path)
+	tempViper.SetConfigName(CliConfigFileName)
+	tempViper.SetConfigType("yaml")
+	// Read configuration into temporary instance
+	if err := tempViper.ReadInConfig(); err != nil {
+		return err
+	}
+	configFilePath := tempViper.ConfigFileUsed()
+
+	v.SetConfigFile(configFilePath)
 	err := v.MergeInConfig()
 	if err != nil {
 		return err
 	}
-	content, err := os.ReadFile(v.ConfigFileUsed())
+	content, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What
- Fixed an issue where multiple configuration files were not loading correctly.
- Now, all configuration files from each specified path are loaded and merged into the Atmos config.

## Why
- Previously, when loading files from multiple paths, only the first file found was loaded, ignoring the rest. This update ensures all configurations are properly merged.
## references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the configuration loading mechanism to improve error handling and ensure accurate processing of YAML configuration files.
- **Tests**
	- Added new tests for configuration merging, including scenarios for missing configuration files and merging multiple configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->