### PR TITLE
Add golangci-lint rule to deprecate the `processArgsAndFlags` function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,12 @@ linters-settings:
   dupl:
     threshold: 150 # Tokens count to trigger issue.
 
+  forbidigo:
+    # Forbid specific function calls
+    forbid:
+      - p: "os\\.Getenv"
+        msg: "Use viper in config package instead of os.Getenv"
+
   funlen:
     lines: 60 # Maximum number of lines per function
     statements: 40 # Maximum number of statements per function

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ linters-settings:
     # Forbid specific function calls
     forbid:
       - p: "os\\.Getenv"
-        msg: "Use viper in config package instead of os.Getenv"
+        msg: "Use `viper.BindEnv` for new environment variables instead of `os.Getenv`"
 
   funlen:
     lines: 60 # Maximum number of lines per function

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -646,7 +646,7 @@ func ProcessStacks(
 // processArgsAndFlags processes args and flags from the provided CLI arguments/flags
 //
 // Deprecated: use Cobra command flag parser instead.
-// Post https://github.com/cloudposse/atmos/pull/1174 we can use the api provided by this pr for better handling of flags.
+// Post https://github.com/cloudposse/atmos/pull/1174 we can use the API provided by this PR for better handling of flags.
 func processArgsAndFlags(
 	componentType string,
 	inputArgsAndFlags []string,

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -644,6 +644,9 @@ func ProcessStacks(
 }
 
 // processArgsAndFlags processes args and flags from the provided CLI arguments/flags
+//
+// Deprecated: use Cobra command flag parser instead.
+// Post https://github.com/cloudposse/atmos/pull/1174 we can use the api provided by this pr for better handling of flags.
 func processArgsAndFlags(
 	componentType string,
 	inputArgsAndFlags []string,


### PR DESCRIPTION
## what

* We are restricting the usage of os.Getenv
* We are also depricating usage/enhancing function processArgsAndFlags

## why

* we should start using viper.BindEnv for new env variables
* For flags we should start using cobra flags and also if possible bind to the viper. The binding would be mandatory post https://github.com/cloudposse/atmos/pull/1174 pr

## references

* [DEV-3112](https://linear.app/cloudposse/issue/DEV-3112/stop-usage-of-osgetenv-and-custom-flag-parsing-logic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new linter setting to enforce coding standards for environment variable access.
- **Refactor**
  - Added deprecation notice for legacy command-line parameter handling, recommending a more robust flag processing approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->