### PR TITLE
Warn on specific TF Environment Variables

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -100,6 +100,10 @@ func setEnv(v *viper.Viper) {
 	bindEnv(v, "settings.gitlab_token", "GITLAB_TOKEN")
 	bindEnv(v, "settings.inject_gitlab_token", "ATMOS_INJECT_GITLAB_TOKEN")
 	bindEnv(v, "settings.atmos_gitlab_token", "ATMOS_GITLAB_TOKEN")
+
+	// Bind base path and CLI config path environment variables
+	bindEnv(v, "base_path", "ATMOS_BASE_PATH")
+	bindEnv(v, "cli_config_path", "ATMOS_CLI_CONFIG_PATH")
 }
 
 func bindEnv(v *viper.Viper, key ...string) {

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -100,10 +100,6 @@ func setEnv(v *viper.Viper) {
 	bindEnv(v, "settings.gitlab_token", "GITLAB_TOKEN")
 	bindEnv(v, "settings.inject_gitlab_token", "ATMOS_INJECT_GITLAB_TOKEN")
 	bindEnv(v, "settings.atmos_gitlab_token", "ATMOS_GITLAB_TOKEN")
-
-	// Bind base path and CLI config path environment variables
-	bindEnv(v, "base_path", "ATMOS_BASE_PATH")
-	bindEnv(v, "cli_config_path", "ATMOS_CLI_CONFIG_PATH")
 }
 
 func bindEnv(v *viper.Viper, key ...string) {


### PR DESCRIPTION
## what
- Only warn on these environment variables:

```
"TF_CLI_ARGS"
"TF_VAR_"
"TF_CLI_ARGS_"
"TF_WORKSPACE"
```

## why
- Previously we warned on all `TF_*` environment variables as requested. This is far too noisy and unnecessary for the majority of use cases.
- Inspired by terraform-exec, we're going to adopt similar convention.

## references
- https://github.com/cloudposse/atmos/issues/1042#issuecomment-2686282413