### PR TITLE
Fix: nested components for list pkg

### DIFF
--- a/pkg/list/list_values.go
+++ b/pkg/list/list_values.go
@@ -164,11 +164,7 @@ func extractComponentValues(stacksMap map[string]interface{}, component string, 
 func processComponentType(component string, componentFilter string, includeAbstract bool) string {
 	// If this is a regular component query with a specific component filter
 	if component == "" && componentFilter != "" {
-		// Extract component name from path
-		componentName := getComponentNameFromPath(componentFilter)
-
-		// Return a direct path to the component.
-		return fmt.Sprintf(".components.%s.%s", KeyTerraform, componentName)
+		return fmt.Sprintf(".components.%s.\"%s\"", KeyTerraform, componentFilter)
 	}
 
 	// Handle special section queries.

--- a/pkg/list/utils/utils.go
+++ b/pkg/list/utils/utils.go
@@ -31,10 +31,6 @@ func CheckComponentExists(atmosConfig *schema.AtmosConfiguration, componentName 
 		return false
 	}
 
-	// Extract component name from path if needed
-	parts := strings.Split(componentName, "/")
-	baseName := parts[len(parts)-1]
-
 	// Get all stacks to check for the component
 	stacksMap, err := e.ExecuteDescribeStacks(*atmosConfig, "", nil, nil, nil, false, false, false, false, nil)
 	if err != nil {
@@ -59,7 +55,7 @@ func CheckComponentExists(atmosConfig *schema.AtmosConfiguration, componentName 
 		}
 
 		// Check if the component exists in this stack
-		_, exists := terraformComponents[baseName]
+		_, exists := terraformComponents[componentName]
 		if exists {
 			return true
 		}


### PR DESCRIPTION
## what

Enabled atmos list vars and atmos list values to correctly display information for nested components (e.g., apis/weather, eks/cluster).

why
previously we assume and extract only the basename of nested components
These changes ensure the full component path is used for both existence checks and data querying.

## references

- Use `closes #1220`