### PR TITLE
Update `stack` after parsing name template in `describe_stacks`

### DIFF
--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -347,6 +347,7 @@ func ExecuteDescribeStacks(
 							}
 
 							// Atmos component, stack, and stack manifest file
+							configAndStacksInfo.Stack = stackName
 							componentSection["atmos_component"] = componentName
 							componentSection["atmos_stack"] = stackName
 							componentSection["stack"] = stackName
@@ -539,6 +540,7 @@ func ExecuteDescribeStacks(
 							finalStacksMap[stackName] = make(map[string]any)
 						}
 
+						configAndStacksInfo.Stack = stackName
 						configAndStacksInfo.ComponentSection["atmos_component"] = componentName
 						configAndStacksInfo.ComponentSection["atmos_stack"] = stackName
 						configAndStacksInfo.ComponentSection["stack"] = stackName


### PR DESCRIPTION
## what

- Fixes initial stack name when using the two-arg form of `!terraform.output`

## why

### Given

```yaml
# atmos.yaml
stacks:
  name_template: "{{.settings.context.project_id}}--{{.settings.context.product}}"
```

```yaml
# stacks/apps/staging.yaml
components:
  terraform:
    apps/app:
      vars:
        project_number: "{{ .settings.context.project_number }}"
        location: "{{ .settings.context.location }}"
        # Pass the `connection-name` output from our `postgres-instance` component to the jii-texting app
        cloudsql_instance: !terraform.output postgres-instance connection_name
        # The 'name' output uses the name of the first bucket, so ensure that the ETL bucket is the first one in the list
        etl_bucket_name:  !terraform.output gcs-buckets name
  postgres-instance:
    # ...
```

`!terraform.output` will fail in `describe_stacks.go` with the following message:
```error
ERRO no config found for the component 'postgres-instance' in the stack manifest 'app/staging'
```

Note that the stack manifest referenced comes from the file name which is [set when looping over stacks](https://github.com/cloudposse/atmos/blob/f42f14b453ee4925404f1491f93a132a69913475/internal/exec/describe_stacks.go#L208). As components are iterated [we parse the stack `name_template`](https://github.com/cloudposse/atmos/blob/f42f14b453ee4925404f1491f93a132a69913475/internal/exec/describe_stacks.go#L305-L310) and assign it to `stackName`. 

This causes a [race condition where `configAndStacksInfo.Stack`](https://github.com/cloudposse/atmos/blob/main/internal/exec/describe_stacks.go#L275-L277) will differ between `stackFileName` on the first iteration and the parsed stack on the second iteration.


## references

- https://sweetops.slack.com/archives/C031919U8A0/p1738867759008499


-- 

I've got no clue how to approach testing this in the Atmos repo, open to any guidance there!