### PR TITLE
fix: Acceptance Tests Snapshots

### DIFF
--- a/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stdout.golden
@@ -170,5 +170,16 @@ docs:
     pagination: false
     generate:
         readme:
+            base-dir: .
+            input:
+                - ./README.yaml
+            template: https://raw.githubusercontent.com/cloudposse/.github/5a599e3b929f871f333cb9681a721d26b237d8de/README.md.gotmpl
             output: ./README.md
+            terraform:
+                source: src/
+                format: markdown
+                show_inputs: true
+                show_outputs: true
+                sort_by: name
+                indent_level: 2
 


### PR DESCRIPTION
## what
- Regenerated snapshots for acceptance tests

## why
- After merging #934 , the result of a test command changed because the content on the main branch changed. The test is still valid and simply needs an updated snapshot

## references
- https://github.com/cloudposse/atmos/actions/runs/14892475437/job/41828129583