### PR TITLE
Write Hook

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -75,7 +75,6 @@ func (h Hooks) RunAll(event HookEvent, atmosConfig *schema.AtmosConfiguration, i
 				u.LogErrorAndExit(err)
 			}
 		}
-
 	}
 	return nil
 }

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -52,7 +52,7 @@ func GetHooks(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStac
 func (h Hooks) RunAll(event HookEvent, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, cmd *cobra.Command, args []string) error {
 	log.Debug("running hooks", "count", len(h.items))
 
-	for _, hook := range h.items {
+	for k, hook := range h.items {
 		switch hook.Command {
 		case "store":
 			storeCmd := &StoreCommand{
@@ -64,7 +64,18 @@ func (h Hooks) RunAll(event HookEvent, atmosConfig *schema.AtmosConfiguration, i
 			if err != nil {
 				u.LogErrorAndExit(err)
 			}
+		case "write":
+			wHook, err := GetWriteHook(atmosConfig, info, k)
+			if err != nil {
+				u.LogErrorAndExit(err)
+			}
+
+			err = wHook.RunE(&hook, event, cmd, args)
+			if err != nil {
+				u.LogErrorAndExit(err)
+			}
 		}
+
 	}
 	return nil
 }

--- a/pkg/hooks/write_cmd.go
+++ b/pkg/hooks/write_cmd.go
@@ -2,8 +2,9 @@ package hooks
 
 import (
 	"fmt"
-	u "github.com/cloudposse/atmos/pkg/utils"
 	"strings"
+
+	u "github.com/cloudposse/atmos/pkg/utils"
 
 	"github.com/charmbracelet/log"
 	e "github.com/cloudposse/atmos/internal/exec"
@@ -64,7 +65,7 @@ func (c *WriteHook) processWriteCommand(hook *Hook) error {
 
 	log.Debug("executing 'after-terraform-apply' hook", "hook", hook.Name, "command", hook.Command)
 	for fileName, output := range c.Output {
-		var newContent = fmt.Sprintf("# This file is stack generated\n# Hook: `%s`\n# Component: %s\n# Stack: %s\n# StackFile: %s\n", c.Name, c.info.Component, c.info.Stack, c.info.StackFile) + output.Content
+		newContent := fmt.Sprintf("# This file is stack generated\n# Hook: `%s`\n# Component: %s\n# Stack: %s\n# StackFile: %s\n", c.Name, c.info.Component, c.info.Stack, c.info.StackFile) + output.Content
 
 		replaceMap := make(map[string]any)
 		for replaceKey, replaceOutputKey := range output.Replacements {

--- a/pkg/hooks/write_cmd.go
+++ b/pkg/hooks/write_cmd.go
@@ -1,0 +1,140 @@
+package hooks
+
+import (
+	"fmt"
+	u "github.com/cloudposse/atmos/pkg/utils"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	e "github.com/cloudposse/atmos/internal/exec"
+	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+//type WriteCommand struct {
+//	//StoreCommand
+//	StoreCommand StoreCommand
+//}
+
+type WriteOutput struct {
+	Content      string            `yaml:"content"`
+	Replacements map[string]string `json:"replacements"`
+}
+type WriteHook struct {
+	Hook
+	Name   string                 `yaml:"name"`
+	Output map[string]WriteOutput `yaml:"output"`
+	config *schema.AtmosConfiguration
+	info   *schema.ConfigAndStacksInfo
+}
+
+func GetWriteHook(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, Name string) (*WriteHook, error) {
+	sections, err := e.ExecuteDescribeComponent(info.ComponentFromArg, info.Stack, true, true, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute describe component: %w", err)
+	}
+
+	hooksSection := sections["hooks"].(map[string]any)
+
+	yamlData, err := yaml.Marshal(hooksSection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal hooksSection: %w", err)
+	}
+
+	var items map[string]WriteHook
+	err = yaml.Unmarshal(yamlData, &items)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to Hooks: %w", err)
+	}
+
+	for k, v := range items {
+		v.config = atmosConfig
+		v.info = info
+
+		if k == Name {
+			return &v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find hook %q in config", Name)
+}
+
+func (c *WriteHook) processWriteCommand(hook *Hook) error {
+	log.Debug("processWriteCommand", "WriteHook", c)
+	if len(c.Output) == 0 {
+		log.Info("skipping hook. no output configured.", "hook", hook.Name, "outputs", hook.Outputs)
+		return nil
+	}
+
+	log.Debug("executing 'after-terraform-apply' hook", "hook", hook.Name, "command", hook.Command)
+	for fileName, output := range c.Output {
+		var newContent = fmt.Sprintf("# This file is stack generated\n# Hook: `%s`\n# Component: %s\n# Stack: %s\n# StackFile: %s\n", c.Name, c.info.Component, c.info.Stack, c.info.StackFile) + output.Content
+
+		replaceMap := make(map[string]any)
+		for replaceKey, replaceOutputKey := range output.Replacements {
+			//for _, replaceOutputKey := range output.Replacements {
+			_, replaceOutput := c.getOutputValue(replaceOutputKey)
+			d, _ := u.ConvertToYAML(replaceOutput)
+			replaceMap[replaceKey] = d
+
+			//yamlData, err := yaml.Marshal(replaceOutput)
+			//if err != nil {
+			//	return fmt.Errorf("failed to marshal output: %w", err)
+			//}
+			//newContent = strings.ReplaceAll(newContent, replaceKey, d)
+
+		}
+		log.Info("ReplacementMap", "replaceMap", replaceMap)
+		//newContent = e.ProcessCustomYamlTags(c.config, replaceMap, newContent, [])
+		//convertedReplaceMap := schema.AtmosSectionMapType(replaceMap)
+		result, _ := e.ProcessCustomYamlTags(*c.config, replaceMap, newContent, []string{})
+		log.Info("result", "result", result)
+		newContent, err := e.ProcessTmpl("write-hook", newContent, result, true)
+
+		//if err != nil {
+		//	fmt.Errorf(err.Error())
+		//}
+		//content, _ := u.ConvertToYAML(newContent)
+		err = os.WriteFile(fileName, []byte(newContent), 0644)
+		//content, _ := yaml.Marshal(result)
+		//err := os.WriteFile(fileName, content, 0644)
+		if err != nil {
+			return err
+		}
+	}
+	//for key, value := range c.Output. {
+	//	outputKey, outputValue := c.getOutputValue(value)
+	//
+	//	err := c.writeOutput(hook, key, outputKey, outputValue)
+	//	if err != nil {
+	//		return err
+	//	}
+	//}
+	return nil
+}
+
+// getOutputValue gets an output from terraform
+func (c *WriteHook) getOutputValue(value string) (string, any) {
+	outputKey := strings.TrimPrefix(value, ".")
+	var outputValue any
+
+	if strings.Index(value, ".") == 0 {
+		outputValue = e.GetTerraformOutput(c.config, c.info.Stack, c.info.ComponentFromArg, outputKey, true)
+	} else {
+		outputValue = value
+	}
+	return outputKey, outputValue
+}
+
+// storeOutput puts the value of the output in the store
+func (c *WriteHook) writeOutput(hook *Hook, key string, outputKey string, outputValue any) error {
+	log.Debug("Writing Output Hook", "OutputFile", c.Output, "hook", hook)
+
+	return nil
+}
+
+func (c *WriteHook) RunE(hook *Hook, event HookEvent, cmd *cobra.Command, args []string) error {
+	return c.processWriteCommand(hook)
+}

--- a/pkg/hooks/write_cmd.go
+++ b/pkg/hooks/write_cmd.go
@@ -3,7 +3,6 @@ package hooks
 import (
 	"fmt"
 	u "github.com/cloudposse/atmos/pkg/utils"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -74,44 +73,20 @@ func (c *WriteHook) processWriteCommand(hook *Hook) error {
 
 		replaceMap := make(map[string]any)
 		for replaceKey, replaceOutputKey := range output.Replacements {
-			//for _, replaceOutputKey := range output.Replacements {
 			_, replaceOutput := c.getOutputValue(replaceOutputKey)
-			d, _ := u.ConvertToYAML(replaceOutput)
-			replaceMap[replaceKey] = d
-
-			//yamlData, err := yaml.Marshal(replaceOutput)
-			//if err != nil {
-			//	return fmt.Errorf("failed to marshal output: %w", err)
-			//}
-			//newContent = strings.ReplaceAll(newContent, replaceKey, d)
-
+			replaceMap[replaceKey] = replaceOutput
 		}
-		log.Info("ReplacementMap", "replaceMap", replaceMap)
-		//newContent = e.ProcessCustomYamlTags(c.config, replaceMap, newContent, [])
-		//convertedReplaceMap := schema.AtmosSectionMapType(replaceMap)
-		result, _ := e.ProcessCustomYamlTags(*c.config, replaceMap, newContent, []string{})
-		log.Info("result", "result", result)
-		newContent, err := e.ProcessTmpl("write-hook", newContent, result, true)
 
-		//if err != nil {
-		//	fmt.Errorf(err.Error())
-		//}
-		//content, _ := u.ConvertToYAML(newContent)
-		err = os.WriteFile(fileName, []byte(newContent), 0644)
-		//content, _ := yaml.Marshal(result)
-		//err := os.WriteFile(fileName, content, 0644)
+		var result map[string]any
+		result, _ = e.ProcessCustomYamlTags(*c.config, replaceMap, newContent, []string{})
+		err := u.WriteToFileAsYAML(fileName, result, 0o644)
+		if err != nil {
+			return err
+		}
 		if err != nil {
 			return err
 		}
 	}
-	//for key, value := range c.Output. {
-	//	outputKey, outputValue := c.getOutputValue(value)
-	//
-	//	err := c.writeOutput(hook, key, outputKey, outputValue)
-	//	if err != nil {
-	//		return err
-	//	}
-	//}
 	return nil
 }
 

--- a/pkg/hooks/write_cmd.go
+++ b/pkg/hooks/write_cmd.go
@@ -12,11 +12,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-//type WriteCommand struct {
-//	//StoreCommand
-//	StoreCommand StoreCommand
-//}
-
 type WriteOutput struct {
 	Content      string            `yaml:"content"`
 	Replacements map[string]string `json:"replacements"`

--- a/tests/fixtures/scenarios/vendor/stacks/test.yaml
+++ b/tests/fixtures/scenarios/vendor/stacks/test.yaml
@@ -1,0 +1,7 @@
+vars:        
+  stage: test
+
+components:
+  terraform:
+    github:
+      vars: {}

--- a/tests/fixtures/scenarios/write-hook/.gitignore
+++ b/tests/fixtures/scenarios/write-hook/.gitignore
@@ -1,0 +1,11 @@
+**/_generated*
+**/.terraform/**
+**/.terraform.lock.hcl
+**/.terraform.tfstate/**
+**/.terraform.tfstate.backup/**
+**/*.tfvars.json
+**/*.planfile
+**/terraform.tfstate
+**/terraform.tfstate.backup
+**/terraform.tfstate.d/**
+**/cache.*.txt

--- a/tests/fixtures/scenarios/write-hook/README.md
+++ b/tests/fixtures/scenarios/write-hook/README.md
@@ -1,0 +1,6 @@
+# Basic
+
+This is an extremely basic example of an Atmos project. We have a single component, `mock`, which is deployed in 2
+stacks, `nonprod` and `prod`.
+
+We use this for the tests in `tests/cli_terraform_test.go`

--- a/tests/fixtures/scenarios/write-hook/atmos.yaml
+++ b/tests/fixtures/scenarios/write-hook/atmos.yaml
@@ -19,4 +19,4 @@ stacks:
 
 logs:
   file: "/dev/stderr"
-  level: Debug
+  level: Info

--- a/tests/fixtures/scenarios/write-hook/atmos.yaml
+++ b/tests/fixtures/scenarios/write-hook/atmos.yaml
@@ -1,0 +1,22 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "."
+  included_paths:
+    - "stacks/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+    - "**/_generated*.yaml"
+  name_pattern: "{stage}"
+
+logs:
+  file: "/dev/stderr"
+  level: Debug

--- a/tests/fixtures/scenarios/write-hook/components/terraform/mock/README.md
+++ b/tests/fixtures/scenarios/write-hook/components/terraform/mock/README.md
@@ -1,0 +1,51 @@
+# Mock Component
+
+This is a mock Terraform component used exclusively for testing purposes. It provides a simple configuration with input variables and corresponding outputs, making it ideal for testing Atmos component functionality and behavior.
+
+## Usage
+
+This component is intended for testing only and should not be used in production environments. It is typically used in conjunction with test fixtures and validation scenarios.
+
+Example stack usage
+
+```yaml
+components:
+  terraform:
+    mock:
+      vars:
+        foo: "default value"
+        bar: "default value"
+        baz: "default value"
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bar"></a> [bar](#input\_bar) | n/a | `string` | `"bar"` | no |
+| <a name="input_baz"></a> [baz](#input\_baz) | n/a | `string` | `"baz"` | no |
+| <a name="input_foo"></a> [foo](#input\_foo) | n/a | `string` | `"foo"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bar"></a> [bar](#output\_bar) | n/a |
+| <a name="output_baz"></a> [baz](#output\_baz) | n/a |
+| <a name="output_foo"></a> [foo](#output\_foo) | n/a |

--- a/tests/fixtures/scenarios/write-hook/components/terraform/mock/main.tf
+++ b/tests/fixtures/scenarios/write-hook/components/terraform/mock/main.tf
@@ -1,0 +1,29 @@
+variable "foo" {
+  type    = string
+  default = "foo"
+}
+
+variable "bar" {
+  type    = string
+  default = "bar"
+}
+
+variable "baz" {
+  type    = string
+  default = "baz"
+}
+
+output "foo" {
+  value = var.foo
+}
+
+output "object" {
+  value = { 
+    "bar": var.bar
+    "baz": var.baz
+  }
+}
+
+output "list" {
+  value = [var.baz, var.baz]
+}

--- a/tests/fixtures/scenarios/write-hook/stacks/stack.yaml
+++ b/tests/fixtures/scenarios/write-hook/stacks/stack.yaml
@@ -37,8 +37,5 @@ components:
                 settings:
                   foo: {{ .foo }}
                   object: {{ .object }}
-                
-                  jsonobject: !template {{  toJson (.object) }}
-                  jsonlist: {{ toJson (.list) }}
                   list: {{ .list }}
             

--- a/tests/fixtures/scenarios/write-hook/stacks/stack.yaml
+++ b/tests/fixtures/scenarios/write-hook/stacks/stack.yaml
@@ -1,0 +1,44 @@
+vars:
+  stage: test
+# This is defined in the global hooks section to ensure that the hooks merging works correctly so that we can
+# use hooks defined in the global section in catalog and region/account default files.
+hooks:
+  write-outputs:
+    events:
+      - after-terraform-apply
+
+# This is defined in the terraform hooks section to ensure that the hooks merging works correctly so that we can
+# use hooks defined in the global section in catalog and region/account default files.
+terraform:
+  hooks:
+    write-outputs:
+
+
+
+components:
+  terraform:
+    mock:
+      metadata:
+        component: mock
+      vars:
+        foo: baz
+      hooks:
+        write-outputs:
+          command: write
+          events:
+            - after-terraform-apply
+          output:
+            stacks/_generated.foo.yaml:
+              replacements:
+                foo: .foo
+                list: .list
+                object: .object
+              content: | 
+                settings:
+                  foo: {{ .foo }}
+                  object: {{ .object }}
+                
+                  jsonobject: !template {{  toJson (.object) }}
+                  jsonlist: {{ toJson (.list) }}
+                  list: {{ .list }}
+            

--- a/website/docs/core-concepts/stacks/hooks.mdx
+++ b/website/docs/core-concepts/stacks/hooks.mdx
@@ -75,7 +75,7 @@ Atmos supports the following lifecycle events:
 
 - `after-terraform-apply` (this event is triggered after the `atmos terraform apply` or `atmos terraform deploy` command is run)
 
-## Supported Commands
+# Supported Commands
 
 ## store
 
@@ -103,4 +103,41 @@ The `store` command is used to write data to a remote store.
   [Terraform output](https://developer.hashicorp.com/terraform/language/values/outputs) and the value will be retrieved
   from the Terraform state for the current component.
   </dd>
+</dl>
+
+## write
+
+<dl>
+    <dt>`hooks.[hook_name]`</dt>
+    <dd>This map key is the name you want to give to the hook. This must be unique for each hook in the component.</dd>
+
+    <dt>`hooks.[hook_name].events`</dt>
+    <dd>
+        This is a list of [Supported Lifecycle Events](#supported-lifecycle-events) that should trigger running the command.
+    </dd>
+
+    <dt>`hooks.[hook_name].command`</dt>
+    <dd>Must be set to `write`</dd>
+    
+    <dt>`hooks.[hook_name].output`</dt>
+    <dd>
+        `output` is a map where the key is the file name, and the value contains two sub-maps:
+          - `replacements`: them mapping of context (key) to the terraform output (value)
+          - `content`: the template to write to the file
+        
+        Example:
+        ```yaml
+          output:
+            stacks/_generated.foo.yaml:
+              replacements:
+                foo: .foo
+                list: .list
+                object: .object
+              content: | 
+                settings:
+                  foo: {{ .foo }}
+                  object: {{ .object }}
+                  list: {{ .list }}
+        ```
+    </dd>
 </dl>


### PR DESCRIPTION
## what

Proposal of a hook type for post apply that can help generate "stacks" or mixins. 

## why

We sometimes need to pass information as a one off or on a low consistency from a terraform output to a stack or mixin. For example Account IDs are a pain to copy and paste. This hook would allow us to
1. add hook to account component
2. define a mixin on the account component that fetches all ID's
3. Use that account ID mixin via settings & templating or other imports to fetch those IDs.

This removes the need for scripts or other workarounds.

The reason to not use KV store and instead use a local write hook is two-fold:
1. you might not have access to a KV store at this point (account IDs)
2. It's a local dependency and reduces fetching complexity.

## Considerations
 - We might want to disable this hook on CICD. debugging stack issues when there are generated files would be troublesome.
 - We might want to make sure these generated files are under the exclude list of atmos config (or at least document it) such that you have to import directly and it doesn't break your stack compilation.


## references
