### PR TITLE
Fix tutorial code that is not formatted correctly

### DIFF
--- a/website/docs/quick-start/simple/extra-credit/add-another-component.mdx
+++ b/website/docs/quick-start/simple/extra-credit/add-another-component.mdx
@@ -21,35 +21,44 @@ For example, the following config shows how to define two Atmos components, `sta
 
 <File title="stacks/deploy/dev.yaml">
 ```yaml
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+vars:
+  stage: dev
+
 import:
   # Import the baseline for all station components
   - catalog/station
 
 components:
   terraform:
-  # Atmos component `station/1`
-  station/1:
-    metadata:
-    # Point to the Terraform component in `components/terraform/weather`
-    component: weather
-    # Inherit the defaults for all station components
-    inherits:
-      - station
-    # Define/override variables specific to this `station/1` component
-    vars:
-      name: station-1
-
-  # Atmos component `station/2`
-  station/2:
-    metadata:
-    # Point to the Terraform component in `components/terraform/weather`
-    component: weather
-    # Inherit the defaults for all station components
-    inherits:
-      - station
-    # Define/override variables specific to this `station/2` component
-    vars:
-      name: station-2
+    station:
+      vars:
+        location: Stockholm
+        lang: se
+    # Atmos component `station/1`
+    station/1:
+      metadata:
+        # Inherit the defaults for all station components
+        inherits:
+          - station
+        # Point to the Terraform component in `components/terraform/weather`
+        component: weather
+      # Define/override variables specific to this `station/1` component
+      vars:
+        name: station-1
+  
+    # Atmos component `station/2`
+    station/2:
+      metadata:
+        # Inherit the defaults for all station components
+        inherits:
+          - station
+        # Point to the Terraform component in `components/terraform/weather`
+        component: weather
+      # Define/override variables specific to this `station/2` component
+      vars:
+        name: station-2
 ```
 </File>
 


### PR DESCRIPTION
## what

The yaml config located at https://atmos.tools/quick-start/simple/extra-credit/add-another-component does not run correctly when applied:

- The syntax is incorrect
- The yaml config is not complete

## why

Example code that is not correct can be frustrating for new users that are learning how to use the tool. It's also not clear from the documentation that this yaml should be added to the existing `deploy/dev.yaml` file created from earlier in the tutorial and will not run on its own (even with the formatting corrected)