### PR TITLE
fix: Atlantis Tests for Windows

### DIFF
--- a/pkg/atlantis/atlantis_generate_repo_config_test.go
+++ b/pkg/atlantis/atlantis_generate_repo_config_test.go
@@ -81,13 +81,19 @@ func TestExecuteAtlantisGenerateRepoConfigAffectedOnly(t *testing.T) {
 	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
 	assert.Nil(t, err)
 
-	// Set the correct base path for the test fixture
+	// We are using `atmos.yaml` from this dir. This `atmos.yaml` has set base_path: "./",
+	// which will be wrong for the remote repo which is cloned into a temp dir.
+	// Set the correct base path for the cloned remote repo
 	atmosConfig.BasePath = "./tests/fixtures/scenarios/complete"
+
+	// Point to the same local repository
+	// This will compare this local repository with itself as the remote target, which should result in an empty `affected` list
+	repoPath := "../../"
 
 	err = e.ExecuteAtlantisGenerateRepoConfigAffectedOnly(
 		atmosConfig,
 		"/dev/stdout",
-		"",
+		repoPath,
 		"",
 		"",
 		"",

--- a/pkg/atlantis/atlantis_generate_repo_config_test.go
+++ b/pkg/atlantis/atlantis_generate_repo_config_test.go
@@ -82,19 +82,15 @@ func TestExecuteAtlantisGenerateRepoConfigAffectedOnly(t *testing.T) {
 	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
 	assert.Nil(t, err)
 
-	// We are using `atmos.yaml` from this dir. This `atmos.yaml` has set base_path: "./",
+	// We are using `atmos.yaml` from this dir. This `atmos.yaml` has set base_path: "../../tests/fixtures/scenarios/complete",
 	// which will be wrong for the remote repo which is cloned into a temp dir.
 	// Set the correct base path for the cloned remote repo
 	atmosConfig.BasePath = "./tests/fixtures/scenarios/complete"
 
-	// Point to the same local repository
-	// This will compare this local repository with itself as the remote target, which should result in an empty `affected` list
-	repoPath := "../../"
-
 	err = e.ExecuteAtlantisGenerateRepoConfigAffectedOnly(
 		atmosConfig,
 		"/dev/stdout",
-		repoPath,
+		"",
 		"",
 		"",
 		"",

--- a/pkg/atlantis/atlantis_generate_repo_config_test.go
+++ b/pkg/atlantis/atlantis_generate_repo_config_test.go
@@ -1,7 +1,6 @@
 package atlantis
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,13 +74,15 @@ func TestExecuteAtlantisGenerateRepoConfig2(t *testing.T) {
 }
 
 func TestExecuteAtlantisGenerateRepoConfigAffectedOnly(t *testing.T) {
+	stacksPath := "../../tests/fixtures/scenarios/complete"
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", stacksPath)
+	t.Setenv("ATMOS_BASE_PATH", stacksPath)
+
 	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
 	assert.Nil(t, err)
 
-	// We are using `atmos.yaml` from this dir. This `atmos.yaml` has set base_path: "../../tests/fixtures/scenarios/complete",
-	// which will be wrong for the remote repo which is cloned into a temp dir.
-	// Set the correct base path for the cloned remote repo
-	atmosConfig.BasePath = filepath.ToSlash("./tests/fixtures/scenarios/complete")
+	// Set the correct base path for the test fixture
+	atmosConfig.BasePath = "./tests/fixtures/scenarios/complete"
 
 	err = e.ExecuteAtlantisGenerateRepoConfigAffectedOnly(
 		atmosConfig,

--- a/pkg/atlantis/atlantis_generate_repo_config_test.go
+++ b/pkg/atlantis/atlantis_generate_repo_config_test.go
@@ -1,6 +1,7 @@
 package atlantis
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,7 +81,7 @@ func TestExecuteAtlantisGenerateRepoConfigAffectedOnly(t *testing.T) {
 	// We are using `atmos.yaml` from this dir. This `atmos.yaml` has set base_path: "../../tests/fixtures/scenarios/complete",
 	// which will be wrong for the remote repo which is cloned into a temp dir.
 	// Set the correct base path for the cloned remote repo
-	atmosConfig.BasePath = "./tests/fixtures/scenarios/complete"
+	atmosConfig.BasePath = filepath.ToSlash("./tests/fixtures/scenarios/complete")
 
 	err = e.ExecuteAtlantisGenerateRepoConfigAffectedOnly(
 		atmosConfig,

--- a/pkg/atlantis/atlantis_generate_repo_config_test.go
+++ b/pkg/atlantis/atlantis_generate_repo_config_test.go
@@ -1,6 +1,7 @@
 package atlantis
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,9 +75,9 @@ func TestExecuteAtlantisGenerateRepoConfig2(t *testing.T) {
 }
 
 func TestExecuteAtlantisGenerateRepoConfigAffectedOnly(t *testing.T) {
-	stacksPath := "../../tests/fixtures/scenarios/complete"
-	t.Setenv("ATMOS_CLI_CONFIG_PATH", stacksPath)
-	t.Setenv("ATMOS_BASE_PATH", stacksPath)
+	// Clear any existing environment variables that might interfere
+	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+	os.Unsetenv("ATMOS_BASE_PATH")
 
 	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
 	assert.Nil(t, err)

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -276,10 +276,8 @@ func ResolveRelativePath(path string, basePath string) string {
 		return filepath.FromSlash(relativePath)
 	}
 
-	// For non-relative paths, ensure we're using the correct path separator for the OS
-	// and that the path is properly joined with the base path
-	joinedPath := filepath.Join(filepath.Dir(normalizedBasePath), normalizedPath)
-	return filepath.FromSlash(joinedPath)
+	// For non-relative paths, return as-is in original format
+	return path
 }
 
 // GetLineEnding returns the appropriate line ending for the current platform

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -276,8 +276,10 @@ func ResolveRelativePath(path string, basePath string) string {
 		return filepath.FromSlash(relativePath)
 	}
 
-	// For non-relative paths, return as-is in original format
-	return path
+	// For non-relative paths, ensure we're using the correct path separator for the OS
+	// and that the path is properly joined with the base path
+	joinedPath := filepath.Join(filepath.Dir(normalizedBasePath), normalizedPath)
+	return filepath.FromSlash(joinedPath)
 }
 
 // GetLineEnding returns the appropriate line ending for the current platform


### PR DESCRIPTION
## what
This pull request updates the test setup for `TestExecuteAtlantisGenerateRepoConfigAffectedOnly` in the `pkg/atlantis/atlantis_generate_repo_config_test.go` file. The changes ensure the test environment variables are explicitly set for better isolation and reliability.

### Test setup improvements:
* Added explicit setting of `ATMOS_CLI_CONFIG_PATH` and `ATMOS_BASE_PATH` environment variables to point to the test fixture directory (`../../tests/fixtures/scenarios/complete`).
* Updated comments to clarify the purpose of setting the base path for the test fixture.
## why
- Fix flaky Windows test, `TestExecuteAtlantisGenerateRepoConfigAffectedOnly`

## references
- https://github.com/cloudposse/atmos/actions/runs/15494165325/job/43640418252?pr=1239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by normalizing file path separators to ensure consistent behavior across different operating systems.
  - Enhanced test setup by configuring environment variables for accurate test fixture paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->