### PR TITLE
bug: fix oidc exchange

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -100,6 +100,10 @@ func setEnv(v *viper.Viper) {
 
 	bindEnv(v, "settings.terminal.pager", "ATMOS_PAGER", "PAGER")
 	bindEnv(v, "settings.terminal.no_color", "ATMOS_NO_COLOR", "NO_COLOR")
+
+	// GitHub OIDC
+	bindEnv(v, "settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+	bindEnv(v, "settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 }
 
 func bindEnv(v *viper.Viper, key ...string) {

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	log "github.com/charmbracelet/log"
@@ -245,8 +244,8 @@ func (c *AtmosProAPIClient) UnlockStack(dto dtos.UnlockStackRequest) (dtos.Unloc
 
 // getGitHubOIDCToken retrieves an OIDC token from GitHub Actions.
 func getGitHubOIDCToken() (string, error) {
-	requestURL := os.Getenv("ATMOS_GITHUB_OIDC_REQUEST_URL")
-	requestToken := os.Getenv("ATMOS_GITHUB_OIDC_REQUEST_TOKEN")
+	requestURL := viper.GetString("settings.pro.github_oidc.request_url")
+	requestToken := viper.GetString("settings.pro.github_oidc.request_token")
 
 	if requestURL == "" || requestToken == "" {
 		return "", ErrNotInGitHubActions

--- a/pkg/pro/api_client_test.go
+++ b/pkg/pro/api_client_test.go
@@ -59,6 +59,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.NoError(t, err)
@@ -79,6 +82,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.NoError(t, err)
@@ -131,6 +137,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.NoError(t, err)
@@ -156,6 +165,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.Error(t, err)
@@ -178,6 +190,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.Error(t, err)
@@ -209,6 +224,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.Error(t, err)
@@ -225,6 +243,9 @@ func TestNewAtmosProAPIClientFromEnv(t *testing.T) {
 
 		viper.Reset()
 		viper.AutomaticEnv()
+		// Add GitHub OIDC bindings like the main application
+		viper.BindEnv("settings.pro.github_oidc.request_url", "ACTIONS_ID_TOKEN_REQUEST_URL")
+		viper.BindEnv("settings.pro.github_oidc.request_token", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		client, err := NewAtmosProAPIClientFromEnv(mockLogger)
 		assert.Error(t, err)


### PR DESCRIPTION
## what

update viper config to read odic env vars

## why

the env vars aren't currently bound the configuration, so they're not being read

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable handling for GitHub OIDC token retrieval to improve configuration consistency.
  - Simplified and enhanced tests related to GitHub OIDC token fetching and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->