### PR TITLE
Fix feature-releases environment branch protection policy

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,3 +11,7 @@ environments:
       custom_branches:
         - name: "*"
           type: branch
+        - name: "*/*"
+          type: branch
+        - name: "*/**/*"
+          type: branch


### PR DESCRIPTION
## what
* Add `*/*` and `**/**/*` to `feature-releases` environment policy protection

## why
* `*` does not includes `/` char

## references
* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#about-branch-protection-rules
