### PR TITLE
Replace `break` with `decouple`

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -39,7 +39,7 @@ screenshots:
     url: "docs/demo.gif"
 
 description: |-
-  ## Use Atmos to break your architecture into reusable [Components](https://atmos.tools/core-concepts/components) that you implement using [Terraform "root modules"](https://atmos.tools/core-concepts/components/terraform). Then tie everything together using [Stack](https://atmos.tools/core-concepts/stacks) configurations defined in YAML.
+  ## Use Atmos to decouple your architecture into reusable [Components](https://atmos.tools/core-concepts/components) that you implement using [Terraform "root modules"](https://atmos.tools/core-concepts/components/terraform). Then tie everything together using [Stack](https://atmos.tools/core-concepts/stacks) configurations defined in YAML.
 
   Atmos can change how you think about the Terraform code you write to build your infrastructure. Atmos is a framework that simplifies complex cloud architectures and DevOps workflows into intuitive CLI commands.
   Its strength in managing DRY configurations at scale for Terraform and is supported by robust design patterns, comprehensive documentation, and a passionate community, making it a versatile tool for both startups and enterprises.


### PR DESCRIPTION
## what
* Replace `break` with `decouple` in 

```
Use Atmos to break your architecture into reusable components
```

## why
* Word `break` has a negative connotation, while `decouple` is a term from computer science and sounds professional 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify terminology by replacing "break" with "decouple" in the description of how architecture is organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->