### PR TITLE
Fix typos in test config files

### DIFF
--- a/tests/fixtures/scenarios/indentation/README.md
+++ b/tests/fixtures/scenarios/indentation/README.md
@@ -1,4 +1,4 @@
-# Identation
+# Indentation
 
 This is a basic test case for indentation.
 We use this for the tests in `tests/test-cases/indentation.yaml`

--- a/tests/fixtures/scenarios/vendor-pulls-ssh/vendor.yaml
+++ b/tests/fixtures/scenarios/vendor-pulls-ssh/vendor.yaml
@@ -14,7 +14,7 @@ spec:
         - "library/cred/{{ .Component }}"
       tags:
         - demo
-    ## Explicit ssh vednoring (the schema is explicitly spcified along with a username, no custom detector is invoked)
+    ## Explicit ssh vendoring (the schema is explicitly specified along with a username, no custom detector is invoked)
     - component: "terraform-null-label-basic"
       source: "git::ssh://git@github.com/cloudposse/terraform-null-label.git?ref={{ .Version }}"
       version: "0.25.0"

--- a/tests/test-cases/demo-vendoring.yaml
+++ b/tests/test-cases/demo-vendoring.yaml
@@ -26,7 +26,7 @@ tests:
 
   - name: atmos vendor pull no tty
     enabled: true
-    snapshot: false # We cant use snapshots because temp paths will always be different
+    snapshot: false # We can't use snapshots because temp paths will always be different
     tty: false
     description: "Vendoring works with pull command"
     workdir: "../examples/demo-vendoring/"

--- a/tests/test-cases/empty-dir.yaml
+++ b/tests/test-cases/empty-dir.yaml
@@ -70,15 +70,15 @@ tests:
       diff: []
       stderr:
         - ".*You're not inside a git repository. Atmos feels lonely outside - bring it home!.*"
-      exit_code: 1 # We expect a non-zero exit code because the dir doesnt have an atmos config
+      exit_code: 1 # We expect a non-zero exit code because the dir doesn't have an atmos config
 
   # We need to test from outside a git repo. 
   # We also need to provide a static path to the atmos config that can we used both in GHA and locally.
   # To do so, we can change up 1 directory outside that atmos project and assume the project is named "atmos".
-  - name: atmos doesnt warn if not in git repo with atmos config
+  - name: atmos doesn't warn if not in git repo with atmos config
     enabled: true
     snapshot: true
-    description: "Test that atmos doesnt warn if not run inside of a git repo but has an atmos config"
+    description: "Test that atmos doesn't warn if not run inside of a git repo but has an atmos config"
     workdir: "../../"
     command: "atmos"
     args:
@@ -96,10 +96,10 @@ tests:
         - "^$"
       exit_code: 0
 
-  - name: atmos doesnt warn if in git repo with atmos config
+  - name: atmos doesn't warn if in git repo with atmos config
     enabled: true
     snapshot: true
-    description: "Test that atmos doesnt warn if run inside of a git repo with an atmos config"
+    description: "Test that atmos doesn't warn if run inside of a git repo with an atmos config"
     workdir: "fixtures/scenarios/complete"
     command: "atmos"
     args:
@@ -116,10 +116,10 @@ tests:
         - "^$"
       exit_code: 0
 
-  - name: atmos doesnt warn if in git repo with no atmos config
+  - name: atmos doesn't warn if in git repo with no atmos config
     enabled: true
     snapshot: true
-    description: "Test that atmos doesnt warn if run inside of a git repo with no atmos config"
+    description: "Test that atmos doesn't warn if run inside of a git repo with no atmos config"
     workdir: "fixtures/scenarios/empty-dir"
     command: "atmos"
     args: []

--- a/tests/test-cases/log-level-validation.yaml
+++ b/tests/test-cases/log-level-validation.yaml
@@ -97,7 +97,7 @@ tests:
       stderr:
         - "^$"
       exit_code: 0
-  - name: "Valid log level in env should be priortized over config"
+  - name: "Valid log level in env should be prioritized over config"
     enabled: true
     snapshot: true
     description: "Test validation of env priority over config"
@@ -115,7 +115,7 @@ tests:
         # We are fine with any debug logs config is set to info but if env gets priority we would get debug
         - "DEBU"
       exit_code: 0
-  - name: "Valid log level in flag should be priortized over env and config"
+  - name: "Valid log level in flag should be prioritized over env and config"
     enabled: true
     snapshot: true
     description: "Test validation of env priority over config"
@@ -135,7 +135,7 @@ tests:
         # We are fine with any debug logs config and env is set to info but if flag gets priority we would get debug logs
         - "DEBU"
       exit_code: 0
-  - name: "Valid log file in env should be priortized over config"
+  - name: "Valid log file in env should be prioritized over config"
     enabled: true
     snapshot: true
     description: "Test validation of env priority over config"
@@ -152,10 +152,10 @@ tests:
       diff:
         - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
       stdout:
-        # Debug logs should be in stdout as we have choosen /dev/stdout in env
+        # Debug logs should be in stdout as we have chosen /dev/stdout in env
         - "DEBU"
       exit_code: 0
-  - name: "Valid log file in flag should be priortized over env and config"
+  - name: "Valid log file in flag should be prioritized over env and config"
     enabled: true
     snapshot: true
     description: "Test validation of env priority over config"
@@ -174,6 +174,6 @@ tests:
       diff:
         - '👽 Atmos (\d+\.\d+\.\d+|test) on [a-z]+/[a-z0-9]+'
       stdout:
-        # Debug logs should be in stdout as we have choosen /dev/stdout in flag
+        # Debug logs should be in stdout as we have chosen /dev/stdout in flag
         - "DEBU"
       exit_code: 0

--- a/website/docs/cli/commands/validate/validate-schema.mdx
+++ b/website/docs/cli/commands/validate/validate-schema.mdx
@@ -36,7 +36,7 @@ atmos validate schema <my_custom_key>
 
 ## How to set my schema validators?
 
-You need to use the `schmeas` key in atmos config.
+You need to use the `schemas` key in atmos config.
 
 ```yaml
 schemas:

--- a/website/docs/cli/configuration/configuration.mdx
+++ b/website/docs/cli/configuration/configuration.mdx
@@ -777,6 +777,6 @@ configuration, Atmos may set the following environment variables in the spawned 
 | ATMOS_SHELL_WORKING_DIR | The directory from which native commands should be run                                                 |
 | ATMOS_SHLVL             | The depth of Atmos shell nesting. When present, it indicates that the shell has been spawned by Atmos. |
 | ATMOS_STACK             | The name of the active stack                                                                           |
-| ATMOS_TERRAFORM_WORKSPACE | The name of the Terraform workspace in which Terraform comamnds should be run                        |
+| ATMOS_TERRAFORM_WORKSPACE | The name of the Terraform workspace in which Terraform commands should be run                        |
 | PS1                     | When a custom shell prompt has been configured in Atmos, the prompt will be set via `PS1`              |
 | TF_CLI_ARGS_*           | Terraform CLI arguments to be passed to Terraform commands                                             |

--- a/website/docs/core-concepts/projects/configuration/stores.mdx
+++ b/website/docs/core-concepts/projects/configuration/stores.mdx
@@ -62,7 +62,7 @@ stores:
   for more information.</dd>
 
   <dt>`stores.[store_name].options.prefix (optional)`</dt>
-  <dd>A prefix path that will be added to all keys stored or retreived from SSM Parameter Store. For example if the prefix
+  <dd>A prefix path that will be added to all keys stored or retrieved from SSM Parameter Store. For example if the prefix
   is `/atmos/infra-live/`, and if the stack is `plat-us2-dev`, the component is `vpc`, and the key is `vpc_id`, the full path
   would be `/atmos/infra-live/plat-us2-dev/vpc/vpc_id`.</dd>
 
@@ -234,7 +234,7 @@ stores:
   <dd>A map of options specific to the store type. For Redis, the following options are supported:</dd>
 
   <dt>`stores.[store_name].options.prefix (optional)`</dt>
-  <dd>A prefix path that will be added to all keys stored or retreived from Redis. For example if the prefix
+  <dd>A prefix path that will be added to all keys stored or retrieved from Redis. For example if the prefix
   is `/atmos/infra-live/`, and if the stack is `plat-us2-dev`, the component is `vpc`, and the key is `vpc_id`, the full path
   would be `/atmos/infra-live/plat-us2-dev/vpc/vpc_id`.</dd>
 

--- a/website/docs/core-concepts/projects/layout.mdx
+++ b/website/docs/core-concepts/projects/layout.mdx
@@ -20,7 +20,7 @@ At the root of your project, you’ll typically find an `atmos.yaml` configurati
 
 ## Recommended Filesystem Layout
 
-Atmos is fully configurable, and you can organize your project in any way that makes sense for your team by adusting the paths in [`atmos.yaml`](/core-concepts/projects/configuration). We also provide detailed guidance on organizing your folder structure, whether it’s for a simple project or enterprise-scale architecture in our [Design Patterns](/design-patterns) section. Choose the model that best fits the stage you plan to reach when you complete the project.
+Atmos is fully configurable, and you can organize your project in any way that makes sense for your team by adjusting the paths in [`atmos.yaml`](/core-concepts/projects/configuration). We also provide detailed guidance on organizing your folder structure, whether it’s for a simple project or enterprise-scale architecture in our [Design Patterns](/design-patterns) section. Choose the model that best fits the stage you plan to reach when you complete the project.
 
 Here's a simple layout, if you just have 3 deployments for things like dev, staging, and prod:
 ```plaintext

--- a/website/docs/core-concepts/stacks/imports.mdx
+++ b/website/docs/core-concepts/stacks/imports.mdx
@@ -36,7 +36,7 @@ Here are some simple examples of how to import configurations:
 import:
   - catalog/file1 # First import "file1" from the catalog
   - catalog/file2 # Second import "file2" from the catalog, deep merging on top of the first import
-  - catalog/file3 # Third import "file3" from the catalog, deep merging on top of the preceeding imports
+  - catalog/file3 # Third import "file3" from the catalog, deep merging on top of the preceding imports
 ```
 
 The base path for imports is specified in the [`atmos.yaml`](/cli/configuration) in the `stacks.base_path` section.
@@ -47,9 +47,9 @@ It's also possible to specify file extensions, although we do not recommend it.
 
 ```yaml
 import:
-  - catalog/file1.yml   # Expicitly load a file with a .yml extension
-  - catalog/file2.yaml  # Expicitly load a file with a .yaml extension
-  - catalog/file3.YAML  # Expicitly load a file with a .YAML extension
+  - catalog/file1.yml   # Explicitly load a file with a .yml extension
+  - catalog/file2.yaml  # Explicitly load a file with a .yaml extension
+  - catalog/file3.YAML  # Explicitly load a file with a .YAML extension
 ```
 
 ### Automatic Template File Detection
@@ -86,7 +86,7 @@ Use [mixins](/core-concepts/stacks/inheritance/mixins) for reusable snippets of 
 
 ## Imports Schema
 
-The `import` section supports two different formats, depending on whether the imported files use templates or not. One is a list of strings respresenting paths to the imported files, and the other is a list of objects with several feature flags.
+The `import` section supports two different formats, depending on whether the imported files use templates or not. One is a list of strings representing paths to the imported files, and the other is a list of objects with several feature flags.
 
 ### Imports without Templates
 
@@ -142,7 +142,7 @@ The `import` section supports the following fields:
   a [Go template](https://pkg.go.dev/text/template))</dd>
 
   <dt>`skip_templates_processing` - (boolean)</dt>
-  <dd>Skip template processing for the imported file. Can be used if the imported file uses `Go` templates that should not be interpretted by atmos. For example, sometimes configurations for components may pass Go template strings not intended for atmos.</dd>
+  <dd>Skip template processing for the imported file. Can be used if the imported file uses `Go` templates that should not be interpreted by atmos. For example, sometimes configurations for components may pass Go template strings not intended for atmos.</dd>
 
   <dt>`ignore_missing_template_values` - (boolean)</dt>
   <dd>Ignore the missing template values in the imported file. Can be used if the imported file uses `Go` templates to configure external systems, e.g. Datadog. In this case, Atmos will process all template values that are provided in the `context`, and will skip the missing values in the templates for the external systems without throwing an error. The `ignore_missing_template_values` setting is different from `skip_templates_processing` in that `skip_templates_processing` skips the template processing completely in the imported file, while `ignore_missing_template_values` processes the templates using the values provided in the `context` and skips all the missing values</dd>

--- a/website/docs/core-concepts/vendor/vendor-manifest.mdx
+++ b/website/docs/core-concepts/vendor/vendor-manifest.mdx
@@ -429,7 +429,7 @@ Pulling sources for the component 'vpc-flow-logs-bucket' from 'github.com/cloudp
 
 Atmos supports vendoring multiple versions of the same component. This is useful when you need to pin stacks to different versions of the same component.
 
-When vendoring multiple versions of the same component, use the `{{ .Version }}` template parameter in the `targets` attribute to ensure the components are vendored into different folders. Then update the stack configuration to point to the correct version of the component, and ensure the `backend.s3.workspace_key_prefix` is defined _without the version_ to ensure you can seamlessly upgrade between versions of a component wihtout losing the state. By default the `workspace_key_prefix` incorporates the `component` relative path, which will include the version if it's included in the path.
+When vendoring multiple versions of the same component, use the `{{ .Version }}` template parameter in the `targets` attribute to ensure the components are vendored into different folders. Then update the stack configuration to point to the correct version of the component, and ensure the `backend.s3.workspace_key_prefix` is defined _without the version_ to ensure you can seamlessly upgrade between versions of a component without losing the state. By default the `workspace_key_prefix` incorporates the `component` relative path, which will include the version if it's included in the path.
 
 ```
 components:

--- a/website/docs/design-patterns/design-patterns.mdx
+++ b/website/docs/design-patterns/design-patterns.mdx
@@ -11,7 +11,7 @@ import Intro from '@site/src/components/Intro'
 import KeyPoints from '@site/src/components/KeyPoints'
 
 <Intro>
-Atmos Design Patterns are a collection of conventions, best practices, concepts, principles and insights derived from our experience building enterprise scale architectures. These are vital for effectively structuring and organizing infrastructures, components, and stacks. They empower implementors and cloud architects alike, by providing access to the collective wisdom of seasoned professionals. 
+Atmos Design Patterns are a collection of conventions, best practices, concepts, principles and insights derived from our experience building enterprise scale architectures. These are vital for effectively structuring and organizing infrastructures, components, and stacks. They empower implementers and cloud architects alike, by providing access to the collective wisdom of seasoned professionals. 
 </Intro>
 
 These patterns serve as a guide for creating solutions that are not only reusable but also robust, flexible, and maintainable. Importantly, they foster convergence amongst engineers on a standard set of recognized patterns, effectively putting a name to the practices and strategies that have proven successful. This standardization aids in streamlining communication and understanding among professionals, enhancing collaboration and efficiency in the field.

--- a/website/docs/design-patterns/organizational-structure-configuration.mdx
+++ b/website/docs/design-patterns/organizational-structure-configuration.mdx
@@ -41,7 +41,7 @@ The **Organizational Structure Configuration** pattern provides the following be
 - New stages/accounts can be easily added to a tenant/OU without affecting the configurations for the existing stages/accounts
 
 - New regions can be added to the infrastructure, configured with Atmos, and components provisioned into the regions. New regions can be used for
-  te general infrastructure, or for disaster recovery (DR), or for compliance and audit
+  the general infrastructure, or for disaster recovery (DR), or for compliance and audit
 
 - After adding new organizations, tenants, accounts or regions, the entire configuration will still remain DRY, reusable and easy to manage thanks to
   using the described folder structure, catalogs, mixins, and hierarchical [imports](/core-concepts/stacks/imports)


### PR DESCRIPTION
## Summary
- fix spelling in indentation scenario README
- fix comments in demo vendor test case
- fix vendor scenario comments
- fix empty dir tests wording
- fix log level validation wording
- fix website docs typos across MDX files

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6852e489919c833295b1ce0e8e31910c