### PR TITLE
Refine logging docs

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,7 +1,41 @@
 
-# Go Log Levels
+# Logging Guidelines
 
-This rubric provides guidance on how to use log levels (`LogWarn`, `LogError`, `LogTrace`, `LogDebug`, `LogFatal`) consistently.
+This document explains how we log events in Atmos. It covers the
+difference between writing to the terminal (TextUI) and writing logs,
+outlines our log levels, and introduces structured and semantic
+logging.
+
+## TextUI vs. Logging
+
+The terminal window is effectively a text-based user interface (TextUI)
+for our CLI. Anything intended for user interaction—menus, prompts,
+animations—should be rendered to the terminal as UI output.
+
+Logging is different: logs are structured records of what the program is
+doing. They help developers debug issues and feed into telemetry or
+monitoring systems. Treat logging like sending messages to the developer
+console in a browser, not to the UI seen by the user.
+
+Keeping TextUI output and logging separate ensures we don't mix user
+interface concerns with operational telemetry.
+
+Atmos provides `utils.PrintfMessageToTUI` for writing TextUI messages.
+It always writes to `stderr` so that `stdout` can remain a clean data
+stream (for example, JSON output that may be piped to another command).
+Avoid using `fmt.Println` or `fmt.Printf` for UI output because they
+default to `stdout` and can corrupt piped data. Log functions such as
+`log.Info` or `log.Error` are not meant for TextUI and may be silenced
+via log level configuration. See
+[structured-logging.md](structured-logging.md) for guidance on composing
+well-structured log messages.
+
+---
+
+## Go Log Levels
+
+This rubric provides guidance on how to use log levels (`LogWarn`,
+`LogError`, `LogTrace`, `LogDebug`, `LogFatal`) consistently.
 
 ---
 
@@ -122,6 +156,19 @@ This rubric provides guidance on how to use log levels (`LogWarn`, `LogError`, `
 - ```console
   "Fatal error: Database connection failed. Application shutting down."
   ```
+
+---
+
+## Structured and Semantic Logging
+
+Structured logs record events as key/value pairs so machines and humans
+can parse them. Semantic logging standardizes those keys so logs can be
+understood across tools and teams. Atmos uses the
+[Charm Logger](https://charm.sh/blog/the-charm-logger/) for this
+purpose.
+
+See [structured-logging.md](structured-logging.md) for detailed guidance
+and examples.
 
 ---
 

--- a/docs/structured-logging.md
+++ b/docs/structured-logging.md
@@ -1,0 +1,77 @@
+# Structured and Semantic Logging
+
+**Structured logging** captures log entries as **key/value pairs** instead of raw strings. This makes logs easier for machines to parse and for humans to search.
+
+**Semantic logging** goes a step further by **standardizing the keys**. Using predictable fields like `component`, `operation`, `request_id`, and `error` makes logs interpretable across different systems and teams.
+
+## Why We Use It
+
+Structured and semantic logging provide:
+
+- **Machine readability** – tools such as Datadog, Splunk, Honeycomb, and OpenTelemetry can process logs without regex or guesswork.
+- **Contextual clarity** – each entry describes what happened and includes metadata about where and to whom.
+- **Searchability and filtering** – query logs by fields like `user_id` or `service` to diagnose issues quickly.
+- **Consistency** – separating the message from context removes the need for string interpolation.
+- **Customizability** – emit colorized terminal output or structured JSON for ingestion.
+
+## How to Write Logs
+
+Describe the core event in the log **message**:
+
+> Failed to validate request
+
+Then add **contextual fields**:
+
+```go
+log.Error("Failed to validate request", "component", "authn", "user", userID, "error", err)
+```
+
+This approach ensures:
+
+- The message captures **what** happened.
+- The key/value pairs capture **who**, **where**, and **why**.
+- You can add whichever keys are meaningful for that event.
+
+## Charm Logger in Atmos
+
+Atmos uses the [Charm Logger](https://charm.sh/blog/the-charm-logger/), which offers:
+
+- Simple APIs such as `log.Info`, `log.Warn`, and `log.Error`
+- Automatic line wrapping and colorized output for terminals
+- Friendly formatting for console output
+- Optional raw JSON output for machine ingestion
+
+Example:
+
+```go
+log.Warn("OCI image has no layers", "image", imageName, "component", "oci-parser")
+```
+
+This renders nicely in the terminal and can be configured to output JSON like:
+
+```json
+{
+  "level": "warn",
+  "message": "OCI image has no layers",
+  "image": "nginx:latest",
+  "component": "oci-parser"
+}
+```
+
+## Linting and Conventions
+
+Atmos runs `golangci-lint`, which includes Staticcheck rule `ST1019`.
+That rule warns when logging keys are non-constant strings. To avoid an
+explosion of rarely reused constants, some common logging keys are
+already excluded from `ST1019` in our configuration. You can define your
+own constants for frequently used keys or suppress the warning when it
+makes the code clearer.
+
+Follow the existing conventions in Atmos and keep suppression comments
+to a minimum.
+
+## Further Reading
+
+- [Charm Logger](https://charm.sh/blog/the-charm-logger/)
+- [Loggly: What is Structured Logging](https://www.loggly.com/use-cases/what-is-structured-logging-and-how-to-use-it/)
+- [Otelic: What is Semantic Logging](https://otelic.com/en/reference-guide/what-is-semantic-logging-and-why-is-it-important)


### PR DESCRIPTION
## what
- shorten logging.md section and link to `structured-logging.md`
- clarify lint rule usage for structured logging keys

## why
- reduce duplication and clarify use of Staticcheck ST1019

## references
- n/a

------
https://chatgpt.com/codex/tasks/task_b_68535c9aa3488332887d805779c0bc63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded and restructured the logging guidelines to clarify the distinction between user-facing UI output and developer-oriented logging.
	- Added detailed explanations of structured and semantic logging, including best practices, benefits, and usage examples.
	- Introduced a new guide on structured logging, covering conventions, tools, and further reading resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->