### PR TITLE
Refactor logging to structured semantics

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -574,7 +574,7 @@ func CheckForAtmosUpdateAndPrintMessage(atmosConfig schema.AtmosConfiguration) {
 	// Load the cache
 	cacheCfg, err := cfg.LoadCache()
 	if err != nil {
-		u.LogWarning(fmt.Sprintf("Could not load cache: %s", err))
+		log.Warn("Could not load cache", "error", err)
 		return
 	}
 
@@ -587,12 +587,12 @@ func CheckForAtmosUpdateAndPrintMessage(atmosConfig schema.AtmosConfiguration) {
 	// Get the latest Atmos release from GitHub
 	latestReleaseTag, err := u.GetLatestGitHubRepoRelease("cloudposse", "atmos")
 	if err != nil {
-		u.LogWarning(fmt.Sprintf("Failed to retrieve latest Atmos release info: %s", err))
+		log.Warn("Failed to retrieve latest Atmos release info", "error", err)
 		return
 	}
 
 	if latestReleaseTag == "" {
-		u.LogWarning("No release information available")
+		log.Warn("No release information available")
 		return
 	}
 
@@ -608,7 +608,7 @@ func CheckForAtmosUpdateAndPrintMessage(atmosConfig schema.AtmosConfiguration) {
 	// Update the cache to mark the current timestamp
 	cacheCfg.LastChecked = time.Now().Unix()
 	if saveErr := cfg.SaveCache(cacheCfg); saveErr != nil {
-		u.LogWarning(fmt.Sprintf("Unable to save cache: %s", saveErr))
+		log.Warn("Unable to save cache", "error", saveErr)
 	}
 }
 

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+	log "github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
@@ -45,7 +46,7 @@ var docsCmd = &cobra.Command{
 			maxWidth := atmosConfig.Settings.Terminal.MaxWidth
 			if maxWidth == 0 && atmosConfig.Settings.Docs.MaxWidth > 0 {
 				maxWidth = atmosConfig.Settings.Docs.MaxWidth
-				u.LogWarning("'settings.docs.max-width' is deprecated and will be removed in a future version. Please use 'settings.terminal.max_width' instead")
+				log.Warn("'settings.docs.max-width' is deprecated and will be removed in a future version. Please use 'settings.terminal.max_width' instead")
 			}
 			defaultWidth := 120
 			screenWidth := defaultWidth
@@ -105,7 +106,7 @@ var docsCmd = &cobra.Command{
 			pager := atmosConfig.Settings.Terminal.IsPagerEnabled()
 			if !pager && atmosConfig.Settings.Docs.Pagination {
 				pager = atmosConfig.Settings.Docs.Pagination
-				u.LogWarning("'settings.docs.pagination' is deprecated and will be removed in a future version. Please use 'settings.terminal.pager' instead")
+				log.Warn("'settings.docs.pagination' is deprecated and will be removed in a future version. Please use 'settings.terminal.pager' instead")
 			}
 
 			if err := u.DisplayDocs(componentDocs, pager); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ var RootCmd = &cobra.Command{
 			if errors.Is(err, cfg.NotFound) {
 				// For help commands or when help flag is set, we don't want to show the error
 				if !isHelpRequested {
-					u.LogWarning(err.Error())
+					log.Warn(err.Error())
 				}
 			} else {
 				u.LogErrorAndExit(err)

--- a/internal/exec/file_utils.go
+++ b/internal/exec/file_utils.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	log "github.com/charmbracelet/log"
 	"github.com/cloudposse/atmos/pkg/schema"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
@@ -21,14 +22,18 @@ const (
 func removeTempDir(path string) {
 	err := os.RemoveAll(path)
 	if err != nil {
-		u.LogWarning(err.Error())
+		log.Warn(err.Error())
 	}
 }
 
 func closeFile(fileName string, file io.ReadCloser) {
 	err := file.Close()
 	if err != nil {
-		u.LogError(fmt.Errorf("error closing the file '%s': %v", fileName, err))
+		log.Error(
+			"error closing the file",
+			"file", fileName,
+			"error", err,
+		)
 	}
 }
 

--- a/internal/exec/file_utils_test.go
+++ b/internal/exec/file_utils_test.go
@@ -66,3 +66,20 @@ func TestPrintOrWriteToFile(t *testing.T) {
 	err = printOrWriteToFile(atmosConfigDefaultTabWidth, "yaml", "", testData)
 	assert.NoError(t, err)
 }
+
+func TestRemoveTempDirAndCloseFile(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atmos-test-*")
+	assert.NoError(t, err)
+	filePath := filepath.Join(dir, "dummy.txt")
+	f, err := os.Create(filePath)
+	assert.NoError(t, err)
+
+	closeFile(filePath, f)
+	closeFile(filePath, f)
+
+	removeTempDir(dir)
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("expected temp dir to be removed")
+	}
+}

--- a/internal/exec/file_utils_test.go
+++ b/internal/exec/file_utils_test.go
@@ -70,8 +70,13 @@ func TestPrintOrWriteToFile(t *testing.T) {
 func TestRemoveTempDirAndCloseFile(t *testing.T) {
 	dir, err := os.MkdirTemp("", "atmos-test-*")
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
 	filePath := filepath.Join(dir, "dummy.txt")
 	f, err := os.Create(filePath)
+	assert.NoError(t, err)
+
+	err = f.Close()
 	assert.NoError(t, err)
 
 	closeFile(filePath, f)
@@ -79,7 +84,6 @@ func TestRemoveTempDirAndCloseFile(t *testing.T) {
 
 	removeTempDir(dir)
 
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		t.Errorf("expected temp dir to be removed")
-	}
+	_, err = os.Stat(dir)
+	assert.True(t, os.IsNotExist(err), "expected temp dir to be removed")
 }

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -283,7 +283,7 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 	// Cleanup
 	err = os.Remove(varFilePath)
 	if err != nil {
-		u.LogWarning(err.Error())
+		log.Warn(err.Error())
 	}
 
 	return nil

--- a/internal/exec/tar_utils.go
+++ b/internal/exec/tar_utils.go
@@ -63,7 +63,11 @@ func processTarHeader(header *tar.Header, tarReader *tar.Reader, extractPath str
 	case tar.TypeReg:
 		return createFileFromTar(filePath, tarReader, header)
 	default:
-		log.Warnf("Unsupported file type: %v in %s", header.Typeflag, header.Name)
+		log.Warn(
+			"Unsupported file type",
+			"type", header.Typeflag,
+			"file", header.Name,
+		)
 	}
 
 	return nil

--- a/internal/exec/tar_utils_test.go
+++ b/internal/exec/tar_utils_test.go
@@ -1,0 +1,14 @@
+package exec
+
+import (
+	"archive/tar"
+	"testing"
+)
+
+func TestProcessTarHeaderUnsupportedType(t *testing.T) {
+	dir := t.TempDir()
+	hdr := &tar.Header{Name: "link", Typeflag: tar.TypeSymlink}
+	if err := processTarHeader(hdr, nil, dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/config/cache.go
+++ b/pkg/config/cache.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/charmbracelet/log"
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-
-	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 type CacheConfig struct {
@@ -104,7 +103,11 @@ func ShouldCheckForUpdates(lastChecked int64, frequency string) bool {
 	interval, err := parseFrequency(frequency)
 	if err != nil {
 		// Log warning and default to daily if we can’t parse
-		u.LogWarning(fmt.Sprintf("Unsupported frequency '%s' encountered. Defaulting to daily.", frequency))
+		log.Warn(
+			"Unsupported frequency encountered. Defaulting to daily",
+			"frequency", frequency,
+			"error", err,
+		)
 		interval = 86400 // daily
 	}
 	return now-lastChecked >= interval

--- a/pkg/config/cache_frequency_test.go
+++ b/pkg/config/cache_frequency_test.go
@@ -35,11 +35,16 @@ func TestParseFrequency(t *testing.T) {
 }
 
 func TestShouldCheckForUpdates(t *testing.T) {
-	now := time.Now().Unix()
-	if !ShouldCheckForUpdates(now-90000, "daily") {
+	const day = 24 * time.Hour
+	now := time.Now()
+
+	past := now.Add(-day - time.Hour).Unix() // 25 hours ago
+	if !ShouldCheckForUpdates(past, "daily") {
 		t.Errorf("expected true for past day check")
 	}
-	if ShouldCheckForUpdates(now-10, "invalid") {
+
+	recent := now.Add(-10 * time.Second).Unix()
+	if ShouldCheckForUpdates(recent, "invalid") {
 		t.Errorf("expected false for recent check with invalid freq")
 	}
 }

--- a/pkg/config/cache_frequency_test.go
+++ b/pkg/config/cache_frequency_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFrequency(t *testing.T) {
+	cases := []struct {
+		freq    string
+		expect  int64
+		wantErr bool
+	}{
+		{"60", 60, false},
+		{"2h", 7200, false},
+		{"daily", 86400, false},
+		{"invalid", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseFrequency(tc.freq)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("expected error for %s", tc.freq)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseFrequency(%s) unexpected error: %v", tc.freq, err)
+			continue
+		}
+		if got != tc.expect {
+			t.Errorf("parseFrequency(%s)=%d, want %d", tc.freq, got, tc.expect)
+		}
+	}
+}
+
+func TestShouldCheckForUpdates(t *testing.T) {
+	now := time.Now().Unix()
+	if !ShouldCheckForUpdates(now-90000, "daily") {
+		t.Errorf("expected true for past day check")
+	}
+	if ShouldCheckForUpdates(now-10, "invalid") {
+		t.Errorf("expected false for recent check with invalid freq")
+	}
+}

--- a/pkg/utils/hcl_utils.go
+++ b/pkg/utils/hcl_utils.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/charmbracelet/log"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/printer"
 	jsonParser "github.com/hashicorp/hcl/json/parser"
@@ -48,7 +49,7 @@ func WriteToFileAsHcl(
 	defer func(f *os.File) {
 		err := f.Close()
 		if err != nil {
-			LogWarning(err.Error())
+			log.Warn(err.Error())
 		}
 	}(f)
 
@@ -129,7 +130,7 @@ func WriteTerraformBackendConfigToFileAsHcl(
 	defer func(f *os.File) {
 		err := f.Close()
 		if err != nil {
-			LogWarning(err.Error())
+			log.Warn(err.Error())
 		}
 	}(f)
 


### PR DESCRIPTION
## Summary
- use Charmbracelet logger directly instead of `u.Log*` helpers
- replace `log.Warnf` and `fmt.Sprintf` calls with structured fields

## Testing
- `make lint` *(fails: can't load config)*
- `make testacc-cover` *(interrupted: took too long)*
- `go test ./...` *(interrupted: build in progress)*

------
https://chatgpt.com/codex/tasks/task_b_68547188e9808332b49ab4a4a42afb1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved logging consistency by adopting structured logging for warnings and errors across the application, enhancing message clarity without affecting user experience.
- **Tests**
  - Added tests for temporary file management, handling of unsupported archive types, and cache update frequency to ensure robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->