### PR TITLE
Fix PostHog client provider param

### DIFF
--- a/pkg/telemetry/mock/mock_telemetry_provider.go
+++ b/pkg/telemetry/mock/mock_telemetry_provider.go
@@ -41,7 +41,7 @@ func (m *MockTelemetryClientProviderMock) EXPECT() *MockTelemetryClientProviderM
 }
 
 // NewMockClient mocks base method.
-func (m *MockTelemetryClientProviderMock) NewMockClient(token string, config posthog_go.Config) (posthog_go.Client, error) {
+func (m *MockTelemetryClientProviderMock) NewMockClient(token string, config *posthog_go.Config) (posthog_go.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewMockClient", token, config)
 	ret0, _ := ret[0].(posthog_go.Client)

--- a/pkg/telemetry/mock/telemetry_client_provider_interface.go
+++ b/pkg/telemetry/mock/telemetry_client_provider_interface.go
@@ -15,5 +15,5 @@ type TelemetryClientProviderMock interface {
 	// Returns:
 	//   - posthog_go.Client: The mock client instance
 	//   - error: Any error that occurred during client creation
-	NewMockClient(token string, config posthog_go.Config) (posthog_go.Client, error)
+	NewMockClient(token string, config *posthog_go.Config) (posthog_go.Client, error)
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -8,12 +8,17 @@ import (
 // TelemetryClientProvider is a function type that creates a PostHog client
 // given a token and configuration. This allows for dependency injection
 // and easier testing by providing mock implementations.
-type TelemetryClientProvider func(string, posthog.Config) (posthog.Client, error)
+// TelemetryClientProvider is a function type that creates a PostHog client
+// given a token and configuration. The configuration is passed by pointer to
+// avoid copying large structs and to allow tests to modify it.
+type TelemetryClientProvider func(string, *posthog.Config) (posthog.Client, error)
 
 // PosthogClientProvider is the default implementation of TelemetryClientProvider
 // that creates a real PostHog client using the provided token and configuration.
-func PosthogClientProvider(token string, config posthog.Config) (posthog.Client, error) {
-	return posthog.NewWithConfig(token, config)
+// PosthogClientProvider is the default implementation of TelemetryClientProvider
+// that creates a real PostHog client using the provided token and configuration.
+func PosthogClientProvider(token string, config *posthog.Config) (posthog.Client, error) {
+	return posthog.NewWithConfig(token, *config)
 }
 
 // Telemetry represents a telemetry system that can capture events and send them
@@ -54,7 +59,7 @@ func (t *Telemetry) Capture(eventName string, properties map[string]interface{})
 	}
 
 	// Create PostHog client using the provided client provider
-	client, err := t.clientProvider(t.token, posthog.Config{
+	client, err := t.clientProvider(t.token, &posthog.Config{
 		Endpoint: t.endpoint,
 	})
 	if err != nil {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -29,7 +29,7 @@ func TestTelemetryConstructor(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, nil).Times(0)
 
@@ -66,7 +66,7 @@ func TestTelemetryCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, nil).Times(1)
 
@@ -105,7 +105,7 @@ func TestTelemetryDisabledCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, nil).Times(0)
 
@@ -148,7 +148,7 @@ func TestTelemetryEmptyTokenCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, nil).Times(0)
 
@@ -191,7 +191,7 @@ func TestTelemetryProviderErrorCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, errors.New("provider error")).Times(1)
 
@@ -234,7 +234,7 @@ func TestTelemetryEnqueueErrorCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
 	}).Return(mockClient, nil).Times(1)
 
@@ -275,11 +275,11 @@ func TestTelemetryPosthogIntegrationCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
-	}).Do(func(token string, config posthog.Config) {
+	}).Do(func(token string, config *posthog.Config) {
 		var err error
-		realPosthogClient, err = posthog.NewWithConfig(token, config)
+		realPosthogClient, err = posthog.NewWithConfig(token, *config)
 		if err != nil {
 			t.Fatalf("Failed to create real PostHog client: %v", err)
 		}
@@ -328,11 +328,11 @@ func TestTelemetryPosthogIntegrationWrongEndpointCaptureMethod(t *testing.T) {
 	mockClientProvider := mock_telemetry.NewMockTelemetryClientProviderMock(ctrl)
 	mockClient := mock_telemetry.NewMockClient(ctrl)
 
-	mockClientProvider.EXPECT().NewMockClient(token, posthog.Config{
+	mockClientProvider.EXPECT().NewMockClient(token, &posthog.Config{
 		Endpoint: endpoint,
-	}).Do(func(token string, config posthog.Config) {
+	}).Do(func(token string, config *posthog.Config) {
 		var err error
-		realPosthogClient, err = posthog.NewWithConfig(token, config)
+		realPosthogClient, err = posthog.NewWithConfig(token, *config)
 		if err != nil {
 			t.Fatalf("Failed to create real PostHog client: %v", err)
 		}


### PR DESCRIPTION
## Summary
- pass `posthog.Config` by pointer in telemetry provider
- update telemetry provider mocks and tests

## Testing
- `make lint` *(fails: can't load config)*
- `make testacc-cover` *(interrupted)*
- `go test ./pkg/telemetry -run TestTelemetryConstructor` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_685981d571308332a34661bcb824bb2f