### PR TITLE
Atmos site Telemetry page

### DIFF
--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -17,9 +17,9 @@ This data helps us identify which features are most valuable and where we can ma
 
 Atmos collects the following anonymous information:
 
-- **Command usage**: Which Atmos commands are executed (e.g., `atmos describe`, `atmos terraform`, `atmos helmfile`)
-- **Error patterns**: Anonymous error information to help identify and fix issues
-- **Environment information**: Operating system, Atmos version, and basic system information
+- **Command Usage**: Tracks which Atmos commands are executed (e.g., `atmos describe`, `atmos terraform`, `atmos helmfile`)  
+- **Error Reports**: Captures anonymized error messages and exit codes to help identify and fix issues  
+- **System Details**: Includes OS, CPU architecture, Atmos version, and other diagnostic metadata
 - **CI Provider information**: If Atmos is running as part of CI workflow, CI provider name
 
 :::info Privacy First
@@ -29,6 +29,7 @@ We **never** collect:
 - Sensitive data or secrets
 - Repository contents or code
 :::
+
 ### Atmos Pro Users
 
 If you're using [**Atmos Pro**](https://atmos-pro.com), Atmos includes your **Workspace ID** with telemetry. This allows us to associate usage with your account and better support your team by understanding adoption and usage patterns.

--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -29,6 +29,9 @@ We **never** collect:
 - Sensitive data or secrets
 - Repository contents or code
 :::
+### Atmos Pro Users
+
+If you're using [**Atmos Pro**](https://atmos-pro.com), Atmos includes your **Workspace ID** with telemetry. This allows us to associate usage with your account and better support your team by understanding adoption and usage patterns.
 
 ### How Telemetry Works
 

--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -64,10 +64,10 @@ Add the following to your `atmos.yaml` configuration file:
 <File title="atmos.yaml">
 ```yaml
 settings:
-    telemetry:
-        enabled: true
-        token: {provide your posthog token}
-        endpoint: {provide your posthog endpoint}
+  telemetry:
+    enabled: true
+    token: {provide your posthog token}
+    endpoint: {provide your posthog endpoint}
 ```
 </File>
 

--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -1,0 +1,79 @@
+---
+title: Telemetry
+description: Collect Atmos usage telemetry
+sidebar_label: Telemetry
+sidebar_position: 5
+---
+import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
+import File from '@site/src/components/File'
+
+<Intro>
+Atmos collects **anonymous telemetry** to help improve the product by understanding how it's used. 
+This data helps us identify which features are most valuable and where we can make improvements.
+</Intro>
+
+### What Data is Collected
+
+Atmos collects the following anonymous information:
+
+- **Command usage**: Which Atmos commands are executed (e.g., `atmos describe`, `atmos terraform`, `atmos helmfile`)
+- **Error patterns**: Anonymous error information to help identify and fix issues
+- **Environment information**: Operating system, Atmos version, and basic system information
+- **CI Provider information**: If Atmos is running as part of CI workflow, CI provider name
+
+:::info Privacy First
+We **never** collect:
+- Personal information (names, emails, IP addresses)
+- Your actual configuration files or stack manifests
+- Sensitive data or secrets
+- Repository contents or code
+:::
+
+### How Telemetry Works
+
+Telemetry data is collected locally and sent securely to [PostHog](https://posthog.com/) analytics service. The data is:
+
+- **Anonymous**: No personally identifiable information is included
+- **Secure**: Transmitted over HTTPS with encryption
+- **Minimal**: Only essential usage data is collected
+- **Transparent**: You can see exactly what's being collected
+
+### Opting Out of Telemetry
+
+You can disable telemetry collection in any of the following ways:
+
+Add the following to your `atmos.yaml` configuration file:
+
+<File title="atmos.yaml">
+```yaml
+settings:
+    telemetry:
+        enabled: false
+```
+</File>
+
+or set environment variable `ATMOS_TELEMETRY_ENABLED` to `false` 
+
+### Collect your own telemetry
+
+You can switch telemery to your own [PostHog](https://posthog.com/) account:
+
+Add the following to your `atmos.yaml` configuration file:
+
+<File title="atmos.yaml">
+```yaml
+settings:
+    telemetry:
+        enabled: true
+        token: {provide your posthog token}
+        endpoint: {provide your posthog endpoint}
+```
+</File>
+
+or set environment variables `ATMOS_TELEMETRY_TOKEN` and `ATMOS_TELEMETRY_ENDPOINT` to your own values
+
+
+## References
+
+- https://posthog.com

--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -76,7 +76,3 @@ settings:
 
 or set environment variables `ATMOS_TELEMETRY_TOKEN` and `ATMOS_TELEMETRY_ENDPOINT` to your own values
 
-
-## References
-
-- https://posthog.com

--- a/website/docs/cli/telemetry.mdx
+++ b/website/docs/cli/telemetry.mdx
@@ -51,8 +51,8 @@ Add the following to your `atmos.yaml` configuration file:
 <File title="atmos.yaml">
 ```yaml
 settings:
-    telemetry:
-        enabled: false
+  telemetry:
+    enabled: false
 ```
 </File>
 


### PR DESCRIPTION
## what
* Atmos site Telemetry page https://pr-1335.atmos-docs.ue2.dev.plat.cloudposse.org/cli/telemetry

## why
* Be transparent about collecting data

## references
* #1308 
* https://pr-1335.atmos-docs.ue2.dev.plat.cloudposse.org/cli/telemetry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced anonymous telemetry collection to help improve the product by understanding usage patterns.
  - Added configuration options to enable or disable telemetry and customize the telemetry endpoint and token.
  - Telemetry events include command usage, error reporting, environment, and CI provider detection.
  - One-time disclosure message informs users about telemetry, with special handling for CI environments.

- **Bug Fixes**
  - Improved test reliability by ensuring cache files and CI environment variables do not affect test outcomes.

- **Documentation**
  - Added a comprehensive documentation page explaining telemetry, what data is collected, privacy assurances, and opt-out instructions.
  - Updated configuration and README documentation to describe telemetry settings and user controls.

- **Tests**
  - Added extensive unit and integration tests for telemetry features, including event capture, configuration, disclosure messaging, and environment detection.

- **Chores**
  - Updated dependencies and excluded mock files from code coverage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->