### PR TITLE
Move github.event.release.prerelease case to shared workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   release:
-    if: ${{ github.event.release.prerelease == false }}
     uses: cloudposse/.github/.github/workflows/shared-release-branches.yml@main
     secrets: inherit
 


### PR DESCRIPTION
## what
* Move github.event.release.prerelease case to shared workflows

## why
* Having a single point responsible for the conditions 

## references
* https://github.com/cloudposse/.github/pull/225 
* https://github.com/cloudposse/.github/blob/main/.github/workflows/shared-release-branches.yml#L19
* https://linear.app/cloudposse/issue/DEV-3436/prevent-cloud-posse-release-branch-manager-to-respect-prerelease-flag
