### PR TITLE
Insert workflow-level stack flag before `--` in workflow args

### DIFF
--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"slices"
 
 	log "github.com/charmbracelet/log"
 	"github.com/pkg/errors"
@@ -138,7 +139,15 @@ func ExecuteWorkflow(
 			}
 
 			if finalStack != "" {
-				args = append(args, []string{"-s", finalStack}...)
+    			if idx := slices.Index(args, "--"); idx != -1 {
+        			// Insert before the "--"
+                    // Take everything up to idx, then add "-s", stack, then tack on the rest
+        			args = append(args[:idx], append([]string{"-s", stack}, args[idx:]...)...)
+    			} else {
+        			// just append at the end
+        			args = append(args, "-s", stack)
+   				}
+
 				log.Debug("Using stack", "stack", finalStack)
 			}
 


### PR DESCRIPTION
This PR updates the workflow utils so that when a workflow-level `stack` is provided, the generated `-s <stack>` flag is placed **before any `--` argument** in the command args (instead of always at the end).  

The `--` marker indicates the end of Atmos CLI arguments; anything after it is passed directly to the underlying tool or script. Appending `-s <stack>` after `--` caused the stack flag to be ignored in such cases.  

## Changes
- In `workflow_utils.go`, modified the logic around appending `-s <stack>`:
  - If `--` exists in `args`, insert the stack flag immediately before it.
  - If no `--` is present, behavior remains the same (flag is appended at the end).

## Example

### Before
```bash
atmos workflow deploy -- foo bar
# produces args: ["deploy", "--", "foo", "bar", "-s", "my-stack"]
# "-s my-stack" is ignored since it's after `--`
```

### After
```bash
atmos workflow deploy -- foo bar
# produces args: ["deploy", "-s", "my-stack", "--", "foo", "bar"]
# stack flag is correctly passed to Atmos
```