### PR TITLE
Fix flaky Packer tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKER_GITHUB_API_TOKEN: ${github.token}
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make testacc-cover
 
       - name: Upload coverage report to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,7 @@ jobs:
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKER_GITHUB_API_TOKEN: ${{ github.token }}
         run: make testacc-cover
 
       - name: Upload coverage report to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKER_GITHUB_API_TOKEN: ${{ github.token }}
+          PACKER_GITHUB_API_TOKEN: ${github.token}
         run: make testacc-cover
 
       - name: Upload coverage report to Codecov


### PR DESCRIPTION
## Summary
- Add `PACKER_GITHUB_API_TOKEN` environment variable to Go acceptance tests
- Fixes intermittent test failures caused by GitHub API rate limiting when Packer is invoked during test execution

## Test plan
- [x] Verify the PACKER_GITHUB_API_TOKEN is set correctly in the acceptance tests step
- [x] CI tests should pass without Packer-related API rate limit errors
- [x] Existing test functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)