### PR TITLE
Fix sample stacks/deploy/dev.yaml in add-another-component.mdx so atmos terraform apply works

### DIFF
--- a/website/docs/quick-start/simple/extra-credit/add-another-component.mdx
+++ b/website/docs/quick-start/simple/extra-credit/add-another-component.mdx
@@ -21,35 +21,38 @@ For example, the following config shows how to define two Atmos components, `sta
 
 <File title="stacks/deploy/dev.yaml">
 ```yaml
+vars:
+  stage: dev
+
 import:
   # Import the baseline for all station components
   - catalog/station
 
 components:
   terraform:
-  # Atmos component `station/1`
-  station/1:
-    metadata:
-    # Point to the Terraform component in `components/terraform/weather`
-    component: weather
-    # Inherit the defaults for all station components
-    inherits:
-      - station
-    # Define/override variables specific to this `station/1` component
-    vars:
-      name: station-1
-
-  # Atmos component `station/2`
-  station/2:
-    metadata:
-    # Point to the Terraform component in `components/terraform/weather`
-    component: weather
-    # Inherit the defaults for all station components
-    inherits:
-      - station
-    # Define/override variables specific to this `station/2` component
-    vars:
-      name: station-2
+    # Atmos component `station/1`
+    station/1:
+      metadata:
+        # Point to the Terraform component in `components/terraform/weather`
+        component: weather
+        # Inherit the defaults for all station components
+        inherits:
+          - station
+      # Define/override variables specific to this `station/1` component
+      vars:
+        name: station-1
+  
+    # Atmos component `station/2`
+    station/2:
+      metadata:
+        # Point to the Terraform component in `components/terraform/weather`
+        component: weather
+        # Inherit the defaults for all station components
+        inherits:
+          - station
+      # Define/override variables specific to this `station/2` component
+      vars:
+        name: station-2
 ```
 </File>
 


### PR DESCRIPTION
Fixed errors in sample `stacks/deploy/dev.yaml` listed in [Atmos Quick Start, Extra Credit - Deploy Another App](https://atmos.tools/quick-start/simple/extra-credit/add-another-component) so that `atmos terraform apply station/1 -s dev` works without error.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

* Altered sample `stacks/deploy/dev.yaml` to correct three errors:
  * Fixed indentation of `station/1:` and `station/2:` under parent `terraform:`.
  * Fixed indentation of `component:` and `inherits:` under their respective `metadata:` parents.
  * Added `vars: stage: dev` at top

The first two changes are just indentation increases by one level to create proper nesting under their parents as YAML is indentation-sensitive for structure.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Without these changes, copying and pasting the sample contents of `stacks/deploy/dev.yaml` then running the command `atmos terraform apply station/1 -s dev` fails with errors like the following:

1. `Error: invalid 'components.terraform' section in the file 'deploy/dev'` (e.g. due to invalid indentation of `station/1:` under `terraform:` and invalid indentation of `component:` and `inherits:` under `metadata:`), then if these are fixed,
2. `Error: Could not find the component 'station/1' in the stack 'dev'.` (due to the missing `vars: stage: dev`)

Fixing this makes the `atmos terraform apply` work.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

[Atmos Quick Start, Extra Credit - Deploy Another App](https://atmos.tools/quick-start/simple/extra-credit/add-another-component)