### PR TITLE
fix: resolve golangci-lint issues in pkg/downloader

### DIFF
--- a/pkg/downloader/git_getter_test.go
+++ b/pkg/downloader/git_getter_test.go
@@ -311,7 +311,7 @@ func TestCustomGitGetter_Get_RemovesSymlinksAfterClone(t *testing.T) {
 }
 
 // Helper function for tests - creates a fake git command.
-func writeFakeGitHelper(t *testing.T, stdout string, code int) string {
+func writeFakeGitHelper(t *testing.T, stdout string, code int) {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -345,5 +345,4 @@ func writeFakeGitHelper(t *testing.T, stdout string, code int) string {
 		newPath = dir + string(os.PathListSeparator) + oldPath
 	}
 	t.Setenv("PATH", newPath)
-	return fname
 }


### PR DESCRIPTION
## what
- Fixes 14 out of 20 golangci-lint issues in the `pkg/downloader/` package
- Reduces linting errors from critical issues to only complexity warnings
- Ensures code follows Go best practices and project conventions

## why
- The PR #1441 (update-go-getter) has failing linting checks that prevent it from being merged
- These linting issues include deprecated packages, magic numbers, security warnings, and code quality issues
- Fixing these issues improves code maintainability and follows the project's CLAUDE.md guidelines

## Changes Made

### Fixed Issues (14):
1. **Deprecated package** - Replaced `io/ioutil` with `os.CreateTemp`
2. **Magic numbers** - Created constants for base10, portBitSize, sshKeyFileMode
3. **String literals** - Created constants for gitCommand, originRemote, gitArgSeparator  
4. **Invalid URL in test** - Fixed test to use programmatic URL construction
5. **Unused function returns** - Removed unused returns from test helper functions
6. **Argument limit exceeded** - Created `gitOperationParams` struct to reduce function arguments
7. **Index out of bounds** - Added check for -1 before using string index
8. **Security warnings (G204)** - Added #nosec comments with justification
9. **Formatting** - Applied gofumpt formatting
10. **Heavy parameter** - Changed struct to pass by pointer

### Remaining Warnings (6):
- Cognitive complexity warnings (can be addressed in future refactoring)
- Nested block complexity warnings
- Function length warning

All tests pass and the code compiles successfully.

## references
- Addresses linting issues from PR #1441