### PR TITLE
Make inline atmos config override config from imports

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -306,6 +306,15 @@ terraform:
 				assert.Equal(t, "Debug", cfg.Logs.Level)
 			},
 		},
+		{
+			name: "valid import custom override",
+			setup: func(t *testing.T, dir string, tc testCase) {
+				changeWorkingDir(t, "../../tests/fixtures/scenarios/atmos-cli-imports-override")
+			},
+			assertions: func(t *testing.T, tempDirPath string, cfg *schema.AtmosConfiguration, err error) {
+				assert.Equal(t, "foo", cfg.Commands[0].Name)
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"gopkg.in/yaml.v3"
 
 	log "github.com/charmbracelet/log"
 	"github.com/spf13/viper"
@@ -273,10 +275,20 @@ func mergeConfig(v *viper.Viper, path string, fileName string, processImports bo
 	if err := tempViper.ReadInConfig(); err != nil {
 		return err
 	}
+
+	if processImports {
+		if err := mergeDefaultImports(path, tempViper); err != nil {
+			log.Debug("error process imports", "path", path, "error", err)
+		}
+		if err := mergeImports(tempViper); err != nil {
+			log.Debug("error process imports", "file", tempViper.ConfigFileUsed(), "error", err)
+		}
+	}
+
 	configFilePath := tempViper.ConfigFileUsed()
 
-	v.SetConfigFile(configFilePath)
-	err := v.MergeInConfig()
+	tempViper.SetConfigFile(configFilePath)
+	err := tempViper.MergeInConfig()
 	if err != nil {
 		return err
 	}
@@ -285,20 +297,25 @@ func mergeConfig(v *viper.Viper, path string, fileName string, processImports bo
 		return err
 	}
 
-	err = preprocessAtmosYamlFunc(content, v)
+	err = preprocessAtmosYamlFunc(content, tempViper)
 	if err != nil {
 		return err
 	}
 
-	if !processImports {
-		return nil
+	// Marshal the temporary Viper instance to YAML content
+	allSettings := tempViper.AllSettings()
+	yamlBytes, err := yaml.Marshal(allSettings)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config to YAML: %w", err)
 	}
-	if err := mergeDefaultImports(path, v); err != nil {
-		log.Debug("error process imports", "path", path, "error", err)
+
+	// Merge the YAML content into the main Viper instance
+	v.SetConfigFile(configFilePath)
+	err = v.MergeConfig(strings.NewReader(string(yamlBytes)))
+	if err != nil {
+		return fmt.Errorf("failed to merge config: %w", err)
 	}
-	if err := mergeImports(v); err != nil {
-		log.Debug("error process imports", "file", v.ConfigFileUsed(), "error", err)
-	}
+
 	return nil
 }
 

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/atmos.yaml
@@ -1,0 +1,13 @@
+# Description: This is an example of a custom import configuration file.
+# The import configuration file is used to load configurations from multiple files and directories.
+# The configurations are merged together to create a single configuration object.
+# The configurations are loaded in the order they are defined in the import section.
+base_path: "./"
+import:
+  - "./commands.yaml"                                                                    # Load a specific file
+
+commands:
+  - name: "foo"
+    description: "Run foo"
+    steps:
+      - echo "foo"

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/commands.yaml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/commands.yaml
@@ -1,0 +1,5 @@
+commands:
+  - name: "bar"
+    description: "Run bar"
+    steps:
+      - echo "bar"

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/commands.yaml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/commands.yaml
@@ -1,0 +1,6 @@
+# Custom CLI commands
+commands:
+  - name: "test"
+    description: "Run all tests"
+    steps:
+      - atmos describe config

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/tools/stack.yml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/tools/stack.yml
@@ -1,0 +1,7 @@
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_pattern: "{dev}"

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/tools/terraform.yaml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/tools/terraform.yaml
@@ -1,0 +1,7 @@
+components:
+  terraform:
+    base_path: "components/terraform"
+    apply_auto_approve: true
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false

--- a/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/vendor.yaml
+++ b/tests/fixtures/scenarios/atmos-cli-imports-override/configs.d/vendor.yaml
@@ -1,0 +1,9 @@
+vendor:
+  # Single file
+  base_path: "./vendor.yaml"
+
+  # Directory with multiple files
+  #base_path: "./vendor"
+
+  # Absolute path
+  #base_path: "vendor.d/vendor1.yaml"


### PR DESCRIPTION
## what
* Atmos config inline definition priorities over imported configs

## why
* Settings defined inlined should have top priority

## references
* DEV-359:  Review and fix `atmos.yaml` imports