### PR TITLE
test(gotcha): add missing skip reason test coverage

### DIFF
--- a/tools/gotcha/internal/markdown/formatters_skip_test.go
+++ b/tools/gotcha/internal/markdown/formatters_skip_test.go
@@ -1,0 +1,94 @@
+package markdown
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudposse/atmos/tools/gotcha/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteSkippedTestsTable_WithReasons(t *testing.T) {
+	tests := []struct {
+		name     string
+		skipped  []types.TestResult
+		expected []string
+	}{
+		{
+			name: "test with skip reason",
+			skipped: []types.TestResult{
+				{
+					Package:    "github.com/cloudposse/atmos/internal/exec",
+					Test:       "TestCopyFile_FailChmod",
+					Status:     "skip",
+					SkipReason: "Skipping test on Windows: chmod simulation not supported",
+				},
+			},
+			expected: []string{
+				"⏭️ Skipped Tests (1)",
+				"| Test | Package | Reason |",
+				"| `TestCopyFile_FailChmod` | exec | Skipping test on Windows: chmod simulation not supported |",
+			},
+		},
+		{
+			name: "test without skip reason",
+			skipped: []types.TestResult{
+				{
+					Package:    "github.com/cloudposse/atmos/internal/exec",
+					Test:       "TestSomeOther",
+					Status:     "skip",
+					SkipReason: "",
+				},
+			},
+			expected: []string{
+				"⏭️ Skipped Tests (1)",
+				"| Test | Package | Reason |",
+				"| `TestSomeOther` | exec | _No reason provided_ |",
+			},
+		},
+		{
+			name: "mixed tests",
+			skipped: []types.TestResult{
+				{
+					Package:    "github.com/cloudposse/atmos/internal/exec",
+					Test:       "TestWithReason",
+					Status:     "skip",
+					SkipReason: "Platform specific test",
+				},
+				{
+					Package:    "github.com/cloudposse/atmos/internal/exec",
+					Test:       "TestWithoutReason",
+					Status:     "skip",
+					SkipReason: "",
+				},
+			},
+			expected: []string{
+				"⏭️ Skipped Tests (2)",
+				"| `TestWithReason` | exec | Platform specific test |",
+				"| `TestWithoutReason` | exec | _No reason provided_ |",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			WriteSkippedTestsTable(&buf, tt.skipped)
+			output := buf.String()
+
+			for _, exp := range tt.expected {
+				assert.Contains(t, output, exp, "Expected to find: %s", exp)
+			}
+
+			// Debug output if test fails
+			if t.Failed() {
+				t.Logf("Full output:\n%s", output)
+				// Also log the skip reasons from input
+				for _, test := range tt.skipped {
+					t.Logf("Test %s has SkipReason: %q", test.Test, test.SkipReason)
+				}
+			}
+		})
+	}
+}
+

--- a/tools/gotcha/internal/markdown/formatters_skip_test.go
+++ b/tools/gotcha/internal/markdown/formatters_skip_test.go
@@ -91,4 +91,3 @@ func TestWriteSkippedTestsTable_WithReasons(t *testing.T) {
 		})
 	}
 }
-

--- a/tools/gotcha/internal/parser/skip_test.go
+++ b/tools/gotcha/internal/parser/skip_test.go
@@ -1,0 +1,31 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSkipReason(t *testing.T) {
+	input := `{"Time":"2025-09-06T15:26:33.449262-06:00","Action":"run","Package":"github.com/cloudposse/atmos/internal/exec","Test":"TestCopyFile_FailChmod"}
+{"Time":"2025-09-06T15:26:33.449323-06:00","Action":"output","Package":"github.com/cloudposse/atmos/internal/exec","Test":"TestCopyFile_FailChmod","Output":"--- SKIP: TestCopyFile_FailChmod (0.00s)\n"}
+{"Time":"2025-09-06T15:26:33.449338-06:00","Action":"output","Package":"github.com/cloudposse/atmos/internal/exec","Test":"TestCopyFile_FailChmod","Output":"    vendor_utils_test.go:424: Skipping test on Windows: chmod simulation not supported\n"}
+{"Time":"2025-09-06T15:26:33.449345-06:00","Action":"skip","Package":"github.com/cloudposse/atmos/internal/exec","Test":"TestCopyFile_FailChmod","Elapsed":0}`
+
+	reader := strings.NewReader(input)
+	summary, err := ParseTestJSON(reader, "", false)
+	
+	assert.NoError(t, err)
+	assert.NotNil(t, summary)
+	assert.Len(t, summary.Skipped, 1)
+	
+	if len(summary.Skipped) > 0 {
+		skip := summary.Skipped[0]
+		assert.Equal(t, "TestCopyFile_FailChmod", skip.Test)
+		assert.Equal(t, "skip", skip.Status)
+		// Check that the skip reason was captured
+		assert.NotEmpty(t, skip.SkipReason, "Skip reason should not be empty")
+		assert.Contains(t, skip.SkipReason, "Skipping test on Windows")
+	}
+}

--- a/tools/gotcha/internal/parser/skip_test.go
+++ b/tools/gotcha/internal/parser/skip_test.go
@@ -15,11 +15,11 @@ func TestParseSkipReason(t *testing.T) {
 
 	reader := strings.NewReader(input)
 	summary, err := ParseTestJSON(reader, "", false)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, summary)
 	assert.Len(t, summary.Skipped, 1)
-	
+
 	if len(summary.Skipped) > 0 {
 		skip := summary.Skipped[0]
 		assert.Equal(t, "TestCopyFile_FailChmod", skip.Test)


### PR DESCRIPTION
## Summary
- Add missing test files that were inadvertently omitted from the previous merge
- These tests provide coverage for the skip reason functionality in gotcha

## Test Files Added
- `tools/gotcha/internal/markdown/formatters_skip_test.go`: Tests markdown table formatting for skipped tests with reasons
- `tools/gotcha/internal/parser/skip_test.go`: Tests parsing skip reasons from JSON test output

## Context
These test files were created as part of the skip reason feature implementation but were not included in the previous PR. They ensure the skip reason functionality works correctly by testing:
1. Proper parsing of skip reasons from test JSON output
2. Correct formatting of skipped tests in markdown tables
3. Handling of tests with and without skip reasons

🤖 Generated with [Claude Code](https://claude.ai/code)