### PR TITLE
fix: auto-remove semver labels from Dependabot PRs to fix CI checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,7 +103,83 @@ jobs:
     name: PR Semver Labels
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
+      # Clean up Dependabot's auto-added semver labels
+      # 
+      # Dependabot automatically adds semver labels (major/minor/patch) based on 
+      # the version changes of dependencies. However, dependency updates do not 
+      # directly correspond to new Atmos releases. Atmos follows its own versioning
+      # based on features and functionality changes, not dependency versions.
+      # 
+      # Dependency updates are bundled together with feature releases, so all 
+      # Dependabot PRs should only have the 'no-release' label.
+      #
+      # NOTE: There is currently no way to disable Dependabot's automatic semver labeling.
+      # See the following GitHub issues for more context:
+      # - https://github.com/dependabot/dependabot-core/issues/3465 (Opt-out of default major/minor/patch labels)
+      # - https://github.com/dependabot/dependabot-core/issues/11783 (labels: [] regression)
+      # - https://github.com/dependabot/dependabot-core/issues/1871 (Why labels are automatically applied)
+      #
+      # This workflow step is a workaround until GitHub provides native support for
+      # disabling automatic semver labels on Dependabot PRs.
+      - name: Remove auto-added semver labels from Dependabot PRs
+        if: github.actor == 'dependabot[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Processing Dependabot PR labels...');
+            console.log('Removing auto-added semver labels (see workflow comments for GitHub issue links)');
+            
+            // Get current labels on the PR
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            
+            console.log(`Current labels: ${labels.map(l => l.name).join(', ')}`);
+            
+            // Dependabot auto-adds semver labels based on dependency version changes,
+            // but these don't determine Atmos releases, so we remove them
+            const semverLabels = ['major', 'minor', 'patch'];
+            const autoAddedLabels = labels
+              .filter(label => semverLabels.includes(label.name))
+              .map(label => label.name);
+            
+            if (autoAddedLabels.length > 0) {
+              console.log(`Removing Dependabot's auto-added semver labels: ${autoAddedLabels.join(', ')}`);
+              console.log('(Dependency updates do not determine Atmos releases)');
+              
+              for (const labelName of autoAddedLabels) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: labelName
+                  });
+                  console.log(`✓ Removed: ${labelName}`);
+                } catch (error) {
+                  console.warn(`Could not remove label ${labelName}: ${error.message}`);
+                }
+              }
+              
+              console.log('Dependabot PRs should only have the no-release label');
+            } else {
+              console.log('No auto-added semver labels to remove');
+            }
+            
+            // Verify no-release label is present
+            const hasNoRelease = labels.some(l => l.name === 'no-release');
+            if (!hasNoRelease) {
+              console.log('Warning: no-release label is missing from this Dependabot PR');
+            }
+      
+      # Check for required semver labels
+      # Every PR must have exactly one: major, minor, patch, or no-release
       - uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly


### PR DESCRIPTION
## Summary
- Adds a workflow step to automatically remove semver labels from Dependabot PRs
- Ensures Dependabot PRs only have the `no-release` label
- Fixes the PR semver label check that was failing due to multiple labels

## Problem
Dependabot automatically adds semver labels (`major`, `minor`, `patch`) based on the version changes of dependencies. This causes our PR checks to fail because:
1. Dependabot PRs have both `no-release` (from our config) AND a semver label (auto-added)
2. Our semver check requires exactly ONE label
3. There's currently no way to disable Dependabot's automatic labeling behavior

## Solution
This PR adds a preprocessing step in the `pr-semver-labels` job that:
- Detects when a PR is from Dependabot
- Removes any auto-added semver labels
- Preserves the `no-release` label
- Then allows the existing semver check to pass

## Rationale
- Dependency version changes don't directly determine Atmos releases
- Atmos follows its own semantic versioning based on features and functionality
- Dependency updates are bundled with feature releases

## References
This is a workaround for a known GitHub limitation. See:
- https://github.com/dependabot/dependabot-core/issues/3465 (Feature request to opt-out)
- https://github.com/dependabot/dependabot-core/issues/11783 (labels: [] regression)
- https://github.com/dependabot/dependabot-core/issues/1871 (Why labels are auto-applied)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with next Dependabot PR to confirm labels are cleaned correctly
- [ ] Ensure regular PRs are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)