### PR TITLE
Change environment from 'demo' to 'screengrabs'

### DIFF
--- a/.github/workflows/screengrabs.yaml
+++ b/.github/workflows/screengrabs.yaml
@@ -35,7 +35,7 @@ jobs:
   build:
     needs: [prepare]
     runs-on: ubuntu-latest
-    environment: demo
+    environment: screengrabs
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## what
* Change environment from 'demo' to 'screengrabs'

## why
* Use an independent environment for screengrab generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use the “screengrabs” environment for build jobs, aligning automation with the correct deployment context.
  * This affects internal pipelines for generating screen captures and does not alter product functionality or UI.
  * No action required from users; performance, features, and behavior remain unchanged.
  * Release contents are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->