### PR TITLE
fix: Corrected Remote File Path for GitHub Actions

### DIFF
--- a/website/docs/integrations/github-actions/affected-stacks.mdx
+++ b/website/docs/integrations/github-actions/affected-stacks.mdx
@@ -30,7 +30,7 @@ Atmos checks component folders for changes first, marking all related components
 
 ## Usage Example
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan.yaml" />
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-plan.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-apply.mdx
@@ -41,7 +41,7 @@ We recommend combining this action with the [`affected-stacks`](/integrations/gi
 
 :::
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-apply.yaml"/>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-apply.yaml"/>
 
 :::info Why Do We have Two Workflows?
 
@@ -51,7 +51,7 @@ GitHub Actions support 256 matrix jobs in a single workflow at most! When planni
 
 :::
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-apply-matrix.yaml"/>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-apply-matrix.yaml"/>
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-drift-detection.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-drift-detection.mdx
@@ -91,7 +91,7 @@ We can quickly see a complete list of all drift components in the "Issues" tab i
 
 #### Usage Example
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-detection.yaml" />
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-drift-detection.yaml" />
 
 #### 256 Matrix Limitation
 
@@ -147,7 +147,7 @@ Once we have an open Issue for a drifted component, we can trigger another workf
 
 #### Usage Example
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-drift-remediation.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-drift-remediation.mdx
@@ -47,7 +47,7 @@ integrations:
 
 In this example drift will be remediated when user sets label `apply` to an issue.
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-drift-remediation.yaml" />
 
 ## Requirements
 

--- a/website/docs/integrations/github-actions/atmos-terraform-plan.mdx
+++ b/website/docs/integrations/github-actions/atmos-terraform-plan.mdx
@@ -53,7 +53,7 @@ We recommend combining this action with the [`affected-stacks`](/integrations/gi
 :::
 
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan.yaml"/>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-plan.yaml"/>
 
 :::info Why Do We have Two Workflows?
 
@@ -63,7 +63,7 @@ GitHub Actions support 256 matrix jobs in a single workflow at most! When planni
 
 :::
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-terraform-plan-matrix.yaml"/>
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-terraform-plan-matrix.yaml"/>
 
 with the following configuration as an example:
 

--- a/website/docs/integrations/github-actions/component-updater.mdx
+++ b/website/docs/integrations/github-actions/component-updater.mdx
@@ -36,7 +36,7 @@ Discover more details and a comprehensive list of `inputs` and `outputs` in the 
 
 ### Workflow example
 
-<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/master/examples/snippets/.github/workflows/atmos-components-updater.yml" />
+<RemoteFile source="https://raw.githubusercontent.com/cloudposse/docs/refs/heads/master/examples/legacy/snippets/.github/workflows/atmos-components-updater.yml" />
 
 ### Requirements
 


### PR DESCRIPTION
## what
- Updated the path for remote files used in the GitHub Action Integration documentation

## why
- We are preparing to migrate to Atmos Pro and have moved the previous version of workflows into a separate folder

## references
- [slack](https://sweetops.slack.com/archives/C031919U8A0/p1758032655977849)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated GitHub Actions integration pages to embed legacy workflow examples via new RemoteFile sources (refs/heads/master).
  - Affected pages: Affected Stacks, Atmos Terraform Plan, Atmos Terraform Apply, Drift Detection, Drift Remediation, and Component Updater.
  - Examples now display the legacy snippets for plan, plan-matrix, apply, apply-matrix, drift detection/remediation, and components updater workflows.
  - No functional changes to the site; content updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->