### PR TITLE
Allow processing of templates without context

### DIFF
--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -217,7 +217,7 @@ func ProcessYAMLConfigFile(
 
 	// Process `Go` templates in the imported stack manifest using the provided `context`
 	// https://atmos.tools/core-concepts/stacks/imports#go-templates-in-imports
-	if !skipTemplatesProcessingInImports && len(context) > 0 {
+	if !skipTemplatesProcessingInImports && (atmosConfig.Templates.Settings.Import.ProcessWithoutContext || len(context) > 0) {
 		stackManifestTemplatesProcessed, err = ProcessTmpl(relativeFilePath, stackYamlConfig, context, ignoreMissingTemplateValues)
 		if err != nil {
 			if atmosConfig.Logs.Level == u.LogLevelTrace || atmosConfig.Logs.Level == u.LogLevelDebug {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -286,6 +286,7 @@ type TemplatesSettings struct {
 	Delimiters  []string                  `yaml:"delimiters,omitempty" json:"delimiters,omitempty" mapstructure:"delimiters"`
 	Evaluations int                       `yaml:"evaluations,omitempty" json:"evaluations,omitempty" mapstructure:"evaluations"`
 	Env         map[string]string         `yaml:"env,omitempty" json:"env,omitempty" mapstructure:"env"`
+	Import      TemplateSettingsImport    `yaml:"import,omitempty" json:"import,omitempty" mapstructure:"import"`
 }
 
 type TemplatesSettingsSprig struct {
@@ -301,6 +302,10 @@ type TemplatesSettingsGomplate struct {
 	Enabled     bool                                           `yaml:"enabled" json:"enabled" mapstructure:"enabled"`
 	Timeout     int                                            `yaml:"timeout" json:"timeout" mapstructure:"timeout"`
 	Datasources map[string]TemplatesSettingsGomplateDatasource `yaml:"datasources" json:"datasources" mapstructure:"datasources"`
+}
+
+type TemplateSettingsImport struct {
+	ProcessWithoutContext bool `yaml:"process_without_context" json:"process_without_context" mapstructure:"process_without_context"`
 }
 
 type Terraform struct {


### PR DESCRIPTION
### Changes
#### Previously
Imported stack manifests had their Go templates processed only when `len(context) > 0`: 
```yaml
import:
  - path: catalog/aws-account.yaml.tmpl
    context:
      foo: bar
```

#### Now 
If `process_without_context`  is `true`, templates are processed even when context is empty. This makes it cleaner to trigger template processing:
```yaml
import:
  - path: catalog/aws-account.yaml.tmpl
```

Default behavior remains unchanged unless explicitly opted-in.

### New config option
* Added `templates.settings.import.process_without_context` to the Atmos schema.
* Defined under a new struct `TemplateSettingsImport` with a single boolean field `process_without_context`.
Example usage in `atmos.yaml`:
```yaml
templates:
  settings:
    import:
      process_without_context: true
```