### PR TITLE
fix: remove redundant MergeInConfig call that broke Windows tests

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -288,11 +288,6 @@ func mergeConfig(v *viper.Viper, path string, fileName string, processImports bo
 
 	configFilePath := tempViper.ConfigFileUsed()
 
-	tempViper.SetConfigFile(configFilePath)
-	err := tempViper.MergeInConfig()
-	if err != nil {
-		return err
-	}
 	content, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
## what
- Remove redundant `tempViper.MergeInConfig()` call in `pkg/config/load.go`
- This call was attempting to merge a Viper config into itself, which broke YAML template function processing

## why
- The bug was causing YAML template functions (like `atmos.Component`) to return `null` values instead of expected outputs
- This specifically affected Windows builds, causing test failures in the CI pipeline
- Tests `TestYamlFuncTerraformOutput` and `TestProcessCustomYamlTags` were failing with errors like:
  ```
  Error: Not equal: 
  expected: string("component-1-a")
  actual: <nil>(<nil>)
  ```

## references
- Fixes regression introduced in #1447 ("Make inline atmos config override config from imports")
- Example of failing Windows CI build: [test failures in acceptance tests](https://github.com/cloudposse/atmos/actions)

## Technical Details

The problematic code was:
```go
tempViper.SetConfigFile(configFilePath)
err := tempViper.MergeInConfig()  // This line was redundant and harmful
```

The `MergeInConfig()` was attempting to merge the config into itself (tempViper into tempViper), which corrupted the configuration state. The correct flow is already implemented: we marshal tempViper to YAML and then merge it into the main Viper instance, making this call unnecessary.

## Testing
- ✅ All tests now pass on macOS
- ✅ Specifically verified `TestYamlFuncTerraformOutput` and `TestProcessCustomYamlTags` pass
- 🔄 Windows CI should now pass (pending verification)