### PR TITLE
fix: Bind GITHUB_TOKEN environment variable for toolchain tests

### DIFF
--- a/toolchain/github_token_test.go
+++ b/toolchain/github_token_test.go
@@ -1,0 +1,84 @@
+package toolchain
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGitHubTokenEnvBinding tests that environment variables are properly bound to Viper in TestMain.
+func TestGitHubTokenEnvBinding(t *testing.T) {
+	// The TestMain function in main_test.go should have already bound the environment variables.
+	// This test verifies that the binding is working correctly.
+	
+	t.Run("GITHUB_TOKEN from CI is accessible", func(t *testing.T) {
+		// Save original value.
+		originalToken := os.Getenv("GITHUB_TOKEN")
+		defer os.Setenv("GITHUB_TOKEN", originalToken)
+		
+		// Simulate CI environment setting GITHUB_TOKEN.
+		testToken := "test-ci-github-token"
+		os.Setenv("GITHUB_TOKEN", testToken)
+		
+		// Since TestMain already bound the env vars, we need to create a new Viper instance
+		// or reset the bound value to test properly.
+		v := viper.New()
+		v.BindEnv("github-token", "ATMOS_GITHUB_TOKEN", "GITHUB_TOKEN")
+		
+		// Verify it's available through the new Viper instance.
+		token := v.GetString("github-token")
+		assert.Equal(t, testToken, token, "GITHUB_TOKEN should be accessible through viper")
+	})
+
+	t.Run("ATMOS_GITHUB_TOKEN takes precedence", func(t *testing.T) {
+		// Save original values.
+		originalGitHub := os.Getenv("GITHUB_TOKEN")
+		originalAtmos := os.Getenv("ATMOS_GITHUB_TOKEN")
+		defer func() {
+			os.Setenv("GITHUB_TOKEN", originalGitHub)
+			os.Setenv("ATMOS_GITHUB_TOKEN", originalAtmos)
+		}()
+		
+		// Set both tokens.
+		os.Setenv("GITHUB_TOKEN", "github-token")
+		os.Setenv("ATMOS_GITHUB_TOKEN", "atmos-github-token")
+		
+		// Create a new Viper instance to test binding.
+		v := viper.New()
+		v.BindEnv("github-token", "ATMOS_GITHUB_TOKEN", "GITHUB_TOKEN")
+		
+		// Verify ATMOS_GITHUB_TOKEN takes precedence.
+		token := v.GetString("github-token")
+		assert.Equal(t, "atmos-github-token", token, "ATMOS_GITHUB_TOKEN should take precedence over GITHUB_TOKEN")
+	})
+
+	t.Run("GitHub API functions work with environment token", func(t *testing.T) {
+		// If GITHUB_TOKEN is set in the environment (as it would be in CI),
+		// GetGitHubToken should return it thanks to TestMain's binding.
+		if envToken := os.Getenv("GITHUB_TOKEN"); envToken != "" {
+			token := GetGitHubToken()
+			// The token should be accessible (either the env token or empty if not set).
+			assert.NotNil(t, token, "GetGitHubToken should not return nil")
+		}
+		
+		// Test that a new GitHub API client can be created.
+		client := NewGitHubAPIClient()
+		assert.NotNil(t, client, "NewGitHubAPIClient should return a valid client")
+	})
+
+	t.Run("TestMain binds environment correctly", func(t *testing.T) {
+		// This test verifies that the binding in TestMain is working.
+		// If GITHUB_TOKEN is set in environment, it should be accessible.
+		if envToken := os.Getenv("GITHUB_TOKEN"); envToken != "" {
+			// The global viper instance should have the binding from TestMain.
+			viperToken := viper.GetString("github-token")
+			assert.Equal(t, envToken, viperToken, "TestMain should have bound GITHUB_TOKEN to viper")
+		} else if envToken := os.Getenv("ATMOS_GITHUB_TOKEN"); envToken != "" {
+			// Or if ATMOS_GITHUB_TOKEN is set, it should be accessible.
+			viperToken := viper.GetString("github-token")
+			assert.Equal(t, envToken, viperToken, "TestMain should have bound ATMOS_GITHUB_TOKEN to viper")
+		}
+	})
+}

--- a/toolchain/main_test.go
+++ b/toolchain/main_test.go
@@ -1,10 +1,23 @@
 package toolchain
 
 import (
+	"os"
 	"strings"
+	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+func TestMain(m *testing.M) {
+	// Initialize Viper environment variable bindings for tests.
+	// This ensures that GITHUB_TOKEN from CI is properly available to the tests.
+	// Bind both ATMOS_GITHUB_TOKEN and GITHUB_TOKEN to the "github-token" key.
+	viper.BindEnv("github-token", "ATMOS_GITHUB_TOKEN", "GITHUB_TOKEN")
+	
+	// Run tests.
+	os.Exit(m.Run())
+}
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
 	buf := new(strings.Builder)


### PR DESCRIPTION
## Summary

Fixed toolchain test failures on macOS and Windows CI caused by missing GitHub token authentication.

## Problem

The toolchain tests were failing with HTTP 403 errors when making GitHub API calls because the `GITHUB_TOKEN` environment variable from CI wasn't being properly bound to Viper's configuration system.

## Solution

- Added a `TestMain` function in `toolchain/main_test.go` to initialize Viper environment variable bindings
- Binds both `ATMOS_GITHUB_TOKEN` and `GITHUB_TOKEN` to the `"github-token"` key
- Added comprehensive tests to verify the token binding works correctly

## Test Plan

- [x] Tests pass locally with `GITHUB_TOKEN` set
- [x] New test `TestGitHubTokenEnvBinding` verifies the binding works
- [ ] CI tests should now pass on macOS and Windows

## Changes

- `toolchain/main_test.go`: Added `TestMain` with environment variable binding
- `toolchain/github_token_test.go`: New test file to verify GitHub token binding

This ensures that when CI sets `GITHUB_TOKEN`, the toolchain tests can properly access it for authenticated GitHub API requests, preventing rate limit errors.

🤖 Generated with [Claude Code](https://claude.ai/code)