### PR TITLE
feat: convert Purpose admonitions to Intro components in documentation

### DIFF
--- a/website/docs/cli/cli.mdx
+++ b/website/docs/cli/cli.mdx
@@ -8,11 +8,12 @@ description: This command starts an interactive UI to select an Atmos command, c
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to start an interactive UI to run Atmos commands against any component or stack. Press `Enter` to execute the command for the selected
 stack and component
-:::
+</Intro>
 
 ## Usage
 

--- a/website/docs/cli/commands/aws/usage.mdx
+++ b/website/docs/cli/commands/aws/usage.mdx
@@ -6,13 +6,14 @@ description: Atmos AWS Commands
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
 <Screengrab title="atmos aws --help" slug="atmos-aws--help" />
 
 ## Subcommands
 
-:::note Purpose
+<Intro>
 Use these subcommands to interact with AWS.
-:::
+</Intro>
 
 <DocCardList/>

--- a/website/docs/cli/commands/commands.mdx
+++ b/website/docs/cli/commands/commands.mdx
@@ -11,10 +11,11 @@ collapsed: false
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these commands to perform operations.
-:::
+</Intro>
 
 <Screengrab title="atmos --help" slug="atmos--help" />
 

--- a/website/docs/cli/commands/completion.mdx
+++ b/website/docs/cli/commands/completion.mdx
@@ -7,10 +7,11 @@ description: Use this command to generate completion scripts for `Bash`, `Zsh`, 
 import Screengrab from '@site/src/components/Screengrab'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to generate completion scripts for `Bash`, `Zsh`, `Fish` and `PowerShell`.
-:::
+</Intro>
 
 <Screengrab title="atmos completion --help" slug="atmos-completion--help" />
 

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -8,10 +8,11 @@ description: This command produces a list of the affected Atmos components and s
 import Terminal from '@site/src/components/Terminal'
 import File from '@site/src/components/File'
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to show a list of the affected Atmos components and stacks given two Git commits.
-:::
+</Intro>
 
 <Screengrab title="atmos describe affected --help" slug="atmos-describe-affected--help" />
 

--- a/website/docs/cli/commands/describe/describe-component.mdx
+++ b/website/docs/cli/commands/describe/describe-component.mdx
@@ -7,11 +7,12 @@ description: Use this command to describe the complete configuration for an Atmo
 ---
 import Terminal from '@site/src/components/Terminal'
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to describe the complete configuration for an [Atmos component](/core-concepts/components) in
 an [Atmos stack](/core-concepts/stacks).
-:::
+</Intro>
 
 <Screengrab title="atmos describe component --help" slug="atmos-describe-component--help" />
 

--- a/website/docs/cli/commands/describe/describe-config.mdx
+++ b/website/docs/cli/commands/describe/describe-config.mdx
@@ -7,10 +7,11 @@ description: Use this command to show the final (deep-merged) CLI configuration 
 ---
 import Terminal from '@site/src/components/Terminal'
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to show the final (deep-merged) [CLI configuration](/cli/configuration) of all `atmos.yaml` file(s).
-:::
+</Intro>
 
 <Screengrab title="atmos describe config --help" slug="atmos-describe-config--help" />
 

--- a/website/docs/cli/commands/describe/describe-dependents.mdx
+++ b/website/docs/cli/commands/describe/describe-dependents.mdx
@@ -8,10 +8,11 @@ description: This command produces a list of Atmos components in Atmos stacks th
 
 import Terminal from '@site/src/components/Terminal'
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to show a list of Atmos components in Atmos stacks that depend on the provided Atmos component.
-:::
+</Intro>
 
 <Screengrab title="atmos describe dependents --help" slug="atmos-describe-dependents--help"/>
 

--- a/website/docs/cli/commands/describe/describe-stacks.mdx
+++ b/website/docs/cli/commands/describe/describe-stacks.mdx
@@ -6,10 +6,11 @@ id: stacks
 description: Use this command to show the fully deep-merged configuration for all stacks and the components in the stacks.
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to show the fully deep-merged configuration for all stacks and the components in the stacks.
-:::
+</Intro>
 
 <Screengrab title="atmos describe stacks --help" slug="atmos-describe-stacks--help" />
 

--- a/website/docs/cli/commands/describe/describe-workflows.mdx
+++ b/website/docs/cli/commands/describe/describe-workflows.mdx
@@ -7,10 +7,11 @@ description: Use this command to show all configured Atmos workflows.
 ---
 import Terminal from '@site/src/components/Terminal'
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to show all configured Atmos workflows.
-:::
+</Intro>
 
 <Screengrab title="atmos describe workflows --help" slug="atmos-describe-workflows--help" />
 

--- a/website/docs/cli/commands/docs/docs-generate.mdx
+++ b/website/docs/cli/commands/docs/docs-generate.mdx
@@ -6,14 +6,15 @@ description: "Generate documentation artifacts based on a named section under `d
 id: generate
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 
 Use this command to generate one of your documentation artifacts (e.g. a README) as defined by the **named** section under `docs.generate.<KEY>` in `atmos.yaml`.
 
 Replace `<KEY>` with the name of the section you want to run (for example, `readme`, `release-notes`, etc.).
 
-:::
+</Intro>
 
 In `atmos.yaml`, you can define **one or more** documentation‐generation blocks under `docs.generate`.  Each top‐level key becomes a CLI argument:
 

--- a/website/docs/cli/commands/docs/usage.mdx
+++ b/website/docs/cli/commands/docs/usage.mdx
@@ -6,10 +6,11 @@ description: Use this command to open the Atmos docs
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to open the [Atmos docs](https://atmos.tools/)
-:::
+</Intro>
 
 <Screengrab title="atmos docs --help" slug="atmos-docs--help" />
 

--- a/website/docs/cli/commands/helmfile/helmfile-generate-varfile.mdx
+++ b/website/docs/cli/commands/helmfile/helmfile-generate-varfile.mdx
@@ -7,10 +7,11 @@ description: Use this command to generate a varfile for a `helmfile` component i
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to generate a varfile for a `helmfile` component in a stack.
-:::
+</Intro>
 
 <Screengrab title="atmos helmfile generate varfile --help" slug="atmos-helmfile-generate-varfile--help" />
 

--- a/website/docs/cli/commands/helmfile/usage.mdx
+++ b/website/docs/cli/commands/helmfile/usage.mdx
@@ -6,10 +6,11 @@ sidebar_class_name: command
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to run `helmfile` commands.
-:::
+</Intro>
 
 <Screengrab title="atmos helmfile --help" slug="atmos-helmfile--help" />
 

--- a/website/docs/cli/commands/list/list-stacks.mdx
+++ b/website/docs/cli/commands/list/list-stacks.mdx
@@ -7,10 +7,11 @@ description: Use this command to list all Stack configurations or a stack of a s
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to list Atmos stacks.
-:::
+</Intro>
 
 <Screengrab title="atmos list stacks --help" slug="atmos-list-stacks--help" />
 

--- a/website/docs/cli/commands/list/usage.mdx
+++ b/website/docs/cli/commands/list/usage.mdx
@@ -7,10 +7,11 @@ description: "List Atmos Stacks and Components"
 
 import Screengrab from '@site/src/components/Screengrab';
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to list sections of Atmos configurations.
-:::
+</Intro>
 
 <Screengrab title="atmos list --help" slug="atmos-list--help" />
 

--- a/website/docs/cli/commands/packer/usage.mdx
+++ b/website/docs/cli/commands/packer/usage.mdx
@@ -8,13 +8,14 @@ import DocCardList from '@theme/DocCardList'
 import File from '@site/src/components/File'
 import Terminal from '@site/src/components/Terminal'
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Intro from '@site/src/components/Intro'
 
 <img width="80" align="right" src={useBaseUrl('/img/hashicorp-packer.svg')} alt="Packer"/>
 
-:::note Purpose
+<Intro>
 Use these subcommands to interact with [HashiCorp Packer](https://developer.hashicorp.com/packer)
 to build automated machine images.
-:::
+</Intro>
 
 ## Usage
 

--- a/website/docs/cli/commands/pro/pro-lock.mdx
+++ b/website/docs/cli/commands/pro/pro-lock.mdx
@@ -7,11 +7,12 @@ description: Use this command to lock a stack in Atmos Pro so that it cannot be 
 ---
 
 import Screengrab from "@site/src/components/Screengrab";
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 This command implements the locking feature of [Atmos Pro](https://atmos-pro.com/docs). Use this command to lock
 a stack in Atmos Pro so that it cannot be planned or applied by another process (pull request, CI/CD, etc.)
-:::
+</Intro>
 
 ## Usage
 

--- a/website/docs/cli/commands/pro/pro-unlock.mdx
+++ b/website/docs/cli/commands/pro/pro-unlock.mdx
@@ -7,11 +7,12 @@ description: Use this command to unlock a stack in Atmos Pro that has previously
 ---
 
 import Screengrab from "@site/src/components/Screengrab";
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 This command implements the locking feature of [Atmos Pro](https://atmos-pro.com/docs). Use this command to unlock
 a stack in Atmos Pro that has previously been locked by the lock command.
-:::
+</Intro>
 
 ## Usage
 

--- a/website/docs/cli/commands/pro/usage.mdx
+++ b/website/docs/cli/commands/pro/usage.mdx
@@ -7,10 +7,11 @@ description: "Atmos Pro Commands"
 
 import Screengrab from "@site/src/components/Screengrab";
 import DocCardList from "@theme/DocCardList";
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to interact with Atmos Pro.
-:::
+</Intro>
 
 ## Subcommands
 

--- a/website/docs/cli/commands/terraform/terraform-generate-varfiles.mdx
+++ b/website/docs/cli/commands/terraform/terraform-generate-varfiles.mdx
@@ -7,11 +7,12 @@ description: Use this command to generate the Terraform varfiles (`.tfvar`) for 
 ---
 
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to generate the Terraform varfiles (`.tfvar`) for all Atmos terraform [components](/core-concepts/components) in
 all [stacks](/core-concepts/stacks).
-:::
+</Intro>
 
 <Screengrab title="atmos terraform generate varfiles --help" slug="atmos-terraform-generate-varfiles--help" />
 

--- a/website/docs/cli/commands/terraform/terraform-shell.mdx
+++ b/website/docs/cli/commands/terraform/terraform-shell.mdx
@@ -6,11 +6,12 @@ id: shell
 description: This command starts a new `SHELL` configured with the environment for an Atmos component in a stack to allow execution of all native terraform commands inside the shell without using any atmos-specific arguments and flags. This may by helpful to debug a component without going through Atmos.
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 This command starts a new `SHELL` configured with the environment for an Atmos component in a Stack to allow executing all native terraform commands
 inside the shell without using any atmos-specific arguments and flags.
-:::
+</Intro>
 
 <Screengrab title="atmos terraform shell --help" slug="atmos-terraform-shell--help" />
 

--- a/website/docs/cli/commands/terraform/terraform-workspace.mdx
+++ b/website/docs/cli/commands/terraform/terraform-workspace.mdx
@@ -6,11 +6,12 @@ id: workspace
 description: This command calculates the `terraform` workspace for an Atmos component (from the context variables and stack config). It runs `terraform init -reconfigure` and selects the workspace by executing the `terraform workspace select` command.
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to calculate the `terraform` workspace for an Atmos component (from the context variables and stack config). It will
 run `terraform init -reconfigure` and then select the workspace by executing the `terraform workspace select` command.
-:::
+</Intro>
 
 <Screengrab title="atmos terraform workspace --help" slug="atmos-terraform-workspace--help" />
 

--- a/website/docs/cli/commands/terraform/usage.mdx
+++ b/website/docs/cli/commands/terraform/usage.mdx
@@ -7,10 +7,11 @@ import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList'
 import File from '@site/src/components/File'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to interact with Terraform and OpenTofu.
-:::
+</Intro>
 
 <Screengrab title="atmos terraform --help" slug="atmos-terraform--help" />
 

--- a/website/docs/cli/commands/validate/usage.mdx
+++ b/website/docs/cli/commands/validate/usage.mdx
@@ -6,10 +6,11 @@ description: "Validate Atmos Configurations"
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to validate Atmos configurations.
-:::
+</Intro>
 
 <Screengrab title="atmos validate --help" slug="atmos-validate--help" />
 

--- a/website/docs/cli/commands/validate/validate-stacks.mdx
+++ b/website/docs/cli/commands/validate/validate-stacks.mdx
@@ -8,10 +8,11 @@ description: Use this command to validate all Stack configurations.
 
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to validate Atmos stack manifest configurations.
-:::
+</Intro>
 
 <Screengrab title="atmos validate stacks --help" slug="atmos-validate-stacks--help" />
 

--- a/website/docs/cli/commands/vendor/usage.mdx
+++ b/website/docs/cli/commands/vendor/usage.mdx
@@ -6,10 +6,11 @@ description: "Vendor Atmos Components and Stacks"
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import DocCardList from '@theme/DocCardList';
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use these subcommands to vendor Atmos components and stacks.
-:::
+</Intro>
 
 <Screengrab title="atmos vendor --help" slug="atmos-vendor--help" />
 

--- a/website/docs/cli/commands/vendor/vendor-pull.mdx
+++ b/website/docs/cli/commands/vendor/vendor-pull.mdx
@@ -6,11 +6,12 @@ id: pull
 description: Use this command to pull sources and mixins from remote repositories for Terraform and Helmfile components and stacks.
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 This command implements [Atmos Vendoring](/core-concepts/vendor/). Use this command to download sources from local and remote
 repositories for Terraform and Helmfile components and stacks.
-:::
+</Intro>
 
 <Screengrab title="atmos vendor pull --help" slug="atmos-vendor-pull--help" />
 

--- a/website/docs/cli/commands/version.mdx
+++ b/website/docs/cli/commands/version.mdx
@@ -5,10 +5,11 @@ sidebar_class_name: command
 description: Use this command to get the Atmos CLI version
 ---
 import Screengrab from '@site/src/components/Screengrab'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to get the Atmos CLI version
-:::
+</Intro>
 
 <Screengrab title="atmos help" slug="atmos-version" />
 

--- a/website/docs/cli/commands/workflow.mdx
+++ b/website/docs/cli/commands/workflow.mdx
@@ -6,10 +6,11 @@ description: Use this command to perform sequential execution of `atmos` and `sh
 ---
 import Screengrab from '@site/src/components/Screengrab'
 import Terminal from '@site/src/components/Terminal'
+import Intro from '@site/src/components/Intro'
 
-:::note Purpose
+<Intro>
 Use this command to perform sequential execution of `atmos` and `shell` commands defined as workflow steps.
-:::
+</Intro>
 
 <Screengrab title="atmos workflow --help" slug="atmos-workflow--help" />
 


### PR DESCRIPTION
## what
- Replace all `:::note Purpose` blocks with `<Intro>` tags across documentation files
- Add import statements for the Intro component where needed
- Update 30 MDX files in the cli/commands directory

## why
- Standardize the documentation format by using the dedicated `<Intro>` component for purpose descriptions
- Provide better semantic markup and consistency across the documentation
- The `<Intro>` component is specifically designed for introductory content, making it more appropriate than generic note admonitions
- Improve maintainability by using purpose-built components rather than generic admonitions

## references
- All links and formatting within the converted content have been preserved
- No functional changes to the documentation content, only the markup format

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized command pages by replacing note blocks with a unified Intro component across CLI docs for AWS, Terraform, Helmfile, Validate, Vendor, Pro, Describe, List, Workflow, Version, and Docs sections.
  * Improved readability and visual consistency of introductions without altering content meaning.
  * Expanded a description to explicitly mention “component and stack” for added clarity.
  * No changes to CLI behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->