### PR TITLE
fix: add missing Dependabot labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -31,3 +31,9 @@ labels:
   - name: release/feature
     color: '#d73a4a'
     description: Create release from this PR
+  - name: dependencies
+    color: '#0366d6'
+    description: Pull requests that update a dependency file
+  - name: go
+    color: '#00add8'
+    description: Pull requests that update Go code


### PR DESCRIPTION
## what
- Add missing `dependencies` and `go` labels to `.github/settings.yml`
- These labels are required by Dependabot configuration but were not defined in the repository

## why
- Dependabot was failing to create pull requests because it couldn't find the required labels
- The error message indicated: "The following labels could not be found: dependencies, go"
- Adding these labels will allow Dependabot to properly label its pull requests for dependency updates

## references
- Fixes Dependabot label creation errors shown in PR comments

🤖 Generated with [Claude Code](https://claude.ai/code)