### PR TITLE
fix: prevent duplicate file deletions in atmos terraform clean

### DIFF
--- a/internal/exec/terraform_clean_duplicate_test.go
+++ b/internal/exec/terraform_clean_duplicate_test.go
@@ -1,0 +1,74 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllStacksComponentsPaths_DuplicateComponents(t *testing.T) {
+	// Test case: Multiple stacks referencing the same component should not produce duplicate paths.
+	stacksMap := map[string]any{
+		"stack1": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vnet-elements": map[string]any{
+						"component": "vnet-elements",
+					},
+					"database": map[string]any{
+						"component": "database",
+					},
+				},
+			},
+		},
+		"stack2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vnet-elements": map[string]any{
+						"component": "vnet-elements", // Same component as stack1
+					},
+					"app": map[string]any{
+						"component": "app",
+					},
+				},
+			},
+		},
+		"stack3": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vnet-elements": map[string]any{
+						"component": "vnet-elements", // Same component again
+					},
+				},
+			},
+		},
+	}
+
+	paths := getAllStacksComponentsPaths(stacksMap)
+	require.NotEmpty(t, paths)
+
+	// Count occurrences of each path.
+	pathCounts := make(map[string]int)
+	for _, path := range paths {
+		pathCounts[path]++
+	}
+
+	// Check for duplicates.
+	hasDuplicates := false
+	for path, count := range pathCounts {
+		if count > 1 {
+			t.Logf("Component path '%s' appears %d times (duplicate)", path, count)
+			hasDuplicates = true
+		}
+	}
+
+	// After the fix, there should be no duplicates.
+	assert.False(t, hasDuplicates, "Component paths should not contain duplicates")
+}
+
+func TestCollectComponentsDirectoryObjects_WithDuplicatePaths(t *testing.T) {
+	// Test that CollectComponentsDirectoryObjects handles duplicate paths correctly.
+	// This test would need actual file system setup or mocking, so keeping it as a placeholder.
+	t.Skipf("Skipping integration test that requires file system setup")
+}

--- a/internal/exec/terraform_clean_util.go
+++ b/internal/exec/terraform_clean_util.go
@@ -15,13 +15,21 @@ var ErrRelPath = errors.New("error determining relative path")
 // getAllStacksComponentsPaths retrieves all components relatives paths to base Terraform directory from the stacks map.
 func getAllStacksComponentsPaths(stacksMap map[string]any) []string {
 	var allComponentsPaths []string
+	uniquePaths := make(map[string]bool)
+
 	for _, stackData := range stacksMap {
 		componentsPath, err := getComponentsPaths(stackData)
 		if err != nil {
 			log.Debug("Skip invalid components path", "path", componentsPath)
 			continue // Skip invalid components path.
 		}
-		allComponentsPaths = append(allComponentsPaths, componentsPath...)
+		// Add only unique paths to avoid duplicates when multiple stacks reference the same component.
+		for _, path := range componentsPath {
+			if !uniquePaths[path] {
+				uniquePaths[path] = true
+				allComponentsPaths = append(allComponentsPaths, path)
+			}
+		}
 	}
 	return allComponentsPaths
 }


### PR DESCRIPTION
## what
- Fixed duplicate file deletion attempts in `atmos terraform clean` command that occur when multiple stacks reference the same component
- Added deduplication logic to prevent the same component path from being processed multiple times
- Added unit test to verify the fix

## why
Users were experiencing intermittent errors where `atmos terraform clean` would attempt to delete the same files twice:
```
✓ Deleted project-name/components/terraform/vnet-elements/.terraform/
✓ Deleted project-name/components/terraform/vnet-elements/vnet-elements-eastus-prd-vnet-elements.terraform.tfvars.json
✓ Deleted project-name/components/terraform/vnet-elements/vnet-elements-eastus-prd-vnet-elements.planfile
✓ Deleted project-name/components/terraform/vnet-elements/.terraform.lock.hcl
✓ Deleted project-name/components/terraform/vnet-elements/backend.tf.json
x Cannot delete project-name/components/terraform/vnet-elements/.terraform/: path does not exist
x Cannot delete project-name/components/terraform/vnet-elements/vnet-elements-eastus-prd-vnet-elements.terraform.tfvars.json: path does not exist
x Cannot delete project-name/components/terraform/vnet-elements/vnet-elements-eastus-prd-vnet-elements.planfile: path does not exist
x Cannot delete project-name/components/terraform/vnet-elements/.terraform.lock.hcl: path does not exist
x Cannot delete project-name/components/terraform/vnet-elements/backend.tf.json: path does not exist
```

This happened because when multiple stacks (e.g., dev, staging, prod) reference the same component (e.g., vnet-elements), the `getAllStacksComponentsPaths` function would collect duplicate component paths. The clean command would then try to delete the same files multiple times - succeeding on the first attempt and failing on subsequent attempts.

The fix ensures each unique component path is only processed once, regardless of how many stacks reference it.

## references
- Fixes user-reported issue with duplicate deletion attempts in `atmos terraform clean`

🤖 Generated with [Claude Code](https://claude.ai/code)