### PR TITLE
docs: define the _defaults.yaml design pattern

### DIFF
--- a/website/docs/cli/configuration/stacks.mdx
+++ b/website/docs/cli/configuration/stacks.mdx
@@ -65,14 +65,20 @@ stacks:
   contain the top-level stack manifests, but just define the default values that get imported into top-level stack manifests
 
   :::note
-  The `_defaults.yaml` files is the recommended way to define the stack manifests with the
-  default configurations for organizations, OUs/tenants, accounts and regions. The `_defaults.yaml` files themselves are not top-level Atmos stacks,
-  they just contain the default values for the organizations, OUs/tenants, accounts and regions (to make the entire configuration reusable and DRY)
+  The `_defaults.yaml` naming convention is the recommended way to define stack manifests with
+  default configurations for organizations, OUs/tenants, accounts and regions. This is a naming convention, not an Atmos feature.
+  The `_defaults.yaml` files themselves are not top-level Atmos stacks—they just contain default values
+  to make the entire configuration reusable and DRY. The underscore prefix ensures these files sort to the top
+  of directory listings and are visually distinct from actual stack configurations.
   :::
 
   :::info
   The `_defaults.yaml` stack manifests are not imported into other Atmos manifests automatically.
-  You need to explicitly import them using [imports](/core-concepts/stacks/imports).
+  You must explicitly import them using [imports](/core-concepts/stacks/imports). Atmos has no special
+  knowledge of this naming pattern—these files are only excluded from stack discovery because they match
+  the `**/_defaults.yaml` pattern in the `excluded_paths` configuration.
+
+  See the [_defaults.yaml Design Pattern](/design-patterns/defaults-pattern) for a complete explanation of this convention.
   :::
 
 - `stacks.name_pattern` configures the name pattern for the top-level Atmos stacks using the context variables `namespace`, `tenant`, `environment`

--- a/website/docs/core-concepts/stacks/imports.mdx
+++ b/website/docs/core-concepts/stacks/imports.mdx
@@ -78,11 +78,45 @@ This means:
 - You don't need to explicitly specify template extensions - Atmos will find them automatically
 :::
 
+## Import Path Resolution
+
+Atmos supports two types of import paths:
+
+### Base-Relative Paths (Default)
+Most imports use paths relative to the `stacks.base_path` configured in `atmos.yaml`:
+- `catalog/vpc/defaults`
+- `mixins/region/us-east-2`
+- `orgs/acme/_defaults`
+
+These paths are resolved from the base stacks directory, regardless of where the importing file is located.
+
+### File-Relative Paths
+Imports starting with `.` or `..` are relative to the current file's directory:
+- `./_defaults` - imports from the same directory as the current file
+- `../shared/_defaults` - imports from a sibling `shared` directory
+
+This is useful when you want to import files that are co-located with the current configuration.
+
 ## Conventions
 
 We recommend placing all baseline "imports" in the `stacks/catalog` folder, however, they can exist anywhere.
 
 Use [mixins](/core-concepts/stacks/inheritance/mixins) for reusable snippets of configurations that alter the behavior of Stacks in some way.
+
+### The _defaults.yaml Pattern
+
+Many Atmos projects use `_defaults.yaml` as a naming convention for default configurations at each level of the hierarchy. This is purely a convention—Atmos has no special handling for these files. They must be explicitly imported like any other file.
+
+The underscore prefix ensures they:
+- Sort to the top of directory listings (lexicographic sorting)
+- Are visually distinct from actual stack configurations
+- Are excluded from stack discovery (via `excluded_paths` configuration)
+
+:::info
+The `_defaults.yaml` pattern is a common convention, not an Atmos feature. These files are only excluded from stack discovery because they match the pattern in `excluded_paths` configuration. They must always be explicitly imported to take effect.
+:::
+
+For a complete explanation of this pattern, see the [_defaults.yaml Design Pattern](/design-patterns/defaults-pattern) documentation.
 
 ## Imports Schema
 

--- a/website/docs/design-patterns/defaults-pattern.mdx
+++ b/website/docs/design-patterns/defaults-pattern.mdx
@@ -1,0 +1,299 @@
+---
+title: The _defaults.yaml Design Pattern
+sidebar_position: 15
+sidebar_label: _defaults.yaml Convention
+description: A naming convention for organizing hierarchical configuration defaults in Atmos
+---
+
+import Intro from '@site/src/components/Intro'
+import PillBox from '@site/src/components/PillBox'
+
+<PillBox>Atmos Design Pattern</PillBox>
+
+<Intro>
+The `_defaults.yaml` pattern is a **naming convention** (not an Atmos feature) for organizing hierarchical configuration defaults. Atmos has no special knowledge of these files—they are treated like any other YAML file that can be imported.
+</Intro>
+
+## What
+
+The `_defaults.yaml` pattern is a naming convention used throughout Atmos configurations to organize default settings at different levels of your infrastructure hierarchy. This is purely a convention adopted by teams for better organization—Atmos itself has no built-in knowledge or special handling of files named `_defaults.yaml`.
+
+## Why We Use This Convention
+
+### 1. Lexicographic Sorting
+The underscore prefix (`_`) ensures these files appear at the top of directory listings, making them immediately visible when browsing the filesystem. This saves time when navigating complex stack structures.
+
+### 2. Visual Distinction
+The naming pattern immediately signals to developers: "this file contains defaults, not a stack definition." This clear visual cue helps prevent confusion between actual stack configurations and their default settings.
+
+### 3. Automatic Exclusion from Stack Discovery
+By convention, we configure Atmos to exclude `**/_defaults.yaml` from stack discovery in `atmos.yaml`:
+
+```yaml
+stacks:
+  excluded_paths:
+    - "**/_defaults.yaml"
+```
+
+This prevents these files from being mistakenly processed as stacks when Atmos discovers stack configurations.
+
+### 4. Explicit Import Control
+Since they're excluded from discovery, these files must be explicitly imported, giving developers precise control over inheritance chains. This explicitness helps prevent unexpected configuration inheritance and makes the configuration flow easier to trace.
+
+## How It Works
+
+### Important: Not Automatic!
+
+:::warning
+Unlike some configuration systems, Atmos does **NOT** automatically import `_defaults.yaml` files. Each must be explicitly imported where needed. This is intentional—it provides explicit control over configuration inheritance.
+:::
+
+### Import Path Resolution
+
+Atmos supports two types of import paths:
+
+**Base-Relative Paths** (most common):
+- Resolved relative to `stacks.base_path` configured in `atmos.yaml`
+- Examples: `orgs/acme/_defaults`, `catalog/vpc/defaults`
+
+**File-Relative Paths**:
+- Start with `./` or `../`
+- Resolved relative to the importing file's directory
+- Examples: `./_defaults`, `../_defaults`
+
+### Typical Usage Pattern
+
+```console
+stacks/
+├── orgs/
+│   └── acme/
+│       ├── _defaults.yaml          # Organization defaults (NOT auto-imported)
+│       ├── core/
+│       │   ├── _defaults.yaml      # OU defaults - must import org defaults
+│       │   └── prod/
+│       │       ├── _defaults.yaml  # Stage defaults - must import OU defaults
+│       │       └── us-east-2.yaml  # Stack - must import stage defaults
+```
+
+## The Convention in Practice
+
+### Step 1: Create defaults at each level
+
+```yaml title="stacks/orgs/acme/_defaults.yaml"
+# Organization-wide defaults
+vars:
+  namespace: acme
+  terraform_version: "1.5.0"
+
+terraform:
+  vars:
+    tags:
+      Organization: acme
+      ManagedBy: Atmos
+```
+
+### Step 2: Import parent defaults in child defaults
+
+```yaml title="stacks/orgs/acme/core/_defaults.yaml"
+import:
+  - orgs/acme/_defaults    # Must explicitly import parent defaults
+
+# OU-specific defaults
+vars:
+  tenant: core
+
+terraform:
+  vars:
+    tags:
+      OrganizationalUnit: core
+```
+
+### Step 3: Import in actual stacks
+
+```yaml title="stacks/orgs/acme/core/prod/us-east-2.yaml"
+import:
+  - orgs/acme/core/prod/_defaults  # Must explicitly import defaults
+  - mixins/region/us-east-2
+
+# Stack-specific configuration
+terraform:
+  vars:
+    environment: prod
+    region: us-east-2
+
+components:
+  terraform:
+    vpc:
+      vars:
+        cidr_block: "10.0.0.0/16"
+```
+
+## Import Chain Example
+
+Here's how a typical import chain works with the `_defaults.yaml` convention:
+
+```mermaid
+graph TD
+    A[us-east-2.yaml] -->|imports| B[prod/_defaults.yaml]
+    B -->|imports| C[core/_defaults.yaml]
+    C -->|imports| D[acme/_defaults.yaml]
+
+    style A fill:#e1f5fe
+    style B fill:#fff3e0
+    style C fill:#fff3e0
+    style D fill:#fff3e0
+```
+
+Each level explicitly imports its parent's defaults, creating a clear inheritance chain.
+
+## Why Not Just Call Them "defaults.yaml"?
+
+Without the underscore prefix:
+- Files would be sorted alphabetically mixed with other files
+- Harder to distinguish defaults from other configurations at a glance
+- Still need to be excluded from stack discovery (just with a different pattern)
+
+The underscore is a small detail that provides significant organizational benefits.
+
+## Alternative Naming Conventions
+
+Teams can choose different conventions if preferred:
+- `defaults.yaml` (without underscore)
+- `.defaults.yaml` (hidden file on Unix systems)
+- `base.yaml`
+- `common.yaml`
+
+Just remember to:
+1. Update `excluded_paths` in `atmos.yaml` to match your pattern
+2. Be consistent across your project
+3. Document your choice for your team
+
+## Common Misunderstandings
+
+### ❌ Myth: Atmos automatically processes `_defaults.yaml` files
+**Reality**: Atmos has no special knowledge of this naming pattern. These files must be explicitly imported like any other YAML file.
+
+### ❌ Myth: The underscore has special meaning to Atmos
+**Reality**: The underscore is purely for lexicographic sorting and visual distinction. Atmos treats `_defaults.yaml` the same as `defaults.yaml` or any other name.
+
+### ❌ Myth: `_defaults.yaml` files are always inherited
+**Reality**: Nothing is inherited unless explicitly imported. You have complete control over what gets imported and when.
+
+### ❌ Myth: Files must be named `_defaults.yaml` for inheritance to work
+**Reality**: You can import any YAML file. The `_defaults.yaml` name is just a helpful convention.
+
+## Best Practices
+
+### Do's
+- **Be Explicit**: Always explicitly import parent defaults
+- **Document Import Chains**: Comment your imports to show the inheritance hierarchy
+- **Keep It Simple**: Don't create too many levels of defaults (typically 3-4 levels maximum)
+- **Stay Consistent**: Use the same naming convention throughout your project
+- **Order Imports Logically**: Import parent defaults before child defaults or mixins
+
+### Don'ts
+- **Don't Assume Auto-Import**: Never assume `_defaults.yaml` files are automatically imported
+- **Don't Create Circular Imports**: Avoid import cycles which will cause errors
+- **Don't Override Everything**: Override only what needs to change at each level
+- **Don't Mix Conventions**: Pick one naming convention and stick with it
+
+## Example: Multi-Tenant, Multi-Region Setup
+
+Here's a real-world example showing how the convention organizes a complex infrastructure:
+
+```yaml title="stacks/orgs/acme/_defaults.yaml"
+# Organization defaults
+vars:
+  namespace: acme
+
+terraform:
+  backend:
+    s3:
+      bucket: "acme-terraform-state"
+      dynamodb_table: "acme-terraform-state-lock"
+```
+
+```yaml title="stacks/orgs/acme/plat/_defaults.yaml"
+import:
+  - orgs/acme/_defaults
+
+vars:
+  tenant: platform
+
+terraform:
+  vars:
+    tags:
+      Tenant: platform
+      CostCenter: engineering
+```
+
+```yaml title="stacks/orgs/acme/plat/dev/_defaults.yaml"
+import:
+  - orgs/acme/plat/_defaults
+  - mixins/stage/dev    # Can also import mixins
+
+vars:
+  stage: dev
+
+terraform:
+  vars:
+    instance_type: t3.small  # Smaller instances for dev
+```
+
+```yaml title="stacks/orgs/acme/plat/dev/us-west-2.yaml"
+import:
+  - orgs/acme/plat/dev/_defaults
+  - mixins/region/us-west-2
+
+# This is the actual stack configuration
+components:
+  terraform:
+    vpc:
+      vars:
+        availability_zones: ["us-west-2a", "us-west-2b"]
+```
+
+## Troubleshooting
+
+### My defaults aren't being applied
+
+**Check these common issues:**
+1. **Missing Import**: Ensure you've explicitly imported the `_defaults.yaml` file
+2. **Wrong Path Style**: Verify you're using the correct path style (base-relative vs file-relative)
+3. **Path Typo**: Check for typos in the import path
+4. **File Location**: Confirm the `_defaults.yaml` file exists where expected
+
+**Debug with:**
+```bash
+# Show the final configuration with all imports processed
+atmos describe component <component> -s <stack>
+```
+
+### I see `_defaults.yaml` in my stack list
+
+This means the exclusion pattern isn't working. Check:
+
+```yaml title="atmos.yaml"
+stacks:
+  excluded_paths:
+    - "**/_defaults.yaml"  # Ensure this pattern is present
+```
+
+### Import path not found
+
+If you get an import error, verify:
+1. The path is relative to `stacks.base_path` (unless it starts with `./` or `../`)
+2. The file extension (`.yaml` is added automatically if omitted)
+3. The file actually exists at that location
+
+## Summary
+
+The `_defaults.yaml` pattern is a simple but effective naming convention that helps organize Atmos configurations. Remember:
+
+- It's a **convention**, not an Atmos feature
+- Files must be **explicitly imported**
+- The underscore provides **lexicographic sorting**
+- It creates **visual distinction** in file listings
+- You have **complete control** over inheritance
+
+This convention has emerged from real-world usage as a best practice for organizing hierarchical configurations in a clear, maintainable way.

--- a/website/docs/design-patterns/organizational-structure-configuration.mdx
+++ b/website/docs/design-patterns/organizational-structure-configuration.mdx
@@ -46,6 +46,24 @@ The **Organizational Structure Configuration** pattern provides the following be
 - After adding new organizations, tenants, accounts or regions, the entire configuration will still remain DRY, reusable and easy to manage thanks to
   using the described folder structure, catalogs, mixins, and hierarchical [imports](/core-concepts/stacks/imports)
 
+## The Role of _defaults.yaml Files
+
+In the organizational structure pattern, `_defaults.yaml` files play a crucial role at each level of the hierarchy. These files:
+
+- **Contain baseline configurations** for their respective level (organization, OU/tenant, account/stage)
+- **Must be explicitly imported** - they are not automatically included (this is by design for explicit control)
+- **Create inheritance chains** by importing parent-level defaults
+- **Are excluded from stack discovery** via the `excluded_paths` configuration
+
+:::info
+The `_defaults.yaml` naming is a convention, not an Atmos feature. The underscore prefix ensures these files:
+- Sort to the top of directory listings (lexicographic ordering)
+- Are visually distinct from actual stack configurations
+- Are excluded from stack discovery (when configured in `excluded_paths`)
+
+See the [_defaults.yaml Design Pattern](/design-patterns/defaults-pattern) for a complete explanation of this convention.
+:::
+
 ## Example
 
 The following example shows the Atmos stack and component configurations to provision the `vpc` and `vpc-flow-logs-bucket` components into


### PR DESCRIPTION
## what
- Add comprehensive documentation for the `_defaults.yaml` naming convention
- Create new design pattern document explaining the convention and its benefits
- Update existing documentation to clarify that it's a convention, not an Atmos feature
- Document import path resolution (base-relative vs file-relative paths)

## why
- Users need to understand why we use this specific naming pattern
- The underscore prefix provides lexicographic sorting benefits (files appear at top of directory listings)
- Clarifies that files must be explicitly imported (not automatic)
- Addresses confusion about what Atmos does vs. what's a human convention

## Key Points Documented

### The Convention Explained
- `_defaults.yaml` is a naming convention, NOT an Atmos feature
- Atmos has no special knowledge or handling of these files
- The underscore ensures lexicographic sorting (appears at top of listings)
- Files are only excluded from stack discovery via `excluded_paths` configuration

### Import Behavior
- Files must be EXPLICITLY imported - nothing is automatic
- Two types of import paths:
  - Base-relative: `orgs/acme/_defaults` (relative to `stacks.base_path`)
  - File-relative: `./_defaults` (relative to current file)

### Documentation Added
1. **New Design Pattern**: `/website/docs/design-patterns/defaults-pattern.mdx`
   - Comprehensive explanation of the convention
   - Why it exists (lexicographic sorting, visual distinction)
   - Common misunderstandings clarified
   - Best practices and anti-patterns
   - Real-world examples with import chains

2. **Updated Existing Docs**:
   - `/website/docs/core-concepts/stacks/imports.mdx` - Added import path resolution section
   - `/website/docs/cli/configuration/stacks.mdx` - Clarified it's a convention
   - `/website/docs/design-patterns/organizational-structure-configuration.mdx` - Added section on role of `_defaults.yaml`

## references
- Closes [DEV-253](https://linear.app/cloudposse/issue/DEV-253/define-the-defaultsyaml-design-pattern)
- Slack discussion: https://cloudposse.slack.com/archives/C02EC1YLTV4/p1704817300409169

🤖 Generated with [Claude Code](https://claude.ai/code)