### PR TITLE
feat: implement dependency order execution for terraform --all flag

### DIFF
--- a/cmd/terraform_utils.go
+++ b/cmd/terraform_utils.go
@@ -92,7 +92,7 @@ func terraformRun(cmd *cobra.Command, actualCmd *cobra.Command, args []string) e
 		a.Upload = false
 		a.OutputFile = ""
 
-		err = e.ExecuteTerraformAffected(&a, &info)
+		err = e.ExecuteTerraformAffectedWithGraph(&a, &info)
 		errUtils.CheckErrorPrintAndExit(err, "", "")
 		return nil
 	}
@@ -103,7 +103,13 @@ func terraformRun(cmd *cobra.Command, actualCmd *cobra.Command, args []string) e
 	// `--query <yq-expression>`
 	// `--stack` (and the `component` argument is not passed)
 	if info.All || len(info.Components) > 0 || info.Query != "" || (info.Stack != "" && info.ComponentFromArg == "") {
-		err = e.ExecuteTerraformQuery(&info)
+		// For commands that need dependency order with --all flag (apply, destroy, deploy)
+		if info.All && (info.SubCommand == "apply" || info.SubCommand == "destroy" || info.SubCommand == "deploy") {
+			err = e.ExecuteTerraformAll(&info)
+		} else {
+			// For other commands or when not using --all, use existing query logic
+			err = e.ExecuteTerraformQuery(&info)
+		}
 		errUtils.CheckErrorPrintAndExit(err, "", "")
 		return nil
 	}

--- a/docs/prd/terraform-dependency-order.md
+++ b/docs/prd/terraform-dependency-order.md
@@ -1,0 +1,324 @@
+# Product Requirements Document: Terraform Dependency Order Execution
+
+## Executive Summary
+
+This PRD outlines the implementation of dependency-ordered execution for Terraform operations in Atmos, specifically for the `--all` flag. The solution will generalize the existing dependency graph logic used by `--affected` to create a reusable dependency management system that ensures components are processed in the correct order based on their dependencies.
+
+## Problem Statement
+
+### Current State
+- The `--affected` flag already implements dependency-ordered execution for affected components
+- The `--all` flag processes all components but does not respect dependency order
+- This can lead to deployment failures when dependent components are processed before their dependencies
+- The dependency logic is tightly coupled with the affected components logic
+
+### Business Impact
+- Risk of deployment failures due to incorrect execution order
+- Manual intervention required to run components in correct order
+- Increased deployment time and operational overhead
+- Potential for infrastructure inconsistencies
+
+## Goals and Objectives
+
+### Primary Goals
+1. Implement dependency-ordered execution for `atmos terraform apply --all`
+2. Create a reusable dependency graph system for both `--all` and `--affected`
+3. Maintain backward compatibility with existing functionality
+4. Improve code maintainability through proper separation of concerns
+
+### Success Criteria
+- `--all` flag respects component dependencies
+- No regression in `--affected` functionality
+- Successful detection and prevention of circular dependencies
+- Clear error messages for dependency issues
+- Performance remains acceptable for large infrastructures
+
+## Solution Overview
+
+### High-Level Approach
+Create a generalized dependency graph package that can:
+1. Build a complete dependency graph from Atmos stack configurations
+2. Perform topological sorting to determine execution order
+3. Detect circular dependencies
+4. Filter graphs for specific use cases (affected components, queries, etc.)
+
+### Architecture
+
+```
+pkg/dependency/          # Reusable dependency graph logic
+├── types.go            # Core types and interfaces
+├── graph.go            # Graph structure and operations
+├── builder.go          # Graph construction
+├── sort.go             # Topological sort implementation
+└── filter.go           # Graph filtering operations
+
+internal/exec/           # Atmos-specific implementation
+├── terraform_all.go    # --all flag implementation
+└── terraform_executor.go # Shared execution logic
+```
+
+## Functional Requirements
+
+### 1. Dependency Graph Construction
+
+#### FR-1.1: Component Discovery
+- System SHALL discover all Terraform components across all stacks
+- System SHALL extract component metadata including dependencies
+- System SHALL handle abstract and disabled components appropriately
+
+#### FR-1.2: Dependency Mapping
+- System SHALL parse `settings.depends_on` configuration from stack files
+- System SHALL build bidirectional dependency relationships
+- System SHALL support cross-stack dependencies
+
+### 2. Dependency Resolution
+
+#### FR-2.1: Topological Sorting
+- System SHALL implement topological sort algorithm (Kahn's or DFS-based)
+- System SHALL determine correct execution order
+- System SHALL handle components with no dependencies (roots)
+
+#### FR-2.2: Cycle Detection
+- System SHALL detect circular dependencies
+- System SHALL provide clear error messages with cycle path
+- System SHALL fail fast when cycles are detected
+
+### 3. Execution Control
+
+#### FR-3.1: Ordered Execution
+- System SHALL execute components in dependency order
+- System SHALL respect dry-run mode
+- System SHALL support all Terraform subcommands (apply, destroy, plan)
+
+#### FR-3.2: Error Handling
+- System SHALL handle missing dependencies gracefully
+- System SHALL provide option to continue or fail on errors
+- System SHALL log execution progress clearly
+
+### 4. Filtering and Selection
+
+#### FR-4.1: Component Filtering
+- System SHALL support filtering by stack
+- System SHALL support filtering by component
+- System SHALL support YQ query expressions
+
+#### FR-4.2: Affected Components
+- System SHALL maintain existing `--affected` functionality
+- System SHALL filter graph to affected components and dependencies
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Dependency graph construction SHALL complete in < 5 seconds for 1000 components
+- Topological sort SHALL complete in O(V + E) time complexity
+- Memory usage SHALL scale linearly with number of components
+
+### NFR-2: Maintainability
+- Code SHALL follow Go best practices and idioms
+- Package structure SHALL separate concerns appropriately
+- Functions SHALL be small and focused (< 150 lines)
+
+### NFR-3: Testability
+- Core logic SHALL have > 80% test coverage
+- Dependency logic SHALL be testable without external dependencies
+- Integration tests SHALL cover complex scenarios
+
+### NFR-4: Usability
+- Error messages SHALL be clear and actionable
+- Progress indicators SHALL show current component being processed
+- Dry-run mode SHALL show planned execution order
+
+## Technical Specifications
+
+### Data Structures
+
+```go
+// Core node structure
+type Node struct {
+    ID           string   // Unique identifier (component-stack)
+    Component    string   // Component name
+    Stack        string   // Stack name
+    Dependencies []string // Node IDs this depends on
+    Dependents   []string // Node IDs that depend on this
+    Metadata     map[string]any
+}
+
+// Dependency graph
+type Graph struct {
+    Nodes map[string]*Node
+    Roots []string // Nodes with no dependencies
+}
+```
+
+### Key Algorithms
+
+#### Topological Sort (Kahn's Algorithm)
+1. Calculate in-degree for all nodes
+2. Queue all nodes with in-degree 0
+3. Process queue:
+   - Remove node from queue
+   - Add to result
+   - Reduce in-degree of dependents
+   - Queue dependents with in-degree 0
+4. Check if all nodes processed (cycle detection)
+
+#### Cycle Detection (DFS)
+1. Maintain visited set and recursion stack
+2. For each unvisited node:
+   - Mark as visited and in recursion stack
+   - Visit all dependencies
+   - If dependency in recursion stack, cycle found
+   - Remove from recursion stack
+
+### API Design
+
+```go
+// Build dependency graph
+graph, err := dependency.BuildGraph(components)
+
+// Get execution order
+order, err := graph.TopologicalSort()
+
+// Filter for affected components
+filtered := graph.Filter(affectedIDs, includeDependencies)
+
+// Detect cycles
+hasCycle, cyclePath := graph.DetectCycles()
+```
+
+## Implementation Plan
+
+### Phase 1: Core Dependency Package (Week 1)
+1. Create `pkg/dependency` package structure
+2. Implement graph data structures
+3. Implement topological sort
+4. Implement cycle detection
+5. Write unit tests
+
+### Phase 2: Terraform Integration (Week 1-2)
+1. Create `ExecuteTerraformAll` function
+2. Integrate dependency graph with stack processing
+3. Update command routing for `--all` flag
+4. Refactor `--affected` to use new graph
+
+### Phase 3: Testing and Documentation (Week 2)
+1. Create integration tests
+2. Test with complex dependency scenarios
+3. Update user documentation
+4. Create example configurations
+
+## Testing Strategy
+
+### Unit Tests
+- Graph construction and manipulation
+- Topological sort correctness
+- Cycle detection accuracy
+- Filter operations
+
+### Integration Tests
+- End-to-end `--all` execution
+- Cross-stack dependencies
+- Error scenarios
+- Performance with large graphs
+
+### Test Scenarios
+```yaml
+# Simple chain: A -> B -> C
+# Diamond: A -> B,C -> D
+# Complex: Multiple roots, shared dependencies
+# Circular: A -> B -> C -> A (should fail)
+```
+
+## Risk Assessment
+
+### Technical Risks
+- **Risk**: Performance degradation with large infrastructures
+- **Mitigation**: Optimize algorithms, add caching, benchmark regularly
+
+- **Risk**: Breaking existing `--affected` functionality
+- **Mitigation**: Comprehensive testing, gradual refactoring
+
+### Operational Risks
+- **Risk**: Incorrect dependency configuration causes failures
+- **Mitigation**: Clear documentation, validation tools, dry-run mode
+
+## Success Metrics
+
+1. **Correctness**: Zero dependency-related deployment failures
+2. **Performance**: < 5 second overhead for dependency resolution
+3. **Adoption**: 90% of users utilize `--all` with dependencies
+4. **Quality**: Zero critical bugs in first month post-release
+5. **Maintainability**: Reduced code complexity metrics
+
+## Migration Strategy
+
+### Backward Compatibility
+- Existing commands continue to work unchanged
+- `--affected` maintains current behavior
+- New functionality is opt-in via flags
+
+### Rollout Plan
+1. Alpha: Internal testing with test environments
+2. Beta: Limited release to power users
+3. GA: Full release with documentation
+
+## Documentation Requirements
+
+### User Documentation
+- Usage examples for `--all` with dependencies
+- Dependency configuration guide
+- Troubleshooting circular dependencies
+- Migration guide from manual ordering
+
+### Developer Documentation
+- Architecture overview
+- API reference
+- Extension guide
+- Contributing guidelines
+
+## Open Questions
+
+1. Should we support parallel execution of independent components?
+2. How should we handle optional dependencies?
+3. Should dependency order be configurable per command?
+4. What level of progress reporting is needed?
+
+## Appendix
+
+### Example Configuration
+
+```yaml
+# stacks/prod.yaml
+components:
+  terraform:
+    vpc:
+      vars:
+        cidr: "10.0.0.0/16"
+
+    database:
+      settings:
+        depends_on:
+          - component: vpc
+      vars:
+        instance_class: "db.t3.medium"
+
+    application:
+      settings:
+        depends_on:
+          - component: database
+          - component: vpc
+      vars:
+        replicas: 3
+```
+
+### Expected Execution Order
+1. vpc (no dependencies)
+2. database (depends on vpc)
+3. application (depends on vpc and database)
+
+## Approval
+
+- **Author**: AI Assistant
+- **Date**: 2024-09-25
+- **Status**: Draft
+- **Reviewers**: TBD

--- a/internal/exec/terraform_affected_graph.go
+++ b/internal/exec/terraform_affected_graph.go
@@ -1,0 +1,156 @@
+package exec
+
+import (
+	"fmt"
+
+	log "github.com/charmbracelet/log"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
+)
+
+// ExecuteTerraformAffectedWithGraph executes terraform commands for affected components using the dependency graph.
+func ExecuteTerraformAffectedWithGraph(args *DescribeAffectedCmdArgs, info *schema.ConfigAndStacksInfo) error {
+	var affectedList []schema.Affected
+	var err error
+
+	// Get the list of affected components (existing logic)
+	switch {
+	case args.RepoPath != "":
+		affectedList, _, _, _, err = ExecuteDescribeAffectedWithTargetRepoPath(
+			args.CLIConfig,
+			args.RepoPath,
+			args.IncludeSpaceliftAdminStacks,
+			args.IncludeSettings,
+			args.Stack,
+			args.ProcessTemplates,
+			args.ProcessYamlFunctions,
+			args.Skip,
+			args.ExcludeLocked,
+		)
+	case args.CloneTargetRef:
+		affectedList, _, _, _, err = ExecuteDescribeAffectedWithTargetRefClone(
+			args.CLIConfig,
+			args.Ref,
+			args.SHA,
+			args.SSHKeyPath,
+			args.SSHKeyPassword,
+			args.IncludeSpaceliftAdminStacks,
+			args.IncludeSettings,
+			args.Stack,
+			args.ProcessTemplates,
+			args.ProcessYamlFunctions,
+			args.Skip,
+			args.ExcludeLocked,
+		)
+	default:
+		affectedList, _, _, _, err = ExecuteDescribeAffectedWithTargetRefCheckout(
+			args.CLIConfig,
+			args.Ref,
+			args.SHA,
+			args.IncludeSpaceliftAdminStacks,
+			args.IncludeSettings,
+			args.Stack,
+			args.ProcessTemplates,
+			args.ProcessYamlFunctions,
+			args.Skip,
+			args.ExcludeLocked,
+		)
+	}
+	if err != nil {
+		return err
+	}
+
+	if len(affectedList) == 0 {
+		log.Info("No affected components found")
+		return nil
+	}
+
+	affectedYaml, err := u.ConvertToYAML(affectedList)
+	if err != nil {
+		return err
+	}
+	log.Debug("Affected", "components", affectedYaml)
+
+	// Get all stacks to build the complete dependency graph
+	stacks, err := ExecuteDescribeStacks(
+		args.CLIConfig,
+		"",  // all stacks
+		nil, // all components
+		[]string{cfg.TerraformComponentType},
+		nil,
+		false,
+		args.ProcessTemplates,
+		args.ProcessYamlFunctions,
+		false,
+		args.Skip,
+	)
+	if err != nil {
+		return fmt.Errorf("error describing stacks: %w", err)
+	}
+
+	// Build the complete dependency graph
+	fullGraph, err := buildTerraformDependencyGraph(
+		args.CLIConfig,
+		stacks,
+		info,
+	)
+	if err != nil {
+		return fmt.Errorf("error building dependency graph: %w", err)
+	}
+
+	// Create list of affected node IDs
+	affectedNodeIDs := []string{}
+	for _, affected := range affectedList {
+		nodeID := fmt.Sprintf("%s-%s", affected.Component, affected.Stack)
+		affectedNodeIDs = append(affectedNodeIDs, nodeID)
+	}
+
+	// Filter the graph to include affected components and their dependencies/dependents
+	filteredGraph := fullGraph.Filter(dependency.Filter{
+		NodeIDs:             affectedNodeIDs,
+		IncludeDependencies: true,                   // Include what affected components depend on
+		IncludeDependents:   args.IncludeDependents, // Include what depends on affected components
+	})
+
+	// Get execution order
+	executionOrder, err := filteredGraph.TopologicalSort()
+	if err != nil {
+		return fmt.Errorf("error determining execution order: %w", err)
+	}
+
+	log.Info("Processing affected components in dependency order", "count", len(executionOrder))
+
+	// Execute components in order
+	for i, node := range executionOrder {
+		// Check if this node is directly affected or just a dependency/dependent
+		isDirectlyAffected := false
+		for _, affected := range affectedList {
+			if node.Component == affected.Component && node.Stack == affected.Stack {
+				isDirectlyAffected = true
+				break
+			}
+		}
+
+		if isDirectlyAffected {
+			log.Info("Processing affected component", "index", i+1, "total", len(executionOrder),
+				"component", node.Component, "stack", node.Stack)
+		} else if args.IncludeDependents {
+			log.Info("Processing dependent component", "index", i+1, "total", len(executionOrder),
+				"component", node.Component, "stack", node.Stack)
+		} else {
+			log.Info("Processing dependency", "index", i+1, "total", len(executionOrder),
+				"component", node.Component, "stack", node.Stack)
+		}
+
+		if err := executeTerraformForNode(node, info); err != nil {
+			return fmt.Errorf("error executing terraform for component %s in stack %s: %w",
+				node.Component, node.Stack, err)
+		}
+	}
+
+	log.Info("Successfully processed affected components", "count", len(executionOrder))
+	return nil
+}

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -1,0 +1,273 @@
+package exec
+
+import (
+	"fmt"
+
+	log "github.com/charmbracelet/log"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
+)
+
+// ExecuteTerraformAll executes terraform commands for all components in dependency order.
+func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
+	atmosConfig, err := cfg.InitCliConfig(*info, true)
+	if err != nil {
+		return fmt.Errorf("error initializing CLI config: %w", err)
+	}
+
+	log.Debug("Executing terraform command for all components in dependency order", "command", info.SubCommand)
+
+	// Get all stacks with terraform components
+	stacks, err := ExecuteDescribeStacks(
+		&atmosConfig,
+		"",  // all stacks
+		nil, // all components
+		[]string{cfg.TerraformComponentType},
+		nil,
+		false,
+		info.ProcessTemplates,
+		info.ProcessFunctions,
+		false,
+		info.Skip,
+	)
+	if err != nil {
+		return fmt.Errorf("error describing stacks: %w", err)
+	}
+
+	// Build dependency graph
+	graph, err := buildTerraformDependencyGraph(
+		&atmosConfig,
+		stacks,
+		info,
+	)
+	if err != nil {
+		return fmt.Errorf("error building dependency graph: %w", err)
+	}
+
+	// Apply filters if specified
+	if info.Query != "" || len(info.Components) > 0 || info.Stack != "" {
+		graph = applyFiltersToGraph(graph, stacks, info)
+	}
+
+	// Get execution order
+	executionOrder, err := graph.TopologicalSort()
+	if err != nil {
+		return fmt.Errorf("error determining execution order: %w", err)
+	}
+
+	log.Info("Processing components in dependency order", "count", len(executionOrder))
+
+	// Execute components in order
+	for i, node := range executionOrder {
+		log.Info("Processing component", "index", i+1, "total", len(executionOrder), "component", node.Component, "stack", node.Stack)
+
+		if err := executeTerraformForNode(node, info); err != nil {
+			return fmt.Errorf("error executing terraform for component %s in stack %s: %w", node.Component, node.Stack, err)
+		}
+	}
+
+	log.Info("Successfully processed all components", "count", len(executionOrder))
+	return nil
+}
+
+// buildTerraformDependencyGraph builds the complete dependency graph from stacks.
+func buildTerraformDependencyGraph(
+	atmosConfig *schema.AtmosConfiguration,
+	stacks map[string]any,
+	info *schema.ConfigAndStacksInfo,
+) (*dependency.Graph, error) {
+	builder := dependency.NewBuilder()
+	nodeMap := make(map[string]string) // Maps component-stack to node ID
+
+	// First pass: add all nodes
+	err := walkTerraformComponents(stacks, func(stackName, componentName string, componentSection map[string]any) error {
+		// Skip abstract components
+		if metadataSection, ok := componentSection[cfg.MetadataSectionName].(map[string]any); ok {
+			if metadataType, ok := metadataSection["type"].(string); ok && metadataType == "abstract" {
+				return nil
+			}
+		}
+
+		// Skip disabled components
+		if metadataSection, ok := componentSection[cfg.MetadataSectionName].(map[string]any); ok {
+			if !isComponentEnabled(metadataSection, componentName) {
+				return nil
+			}
+		}
+
+		nodeID := fmt.Sprintf("%s-%s", componentName, stackName)
+		node := &dependency.Node{
+			ID:        nodeID,
+			Component: componentName,
+			Stack:     stackName,
+			Type:      cfg.TerraformComponentType,
+			Metadata:  componentSection,
+		}
+
+		nodeMap[nodeID] = nodeID
+		return builder.AddNode(node)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error adding nodes to dependency graph: %w", err)
+	}
+
+	// Second pass: build dependencies using settings.depends_on
+	err = walkTerraformComponents(stacks, func(stackName, componentName string, componentSection map[string]any) error {
+		// Skip abstract components
+		if metadataSection, ok := componentSection[cfg.MetadataSectionName].(map[string]any); ok {
+			if metadataType, ok := metadataSection["type"].(string); ok && metadataType == "abstract" {
+				return nil
+			}
+		}
+
+		// Skip disabled components
+		if metadataSection, ok := componentSection[cfg.MetadataSectionName].(map[string]any); ok {
+			if !isComponentEnabled(metadataSection, componentName) {
+				return nil
+			}
+		}
+
+		fromID := fmt.Sprintf("%s-%s", componentName, stackName)
+
+		// Check for dependencies in settings.depends_on
+		if settingsSection, ok := componentSection[cfg.SettingsSectionName].(map[string]any); ok {
+			if dependsOn, ok := settingsSection["depends_on"].([]any); ok {
+				for _, dep := range dependsOn {
+					if depMap, ok := dep.(map[string]any); ok {
+						if depComponent, ok := depMap["component"].(string); ok {
+							// Default to same stack if not specified
+							depStack := stackName
+							if depStackVal, ok := depMap["stack"].(string); ok {
+								depStack = depStackVal
+							}
+
+							toID := fmt.Sprintf("%s-%s", depComponent, depStack)
+
+							// Only add dependency if the target node exists
+							if _, exists := nodeMap[toID]; exists {
+								if err := builder.AddDependency(fromID, toID); err != nil {
+									log.Warn("Failed to add dependency", "from", fromID, "to", toID, "error", err)
+								}
+							} else {
+								log.Warn("Dependency target not found", "from", fromID, "to", toID)
+							}
+						}
+					} else if depMap, ok := dep.(map[any]any); ok {
+						// Handle map[any]any case
+						if depComponent, ok := depMap["component"].(string); ok {
+							depStack := stackName
+							if depStackVal, ok := depMap["stack"].(string); ok {
+								depStack = depStackVal
+							}
+
+							toID := fmt.Sprintf("%s-%s", depComponent, depStack)
+
+							if _, exists := nodeMap[toID]; exists {
+								if err := builder.AddDependency(fromID, toID); err != nil {
+									log.Warn("Failed to add dependency", "from", fromID, "to", toID, "error", err)
+								}
+							} else {
+								log.Warn("Dependency target not found", "from", fromID, "to", toID)
+							}
+						}
+					}
+				}
+			} else if dependsOn, ok := settingsSection["depends_on"].(map[string]any); ok {
+				// Handle map format: depends_on: { "1": { component: "vpc" } }
+				for _, dep := range dependsOn {
+					if depMap, ok := dep.(map[string]any); ok {
+						if depComponent, ok := depMap["component"].(string); ok {
+							depStack := stackName
+							if depStackVal, ok := depMap["stack"].(string); ok {
+								depStack = depStackVal
+							}
+
+							toID := fmt.Sprintf("%s-%s", depComponent, depStack)
+
+							if _, exists := nodeMap[toID]; exists {
+								if err := builder.AddDependency(fromID, toID); err != nil {
+									log.Warn("Failed to add dependency", "from", fromID, "to", toID, "error", err)
+								}
+							} else {
+								log.Warn("Dependency target not found", "from", fromID, "to", toID)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error building dependencies: %w", err)
+	}
+
+	// Build the final graph
+	graph, err := builder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("error finalizing dependency graph: %w", err)
+	}
+
+	log.Debug("Dependency graph built", "nodes", graph.Size(), "roots", len(graph.Roots))
+	return graph, nil
+}
+
+// applyFiltersToGraph applies query and component filters to the graph.
+func applyFiltersToGraph(graph *dependency.Graph, stacks map[string]any, info *schema.ConfigAndStacksInfo) *dependency.Graph {
+	nodeIDs := []string{}
+
+	// If specific components are specified, filter to those
+	if len(info.Components) > 0 {
+		for _, node := range graph.Nodes {
+			for _, comp := range info.Components {
+				if node.Component == comp {
+					if info.Stack == "" || node.Stack == info.Stack {
+						nodeIDs = append(nodeIDs, node.ID)
+					}
+				}
+			}
+		}
+	} else if info.Stack != "" {
+		// Filter to specific stack
+		for _, node := range graph.Nodes {
+			if node.Stack == info.Stack {
+				nodeIDs = append(nodeIDs, node.ID)
+			}
+		}
+	}
+
+	// Apply YQ query if specified
+	if info.Query != "" {
+		filteredNodeIDs := []string{}
+		for _, nodeID := range nodeIDs {
+			node := graph.Nodes[nodeID]
+			if node.Metadata != nil {
+				queryResult, err := u.EvaluateYqExpression(&schema.AtmosConfiguration{}, node.Metadata, info.Query)
+				if err == nil {
+					if queryPassed, ok := queryResult.(bool); ok && queryPassed {
+						filteredNodeIDs = append(filteredNodeIDs, nodeID)
+					}
+				}
+			}
+		}
+		nodeIDs = filteredNodeIDs
+	}
+
+	// If no specific filters, include all
+	if len(info.Components) == 0 && info.Stack == "" && info.Query == "" {
+		for id := range graph.Nodes {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+
+	// Filter the graph
+	return graph.Filter(dependency.Filter{
+		NodeIDs:             nodeIDs,
+		IncludeDependencies: true,  // Include what these components depend on
+		IncludeDependents:   false, // Don't include what depends on these
+	})
+}

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -1,0 +1,241 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+func TestBuildTerraformDependencyGraph(t *testing.T) {
+	// Test building dependency graph from stacks
+	stacks := map[string]any{
+		"dev": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"vars": map[string]any{
+							"cidr": "10.0.0.0/16",
+						},
+					},
+					"database": map[string]any{
+						"vars": map[string]any{
+							"engine": "postgres",
+						},
+						"settings": map[string]any{
+							"depends_on": []any{
+								map[string]any{
+									"component": "vpc",
+								},
+							},
+						},
+					},
+					"app": map[string]any{
+						"vars": map[string]any{
+							"replicas": 3,
+						},
+						"settings": map[string]any{
+							"depends_on": []any{
+								map[string]any{
+									"component": "database",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := &schema.ConfigAndStacksInfo{}
+
+	graph, err := buildTerraformDependencyGraph(atmosConfig, stacks, info)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, graph)
+	assert.Equal(t, 3, graph.Size())
+
+	// Verify nodes exist
+	vpcNode, exists := graph.GetNode("vpc-dev")
+	assert.True(t, exists)
+	assert.Equal(t, "vpc", vpcNode.Component)
+	assert.Equal(t, "dev", vpcNode.Stack)
+
+	dbNode, exists := graph.GetNode("database-dev")
+	assert.True(t, exists)
+	assert.Equal(t, "database", dbNode.Component)
+	assert.Equal(t, 1, len(dbNode.Dependencies))
+
+	appNode, exists := graph.GetNode("app-dev")
+	assert.True(t, exists)
+	assert.Equal(t, "app", appNode.Component)
+	assert.Equal(t, 1, len(appNode.Dependencies))
+
+	// Verify execution order
+	order, err := graph.TopologicalSort()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(order))
+	assert.Equal(t, "vpc", order[0].Component)
+	assert.Equal(t, "database", order[1].Component)
+	assert.Equal(t, "app", order[2].Component)
+}
+
+func TestBuildTerraformDependencyGraph_WithAbstractComponents(t *testing.T) {
+	// Test that abstract components are filtered out
+	stacks := map[string]any{
+		"dev": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"base": map[string]any{
+						"metadata": map[string]any{
+							"type": "abstract",
+						},
+						"vars": map[string]any{
+							"common": "value",
+						},
+					},
+					"real": map[string]any{
+						"metadata": map[string]any{
+							"component": "mock",
+						},
+						"vars": map[string]any{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := &schema.ConfigAndStacksInfo{}
+
+	graph, err := buildTerraformDependencyGraph(atmosConfig, stacks, info)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, graph)
+	assert.Equal(t, 1, graph.Size()) // Only "real" component
+
+	_, exists := graph.GetNode("base-dev")
+	assert.False(t, exists) // Abstract component not in graph
+
+	realNode, exists := graph.GetNode("real-dev")
+	assert.True(t, exists)
+	assert.Equal(t, "real", realNode.Component)
+}
+
+func TestBuildTerraformDependencyGraph_WithDisabledComponents(t *testing.T) {
+	// Test that disabled components are filtered out
+	stacks := map[string]any{
+		"dev": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"disabled": map[string]any{
+						"metadata": map[string]any{
+							"enabled": false,
+						},
+						"vars": map[string]any{
+							"foo": "bar",
+						},
+					},
+					"enabled": map[string]any{
+						"metadata": map[string]any{
+							"enabled": true,
+						},
+						"vars": map[string]any{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := &schema.ConfigAndStacksInfo{}
+
+	graph, err := buildTerraformDependencyGraph(atmosConfig, stacks, info)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, graph)
+	assert.Equal(t, 1, graph.Size()) // Only "enabled" component
+
+	_, exists := graph.GetNode("disabled-dev")
+	assert.False(t, exists) // Disabled component not in graph
+
+	enabledNode, exists := graph.GetNode("enabled-dev")
+	assert.True(t, exists)
+	assert.Equal(t, "enabled", enabledNode.Component)
+}
+
+func TestApplyFiltersToGraph(t *testing.T) {
+	// Create a test graph
+	graph := dependency.NewGraph()
+
+	node1 := &dependency.Node{
+		ID:        "vpc-dev",
+		Component: "vpc",
+		Stack:     "dev",
+		Type:      config.TerraformComponentType,
+	}
+	node2 := &dependency.Node{
+		ID:        "database-dev",
+		Component: "database",
+		Stack:     "dev",
+		Type:      config.TerraformComponentType,
+	}
+	node3 := &dependency.Node{
+		ID:        "app-prod",
+		Component: "app",
+		Stack:     "prod",
+		Type:      config.TerraformComponentType,
+	}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+	_ = graph.AddDependency("database-dev", "vpc-dev")
+
+	t.Run("filter by stack", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{
+			Stack: "dev",
+		}
+
+		filtered := applyFiltersToGraph(graph, nil, info)
+		assert.Equal(t, 2, filtered.Size()) // Only dev stack components
+
+		_, exists := filtered.GetNode("vpc-dev")
+		assert.True(t, exists)
+		_, exists = filtered.GetNode("database-dev")
+		assert.True(t, exists)
+		_, exists = filtered.GetNode("app-prod")
+		assert.False(t, exists) // prod stack component filtered out
+	})
+
+	t.Run("filter by components", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{
+			Components: []string{"vpc", "database"},
+		}
+
+		filtered := applyFiltersToGraph(graph, nil, info)
+		assert.Equal(t, 2, filtered.Size())
+
+		_, exists := filtered.GetNode("vpc-dev")
+		assert.True(t, exists)
+		_, exists = filtered.GetNode("database-dev")
+		assert.True(t, exists)
+		_, exists = filtered.GetNode("app-prod")
+		assert.False(t, exists) // app component filtered out
+	})
+
+	t.Run("no filters", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{}
+
+		filtered := applyFiltersToGraph(graph, nil, info)
+		assert.Equal(t, 3, filtered.Size()) // All components included
+	})
+}

--- a/internal/exec/terraform_executor.go
+++ b/internal/exec/terraform_executor.go
@@ -1,0 +1,83 @@
+package exec
+
+import (
+	"fmt"
+
+	log "github.com/charmbracelet/log"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
+)
+
+// executeTerraformForNode executes terraform for a single dependency graph node.
+func executeTerraformForNode(
+	node dependency.Node,
+	info *schema.ConfigAndStacksInfo,
+) error {
+	// Skip abstract components (double check even though they shouldn't be in the graph)
+	if metadata, ok := node.Metadata[cfg.MetadataSectionName].(map[string]any); ok {
+		if metadataType, ok := metadata["type"].(string); ok && metadataType == "abstract" {
+			log.Debug("Skipping abstract component", "component", node.Component, "stack", node.Stack)
+			return nil
+		}
+
+		// Skip disabled components
+		if !isNodeComponentEnabled(metadata, node.Component) {
+			log.Debug("Skipping disabled component", "component", node.Component, "stack", node.Stack)
+			return nil
+		}
+	}
+
+	// Set component and stack information
+	info.Component = node.Component
+	info.ComponentFromArg = node.Component
+	info.Stack = node.Stack
+	info.StackFromArg = node.Stack
+
+	command := fmt.Sprintf("atmos terraform %s %s -s %s", info.SubCommand, node.Component, node.Stack)
+
+	// Apply query filter if specified
+	if info.Query != "" && node.Metadata != nil {
+		atmosConfig, err := cfg.InitCliConfig(*info, true)
+		if err != nil {
+			return fmt.Errorf("error initializing CLI config: %w", err)
+		}
+
+		queryResult, err := u.EvaluateYqExpression(&atmosConfig, node.Metadata, info.Query)
+		if err != nil {
+			return fmt.Errorf("error evaluating query expression: %w", err)
+		}
+
+		if queryPassed, ok := queryResult.(bool); !ok || !queryPassed {
+			log.Debug("Skipping component due to query criteria", "command", command, "query", info.Query)
+			return nil
+		}
+	}
+
+	if info.DryRun {
+		log.Info("Would execute", "command", command)
+		return nil
+	}
+
+	log.Debug("Executing", "command", command)
+
+	// Execute the terraform command
+	if err := ExecuteTerraform(*info); err != nil {
+		return fmt.Errorf("terraform execution failed: %w", err)
+	}
+
+	return nil
+}
+
+// isNodeComponentEnabled checks if a component is enabled based on metadata.
+func isNodeComponentEnabled(metadata map[string]any, componentName string) bool {
+	// Check if explicitly disabled
+	if enabled, ok := metadata["enabled"].(bool); ok && !enabled {
+		return false
+	}
+
+	// Component is enabled by default
+	return true
+}

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -178,6 +178,7 @@ func isWorkspacesEnabled(atmosConfig *schema.AtmosConfiguration, info *schema.Co
 }
 
 // ExecuteTerraformAffected executes `atmos terraform <command> --affected`.
+// Deprecated: Use ExecuteTerraformAffectedWithGraph instead, which uses the generalized dependency graph.
 func ExecuteTerraformAffected(args *DescribeAffectedCmdArgs, info *schema.ConfigAndStacksInfo) error {
 	var affectedList []schema.Affected
 	var err error

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -88,7 +88,7 @@ func TestIsWorkspacesEnabled(t *testing.T) {
 	}
 }
 
-func TestExecuteTerraformAffectedWithDependents(t *testing.T) {
+func TestExecuteTerraformAffectedWithGraphAndDependents(t *testing.T) {
 	// Check for valid Git remote URL before running test
 	tests.RequireGitRemoteWithValidURL(t)
 
@@ -140,9 +140,9 @@ func TestExecuteTerraformAffectedWithDependents(t *testing.T) {
 		CloneTargetRef:    true,
 	}
 
-	err = ExecuteTerraformAffected(&a, &info)
+	err = ExecuteTerraformAffectedWithGraph(&a, &info)
 	if err != nil {
-		t.Fatalf("Failed to execute 'ExecuteTerraformAffected': %v", err)
+		t.Fatalf("Failed to execute 'ExecuteTerraformAffectedWithGraph': %v", err)
 	}
 
 	w.Close()

--- a/pkg/dependency/builder.go
+++ b/pkg/dependency/builder.go
@@ -1,0 +1,74 @@
+package dependency
+
+import (
+	"fmt"
+)
+
+// GraphBuilder implements the Builder interface for constructing dependency graphs.
+type GraphBuilder struct {
+	graph *Graph
+	// Track if build has been called to prevent modifications after build
+	built bool
+}
+
+// NewBuilder creates a new graph builder.
+func NewBuilder() *GraphBuilder {
+	return &GraphBuilder{
+		graph: NewGraph(),
+		built: false,
+	}
+}
+
+// AddNode adds a node to the graph being built.
+func (b *GraphBuilder) AddNode(node *Node) error {
+	if b.built {
+		return fmt.Errorf("cannot add node after graph has been built")
+	}
+
+	return b.graph.AddNode(node)
+}
+
+// AddDependency creates a dependency relationship between two nodes.
+// fromID depends on toID (fromID -> toID).
+func (b *GraphBuilder) AddDependency(fromID, toID string) error {
+	if b.built {
+		return fmt.Errorf("cannot add dependency after graph has been built")
+	}
+
+	return b.graph.AddDependency(fromID, toID)
+}
+
+// Build finalizes the graph construction and returns the built graph.
+func (b *GraphBuilder) Build() (*Graph, error) {
+	if b.built {
+		return nil, fmt.Errorf("graph has already been built")
+	}
+
+	// Validate the graph for cycles
+	if hasCycle, cyclePath := b.graph.HasCycles(); hasCycle {
+		return nil, fmt.Errorf("circular dependency detected: %v", cyclePath)
+	}
+
+	// Identify root nodes
+	b.graph.IdentifyRoots()
+
+	// Check if we have at least one root node (unless the graph is empty)
+	if len(b.graph.Nodes) > 0 && len(b.graph.Roots) == 0 {
+		return nil, fmt.Errorf("no root nodes found - possible circular dependency involving all nodes")
+	}
+
+	b.built = true
+	return b.graph, nil
+}
+
+// GetGraph returns the current state of the graph (for debugging purposes).
+// Note: This should not be used in production code; use Build() instead.
+func (b *GraphBuilder) GetGraph() *Graph {
+	return b.graph
+}
+
+// Reset resets the builder to start building a new graph.
+func (b *GraphBuilder) Reset() {
+	b.graph = NewGraph()
+	b.built = false
+}

--- a/pkg/dependency/filter.go
+++ b/pkg/dependency/filter.go
@@ -1,0 +1,220 @@
+package dependency
+
+// Filter creates a new graph containing only the specified nodes and their relationships.
+func (g *Graph) Filter(filter Filter) *Graph {
+	filtered := NewGraph()
+	toInclude := make(map[string]bool)
+
+	// Mark nodes to include based on filter
+	for _, id := range filter.NodeIDs {
+		if _, exists := g.Nodes[id]; exists {
+			toInclude[id] = true
+
+			// Include dependencies if requested
+			if filter.IncludeDependencies {
+				g.markDependencies(id, toInclude)
+			}
+
+			// Include dependents if requested
+			if filter.IncludeDependents {
+				g.markDependents(id, toInclude)
+			}
+		}
+	}
+
+	// Copy included nodes to the filtered graph
+	for id := range toInclude {
+		if node, exists := g.Nodes[id]; exists {
+			// Create a new node with the same data
+			newNode := &Node{
+				ID:           node.ID,
+				Component:    node.Component,
+				Stack:        node.Stack,
+				Type:         node.Type,
+				Dependencies: []string{},
+				Dependents:   []string{},
+				Metadata:     node.Metadata,
+				Processed:    node.Processed,
+			}
+
+			// Only include dependencies/dependents that are also in the filtered set
+			for _, depID := range node.Dependencies {
+				if toInclude[depID] {
+					newNode.Dependencies = append(newNode.Dependencies, depID)
+				}
+			}
+
+			for _, depID := range node.Dependents {
+				if toInclude[depID] {
+					newNode.Dependents = append(newNode.Dependents, depID)
+				}
+			}
+
+			filtered.Nodes[id] = newNode
+		}
+	}
+
+	// Identify roots in the filtered graph
+	filtered.IdentifyRoots()
+
+	return filtered
+}
+
+// FilterByType creates a new graph containing only nodes of the specified type.
+func (g *Graph) FilterByType(nodeType string) *Graph {
+	nodeIDs := []string{}
+	for id, node := range g.Nodes {
+		if node.Type == nodeType {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+
+	return g.Filter(Filter{
+		NodeIDs:             nodeIDs,
+		IncludeDependencies: true,
+		IncludeDependents:   false,
+	})
+}
+
+// FilterByStack creates a new graph containing only nodes from the specified stack.
+func (g *Graph) FilterByStack(stack string) *Graph {
+	nodeIDs := []string{}
+	for id, node := range g.Nodes {
+		if node.Stack == stack {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+
+	return g.Filter(Filter{
+		NodeIDs:             nodeIDs,
+		IncludeDependencies: true,
+		IncludeDependents:   false,
+	})
+}
+
+// FilterByComponent creates a new graph containing only nodes with the specified component name.
+func (g *Graph) FilterByComponent(component string) *Graph {
+	nodeIDs := []string{}
+	for id, node := range g.Nodes {
+		if node.Component == component {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+
+	return g.Filter(Filter{
+		NodeIDs:             nodeIDs,
+		IncludeDependencies: true,
+		IncludeDependents:   true,
+	})
+}
+
+// markDependencies recursively marks all dependencies of a node for inclusion.
+func (g *Graph) markDependencies(nodeID string, toInclude map[string]bool) {
+	node, exists := g.Nodes[nodeID]
+	if !exists {
+		return
+	}
+
+	for _, depID := range node.Dependencies {
+		if !toInclude[depID] {
+			toInclude[depID] = true
+			g.markDependencies(depID, toInclude)
+		}
+	}
+}
+
+// markDependents recursively marks all dependents of a node for inclusion.
+func (g *Graph) markDependents(nodeID string, toInclude map[string]bool) {
+	node, exists := g.Nodes[nodeID]
+	if !exists {
+		return
+	}
+
+	for _, depID := range node.Dependents {
+		if !toInclude[depID] {
+			toInclude[depID] = true
+			g.markDependents(depID, toInclude)
+		}
+	}
+}
+
+// GetConnectedComponents returns all connected components in the graph.
+// Each connected component is a subgraph where all nodes are reachable from each other.
+func (g *Graph) GetConnectedComponents() []*Graph {
+	visited := make(map[string]bool)
+	components := []*Graph{}
+
+	// DFS to find all nodes in a connected component
+	var dfs func(nodeID string, component *Graph)
+	dfs = func(nodeID string, component *Graph) {
+		if visited[nodeID] {
+			return
+		}
+		visited[nodeID] = true
+
+		node := g.Nodes[nodeID]
+		component.Nodes[nodeID] = node
+
+		// Visit all connected nodes (both dependencies and dependents)
+		for _, depID := range node.Dependencies {
+			dfs(depID, component)
+		}
+		for _, depID := range node.Dependents {
+			dfs(depID, component)
+		}
+	}
+
+	// Find all connected components
+	for id := range g.Nodes {
+		if !visited[id] {
+			component := NewGraph()
+			dfs(id, component)
+			component.IdentifyRoots()
+			components = append(components, component)
+		}
+	}
+
+	return components
+}
+
+// RemoveNode removes a node and all its relationships from the graph.
+func (g *Graph) RemoveNode(nodeID string) error {
+	node, exists := g.Nodes[nodeID]
+	if !exists {
+		return nil // Node doesn't exist, nothing to remove
+	}
+
+	// Remove this node from its dependencies' dependents lists
+	for _, depID := range node.Dependencies {
+		if depNode, exists := g.Nodes[depID]; exists {
+			newDependents := []string{}
+			for _, dependent := range depNode.Dependents {
+				if dependent != nodeID {
+					newDependents = append(newDependents, dependent)
+				}
+			}
+			depNode.Dependents = newDependents
+		}
+	}
+
+	// Remove this node from its dependents' dependencies lists
+	for _, depID := range node.Dependents {
+		if depNode, exists := g.Nodes[depID]; exists {
+			newDependencies := []string{}
+			for _, dependency := range depNode.Dependencies {
+				if dependency != nodeID {
+					newDependencies = append(newDependencies, dependency)
+				}
+			}
+			depNode.Dependencies = newDependencies
+		}
+	}
+
+	// Remove the node from the graph
+	delete(g.Nodes, nodeID)
+
+	// Update roots
+	g.IdentifyRoots()
+
+	return nil
+}

--- a/pkg/dependency/graph.go
+++ b/pkg/dependency/graph.go
@@ -1,0 +1,176 @@
+package dependency
+
+import (
+	"fmt"
+)
+
+// NewGraph creates a new dependency graph.
+func NewGraph() *Graph {
+	return &Graph{
+		Nodes: make(map[string]*Node),
+		Roots: []string{},
+	}
+}
+
+// AddNode adds a node to the graph.
+func (g *Graph) AddNode(node *Node) error {
+	if node == nil {
+		return fmt.Errorf("cannot add nil node to graph")
+	}
+
+	if node.ID == "" {
+		return fmt.Errorf("node ID cannot be empty")
+	}
+
+	if _, exists := g.Nodes[node.ID]; exists {
+		return fmt.Errorf("node %s already exists in graph", node.ID)
+	}
+
+	// Initialize slices if nil
+	if node.Dependencies == nil {
+		node.Dependencies = []string{}
+	}
+	if node.Dependents == nil {
+		node.Dependents = []string{}
+	}
+
+	g.Nodes[node.ID] = node
+	return nil
+}
+
+// AddDependency creates a dependency relationship between two nodes.
+// fromID depends on toID (fromID -> toID).
+func (g *Graph) AddDependency(fromID, toID string) error {
+	if fromID == "" || toID == "" {
+		return fmt.Errorf("dependency IDs cannot be empty")
+	}
+
+	if fromID == toID {
+		return fmt.Errorf("node %s cannot depend on itself", fromID)
+	}
+
+	fromNode, fromExists := g.Nodes[fromID]
+	if !fromExists {
+		return fmt.Errorf("node %s does not exist in graph", fromID)
+	}
+
+	toNode, toExists := g.Nodes[toID]
+	if !toExists {
+		return fmt.Errorf("node %s does not exist in graph", toID)
+	}
+
+	// Check if dependency already exists
+	for _, dep := range fromNode.Dependencies {
+		if dep == toID {
+			return nil // Dependency already exists, skip
+		}
+	}
+
+	// Add the dependency relationship
+	fromNode.Dependencies = append(fromNode.Dependencies, toID)
+	toNode.Dependents = append(toNode.Dependents, fromID)
+
+	return nil
+}
+
+// IdentifyRoots finds all nodes with no dependencies.
+func (g *Graph) IdentifyRoots() {
+	g.Roots = []string{}
+
+	for id, node := range g.Nodes {
+		if len(node.Dependencies) == 0 {
+			g.Roots = append(g.Roots, id)
+		}
+	}
+}
+
+// GetNode retrieves a node by its ID.
+func (g *Graph) GetNode(id string) (*Node, bool) {
+	node, exists := g.Nodes[id]
+	return node, exists
+}
+
+// Size returns the number of nodes in the graph.
+func (g *Graph) Size() int {
+	return len(g.Nodes)
+}
+
+// HasCycles checks if the graph contains any cycles.
+func (g *Graph) HasCycles() (bool, []string) {
+	visited := make(map[string]bool)
+	recStack := make(map[string]bool)
+	var cyclePath []string
+
+	// Helper function for DFS
+	var dfs func(nodeID string) bool
+	dfs = func(nodeID string) bool {
+		visited[nodeID] = true
+		recStack[nodeID] = true
+
+		node := g.Nodes[nodeID]
+		for _, depID := range node.Dependencies {
+			if !visited[depID] {
+				if dfs(depID) {
+					cyclePath = append([]string{nodeID}, cyclePath...)
+					return true
+				}
+			} else if recStack[depID] {
+				// Cycle detected
+				cyclePath = []string{nodeID, depID}
+				return true
+			}
+		}
+
+		recStack[nodeID] = false
+		return false
+	}
+
+	// Check all unvisited nodes
+	for id := range g.Nodes {
+		if !visited[id] {
+			if dfs(id) {
+				return true, cyclePath
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// Reset clears the processed flag for all nodes.
+func (g *Graph) Reset() {
+	for _, node := range g.Nodes {
+		node.Processed = false
+	}
+}
+
+// Clone creates a deep copy of the graph.
+func (g *Graph) Clone() *Graph {
+	newGraph := NewGraph()
+
+	// Clone all nodes
+	for id, node := range g.Nodes {
+		newNode := &Node{
+			ID:           node.ID,
+			Component:    node.Component,
+			Stack:        node.Stack,
+			Type:         node.Type,
+			Dependencies: make([]string, len(node.Dependencies)),
+			Dependents:   make([]string, len(node.Dependents)),
+			Metadata:     node.Metadata, // Note: This is a shallow copy of the map
+			Processed:    node.Processed,
+		}
+
+		// Copy slices
+		copy(newNode.Dependencies, node.Dependencies)
+		copy(newNode.Dependents, node.Dependents)
+
+		newGraph.Nodes[id] = newNode
+	}
+
+	// Copy roots
+	newGraph.Roots = make([]string, len(g.Roots))
+	copy(newGraph.Roots, g.Roots)
+
+	return newGraph
+}

--- a/pkg/dependency/graph_test.go
+++ b/pkg/dependency/graph_test.go
@@ -1,0 +1,177 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGraph(t *testing.T) {
+	graph := NewGraph()
+
+	assert.NotNil(t, graph)
+	assert.NotNil(t, graph.Nodes)
+	assert.NotNil(t, graph.Roots)
+	assert.Equal(t, 0, len(graph.Nodes))
+	assert.Equal(t, 0, len(graph.Roots))
+}
+
+func TestGraph_AddNode(t *testing.T) {
+	graph := NewGraph()
+
+	// Test adding a valid node
+	node := &Node{
+		ID:        "test-node",
+		Component: "test",
+		Stack:     "dev",
+		Type:      "terraform",
+	}
+
+	err := graph.AddNode(node)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, graph.Size())
+	assert.NotNil(t, graph.Nodes["test-node"])
+
+	// Test adding nil node
+	err = graph.AddNode(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot add nil node")
+
+	// Test adding node with empty ID
+	emptyNode := &Node{Component: "test"}
+	err = graph.AddNode(emptyNode)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "node ID cannot be empty")
+
+	// Test adding duplicate node
+	err = graph.AddNode(node)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestGraph_AddDependency(t *testing.T) {
+	graph := NewGraph()
+
+	// Add two nodes
+	node1 := &Node{ID: "node1", Component: "comp1", Stack: "dev"}
+	node2 := &Node{ID: "node2", Component: "comp2", Stack: "dev"}
+
+	err := graph.AddNode(node1)
+	assert.NoError(t, err)
+	err = graph.AddNode(node2)
+	assert.NoError(t, err)
+
+	// Test adding valid dependency
+	err = graph.AddDependency("node1", "node2")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(node1.Dependencies))
+	assert.Equal(t, "node2", node1.Dependencies[0])
+	assert.Equal(t, 1, len(node2.Dependents))
+	assert.Equal(t, "node1", node2.Dependents[0])
+
+	// Test adding duplicate dependency (should be idempotent)
+	err = graph.AddDependency("node1", "node2")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(node1.Dependencies))
+
+	// Test adding self-dependency
+	err = graph.AddDependency("node1", "node1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot depend on itself")
+
+	// Test adding dependency with non-existent nodes
+	err = graph.AddDependency("node1", "non-existent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+
+	err = graph.AddDependency("non-existent", "node1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+
+	// Test empty IDs
+	err = graph.AddDependency("", "node1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IDs cannot be empty")
+}
+
+func TestGraph_IdentifyRoots(t *testing.T) {
+	graph := NewGraph()
+
+	// Add nodes with dependencies
+	node1 := &Node{ID: "node1", Component: "comp1", Stack: "dev"}
+	node2 := &Node{ID: "node2", Component: "comp2", Stack: "dev"}
+	node3 := &Node{ID: "node3", Component: "comp3", Stack: "dev"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+
+	// node2 depends on node1, node3 depends on node2
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node2")
+
+	graph.IdentifyRoots()
+
+	assert.Equal(t, 1, len(graph.Roots))
+	assert.Equal(t, "node1", graph.Roots[0])
+}
+
+func TestGraph_HasCycles(t *testing.T) {
+	// Test graph with no cycles
+	graph := NewGraph()
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+	node3 := &Node{ID: "node3"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node2")
+
+	hasCycle, cyclePath := graph.HasCycles()
+	assert.False(t, hasCycle)
+	assert.Nil(t, cyclePath)
+
+	// Test graph with direct cycle
+	_ = graph.AddDependency("node1", "node3")
+
+	hasCycle, cyclePath = graph.HasCycles()
+	assert.True(t, hasCycle)
+	assert.NotNil(t, cyclePath)
+}
+
+func TestGraph_Clone(t *testing.T) {
+	graph := NewGraph()
+
+	// Add nodes and dependencies
+	node1 := &Node{ID: "node1", Component: "comp1", Stack: "dev"}
+	node2 := &Node{ID: "node2", Component: "comp2", Stack: "dev"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddDependency("node2", "node1")
+	graph.IdentifyRoots()
+
+	// Clone the graph
+	cloned := graph.Clone()
+
+	// Verify the clone
+	assert.Equal(t, graph.Size(), cloned.Size())
+	assert.Equal(t, len(graph.Roots), len(cloned.Roots))
+
+	// Verify nodes are cloned
+	clonedNode1 := cloned.Nodes["node1"]
+	assert.NotNil(t, clonedNode1)
+	assert.Equal(t, node1.Component, clonedNode1.Component)
+
+	// Modify the clone and verify original is unchanged
+	clonedNode1.Component = "modified"
+	assert.NotEqual(t, node1.Component, clonedNode1.Component)
+
+	// Verify dependencies are cloned
+	clonedNode2 := cloned.Nodes["node2"]
+	assert.Equal(t, 1, len(clonedNode2.Dependencies))
+	assert.Equal(t, "node1", clonedNode2.Dependencies[0])
+}

--- a/pkg/dependency/sort.go
+++ b/pkg/dependency/sort.go
@@ -1,0 +1,184 @@
+package dependency
+
+import (
+	"fmt"
+)
+
+// TopologicalSort returns nodes in dependency order using Kahn's algorithm.
+// Nodes with no dependencies are processed first, followed by nodes that depend on them.
+func (g *Graph) TopologicalSort() (ExecutionOrder, error) {
+	// Create a copy of the graph to avoid modifying the original
+	workGraph := g.Clone()
+
+	// Calculate in-degrees for all nodes
+	inDegree := make(map[string]int)
+	for id, node := range workGraph.Nodes {
+		inDegree[id] = len(node.Dependencies)
+	}
+
+	// Initialize queue with nodes that have no dependencies
+	queue := []string{}
+	for id, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, id)
+		}
+	}
+
+	// Process nodes in topological order
+	result := ExecutionOrder{}
+	processedCount := 0
+
+	for len(queue) > 0 {
+		// Dequeue the first node
+		currentID := queue[0]
+		queue = queue[1:]
+
+		// Add to result
+		currentNode := workGraph.Nodes[currentID]
+		result = append(result, *currentNode)
+		processedCount++
+
+		// Process all dependents of the current node
+		for _, dependentID := range currentNode.Dependents {
+			inDegree[dependentID]--
+			if inDegree[dependentID] == 0 {
+				queue = append(queue, dependentID)
+			}
+		}
+	}
+
+	// Check if all nodes were processed
+	if processedCount != len(workGraph.Nodes) {
+		// Find nodes that weren't processed (involved in cycles)
+		unprocessed := []string{}
+		for id := range workGraph.Nodes {
+			if inDegree[id] > 0 {
+				unprocessed = append(unprocessed, id)
+			}
+		}
+		return nil, fmt.Errorf("circular dependency detected involving nodes: %v", unprocessed)
+	}
+
+	return result, nil
+}
+
+// ReverseTopologicalSort returns nodes in reverse dependency order.
+// Nodes that depend on others are processed first.
+func (g *Graph) ReverseTopologicalSort() (ExecutionOrder, error) {
+	order, err := g.TopologicalSort()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reverse the order
+	reversed := make(ExecutionOrder, len(order))
+	for i, node := range order {
+		reversed[len(order)-1-i] = node
+	}
+
+	return reversed, nil
+}
+
+// GetExecutionLevels returns nodes grouped by execution level.
+// Level 0 contains nodes with no dependencies, level 1 contains nodes that only depend on level 0, etc.
+func (g *Graph) GetExecutionLevels() ([][]Node, error) {
+	// Check for cycles first
+	if hasCycle, cyclePath := g.HasCycles(); hasCycle {
+		return nil, fmt.Errorf("circular dependency detected: %v", cyclePath)
+	}
+
+	levels := [][]Node{}
+	processed := make(map[string]bool)
+	nodeLevel := make(map[string]int)
+
+	// Calculate the level for each node
+	var calculateLevel func(nodeID string) int
+	calculateLevel = func(nodeID string) int {
+		if level, exists := nodeLevel[nodeID]; exists {
+			return level
+		}
+
+		node := g.Nodes[nodeID]
+		maxDepLevel := -1
+
+		for _, depID := range node.Dependencies {
+			depLevel := calculateLevel(depID)
+			if depLevel > maxDepLevel {
+				maxDepLevel = depLevel
+			}
+		}
+
+		level := maxDepLevel + 1
+		nodeLevel[nodeID] = level
+		return level
+	}
+
+	// Calculate levels for all nodes
+	maxLevel := -1
+	for id := range g.Nodes {
+		level := calculateLevel(id)
+		if level > maxLevel {
+			maxLevel = level
+		}
+	}
+
+	// Initialize levels slice
+	for i := 0; i <= maxLevel; i++ {
+		levels = append(levels, []Node{})
+	}
+
+	// Group nodes by level
+	for id, node := range g.Nodes {
+		level := nodeLevel[id]
+		levels[level] = append(levels[level], *node)
+		processed[id] = true
+	}
+
+	return levels, nil
+}
+
+// FindPath finds a path from one node to another if it exists.
+func (g *Graph) FindPath(fromID, toID string) ([]string, bool) {
+	if fromID == toID {
+		return []string{fromID}, true
+	}
+
+	visited := make(map[string]bool)
+	path := []string{}
+
+	var dfs func(currentID string) bool
+	dfs = func(currentID string) bool {
+		if visited[currentID] {
+			return false
+		}
+		visited[currentID] = true
+		path = append(path, currentID)
+
+		if currentID == toID {
+			return true
+		}
+
+		node := g.Nodes[currentID]
+		for _, depID := range node.Dependencies {
+			if dfs(depID) {
+				return true
+			}
+		}
+
+		// Backtrack
+		path = path[:len(path)-1]
+		return false
+	}
+
+	if dfs(fromID) {
+		return path, true
+	}
+
+	return nil, false
+}
+
+// IsReachable checks if one node is reachable from another.
+func (g *Graph) IsReachable(fromID, toID string) bool {
+	_, found := g.FindPath(fromID, toID)
+	return found
+}

--- a/pkg/dependency/sort_test.go
+++ b/pkg/dependency/sort_test.go
@@ -1,0 +1,254 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraph_TopologicalSort(t *testing.T) {
+	t.Run("simple linear dependency", func(t *testing.T) {
+		graph := NewGraph()
+
+		// Create a simple chain: node1 -> node2 -> node3
+		node1 := &Node{ID: "node1", Component: "comp1", Stack: "dev"}
+		node2 := &Node{ID: "node2", Component: "comp2", Stack: "dev"}
+		node3 := &Node{ID: "node3", Component: "comp3", Stack: "dev"}
+
+		_ = graph.AddNode(node1)
+		_ = graph.AddNode(node2)
+		_ = graph.AddNode(node3)
+
+		_ = graph.AddDependency("node2", "node1")
+		_ = graph.AddDependency("node3", "node2")
+
+		order, err := graph.TopologicalSort()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(order))
+		assert.Equal(t, "node1", order[0].ID)
+		assert.Equal(t, "node2", order[1].ID)
+		assert.Equal(t, "node3", order[2].ID)
+	})
+
+	t.Run("diamond dependency", func(t *testing.T) {
+		graph := NewGraph()
+
+		// Create a diamond: A -> B,C -> D
+		nodeA := &Node{ID: "A"}
+		nodeB := &Node{ID: "B"}
+		nodeC := &Node{ID: "C"}
+		nodeD := &Node{ID: "D"}
+
+		_ = graph.AddNode(nodeA)
+		_ = graph.AddNode(nodeB)
+		_ = graph.AddNode(nodeC)
+		_ = graph.AddNode(nodeD)
+
+		_ = graph.AddDependency("B", "A")
+		_ = graph.AddDependency("C", "A")
+		_ = graph.AddDependency("D", "B")
+		_ = graph.AddDependency("D", "C")
+
+		order, err := graph.TopologicalSort()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 4, len(order))
+		assert.Equal(t, "A", order[0].ID)
+		// B and C can be in any order, but both must come before D
+		assert.Contains(t, []string{"B", "C"}, order[1].ID)
+		assert.Contains(t, []string{"B", "C"}, order[2].ID)
+		assert.Equal(t, "D", order[3].ID)
+	})
+
+	t.Run("multiple roots", func(t *testing.T) {
+		graph := NewGraph()
+
+		// Multiple independent chains
+		node1 := &Node{ID: "node1"}
+		node2 := &Node{ID: "node2"}
+		node3 := &Node{ID: "node3"}
+		node4 := &Node{ID: "node4"}
+
+		_ = graph.AddNode(node1)
+		_ = graph.AddNode(node2)
+		_ = graph.AddNode(node3)
+		_ = graph.AddNode(node4)
+
+		_ = graph.AddDependency("node2", "node1")
+		_ = graph.AddDependency("node4", "node3")
+
+		order, err := graph.TopologicalSort()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 4, len(order))
+
+		// Create a map to check positions
+		positions := make(map[string]int)
+		for i, node := range order {
+			positions[node.ID] = i
+		}
+
+		// node1 must come before node2
+		assert.Less(t, positions["node1"], positions["node2"])
+		// node3 must come before node4
+		assert.Less(t, positions["node3"], positions["node4"])
+	})
+
+	t.Run("circular dependency", func(t *testing.T) {
+		graph := NewGraph()
+
+		node1 := &Node{ID: "node1"}
+		node2 := &Node{ID: "node2"}
+		node3 := &Node{ID: "node3"}
+
+		_ = graph.AddNode(node1)
+		_ = graph.AddNode(node2)
+		_ = graph.AddNode(node3)
+
+		_ = graph.AddDependency("node1", "node2")
+		_ = graph.AddDependency("node2", "node3")
+		_ = graph.AddDependency("node3", "node1") // Creates cycle
+
+		order, err := graph.TopologicalSort()
+
+		assert.Error(t, err)
+		assert.Nil(t, order)
+		assert.Contains(t, err.Error(), "circular dependency")
+	})
+
+	t.Run("empty graph", func(t *testing.T) {
+		graph := NewGraph()
+
+		order, err := graph.TopologicalSort()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(order))
+	})
+}
+
+func TestGraph_ReverseTopologicalSort(t *testing.T) {
+	graph := NewGraph()
+
+	// Create a simple chain: node1 -> node2 -> node3
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+	node3 := &Node{ID: "node3"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node2")
+
+	order, err := graph.ReverseTopologicalSort()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(order))
+	assert.Equal(t, "node3", order[0].ID)
+	assert.Equal(t, "node2", order[1].ID)
+	assert.Equal(t, "node1", order[2].ID)
+}
+
+func TestGraph_GetExecutionLevels(t *testing.T) {
+	graph := NewGraph()
+
+	// Create a complex graph with multiple levels
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+	node3 := &Node{ID: "node3"}
+	node4 := &Node{ID: "node4"}
+	node5 := &Node{ID: "node5"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+	_ = graph.AddNode(node4)
+	_ = graph.AddNode(node5)
+
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node1")
+	_ = graph.AddDependency("node4", "node2")
+	_ = graph.AddDependency("node4", "node3")
+	_ = graph.AddDependency("node5", "node4")
+
+	levels, err := graph.GetExecutionLevels()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(levels))
+
+	// Level 0: node1
+	assert.Equal(t, 1, len(levels[0]))
+	assert.Equal(t, "node1", levels[0][0].ID)
+
+	// Level 1: node2, node3
+	assert.Equal(t, 2, len(levels[1]))
+	nodeIDs := []string{levels[1][0].ID, levels[1][1].ID}
+	assert.Contains(t, nodeIDs, "node2")
+	assert.Contains(t, nodeIDs, "node3")
+
+	// Level 2: node4
+	assert.Equal(t, 1, len(levels[2]))
+	assert.Equal(t, "node4", levels[2][0].ID)
+
+	// Level 3: node5
+	assert.Equal(t, 1, len(levels[3]))
+	assert.Equal(t, "node5", levels[3][0].ID)
+}
+
+func TestGraph_FindPath(t *testing.T) {
+	graph := NewGraph()
+
+	// Create a graph: node1 -> node2 -> node3
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+	node3 := &Node{ID: "node3"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node2")
+
+	// Test finding existing path
+	path, found := graph.FindPath("node3", "node1")
+	assert.True(t, found)
+	assert.Equal(t, 3, len(path))
+	assert.Equal(t, "node3", path[0])
+	assert.Equal(t, "node2", path[1])
+	assert.Equal(t, "node1", path[2])
+
+	// Test no path exists
+	path, found = graph.FindPath("node1", "node3")
+	assert.False(t, found)
+	assert.Nil(t, path)
+
+	// Test same node
+	path, found = graph.FindPath("node1", "node1")
+	assert.True(t, found)
+	assert.Equal(t, 1, len(path))
+	assert.Equal(t, "node1", path[0])
+}
+
+func TestGraph_IsReachable(t *testing.T) {
+	graph := NewGraph()
+
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+	node3 := &Node{ID: "node3"}
+
+	_ = graph.AddNode(node1)
+	_ = graph.AddNode(node2)
+	_ = graph.AddNode(node3)
+
+	_ = graph.AddDependency("node2", "node1")
+	_ = graph.AddDependency("node3", "node2")
+
+	// Test reachability
+	assert.True(t, graph.IsReachable("node3", "node1"))
+	assert.True(t, graph.IsReachable("node2", "node1"))
+	assert.False(t, graph.IsReachable("node1", "node3"))
+	assert.True(t, graph.IsReachable("node1", "node1"))
+}

--- a/pkg/dependency/types.go
+++ b/pkg/dependency/types.go
@@ -1,0 +1,64 @@
+package dependency
+
+// Node represents a component in the dependency graph.
+type Node struct {
+	// ID is the unique identifier for the node (typically component-stack).
+	ID string
+
+	// Component is the name of the component.
+	Component string
+
+	// Stack is the stack name where this component is defined.
+	Stack string
+
+	// Type indicates the component type (e.g., "terraform", "helmfile").
+	Type string
+
+	// Dependencies contains IDs of nodes that this node depends on.
+	Dependencies []string
+
+	// Dependents contains IDs of nodes that depend on this node.
+	Dependents []string
+
+	// Metadata stores additional component-specific data.
+	Metadata map[string]any
+
+	// Processed indicates whether this node has been processed during traversal.
+	Processed bool
+}
+
+// Graph represents a dependency graph of components.
+type Graph struct {
+	// Nodes maps node IDs to their corresponding Node structures.
+	Nodes map[string]*Node
+
+	// Roots contains IDs of nodes with no dependencies (entry points).
+	Roots []string
+}
+
+// Builder defines the interface for constructing dependency graphs.
+type Builder interface {
+	// AddNode adds a node to the graph being built.
+	AddNode(node *Node) error
+
+	// AddDependency creates a dependency relationship between two nodes.
+	AddDependency(fromID, toID string) error
+
+	// Build finalizes the graph construction and returns the built graph.
+	Build() (*Graph, error)
+}
+
+// ExecutionOrder represents a slice of nodes in dependency order.
+type ExecutionOrder []Node
+
+// Filter defines options for filtering a dependency graph.
+type Filter struct {
+	// NodeIDs specifies which nodes to include.
+	NodeIDs []string
+
+	// IncludeDependencies indicates whether to include all dependencies of filtered nodes.
+	IncludeDependencies bool
+
+	// IncludeDependents indicates whether to include all dependents of filtered nodes.
+	IncludeDependents bool
+}

--- a/tests/fixtures/scenarios/terraform-apply-all-dependencies/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-apply-all-dependencies/atmos.yaml
@@ -1,0 +1,18 @@
+base_path: "."
+
+components:
+  terraform:
+    base_path: "../../../test-cases/terraform"
+    apply_auto_approve: false
+    deploy_run_init: false
+    init_run_reconfigure: false
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/*.yaml"
+  name_pattern: "{stage}"
+
+logs:
+  level: Debug

--- a/tests/fixtures/scenarios/terraform-apply-all-dependencies/stacks/deploy/dev.yaml
+++ b/tests/fixtures/scenarios/terraform-apply-all-dependencies/stacks/deploy/dev.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+vars:
+  stage: dev
+
+components:
+  terraform:
+    # Test 'terraform apply --all' with dependencies
+    # Expected execution order: vpc -> database -> cache -> application
+
+    vpc:
+      metadata:
+        component: mock
+      vars:
+        cidr: "10.0.0.0/16"
+        name: "dev-vpc"
+        tags:
+          environment: dev
+          layer: network
+
+    database:
+      metadata:
+        component: mock
+      vars:
+        instance_class: "db.t3.medium"
+        engine: "postgres"
+        tags:
+          environment: dev
+          layer: data
+      settings:
+        depends_on:
+          - component: vpc
+
+    cache:
+      metadata:
+        component: mock
+      vars:
+        node_type: "cache.t3.micro"
+        engine: "redis"
+        tags:
+          environment: dev
+          layer: data
+      settings:
+        depends_on:
+          - component: vpc
+
+    application:
+      metadata:
+        component: mock
+      vars:
+        instance_type: "t3.small"
+        desired_count: 2
+        tags:
+          environment: dev
+          layer: application
+      settings:
+        depends_on:
+          - component: database
+          - component: cache

--- a/tests/fixtures/scenarios/terraform-apply-all-dependencies/stacks/deploy/prod.yaml
+++ b/tests/fixtures/scenarios/terraform-apply-all-dependencies/stacks/deploy/prod.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+vars:
+  stage: prod
+
+components:
+  terraform:
+    # Test cross-stack dependencies with 'terraform apply --all'
+    # Expected execution order: shared-vpc, monitoring -> prod components
+
+    shared-vpc:
+      metadata:
+        component: mock
+      vars:
+        cidr: "10.100.0.0/16"
+        name: "shared-vpc"
+        tags:
+          environment: prod
+          layer: network
+          shared: true
+
+    monitoring:
+      metadata:
+        component: mock
+      vars:
+        retention_days: 90
+        tags:
+          environment: prod
+          layer: observability
+
+    prod-database:
+      metadata:
+        component: mock
+      vars:
+        instance_class: "db.r5.xlarge"
+        engine: "postgres"
+        multi_az: true
+        tags:
+          environment: prod
+          layer: data
+      settings:
+        depends_on:
+          - component: shared-vpc
+          - component: monitoring
+
+    prod-application:
+      metadata:
+        component: mock
+      vars:
+        instance_type: "c5.large"
+        desired_count: 10
+        tags:
+          environment: prod
+          layer: application
+      settings:
+        depends_on:
+          - component: prod-database


### PR DESCRIPTION
## what
- Implement dependency-ordered execution for `atmos terraform apply --all` command
- Create a reusable dependency graph package that both `--all` and `--affected` flags can use
- Ensure Terraform components are always processed in the correct order based on their dependencies

## why
- The `--all` flag was processing components without respecting dependency order, which could lead to deployment failures
- The dependency logic was tightly coupled with the `--affected` functionality and needed to be generalized
- Users need a reliable way to deploy all components while respecting inter-component dependencies

## Key Features
- ✅ Dependency order execution for `--all` flag
- ✅ Circular dependency detection with clear error messages
- ✅ Support for cross-stack dependencies
- ✅ Filtering by stack, components, and YQ queries
- ✅ Skipping of abstract and disabled components
- ✅ Dry-run mode support
- ✅ Reusable graph logic for both `--all` and `--affected`

## Implementation Details

### New Dependency Graph Package (`pkg/dependency/`)
Created a generalized, reusable dependency graph implementation:
- **graph.go** - Core graph structure and operations
- **builder.go** - Builder pattern for safe graph construction
- **sort.go** - Topological sort using Kahn's algorithm
- **filter.go** - Graph filtering operations
- **types.go** - Core types and interfaces

### Terraform Execution Updates
- **terraform_all.go** - New ExecuteTerraformAll function for `--all` flag
- **terraform_affected_graph.go** - Refactored ExecuteTerraformAffected to use the graph
- **terraform_executor.go** - Shared execution logic for processing nodes

### Testing
- Comprehensive unit tests for the dependency graph package
- Integration tests for terraform execution
- Test fixtures with complex dependency scenarios
- All existing tests continue to pass

## Example
Given this configuration:
```yaml
components:
  terraform:
    vpc:
      vars:
        cidr: "10.0.0.0/16"
    
    database:
      settings:
        depends_on:
          - component: vpc
    
    application:
      settings:
        depends_on:
          - component: database
```

Running `atmos terraform apply --all` will execute in order:
1. vpc (no dependencies)
2. database (depends on vpc)
3. application (depends on database)

## Testing
- Run unit tests: `go test ./pkg/dependency/...`
- Run integration tests: `go test ./internal/exec -run TestBuildTerraformDependencyGraph`
- Test with fixture: `atmos terraform plan --all --dry-run` in `tests/fixtures/scenarios/terraform-apply-all-dependencies/`

## references
- Closes DEV-3512
- Linear issue: https://linear.app/cloudposse/issue/DEV-3512/implement-atmos-terraform-apply-all-in-dependency-order

🤖 Generated with [Claude Code](https://claude.ai/code)