### PR TITLE
fix: prevent go-getter from processing local file paths

### DIFF
--- a/pkg/utils/yaml_include_by_extension.go
+++ b/pkg/utils/yaml_include_by_extension.go
@@ -76,12 +76,16 @@ func processIncludeTagInternal(
 		if err != nil {
 			return err
 		}
-	} else {
-		// Process remote file
+	} else if isRemoteURL(includeFile) {
+		// Only process as remote if it's actually a remote URL
 		res, err = processRemoteFile(atmosConfig, includeFile, forceRaw)
 		if err != nil {
 			return err
 		}
+	} else {
+		// Local file not found - provide helpful error message
+		return fmt.Errorf("%w: could not find local file '%s' (tried relative to manifest '%s' and base path '%s')",
+			ErrIncludeYamlFunctionInvalidFile, includeFile, file, atmosConfig.BasePath)
 	}
 
 	// Apply YQ expression if provided

--- a/pkg/utils/yaml_include_by_extension_regression_test.go
+++ b/pkg/utils/yaml_include_by_extension_regression_test.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestIncludeLocalFileRelativePath tests the regression where local relative paths
+// were being incorrectly sent to go-getter instead of being resolved locally.
+// This reproduces the issue reported in DEV-3643.
+func TestIncludeLocalFileRelativePath(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create the directory structure
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	objectsDir := filepath.Join(stacksDir, "objects")
+	catalogDir := filepath.Join(tmpDir, "catalog", "waf")
+
+	err := os.MkdirAll(objectsDir, 0o755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(catalogDir, 0o755)
+	assert.NoError(t, err)
+
+	// Create the included file
+	ipsContent := `# IP addresses
+addresses:
+  - "3.1.36.99/32"
+  - "3.1.219.207/32"
+`
+	includedFile := filepath.Join(objectsDir, "ips-org-gateways.yaml")
+	err = os.WriteFile(includedFile, []byte(ipsContent), 0o644)
+	assert.NoError(t, err)
+
+	// Create a catalog file with !include directive
+	catalogContent := `components:
+  terraform:
+    waf:
+      settings:
+        ips:
+          org:
+            inet_gws: !include "stacks/objects/ips-org-gateways.yaml"
+      vars:
+        name: waf
+`
+	catalogFile := filepath.Join(catalogDir, "waf.yaml")
+	err = os.WriteFile(catalogFile, []byte(catalogContent), 0o644)
+	assert.NoError(t, err)
+
+	// Create atmos config
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:               tmpDir,
+		StacksBaseAbsolutePath: stacksDir,
+	}
+
+	// Parse the YAML with the include
+	var node yaml.Node
+	err = yaml.Unmarshal([]byte(catalogContent), &node)
+	assert.NoError(t, err)
+
+	// Process custom tags (including !include)
+	err = processCustomTags(atmosConfig, &node, catalogFile)
+	assert.NoError(t, err)
+
+	// Verify the content was included correctly
+	var result map[string]any
+	err = node.Decode(&result)
+	assert.NoError(t, err)
+
+	// Check that the addresses were included
+	components := result["components"].(map[string]any)
+	terraform := components["terraform"].(map[string]any)
+	waf := terraform["waf"].(map[string]any)
+	settings := waf["settings"].(map[string]any)
+	ips := settings["ips"].(map[string]any)
+	org := ips["org"].(map[string]any)
+	inetGws := org["inet_gws"].(map[string]any)
+	addresses := inetGws["addresses"].([]any)
+
+	assert.Len(t, addresses, 2)
+	assert.Equal(t, "3.1.36.99/32", addresses[0])
+	assert.Equal(t, "3.1.219.207/32", addresses[1])
+}
+
+// TestIncludeLocalFileNotFound tests that when a local file is not found,
+// we get a clear error message and don't try to download it with go-getter.
+func TestIncludeLocalFileNotFound(t *testing.T) {
+	// Create a temporary directory
+	tmpDir := t.TempDir()
+
+	// Create a catalog file with !include directive pointing to non-existent file
+	catalogContent := `components:
+  terraform:
+    waf:
+      settings:
+        ips: !include "stacks/objects/non-existent.yaml"
+`
+	catalogFile := filepath.Join(tmpDir, "catalog.yaml")
+	err := os.WriteFile(catalogFile, []byte(catalogContent), 0o644)
+	assert.NoError(t, err)
+
+	// Create atmos config
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath: tmpDir,
+	}
+
+	// Parse the YAML with the include
+	var node yaml.Node
+	err = yaml.Unmarshal([]byte(catalogContent), &node)
+	assert.NoError(t, err)
+
+	// Process custom tags - this should fail with a clear error
+	err = processCustomTags(atmosConfig, &node, catalogFile)
+	assert.Error(t, err)
+
+	// The error should NOT contain "relative paths require a module with a pwd"
+	// which would indicate go-getter was incorrectly invoked
+	assert.NotContains(t, err.Error(), "relative paths require a module with a pwd")
+	assert.NotContains(t, err.Error(), "relative path")
+	assert.NotContains(t, err.Error(), "pwd")
+}


### PR DESCRIPTION
## what
- Fixed regression where local file paths in `!include` directives were being incorrectly sent to go-getter
- Added proper validation to distinguish between local paths and remote URLs
- Improved error messages when local files cannot be found

## why
- The regression was introduced in PR #1493 which refactored the include processing logic
- When local files couldn't be found, the code was falling back to go-getter which failed with "relative paths require a module with a pwd"
- This particularly affected `describe affected` when run with `--repo-path` flag

## references
- Closes #1520 
- Regression introduced in #1493