### PR TITLE
fix: normalize path separators in terraform clean output

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -30,6 +30,7 @@ var (
 	ErrEmptyFilePath                         = errors.New("file path is empty")
 	ErrPathResolution                        = errors.New("failed to resolve absolute path")
 	ErrInvalidTemplateFunc                   = errors.New("invalid template function")
+	ErrRefuseDeleteSymbolicLink              = errors.New("refusing to delete symbolic link")
 	ErrNoDocsGenerateEntry                   = errors.New("no docs.generate entry found")
 	ErrMissingDocType                        = errors.New("doc-type argument missing")
 	ErrUnsupportedInputType                  = errors.New("unsupported input type")

--- a/internal/exec/terraform_clean.go
+++ b/internal/exec/terraform_clean.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	log "github.com/charmbracelet/log"
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui/theme"
 	u "github.com/cloudposse/atmos/pkg/utils"
@@ -276,26 +277,29 @@ func confirmDeleteTerraformLocal(message string) (confirm bool, err error) {
 
 // DeletePathTerraform deletes the specified file or folder. with a checkmark or xmark
 func DeletePathTerraform(fullPath string, objectName string) error {
+	// Normalize path separators to forward slashes for consistent output across platforms
+	normalizedObjectName := filepath.ToSlash(objectName)
+
 	fileInfo, err := os.Lstat(fullPath)
 	if os.IsNotExist(err) {
 		xMark := theme.Styles.XMark
-		fmt.Printf("%s Cannot delete %s: path does not exist", xMark, objectName)
+		fmt.Printf("%s Cannot delete %s: path does not exist", xMark, normalizedObjectName)
 		fmt.Println()
 		return err
 	}
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to delete symbolic link: %s", objectName)
+		return fmt.Errorf("%w: %s", errUtils.ErrRefuseDeleteSymbolicLink, normalizedObjectName)
 	}
 	// Proceed with deletion
 	err = os.RemoveAll(fullPath)
 	if err != nil {
 		xMark := theme.Styles.XMark
-		fmt.Printf("%s Error deleting %s", xMark, objectName)
+		fmt.Printf("%s Error deleting %s", xMark, normalizedObjectName)
 		fmt.Println()
 		return err
 	}
 	checkMark := theme.Styles.Checkmark
-	fmt.Printf("%s Deleted %s", checkMark, objectName)
+	fmt.Printf("%s Deleted %s", checkMark, normalizedObjectName)
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
## what
- Normalize path separators to forward slashes in terraform clean command output
- Add static error for symbolic link deletion to satisfy linting requirements

## why
- Windows tests were failing due to path separator mismatches in output
- The clean command was displaying paths with backslashes on Windows (e.g., `basic/components\terraform\mock\.terraform/`)
- Test assertions expected forward slashes, causing failures on Windows CI
- Using `filepath.ToSlash()` ensures consistent output across all platforms

## references
- Fixes Windows test failures in CI
- Addresses path display inconsistency in terraform clean command

🤖 Generated with [Claude Code](https://claude.ai/code)