### PR TITLE
fix: update GitHub Actions to use explicit tokens and latest versions

### DIFF
--- a/.github/actions/pr-sizer/action.yml
+++ b/.github/actions/pr-sizer/action.yml
@@ -57,8 +57,9 @@ runs:
   using: 'composite'
   steps:
     - name: Label PR based on size
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
+        github-token: ${{ github.token }}
         script: |
           const prNumber = context.issue.number;
           const owner = context.repo.owner;

--- a/.github/actions/remove-dependabot-semver-labels/action.yml
+++ b/.github/actions/remove-dependabot-semver-labels/action.yml
@@ -15,8 +15,9 @@ runs:
   using: 'composite'
   steps:
     - name: Remove auto-added semver labels
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
+        github-token: ${{ github.token }}
         script: |
           // Check if this is a pull request event
           if (!context.payload.pull_request) {


### PR DESCRIPTION
## Summary
- Update actions/github-script from v7 to v8 (latest version)
- Add explicit github-token parameter to prevent API rate limiting
- Applies to both pr-sizer and remove-dependabot-semver-labels actions

## Why
The PR size labeler and Dependabot label remover actions were using an older version of github-script (v7) and weren't explicitly configuring the GitHub token. This could lead to:
- API rate limiting issues (60 requests/hour for unauthenticated vs 5,000/hour for authenticated)
- Missing out on security updates and bug fixes in v8
- Implicit token usage that isn't clear from reading the action configuration

## Changes
1. Updated `actions/github-script@v7` to `actions/github-script@v8` in:
   - `.github/actions/pr-sizer/action.yml`
   - `.github/actions/remove-dependabot-semver-labels/action.yml`

2. Added explicit `github-token: ${{ github.token }}` parameter to both actions to ensure proper authentication

## Test Plan
The changes will be tested when this PR is opened, as both actions run on pull request events:
- The PR size labeler will run and apply appropriate size labels
- The remove-dependabot-semver-labels action will run (though it won't do anything since this isn't a Dependabot PR)

🤖 Generated with [Claude Code](https://claude.ai/code)