### PR TITLE
test: add coverage for vendor URI helpers and config error handling

### DIFF
--- a/internal/exec/vendor_uri_helpers_test.go
+++ b/internal/exec/vendor_uri_helpers_test.go
@@ -890,6 +890,27 @@ func TestNeedsDoubleSlashDot(t *testing.T) {
 			uri:      "https://example.com/archive.tar.gz",
 			expected: false,
 		},
+		// Special case: URIs that pass isGitURI() but are special types (lines 243-245).
+		{
+			name:     "file:// with .git pattern",
+			uri:      "file:///tmp/repo.git",
+			expected: false, // Has .git but file:// URIs should not get //.
+		},
+		{
+			name:     "github archive download URL",
+			uri:      "https://github.com/cloudposse/atmos/archive/refs/tags/v1.0.tar.gz",
+			expected: false, // Contains github.com but is an archive, not a Git repo.
+		},
+		{
+			name:     "github release tarball",
+			uri:      "https://github.com/owner/repo/releases/download/v1.0/package.tgz",
+			expected: false, // Contains github.com but is a release archive, not Git.
+		},
+		{
+			name:     "gitlab archive URL with .git in path",
+			uri:      "https://gitlab.com/group/project/-/archive/main/project.tar.gz",
+			expected: false, // Contains gitlab.com but is an archive URL.
+		},
 		// Edge cases
 		{
 			name:     "empty string",


### PR DESCRIPTION
## what
- Add test cases for `needsDoubleSlashDot` to cover special URI types (file://, GitHub archives, GitLab archives)
- Add test cases for `processConfigImportsAndReapply` to cover malformed YAML error handling
- Improves coverage for `vendor_uri_helpers.go` lines 243-245 (special URI type detection)
- Improves coverage for `load.go` error paths in config processing

## why
- Identified coverage gaps during code review of #1504
- These edge cases ensure proper handling of URIs that pass `isGitURI()` but are actually archives or special types
- Malformed YAML tests ensure error paths are properly covered for config validation

## references
- Builds on #1504 (fix: normalize legacy triple-slash vendor URIs for go-getter compatibility)
- Addresses coverage improvement opportunities identified during PR review