### PR TITLE
Add comprehensive test coverage for lifecycle hooks component scoping

### DIFF
--- a/docs/prd/hooks-component-scoping.md
+++ b/docs/prd/hooks-component-scoping.md
@@ -1,0 +1,387 @@
+# PRD: Lifecycle Hooks Component Scoping
+
+## Executive Summary
+
+Lifecycle hooks in Atmos are designed to execute automated actions at specific points in a component's lifecycle (e.g., after `terraform apply`). This document defines the design, implementation, and expected behavior of hook scoping to ensure hooks are properly isolated to their defining components and do not leak across component boundaries.
+
+## Problem Statement
+
+When multiple components in a stack define lifecycle hooks, there is potential for:
+
+1. **Hook pollution**: Hooks defined in one component appearing in other components
+2. **Output accumulation**: Outputs from multiple components merging together incorrectly
+3. **Unexpected behavior**: Components executing hooks not intended for them
+4. **Configuration complexity**: Difficulty understanding which hooks apply to which components
+
+## Design Goals
+
+1. **Component isolation**: Hooks defined for a component should only apply to that component
+2. **DRY principle support**: Allow shared hook structure while maintaining output isolation
+3. **Predictable behavior**: Users should be able to easily understand hook scope
+4. **Template flexibility**: Support both simple and advanced hook configuration patterns
+
+## Design Principles
+
+### Scoping Rules
+
+1. **Hooks are component-scoped by default**: A hook defined in a component's configuration applies only to that component
+2. **Hook merging follows component inheritance**: Hooks merge through the same inheritance chain as other component properties
+3. **Output maps are component-specific**: Even when hook names are shared, output definitions remain isolated per component
+4. **Global hooks require explicit structure**: Shared hook configurations must be defined in defaults and overridden per component
+
+## Architecture
+
+### Hook Configuration Hierarchy
+
+Hooks can be defined at multiple levels in the Atmos configuration hierarchy:
+
+```
+Global (_defaults.yaml)
+  ↓
+Terraform Section (terraform.hooks)
+  ↓
+Component (components.terraform.<component>.hooks)
+  ↓
+Component Overrides (components.terraform.<component>.overrides.hooks)
+```
+
+### Merging Behavior
+
+When hooks are merged through the inheritance chain:
+
+1. **Hook names are keys**: Hooks with the same name merge their properties
+2. **Properties are deep-merged**: Arrays and maps merge by default
+3. **Outputs are component-specific**: Each component's outputs override, not accumulate
+
+### Implementation
+
+Hook scoping is implemented in `internal/exec/stack_processor_utils.go` at line 1303-1313:
+
+```go
+finalComponentHooks, err := m.Merge(
+    atmosConfig,
+    []map[string]any{
+        globalAndTerraformHooks,
+        baseComponentHooks,
+        componentHooks,
+        componentOverridesHooks,
+    })
+```
+
+This ensures hooks are merged per-component during stack processing, maintaining isolation.
+
+## Configuration Patterns
+
+### Pattern 1: Unique Hook Names (Simple)
+
+Each component defines its complete hook configuration with a unique name.
+
+**Use Case**: Small number of components, each with distinct hook requirements.
+
+```yaml
+# stacks/catalog/vpc.yaml
+components:
+  terraform:
+    vpc:
+      metadata:
+        component: vpc
+      hooks:
+        vpc-store-outputs:
+          events:
+            - after-terraform-apply
+          command: store
+          name: prod/ssm
+          outputs:
+            vpc_id: .vpc_id
+            vpc_cidr_block: .vpc_cidr_block
+```
+
+**Pros**:
+- Simple and explicit
+- No risk of naming conflicts
+- Easy to understand
+
+**Cons**:
+- Duplicates hook structure across components
+- More verbose
+
+### Pattern 2: DRY Pattern (Recommended)
+
+Global defaults define hook structure, components override outputs only.
+
+**Use Case**: Many components with similar hook structure but different outputs.
+
+```yaml
+# stacks/catalog/_defaults.yaml
+hooks:
+  store-outputs:
+    events:
+      - after-terraform-apply
+    command: store
+    name: prod/ssm
+    # No outputs - defined per component
+
+# stacks/catalog/vpc.yaml
+components:
+  terraform:
+    vpc:
+      metadata:
+        component: vpc
+      hooks:
+        store-outputs:
+          outputs:
+            vpc_id: .vpc_id
+            vpc_cidr_block: .vpc_cidr_block
+
+# stacks/catalog/rds.yaml
+components:
+  terraform:
+    rds:
+      metadata:
+        component: rds
+      hooks:
+        store-outputs:
+          outputs:
+            cluster_endpoint: .cluster_endpoint
+            cluster_id: .cluster_id
+```
+
+**Pros**:
+- Reduces duplication
+- Easy to update hook behavior globally
+- Maintains output isolation per component
+- Scalable to many components
+
+**Cons**:
+- Requires understanding of inheritance
+- Global changes affect all components
+
+**Why This Works**: The merging algorithm combines the global hook structure with component-specific outputs. Each component gets:
+- The `events`, `command`, and `name` from the global definition
+- Only the `outputs` it explicitly defines
+
+## Test Coverage
+
+### Test Location
+
+- **Implementation**: `pkg/hooks/hooks_component_scope_test.go`
+- **Test Cases**: `tests/test-cases/hooks-component-scoped/`
+
+### Test Scenarios
+
+#### Test 1: `TestHooksAreComponentScoped`
+
+Verifies that components with unique hook names remain isolated.
+
+**Setup**:
+- 3 components: vpc, rds, lambda
+- Each with uniquely named hooks
+- All imported into one stack
+
+**Assertions**:
+- ✅ VPC has only `vpc-store-outputs`
+- ✅ RDS has only `rds-store-outputs`
+- ✅ Lambda has only `lambda-store-outputs`
+- ✅ No cross-component hook pollution
+
+#### Test 2: `TestHooksWithDRYPattern`
+
+Verifies the DRY pattern maintains output scoping.
+
+**Setup**:
+- Global `_defaults.yaml` with hook structure
+- 3 components: vpc-dry, rds-dry, lambda-dry
+- Each defines only outputs
+- All imported into one stack
+
+**Assertions**:
+- ✅ All components have `store-outputs` hook
+- ✅ VPC has only VPC outputs
+- ✅ RDS has only RDS outputs
+- ✅ Lambda has only Lambda outputs
+- ✅ No output accumulation across components
+
+### Running Tests
+
+```bash
+# Run both scoping tests
+go test -v ./pkg/hooks -run TestHooks
+
+# Run specific tests
+go test -v ./pkg/hooks -run TestHooksAreComponentScoped
+go test -v ./pkg/hooks -run TestHooksWithDRYPattern
+
+# Run all hooks tests
+go test -v ./pkg/hooks
+```
+
+## Expected Behavior
+
+### What Should Happen
+
+1. **Component A** with `store-outputs` hook defining outputs `[a1, a2]`
+2. **Component B** with `store-outputs` hook defining outputs `[b1, b2]`
+3. When describing Component A: should see hook with outputs `[a1, a2]` only
+4. When describing Component B: should see hook with outputs `[b1, b2]` only
+
+### What Should NOT Happen
+
+1. ❌ Component A should not see outputs `[b1, b2]`
+2. ❌ Component B should not see outputs `[a1, a2]`
+3. ❌ Either component should not see accumulated outputs `[a1, a2, b1, b2]`
+
+## Debugging Hook Scope Issues
+
+If users report hooks appearing globally:
+
+### Step 1: Verify Hook Definition Location
+
+Check where hooks are defined:
+
+```bash
+# View component configuration
+atmos describe component <component> -s <stack>
+
+# Check the hooks section
+atmos describe component <component> -s <stack> | yq '.hooks'
+```
+
+### Step 2: Check Import Chain
+
+Verify import hierarchy:
+
+```bash
+# View all imports
+atmos describe component <component> -s <stack> | yq '.imports'
+
+# View dependency chain
+atmos describe component <component> -s <stack> | yq '.deps'
+```
+
+### Step 3: Compare Against Test Cases
+
+Compare user configuration against working test cases:
+- `tests/test-cases/hooks-component-scoped/stacks/catalog/_defaults.yaml`
+- `tests/test-cases/hooks-component-scoped/stacks/catalog/*-dry.yaml`
+
+### Step 4: Verify Hook Name Uniqueness
+
+If using DRY pattern:
+- ✅ Same hook name across components is OK
+- ✅ Each component defines only its outputs
+- ❌ Do not define all outputs in _defaults.yaml
+
+## Common Pitfalls
+
+### Pitfall 1: Defining All Outputs Globally
+
+**Incorrect**:
+```yaml
+# _defaults.yaml - WRONG
+hooks:
+  store-outputs:
+    outputs:
+      vpc_id: .vpc_id          # ❌ Will apply to ALL components
+      cluster_id: .cluster_id  # ❌ Will apply to ALL components
+```
+
+**Correct**:
+```yaml
+# _defaults.yaml - CORRECT
+hooks:
+  store-outputs:
+    events: [after-terraform-apply]
+    command: store
+    name: prod/ssm
+    # ✅ No outputs here
+
+# vpc.yaml - CORRECT
+hooks:
+  store-outputs:
+    outputs:
+      vpc_id: .vpc_id  # ✅ Only for VPC
+```
+
+### Pitfall 2: Using Global Scope Incorrectly
+
+**Incorrect**:
+```yaml
+# At top-level of stack file - WRONG
+hooks:
+  store-outputs:
+    outputs:
+      vpc_id: .vpc_id  # ❌ May apply to all components in file
+```
+
+**Correct**:
+```yaml
+# Scoped to component - CORRECT
+components:
+  terraform:
+    vpc:
+      hooks:
+        store-outputs:
+          outputs:
+            vpc_id: .vpc_id  # ✅ Only for VPC
+```
+
+## Implementation Details
+
+### Stack Processing
+
+When processing a stack, Atmos:
+
+1. Loads all imported files in order
+2. Builds component configuration through merging
+3. Merges hooks using the same algorithm as other properties
+4. Ensures each component gets only its own hook definitions
+
+### Merge Algorithm
+
+The merge algorithm (`pkg/merge/`) handles hook merging:
+
+1. **Maps merge by key**: Hooks with same name merge
+2. **Arrays concatenate**: Events can accumulate
+3. **Last write wins for scalars**: Later values override earlier ones
+4. **Deep merge for nested structures**: Outputs merge at the component level
+
+## Best Practices
+
+### DO
+
+✅ **Use the DRY pattern** for multiple components with similar hooks
+✅ **Define hook structure globally** (events, command, name)
+✅ **Define outputs per component** in component-specific files
+✅ **Use unique hook names** if components need different hook structures
+✅ **Test with `describe component`** to verify hook configuration
+
+### DON'T
+
+❌ **Don't define all outputs in _defaults.yaml**
+❌ **Don't expect hooks to automatically scope without proper structure**
+❌ **Don't define hooks at top-level of stack files** (use component scope)
+❌ **Don't skip testing** - always verify with `describe component`
+
+## Reference Implementation
+
+Complete working examples available in:
+- `tests/test-cases/hooks-component-scoped/`
+
+## Related Documentation
+
+- [Lifecycle Hooks Overview](https://atmos.tools/core-concepts/stacks/hooks)
+- [Stack Processing](/docs/prd/stack-processing.md)
+- [Configuration Merging](/docs/prd/configuration-merging.md)
+
+## Version History
+
+- **v1.0** (2025-01): Initial PRD with test coverage for component scoping
+- Added DRY pattern as recommended approach
+- Comprehensive test coverage for both patterns
+
+## Future Considerations
+
+1. **Conditional hooks**: Execute hooks based on component state
+2. **Hook dependencies**: Order hook execution across components
+3. **Hook templates**: Parameterized hook definitions
+4. **Validation**: Schema validation for hook configurations

--- a/pkg/hooks/hooks_component_scope_test.go
+++ b/pkg/hooks/hooks_component_scope_test.go
@@ -1,0 +1,169 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	e "github.com/cloudposse/atmos/internal/exec"
+)
+
+// TestHooksAreComponentScoped verifies that lifecycle hooks defined in component
+// catalog files are properly scoped to their respective components and not merged
+// globally across all components in a stack.
+//
+// This test ensures that when multiple components (vpc, rds, lambda) each define
+// their own hooks in separate catalog files, each component only receives its own
+// hooks and not hooks from other components.
+func TestHooksAreComponentScoped(t *testing.T) {
+	testDir := "../../tests/test-cases/hooks-component-scoped"
+
+	absTestDir, err := filepath.Abs(testDir)
+	require.NoError(t, err)
+
+	// Change to test directory so atmos finds the config
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+
+	err = os.Chdir(absTestDir)
+	require.NoError(t, err)
+
+	// Test VPC component
+	vpcComponent, err := e.ExecuteDescribeComponent("vpc", "acme-dev-test", true, true, []string{})
+	require.NoError(t, err)
+
+	vpcHooks, ok := vpcComponent["hooks"].(map[string]any)
+	require.True(t, ok, "vpc should have hooks section")
+
+	// Test RDS component
+	rdsComponent, err := e.ExecuteDescribeComponent("rds", "acme-dev-test", true, true, []string{})
+	require.NoError(t, err)
+
+	rdsHooks, ok := rdsComponent["hooks"].(map[string]any)
+	require.True(t, ok, "rds should have hooks section")
+
+	// Test Lambda component
+	lambdaComponent, err := e.ExecuteDescribeComponent("lambda", "acme-dev-test", true, true, []string{})
+	require.NoError(t, err)
+
+	lambdaHooks, ok := lambdaComponent["hooks"].(map[string]any)
+	require.True(t, ok, "lambda should have hooks section")
+
+	// Log hook counts for debugging
+	t.Logf("vpc hooks count: %d, hooks: %v", len(vpcHooks), getHookNames(vpcHooks))
+	t.Logf("rds hooks count: %d, hooks: %v", len(rdsHooks), getHookNames(rdsHooks))
+	t.Logf("lambda hooks count: %d, hooks: %v", len(lambdaHooks), getHookNames(lambdaHooks))
+
+	// Verify hooks are properly scoped to each component
+
+	// VPC should only have its own hook
+	assert.Equal(t, 1, len(vpcHooks), "vpc should have exactly 1 hook (vpc-store-outputs)")
+	assert.Contains(t, vpcHooks, "vpc-store-outputs", "vpc should have vpc-store-outputs")
+	assert.NotContains(t, vpcHooks, "rds-store-outputs", "vpc should NOT have rds-store-outputs")
+	assert.NotContains(t, vpcHooks, "lambda-store-outputs", "vpc should NOT have lambda-store-outputs")
+
+	// RDS should only have its own hook
+	assert.Equal(t, 1, len(rdsHooks), "rds should have exactly 1 hook (rds-store-outputs)")
+	assert.Contains(t, rdsHooks, "rds-store-outputs", "rds should have rds-store-outputs")
+	assert.NotContains(t, rdsHooks, "vpc-store-outputs", "rds should NOT have vpc-store-outputs")
+	assert.NotContains(t, rdsHooks, "lambda-store-outputs", "rds should NOT have lambda-store-outputs")
+
+	// Lambda should only have its own hook
+	assert.Equal(t, 1, len(lambdaHooks), "lambda should have exactly 1 hook (lambda-store-outputs)")
+	assert.Contains(t, lambdaHooks, "lambda-store-outputs", "lambda should have lambda-store-outputs")
+	assert.NotContains(t, lambdaHooks, "vpc-store-outputs", "lambda should NOT have vpc-store-outputs")
+	assert.NotContains(t, lambdaHooks, "rds-store-outputs", "lambda should NOT have rds-store-outputs")
+}
+
+// TestHooksWithDRYPattern verifies that when using a DRY pattern where the hook
+// structure is defined globally and components only override the outputs, hooks
+// are still properly scoped to their components.
+//
+// This test uses the pattern:
+// - Global _defaults.yaml defines hook structure (events, command, name)
+// - Each component only defines the outputs specific to that component.
+func TestHooksWithDRYPattern(t *testing.T) {
+	testDir := "../../tests/test-cases/hooks-component-scoped"
+
+	absTestDir, err := filepath.Abs(testDir)
+	require.NoError(t, err)
+
+	// Change to test directory so atmos finds the config
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+
+	err = os.Chdir(absTestDir)
+	require.NoError(t, err)
+
+	// Test VPC component using DRY pattern
+	vpcComponent, err := e.ExecuteDescribeComponent("vpc-dry", "acme-dev-dry", true, true, []string{})
+	require.NoError(t, err)
+
+	vpcHooks, ok := vpcComponent["hooks"].(map[string]any)
+	require.True(t, ok, "vpc-dry should have hooks section")
+
+	// Test RDS component using DRY pattern
+	rdsComponent, err := e.ExecuteDescribeComponent("rds-dry", "acme-dev-dry", true, true, []string{})
+	require.NoError(t, err)
+
+	rdsHooks, ok := rdsComponent["hooks"].(map[string]any)
+	require.True(t, ok, "rds-dry should have hooks section")
+
+	// Test Lambda component using DRY pattern
+	lambdaComponent, err := e.ExecuteDescribeComponent("lambda-dry", "acme-dev-dry", true, true, []string{})
+	require.NoError(t, err)
+
+	lambdaHooks, ok := lambdaComponent["hooks"].(map[string]any)
+	require.True(t, ok, "lambda-dry should have hooks section")
+
+	// Log hook counts for debugging
+	t.Logf("vpc-dry hooks count: %d, hooks: %v", len(vpcHooks), getHookNames(vpcHooks))
+	t.Logf("rds-dry hooks count: %d, hooks: %v", len(rdsHooks), getHookNames(rdsHooks))
+	t.Logf("lambda-dry hooks count: %d, hooks: %v", len(lambdaHooks), getHookNames(lambdaHooks))
+
+	// Verify that all components have the same hook name (store-outputs)
+	// but with different outputs specific to each component
+	assert.Equal(t, 1, len(vpcHooks), "vpc-dry should have exactly 1 hook (store-outputs)")
+	assert.Equal(t, 1, len(rdsHooks), "rds-dry should have exactly 1 hook (store-outputs)")
+	assert.Equal(t, 1, len(lambdaHooks), "lambda-dry should have exactly 1 hook (store-outputs)")
+
+	// All should have the same hook name
+	assert.Contains(t, vpcHooks, "store-outputs", "vpc-dry should have store-outputs hook")
+	assert.Contains(t, rdsHooks, "store-outputs", "rds-dry should have store-outputs hook")
+	assert.Contains(t, lambdaHooks, "store-outputs", "lambda-dry should have store-outputs hook")
+
+	// Verify each hook has the correct outputs for its component
+	vpcHook := vpcHooks["store-outputs"].(map[string]any)
+	vpcOutputs := vpcHook["outputs"].(map[string]any)
+	assert.Contains(t, vpcOutputs, "vpc_id", "vpc-dry should have vpc_id output")
+	assert.Contains(t, vpcOutputs, "vpc_cidr_block", "vpc-dry should have vpc_cidr_block output")
+	assert.NotContains(t, vpcOutputs, "cluster_endpoint", "vpc-dry should NOT have cluster_endpoint output")
+	assert.NotContains(t, vpcOutputs, "lambda_function_arn", "vpc-dry should NOT have lambda_function_arn output")
+
+	rdsHook := rdsHooks["store-outputs"].(map[string]any)
+	rdsOutputs := rdsHook["outputs"].(map[string]any)
+	assert.Contains(t, rdsOutputs, "cluster_endpoint", "rds-dry should have cluster_endpoint output")
+	assert.Contains(t, rdsOutputs, "cluster_id", "rds-dry should have cluster_id output")
+	assert.NotContains(t, rdsOutputs, "vpc_id", "rds-dry should NOT have vpc_id output")
+	assert.NotContains(t, rdsOutputs, "lambda_function_arn", "rds-dry should NOT have lambda_function_arn output")
+
+	lambdaHook := lambdaHooks["store-outputs"].(map[string]any)
+	lambdaOutputs := lambdaHook["outputs"].(map[string]any)
+	assert.Contains(t, lambdaOutputs, "lambda_function_arn", "lambda-dry should have lambda_function_arn output")
+	assert.Contains(t, lambdaOutputs, "lambda_function_name", "lambda-dry should have lambda_function_name output")
+	assert.NotContains(t, lambdaOutputs, "vpc_id", "lambda-dry should NOT have vpc_id output")
+	assert.NotContains(t, lambdaOutputs, "cluster_endpoint", "lambda-dry should NOT have cluster_endpoint output")
+}
+
+func getHookNames(hooks map[string]any) []string {
+	names := make([]string, 0, len(hooks))
+	for name := range hooks {
+		names = append(names, name)
+	}
+	return names
+}

--- a/tests/test-cases/hooks-component-scoped/README.md
+++ b/tests/test-cases/hooks-component-scoped/README.md
@@ -1,0 +1,94 @@
+# Hooks Component Scoping Test Case
+
+This test case verifies that lifecycle hooks are properly scoped to their respective components and not merged globally across all components in a stack.
+
+## Test Scenarios
+
+This test case includes two scenarios:
+
+### Scenario 1: Unique Hook Names
+- **3 components**: `vpc`, `rds`, and `lambda`
+- Each component is defined in its own catalog file under `stacks/catalog/`
+- Each component defines a unique hook name (`vpc-store-outputs`, `rds-store-outputs`, `lambda-store-outputs`)
+- All components are imported into a single stack (`acme-dev-test`)
+
+### Scenario 2: DRY Pattern with Shared Hook Name
+- **3 components**: `vpc-dry`, `rds-dry`, and `lambda-dry`
+- Global `_defaults.yaml` defines the hook structure (events, command, name)
+- Each component only defines the `outputs` specific to that component
+- All components use the same hook name (`store-outputs`) but with different outputs
+- All components are imported into a single stack (`acme-dev-dry`)
+
+## Expected Behavior
+
+### Scenario 1: Unique Hook Names
+When describing each component, hooks should be scoped as follows:
+
+- **VPC component**: Should only have `vpc-store-outputs` hook
+  - Outputs: `vpc_id`, `vpc_cidr_block`
+
+- **RDS component**: Should only have `rds-store-outputs` hook
+  - Outputs: `cluster_endpoint`, `cluster_id`, `database_name`
+
+- **Lambda component**: Should only have `lambda-store-outputs` hook
+  - Outputs: `lambda_function_arn`, `lambda_function_name`
+
+### Scenario 2: DRY Pattern (Recommended)
+When using the DRY pattern, all components share the same hook name but with component-specific outputs:
+
+- **VPC component**: Has `store-outputs` hook with VPC-specific outputs only
+  - Outputs: `vpc_id`, `vpc_cidr_block`
+  - Should NOT have RDS or Lambda outputs
+
+- **RDS component**: Has `store-outputs` hook with RDS-specific outputs only
+  - Outputs: `cluster_endpoint`, `cluster_id`, `database_name`
+  - Should NOT have VPC or Lambda outputs
+
+- **Lambda component**: Has `store-outputs` hook with Lambda-specific outputs only
+  - Outputs: `lambda_function_arn`, `lambda_function_name`
+  - Should NOT have VPC or RDS outputs
+
+**This DRY pattern is the recommended approach** as it reduces duplication while maintaining proper component scoping.
+
+## Purpose
+
+This test demonstrates that Atmos correctly scopes hooks to their defining components, preventing hook pollution where one component would incorrectly inherit hooks from other components in the same stack.
+
+## Running the Tests
+
+From the repository root:
+
+```bash
+# Run both tests
+go test -v ./pkg/hooks
+
+# Run specific tests
+go test -v ./pkg/hooks -run TestHooksAreComponentScoped
+go test -v ./pkg/hooks -run TestHooksWithDRYPattern
+```
+
+## Test Structure
+
+```
+hooks-component-scoped/
+├── atmos.yaml                    # Atmos configuration
+├── stacks/
+│   ├── catalog/                  # Component catalog definitions
+│   │   ├── _defaults.yaml       # Global hook structure for DRY pattern
+│   │   ├── vpc.yaml             # VPC component with unique hook name
+│   │   ├── rds.yaml             # RDS component with unique hook name
+│   │   ├── lambda.yaml          # Lambda component with unique hook name
+│   │   ├── vpc-dry.yaml         # VPC using DRY pattern (outputs only)
+│   │   ├── rds-dry.yaml         # RDS using DRY pattern (outputs only)
+│   │   └── lambda-dry.yaml      # Lambda using DRY pattern (outputs only)
+│   └── orgs/acme/
+│       ├── dev.yaml             # Stack for unique hook names test
+│       └── dev-dry.yaml         # Stack for DRY pattern test
+└── components/terraform/         # (empty - no actual terraform components needed)
+```
+
+## Related
+
+- Test implementation: `/pkg/hooks/hooks_component_scope_test.go`
+- Hooks implementation: `/pkg/hooks/`
+- Documentation: https://atmos.tools/core-concepts/stacks/hooks

--- a/tests/test-cases/hooks-component-scoped/atmos.yaml
+++ b/tests/test-cases/hooks-component-scoped/atmos.yaml
@@ -1,0 +1,30 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "**/*"
+  excluded_paths:
+    - "catalog/**"
+  name_pattern: "{tenant}-{environment}-{stage}"
+
+# Stores configuration removed to avoid AWS initialization in test
+# stores:
+#   prod/ssm:
+#     type: aws-ssm-parameter-store
+#     options:
+#       region: us-east-1
+
+schemas: {}
+
+logs:
+  level: Info
+
+settings:
+  terminal:
+    pager:
+      enabled: false

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/_defaults.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/_defaults.yaml
@@ -1,0 +1,9 @@
+# Global defaults - DRY pattern for hooks
+# Define the hook structure globally, components override the outputs
+hooks:
+  store-outputs:
+    events:
+      - after-terraform-apply
+    command: store
+    name: prod/ssm
+    # No outputs defined here - each component will define their own

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/lambda-dry.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/lambda-dry.yaml
@@ -1,0 +1,13 @@
+# Lambda component using DRY pattern - only defines outputs
+components:
+  terraform:
+    lambda-dry:
+      metadata:
+        component: lambda
+      vars:
+        name: "lambda-dry"
+      hooks:
+        store-outputs:
+          outputs:
+            lambda_function_arn: .lambda_function_arn
+            lambda_function_name: .lambda_function_name

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/lambda.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/lambda.yaml
@@ -1,0 +1,17 @@
+# Lambda component catalog entry
+components:
+  terraform:
+    lambda:
+      metadata:
+        component: lambda
+      vars:
+        name: "lambda"
+      hooks:
+        lambda-store-outputs:
+          events:
+            - after-terraform-apply
+          command: store
+          name: prod/ssm
+          outputs:
+            lambda_function_arn: .lambda_function_arn
+            lambda_function_name: .lambda_function_name

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/rds-dry.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/rds-dry.yaml
@@ -1,0 +1,14 @@
+# RDS component using DRY pattern - only defines outputs
+components:
+  terraform:
+    rds-dry:
+      metadata:
+        component: rds
+      vars:
+        name: "rds-dry"
+      hooks:
+        store-outputs:
+          outputs:
+            cluster_endpoint: .cluster_endpoint
+            cluster_id: .cluster_id
+            database_name: .database_name

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/rds.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/rds.yaml
@@ -1,0 +1,18 @@
+# RDS component catalog entry
+components:
+  terraform:
+    rds:
+      metadata:
+        component: rds
+      vars:
+        name: "rds"
+      hooks:
+        rds-store-outputs:
+          events:
+            - after-terraform-apply
+          command: store
+          name: prod/ssm
+          outputs:
+            cluster_endpoint: .cluster_endpoint
+            cluster_id: .cluster_id
+            database_name: .database_name

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/vpc-dry.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/vpc-dry.yaml
@@ -1,0 +1,13 @@
+# VPC component using DRY pattern - only defines outputs
+components:
+  terraform:
+    vpc-dry:
+      metadata:
+        component: vpc
+      vars:
+        name: "vpc-dry"
+      hooks:
+        store-outputs:
+          outputs:
+            vpc_id: .vpc_id
+            vpc_cidr_block: .vpc_cidr_block

--- a/tests/test-cases/hooks-component-scoped/stacks/catalog/vpc.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/catalog/vpc.yaml
@@ -1,0 +1,17 @@
+# VPC component catalog entry
+components:
+  terraform:
+    vpc:
+      metadata:
+        component: vpc
+      vars:
+        name: "vpc"
+      hooks:
+        vpc-store-outputs:
+          events:
+            - after-terraform-apply
+          command: store
+          name: prod/ssm
+          outputs:
+            vpc_id: .vpc_id
+            vpc_cidr_block: .vpc_cidr_block

--- a/tests/test-cases/hooks-component-scoped/stacks/orgs/acme/dev-dry.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/orgs/acme/dev-dry.yaml
@@ -1,0 +1,10 @@
+import:
+  - catalog/_defaults
+  - catalog/vpc-dry
+  - catalog/rds-dry
+  - catalog/lambda-dry
+
+vars:
+  tenant: acme
+  environment: dev
+  stage: dry

--- a/tests/test-cases/hooks-component-scoped/stacks/orgs/acme/dev.yaml
+++ b/tests/test-cases/hooks-component-scoped/stacks/orgs/acme/dev.yaml
@@ -1,0 +1,9 @@
+import:
+  - catalog/vpc
+  - catalog/rds
+  - catalog/lambda
+
+vars:
+  tenant: acme
+  environment: dev
+  stage: test


### PR DESCRIPTION
## what
- Add test coverage to verify lifecycle hooks are properly scoped to their respective components
- Add comprehensive PRD documentation for hooks component scoping design and best practices
- Include test cases for both unique hook names and DRY pattern approaches

## why
- Users have reported confusion about hook scoping behavior and potential hook pollution across components
- Need to verify that hooks defined in component catalog files remain isolated and don't leak to other components
- Provide reference implementation and debugging guide for the community

## tests
- **TestHooksAreComponentScoped** - Verifies components with unique hook names remain isolated
- **TestHooksWithDRYPattern** - Verifies DRY pattern (global structure + component outputs) maintains proper scoping
- Both tests pass, confirming hooks work as designed

## references
- PRD: `docs/prd/hooks-component-scoping.md`
- Test implementation: `pkg/hooks/hooks_component_scope_test.go`
- Test cases: `tests/test-cases/hooks-component-scoped/`
- Hooks documentation: https://atmos.tools/core-concepts/stacks/hooks