### PR TITLE
chore: migrate from unmaintained gopkg.in/yaml.v3 to maintained go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/terraform-docs/terraform-docs v0.20.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.17.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/oauth2 v0.31.0
 	golang.org/x/term v0.35.0
 	golang.org/x/text v0.29.0
@@ -90,7 +91,6 @@ require (
 	google.golang.org/grpc v1.75.1
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/sh/v3 v3.12.0
 )
 
@@ -348,7 +348,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
@@ -368,6 +367,7 @@ require (
 	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a // indirect
 	k8s.io/client-go v0.33.2 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/internal/exec/docs_generate.go
+++ b/internal/exec/docs_generate.go
@@ -11,7 +11,7 @@ import (
 	tfdocsFormat "github.com/terraform-docs/terraform-docs/format"
 	tfdocsPrint "github.com/terraform-docs/terraform-docs/print"
 	tfdocsTf "github.com/terraform-docs/terraform-docs/terraform"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"

--- a/internal/exec/vendor_utils.go
+++ b/internal/exec/vendor_utils.go
@@ -12,7 +12,7 @@ import (
 	cp "github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"

--- a/internal/exec/yaml_func_test.go
+++ b/internal/exec/yaml_func_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/cloudposse/atmos/pkg/schema"
 	u "github.com/cloudposse/atmos/pkg/utils"

--- a/pkg/config/cache.go
+++ b/pkg/config/cache.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
-	errUtils "github.com/cloudposse/atmos/errors"
-	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	log "github.com/cloudposse/atmos/pkg/logger"
 )
 
 type CacheConfig struct {

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -10,9 +10,8 @@ import (
 	"runtime"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/spf13/viper"
+	"go.yaml.in/yaml/v3"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/config/go-homedir"

--- a/pkg/config/process_yaml.go
+++ b/pkg/config/process_yaml.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/viper"
+	"go.yaml.in/yaml/v3"
+
 	log "github.com/cloudposse/atmos/pkg/logger"
 	u "github.com/cloudposse/atmos/pkg/utils"
-	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/pkg/filetype/filetype.go
+++ b/pkg/filetype/filetype.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/zclconf/go-cty/cty"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var ErrFailedToProcessHclFile = errors.New("failed to process HCL file")

--- a/pkg/filetype/filetype_test.go
+++ b/pkg/filetype/filetype_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestParseYAML(t *testing.T) {

--- a/pkg/list/list_vendor.go
+++ b/pkg/list/list_vendor.go
@@ -7,15 +7,16 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+	"go.yaml.in/yaml/v3"
+	"golang.org/x/term"
+
 	"github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/filetype"
 	"github.com/cloudposse/atmos/pkg/list/format"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/utils"
-	"github.com/pkg/errors"
-	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/pkg/list/list_workflows.go
+++ b/pkg/list/list_workflows.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/samber/lo"
+	"go.yaml.in/yaml/v3"
+
 	"github.com/cloudposse/atmos/internal/tui/templates/term"
 	"github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui/theme"
 	"github.com/cloudposse/atmos/pkg/utils"
-	"github.com/samber/lo"
-	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/pkg/profiler/profiler_test.go
+++ b/pkg/profiler/profiler_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func getFreeTCPPort(t *testing.T) int {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/cloudposse/atmos/pkg/profiler"
 	"github.com/cloudposse/atmos/pkg/store"

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestAtmosConfigurationWorksWithOpa(t *testing.T) {

--- a/pkg/utils/yaml_include_by_extension.go
+++ b/pkg/utils/yaml_include_by_extension.go
@@ -6,13 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cloudposse/atmos/pkg/perf"
-
 	"github.com/hashicorp/go-getter"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/cloudposse/atmos/pkg/downloader"
 	"github.com/cloudposse/atmos/pkg/filetype"
+	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 

--- a/pkg/utils/yaml_include_by_extension_regression_test.go
+++ b/pkg/utils/yaml_include_by_extension_regression_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/cloudposse/atmos/pkg/schema"
 )

--- a/pkg/utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"

--- a/pkg/utils/yq_utils.go
+++ b/pkg/utils/yq_utils.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
+	"go.yaml.in/yaml/v3"
 	"gopkg.in/op/go-logging.v1"
-	"gopkg.in/yaml.v3"
 
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"

--- a/pkg/utils/yq_utils_test.go
+++ b/pkg/utils/yq_utils_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestEvaluateYqExpression_InvalidYAML tests the error case when yaml.Unmarshal fails.

--- a/pkg/validator/schema_validator.go
+++ b/pkg/validator/schema_validator.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/xeipuuv/gojsonschema"
+	"go.yaml.in/yaml/v3"
+
 	"github.com/cloudposse/atmos/pkg/datafetcher"
 	"github.com/cloudposse/atmos/pkg/schema"
-	"github.com/xeipuuv/gojsonschema"
-	"gopkg.in/yaml.v3"
 )
 
 var ErrSchemaNotFound = errors.New("failed to fetch schema")

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	log "github.com/cloudposse/atmos/pkg/logger"
-	"github.com/cloudposse/atmos/tests/testhelpers"
 	"github.com/creack/pty"
 	"github.com/go-git/go-git/v5"
 	"github.com/hexops/gotextdiff"
@@ -31,13 +29,15 @@ import (
 	"github.com/otiai10/copy"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/assert"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 
 	"github.com/adrg/xdg"
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/config"
+	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/telemetry"
+	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // Command-line flag for regenerating snapshots.

--- a/tests/testhelpers/sandbox.go
+++ b/tests/testhelpers/sandbox.go
@@ -8,9 +8,10 @@ import (
 	"runtime"
 	"testing"
 
+	"go.yaml.in/yaml/v3"
+
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 // SandboxEnvironment holds the state for a sandboxed test.


### PR DESCRIPTION
## what
- Migrate all YAML v3 imports from unmaintained `gopkg.in/yaml.v3` to maintained `go.yaml.in/yaml/v3`
- Update 21 Go files with new import paths
- Update `go.mod` to use `go.yaml.in/yaml/v3 v3.0.4` as direct dependency

## why
- The `gopkg.in/yaml.v3` repository was marked as UNMAINTAINED by the author in April 2025
- `go.yaml.in/yaml/v3` is the new official maintained version by the YAML organization
- This is a drop-in replacement with the same API (zero breaking changes)
- Ensures we receive bug fixes and security patches going forward
- Eliminates dependency confusion (we previously had both old and new v3 in our dependency tree)

## references
- Migration follows the two-phase approach: migrate to stable v3 now, evaluate v4 (currently RC) later
- All tests passing: compilation, unit tests, and linting
- Import statements reorganized following the 3-section import style (Go stdlib, 3rd-party, Atmos packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>