### PR TITLE
chore: make Codecov patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,15 +6,15 @@ coverage:
     project:
       default:
         target: auto      # Automatically use the base branch's coverage
-        threshold: 1%     # Allow up to 1% drop in overall project coverage
+        threshold: 0%     # Do not allow any drop in overall project coverage
         base: auto
         if_not_found: success  # Don't fail if base coverage is missing
         paths:            # Only track Go files for coverage calculations
           - "**/*.go"
     patch:
       default:
-        target: 80% # Require at least 80% test coverage on new/changed lines
-        threshold: 2% # Allow a small drop in coverage
+        target: 80% # Target at least 80% test coverage on new/changed lines
+        informational: true # Make patch coverage informational only
         base: auto
         paths:            # Only track Go files for coverage calculations
           - "**/*.go"
@@ -27,7 +27,7 @@ comment:
   layout: "reach,diff,flags,tree"  # Display different coverage views
   behavior: default                # Default PR comment behavior
   require_changes: true             # Only post if coverage changes
-  require_base: true                 # Compare against base branch coverage
+  require_base: true                # Compare against base branch coverage
 
 github_checks:
   annotations: true    # Enable GitHub Checks Annotations


### PR DESCRIPTION
## what
- Make Codecov patch coverage informational only (won't fail builds)
- Set project coverage threshold to 0% (no decrease allowed)
- Maintain 80% patch coverage target for visibility

## why
- Patch coverage should provide feedback without blocking PRs
- Overall project coverage must not decrease to maintain quality
- Reduce noise by only posting comments when coverage changes

## references
- Codecov documentation on informational status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)