### PR TITLE
Add --version flag as alias for version command

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -592,7 +592,7 @@ func CheckForAtmosUpdateAndPrintMessage(atmosConfig schema.AtmosConfiguration) {
 
 // Check Atmos is version command.
 func isVersionCommand() bool {
-	return len(os.Args) > 1 && os.Args[1] == "version"
+	return len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version")
 }
 
 // handleHelpRequest shows help content and exits only if the first argument is "help" or "--help" or "-h".

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -165,6 +165,11 @@ func TestIsVersionCommand(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "--version flag",
+			args:     []string{"--version"},
+			expected: true,
+		},
+		{
 			name:     "not version command",
 			args:     []string{"help"},
 			expected: false,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/telemetry"
 	"github.com/cloudposse/atmos/pkg/ui/heatmap"
 	"github.com/cloudposse/atmos/pkg/utils"
+	"github.com/cloudposse/atmos/pkg/version"
 )
 
 const (
@@ -56,6 +57,13 @@ var RootCmd = &cobra.Command{
 	Long:               `Atmos is a universal tool for DevOps and cloud automation used for provisioning, managing and orchestrating workflows across various toolchains`,
 	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Check for --version flag first (simple version output, no other flags supported).
+		if versionFlag, _ := cmd.Flags().GetBool("version"); versionFlag {
+			fmt.Printf("atmos %s\n", version.Version)
+			utils.OsExit(0)
+			return
+		}
+
 		// Determine if the command is a help command or if the help flag is set.
 		isHelpCommand := cmd.Name() == "help"
 		helpFlag := cmd.Flags().Changed("help")
@@ -515,6 +523,7 @@ func init() {
 
 	RootCmd.PersistentFlags().String("redirect-stderr", "", "File descriptor to redirect `stderr` to. "+
 		"Errors can be redirected to any file or any standard file descriptor (including `/dev/null`)")
+	RootCmd.PersistentFlags().Bool("version", false, "Show version information")
 
 	RootCmd.PersistentFlags().String("logs-level", "Info", "Logs level. Supported log levels are Trace, Debug, Info, Warning, Off. If the log level is set to Off, Atmos will not log any messages")
 	RootCmd.PersistentFlags().String("logs-file", "/dev/stderr", "The file to write Atmos logs to. Logs can be written to any file or any standard file descriptor, including '/dev/stdout', '/dev/stderr' and '/dev/null'")

--- a/tests/test-cases/empty-dir.yaml
+++ b/tests/test-cases/empty-dir.yaml
@@ -14,6 +14,21 @@ tests:
         - "^$"
       exit_code: 0
 
+  - name: check atmos --version in empty-dir
+    enabled: true
+    snapshot: false
+    description: "Check that atmos --version flag works without configuration."
+    workdir: "fixtures/scenarios/empty-dir"
+    command: "atmos"
+    args:
+      - "--version"
+    expect:
+      stdout:
+        - 'atmos (\d+\.\d+\.\d+|test)'
+      stderr:
+        - "^$"
+      exit_code: 0
+
   - name: atmos support
     enabled: true
     snapshot: true


### PR DESCRIPTION
## what
- Add `--version` persistent flag to RootCmd as a simple alias for `atmos version` command
- Update `isVersionCommand()` helper to detect both `version` and `--version` forms
- Add test case for `atmos --version` in empty directory (no config required)
- Add test case for `--version` flag to `TestIsVersionCommand`

## why
- Provides a conventional CLI experience - most command-line tools support `--version` flag
- Aligns with standard POSIX/GNU conventions for version flags
- Makes version checking easier for users and scripts
- Both `atmos version` and `atmos --version` now work without requiring `atmos.yaml` configuration

## references
- `atmos --version` outputs simple format: `atmos <version>`
- `atmos version` outputs full styled format with update checks
- The `--version` flag does not support additional flags like `--check` or `--format` (use `atmos version` for those features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)