### PR TITLE
Bugfix: `auth` identities should default load the AWS Environment vars (if AWS based identities)

### DIFF
--- a/pkg/auth/identities/aws/assume_role.go
+++ b/pkg/auth/identities/aws/assume_role.go
@@ -172,6 +172,24 @@ func (i *assumeRoleIdentity) Validate() error {
 func (i *assumeRoleIdentity) Environment() (map[string]string, error) {
 	env := make(map[string]string)
 
+	// Get provider name for AWS file paths.
+	providerName, err := i.GetProviderName()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get AWS file environment variables.
+	awsFileManager, err := awsCloud.NewAWSFileManager()
+	if err != nil {
+		return nil, errors.Join(errUtils.ErrAuthAwsFileManagerFailed, err)
+	}
+	awsEnvVars := awsFileManager.GetEnvironmentVariables(providerName, i.name)
+
+	// Convert to map format.
+	for _, envVar := range awsEnvVars {
+		env[envVar.Key] = envVar.Value
+	}
+
 	// Add environment variables from identity config.
 	for _, envVar := range i.config.Env {
 		env[envVar.Key] = envVar.Value

--- a/pkg/auth/identities/aws/assume_role_test.go
+++ b/pkg/auth/identities/aws/assume_role_test.go
@@ -69,10 +69,17 @@ func TestAssumeRoleIdentity_Environment(t *testing.T) {
 		Kind:      "aws/assume-role",
 		Principal: map[string]any{"assume_role": "arn:aws:iam::123:role/x"},
 		Env:       []schema.EnvironmentVariable{{Key: "FOO", Value: "BAR"}},
+		Via:       &schema.IdentityVia{Provider: "test-provider"},
 	}}
 	env, err := i.Environment()
 	assert.NoError(t, err)
+	// Should include custom env vars from config.
 	assert.Equal(t, "BAR", env["FOO"])
+	// Should include AWS file environment variables.
+	assert.NotEmpty(t, env["AWS_SHARED_CREDENTIALS_FILE"])
+	assert.NotEmpty(t, env["AWS_CONFIG_FILE"])
+	assert.NotEmpty(t, env["AWS_PROFILE"])
+	assert.Equal(t, "role", env["AWS_PROFILE"])
 }
 
 func TestAssumeRoleIdentity_BuildAssumeRoleInput(t *testing.T) {

--- a/pkg/auth/identities/aws/permission_set.go
+++ b/pkg/auth/identities/aws/permission_set.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -134,6 +135,24 @@ func (i *permissionSetIdentity) Validate() error {
 // Environment returns environment variables for this identity.
 func (i *permissionSetIdentity) Environment() (map[string]string, error) {
 	env := make(map[string]string)
+
+	// Get provider name for AWS file paths.
+	providerName, err := i.GetProviderName()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get AWS file environment variables.
+	awsFileManager, err := awsCloud.NewAWSFileManager()
+	if err != nil {
+		return nil, errors.Join(errUtils.ErrAuthAwsFileManagerFailed, err)
+	}
+	awsEnvVars := awsFileManager.GetEnvironmentVariables(providerName, i.name)
+
+	// Convert to map format.
+	for _, envVar := range awsEnvVars {
+		env[envVar.Key] = envVar.Value
+	}
 
 	// Add environment variables from identity config.
 	for _, envVar := range i.config.Env {


### PR DESCRIPTION
## what
 - Bugfix: `Atmos auth exec` and `atmos auth env` need the default AWS Env variables of AWS to function properly. Main implementation had this feature, but was removed unintentionally from refactoring how the Environment() block was used.


## why

 - Allows `atmos auth exec -- aws s3 ls` and selecting an identity to work as expected.

## references

 - #1475 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically merges AWS file-based environment variables (e.g., profile and config/credentials settings) for Assume Role and Permission Set identities, applied before app-level environment overrides. This improves compatibility with existing AWS CLI configurations.

- Tests
  - Updated tests to verify inclusion of AWS file-based variables alongside custom configuration variables in the final environment output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->