### PR TITLE
chore: upgrade bearsh/hid to v1.6.0 to fix macOS deprecation warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/baulk/chardet v0.1.0 // indirect
-	github.com/bearsh/hid v1.3.0 // indirect
+	github.com/bearsh/hid v1.6.0 // indirect
 	github.com/beevik/etree v1.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,9 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/baulk/chardet v0.1.0 h1:6/r5nPMikB9OG1Njs10VfVHZTDMFH6BdybHPISpfUVA=
 github.com/baulk/chardet v0.1.0/go.mod h1:0ibN6068qswel5Hv54U7GNJUU57njfzPJrLIq7Y8xas=
-github.com/bearsh/hid v1.3.0 h1:GLNa8hvEzJxzQEEpheDUr2SivvH7iwTrJrDhFKutfX8=
 github.com/bearsh/hid v1.3.0/go.mod h1:KbQByg8WfPr92v7aaKAHTtZUEVG7e2XRpcF8+TopQv8=
+github.com/bearsh/hid v1.6.0 h1:eOBSuF2pg+SCytKGuGjOzZx73xQ72gevJ5IlFvzgfGE=
+github.com/bearsh/hid v1.6.0/go.mod h1:7JhM3r/tm4ALu4WWFqshda+Q6aIcnGRpUR08sx/dHdc=
 github.com/beevik/etree v1.4.1 h1:PmQJDDYahBGNKDcpdX8uPy1xRCwoCGVUiW669MEirVI=
 github.com/beevik/etree v1.4.1/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
## what
- Upgrade `bearsh/hid` transitive dependency from v1.3.0 to v1.6.0
- Add `replace` directive in `go.mod` to force the upgraded version
- Eliminate macOS 12+ deprecation warning for `kIOMasterPortDefault`

## why
- The older `bearsh/hid` v1.3.0 uses the deprecated `kIOMasterPortDefault` constant
- This causes build warnings on macOS 12 and later:
  ```
  warning: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0
  ```
- The latest version (v1.6.0) no longer uses the deprecated constant
- Since `bearsh/hid` is a transitive dependency via `versent/saml2aws/v2` (used for Atmos auth), we use a `replace` directive to ensure the upgraded version is used

## references
- Dependency chain: `atmos` → `versent/saml2aws/v2@v2.36.19` → `marshallbrekka/go-u2fhost` → `bearsh/hid@v1.3.0`
- The `replace` directive overrides the version to use `bearsh/hid@v1.6.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the HID library to v1.6.0 to standardize module resolution.
  * Improves build reproducibility and reduces variations between installations.
  * No changes to UI, workflows, or runtime behavior.
  * Internal maintenance only; end-user experience remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->