### PR TITLE
`auth` docs improvement - `account.id` vs `account.name` in type `aws/permissionset`

### DIFF
--- a/pkg/auth/docs/ARCHITECTURE.md
+++ b/pkg/auth/docs/ARCHITECTURE.md
@@ -166,7 +166,9 @@ identities:
     principal:
       name: AdminAccess
       account:
-        name: "123456789012"
+        name: "sandbox"
+        # OR use account ID directly:
+        # id: "123456789012"
 ```
 
 ### Identity Chaining

--- a/pkg/auth/docs/PRD/PRD-Atmos-Auth.md
+++ b/pkg/auth/docs/PRD/PRD-Atmos-Auth.md
@@ -983,6 +983,17 @@ identities:
 
 #### AWS Permission Set
 
+AWS Permission Set identities assume roles via AWS IAM Identity Center (SSO). The `account` field specifies which AWS account contains the permission set.
+
+**Account Specification Options:**
+
+You can specify the account using either:
+
+- `account.name` - Account name/alias (resolved via SSO ListAccounts API)
+- `account.id` - Numeric account ID (used directly, no lookup required)
+
+**Example with Account Name (Recommended):**
+
 ```yaml
 identities:
   dev-access:
@@ -992,11 +1003,19 @@ identities:
       name: DeveloperAccess
       account:
         name: dev
-    env:
-      - key: AWS_PROFILE
-        value: dev-access
-      - key: ENVIRONMENT
-        value: development
+```
+
+**Example with Account ID:**
+
+```yaml
+identities:
+  dev-access:
+    kind: aws/permission-set
+    via: { provider: aws-sso }
+    principal:
+      name: DeveloperAccess
+      account:
+        id: "123456789012"
 ```
 
 #### AWS Assume Role
@@ -1210,6 +1229,7 @@ auth:
         name: IdentityManagersTeamAccess
         account:
           name: core-identity
+
 
       # AWS files automatically managed:
       # ~/.aws/atmos/cplive-sso/credentials

--- a/pkg/auth/docs/UserGuide.md
+++ b/pkg/auth/docs/UserGuide.md
@@ -100,7 +100,7 @@ identities:
     principal:
       name: AdminAccess
       account:
-        name: "123456789012"
+        name: "production"
 
   # Cross-account role using base permissions
   prod-admin:
@@ -133,7 +133,9 @@ auth:
       principal:
         name: AdminAccess
         account:
-          name: "123456789012"
+          name: "development"
+          # OR use account ID directly:
+          # id: "123456789012"
 
     prod-readonly:
       kind: aws/permission-set
@@ -142,7 +144,9 @@ auth:
       principal:
         name: ReadOnlyAccess
         account:
-          name: "999999999999"
+          name: "production"
+          # OR use account ID directly:
+          # id: "999999999999"
 ```
 
 ### AWS SAML Authentication


### PR DESCRIPTION
## what

This pull request updates documentation for specifying AWS account references in identity configurations, improving clarity and flexibility for users. The most important changes provide guidance on using either account names or IDs when configuring AWS identities, and update examples to reflect these options.

**Documentation improvements for AWS account specification:**

* Added explanations in `pkg/auth/docs/PRD/PRD-Atmos-Auth.md` about specifying AWS accounts using either `account.name` (recommended) or `account.id`, with examples for both methods. [[1]](diffhunk://#diff-d42f6a6a43ec1ff7d910c66d5f7d6cb87147ee5540dc8427418ca91ba538270aR986-R996) [[2]](diffhunk://#diff-d42f6a6a43ec1ff7d910c66d5f7d6cb87147ee5540dc8427418ca91ba538270aL995-R1018)
* Updated example configurations in `pkg/auth/docs/ARCHITECTURE.md` and `pkg/auth/docs/UserGuide.md` to use descriptive account names (e.g., "sandbox", "production", "development") instead of numeric IDs, and included comments showing how to use the account ID directly. [[1]](diffhunk://#diff-62eb080dfae5c5567c48895da48779fc1b0339f712c0ee9747905f7ffd0d1fdeL169-R171) [[2]](diffhunk://#diff-397d1a2e50118dbd9ed94da2422e31ec4d4dbc207aaac5b51e0b0756a21b4a03L103-R103) [[3]](diffhunk://#diff-397d1a2e50118dbd9ed94da2422e31ec4d4dbc207aaac5b51e0b0756a21b4a03L136-R138) [[4]](diffhunk://#diff-397d1a2e50118dbd9ed94da2422e31ec4d4dbc207aaac5b51e0b0756a21b4a03L145-R149)

**Minor documentation adjustments:**

* Minor formatting and clarification changes in `pkg/auth/docs/PRD/PRD-Atmos-Auth.md` to improve readability of the `auth:` section.

## why

- Improve docs for better getting started experience

## references

- #1475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guides to use environment-based account names (e.g., “production”, “development”) instead of numeric IDs in examples.
  * Added explicit guidance for configuring AWS Permission Set identities.
  * Provided parallel example configurations for specifying accounts by name or by ID (with an alternative commented option).
  * Restored environment variable blocks in relevant examples and refined example formatting.
  * Minor text/whitespace cleanups.
  * No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->