### PR TITLE
Refactor Leapp migration docs for clarity

### DIFF
--- a/website/docs/cli/commands/auth/tutorials/migrating-from-leapp.mdx
+++ b/website/docs/cli/commands/auth/tutorials/migrating-from-leapp.mdx
@@ -51,6 +51,10 @@ auth:
 
 **That's it!** The configuration maps directly from what you see in Leapp to your `atmos.yaml`. Now you can run `atmos auth login` and you're ready to go.
 
+## Step-by-Step Migration
+
+Need more detail? Here's how to migrate each piece of your Leapp configuration:
+
 <details>
 <summary>Understanding Leapp Terminology (Optional)</summary>
 
@@ -63,10 +67,6 @@ In Leapp, authentication consists of:
 5. **Region**: AWS region for the session
 
 </details>
-
-## Step-by-Step Migration
-
-Need more detail? Here's how to migrate each piece of your Leapp configuration:
 
 <details>
 <summary>Field Mapping Reference (Quick Lookup)</summary>


### PR DESCRIPTION
## what

- Moved the "Quick Migration Example" section to be more prominent, appearing immediately after the overview.
- Encapsulated the detailed "Understanding Leapp Components" section within a collapsible `<details>` block, making it optional for users who need more context.
- Simplified the "Using with Geodesic" section by reducing its length and directly linking to the dedicated Geodesic configuration guide.
- Removed specific reference architecture terminology and concepts to provide a more general guide.

## why

- To address feedback that the migration page was too verbose and conflated general Atmos concepts with specific reference architectures.
- The goal is to make it easier for users to quickly understand what they need to change and how to log in when migrating from Leapp to Atmos Auth.
- Collapsing detailed explanations and linking to dedicated guides improves scannability and focuses the primary content on the migration itself.

## references

- closes #
