### PR TITLE
Add step to get dependencies in Go setup workflow

### DIFF
--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -38,4 +38,3 @@ jobs:
 
       - name: Get deps
         run: make deps
-


### PR DESCRIPTION
## what
* Add step to get dependencies in Go setup workflow

## why
* To cache actual dependencies 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run dependency fetching during build setup, ensuring dependencies are retrieved earlier and improving build preparation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->