### PR TITLE
fix: Only log verbose test output on failure

### DIFF
--- a/pkg/component/component_processor_test.go
+++ b/pkg/component/component_processor_test.go
@@ -13,7 +13,6 @@ func TestComponentProcessor(t *testing.T) {
 	var component string
 	var stack string
 	namespace := ""
-	var yamlConfig string
 
 	var tenant1Ue2DevTestTestComponent map[string]any
 	component = "test/test-component"
@@ -75,9 +74,17 @@ func TestComponentProcessor(t *testing.T) {
 	assert.Equal(t, "orgs/cp/tenant1/dev/us-east-2", tenant1Ue2DevTestTestComponentDeps2[8])
 	assert.Equal(t, "tenant1-ue2-dev", tenant1Ue2DevTestTestComponentTerraformWorkspace2)
 
-	yamlConfig, err = u.ConvertToYAML(tenant1Ue2DevTestTestComponent)
+	yamlConfig, err := u.ConvertToYAML(tenant1Ue2DevTestTestComponent)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Component configuration:\n%s", yamlConfig)
+			} else {
+				t.Logf("Component configuration (raw): %+v", tenant1Ue2DevTestTestComponent)
+			}
+		}
+	})
 
 	var tenant1Ue2DevTestTestComponentOverrideComponent map[string]any
 	component = "test/test-component-override"
@@ -122,9 +129,17 @@ func TestComponentProcessor(t *testing.T) {
 	assert.Equal(t, "tenant1-ue2-dev-test-test-component-override-2", tenant1Ue2DevTestTestComponentOverrideComponent2Workspace)
 	assert.Equal(t, "test-test-component", tenant1Ue2DevTestTestComponentOverrideComponent2WorkspaceKeyPrefix)
 
-	yamlConfig, err = u.ConvertToYAML(tenant1Ue2DevTestTestComponentOverrideComponent2)
+	yamlConfig2, err := u.ConvertToYAML(tenant1Ue2DevTestTestComponentOverrideComponent2)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig2 != "" {
+				t.Logf("Component override 2 configuration:\n%s", yamlConfig2)
+			} else {
+				t.Logf("Component override 2 configuration (raw): %+v", tenant1Ue2DevTestTestComponentOverrideComponent2)
+			}
+		}
+	})
 
 	// Test having a dash `-` in the stage name
 	var tenant1Ue2Test1TestTestComponentOverrideComponent2 map[string]any
@@ -163,7 +178,6 @@ func TestComponentProcessor(t *testing.T) {
 }
 
 func TestComponentProcessorHierarchicalInheritance(t *testing.T) {
-	var yamlConfig string
 	namespace := ""
 	component := "derived-component-2"
 	tenant := "tenant1"
@@ -177,9 +191,17 @@ func TestComponentProcessorHierarchicalInheritance(t *testing.T) {
 	componentHierarchicalInheritanceTestVar := componentVars["hierarchical_inheritance_test"].(string)
 	assert.Equal(t, "base-component-1", componentHierarchicalInheritanceTestVar)
 
-	yamlConfig, err = u.ConvertToYAML(componentMap)
+	yamlConfig, err := u.ConvertToYAML(componentMap)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Component map configuration:\n%s", yamlConfig)
+			} else {
+				t.Logf("Component map configuration (raw): %+v", componentMap)
+			}
+		}
+	})
 }
 
 func TestComponentProcessor_StackNameTemplate(t *testing.T) {

--- a/pkg/describe/describe_affected_test.go
+++ b/pkg/describe/describe_affected_test.go
@@ -1,7 +1,6 @@
 package describe
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,8 +52,15 @@ func TestDescribeAffectedWithTargetRefClone(t *testing.T) {
 
 	affectedYaml, err := u.ConvertToYAML(affected)
 	assert.Nil(t, err)
-
-	t.Log(fmt.Sprintf("\nAffected components and stacks:\n%v", affectedYaml))
+	t.Cleanup(func() {
+		if t.Failed() {
+			if affectedYaml != "" {
+				t.Logf("Affected components and stacks:\n%s", affectedYaml)
+			} else {
+				t.Logf("Affected components and stacks (raw): %+v", affected)
+			}
+		}
+	})
 }
 
 func TestDescribeAffectedWithTargetRepoPath(t *testing.T) {
@@ -90,6 +96,13 @@ func TestDescribeAffectedWithTargetRepoPath(t *testing.T) {
 
 	affectedYaml, err := u.ConvertToYAML(affected)
 	assert.Nil(t, err)
-
-	t.Log(fmt.Sprintf("\nAffected components and stacks:\n%v", affectedYaml))
+	t.Cleanup(func() {
+		if t.Failed() {
+			if affectedYaml != "" {
+				t.Logf("Affected components and stacks:\n%s", affectedYaml)
+			} else {
+				t.Logf("Affected components and stacks (raw): %+v", affected)
+			}
+		}
+	})
 }

--- a/pkg/describe/describe_component_test.go
+++ b/pkg/describe/describe_component_test.go
@@ -18,7 +18,15 @@ func TestDescribeComponent(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }
 
 func TestDescribeTemplatedComponent(t *testing.T) {
@@ -40,7 +48,15 @@ func TestDescribeComponent2(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }
 
 func TestDescribeComponent3(t *testing.T) {
@@ -52,7 +68,15 @@ func TestDescribeComponent3(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }
 
 func TestDescribeComponent5(t *testing.T) {
@@ -64,7 +88,15 @@ func TestDescribeComponent5(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }
 
 func TestDescribeComponent6(t *testing.T) {
@@ -76,7 +108,15 @@ func TestDescribeComponent6(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }
 
 func TestDescribeComponent7(t *testing.T) {
@@ -88,5 +128,13 @@ func TestDescribeComponent7(t *testing.T) {
 
 	componentSectionYaml, err := u.ConvertToYAML(componentSection)
 	assert.Nil(t, err)
-	t.Log(componentSectionYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if componentSectionYaml != "" {
+				t.Logf("Component section:\n%s", componentSectionYaml)
+			} else {
+				t.Logf("Component section (raw): %+v", componentSection)
+			}
+		}
+	})
 }

--- a/pkg/describe/describe_dependents_test.go
+++ b/pkg/describe/describe_dependents_test.go
@@ -26,7 +26,15 @@ func TestDescribeDependents(t *testing.T) {
 
 	dependentsYaml, err := u.ConvertToYAML(dependents)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if dependentsYaml != "" {
+				t.Logf("Dependents:\n%s", dependentsYaml)
+			} else {
+				t.Logf("Dependents (raw): %+v", dependents)
+			}
+		}
+	})
 }
 
 func TestDescribeDependents2(t *testing.T) {
@@ -44,5 +52,13 @@ func TestDescribeDependents2(t *testing.T) {
 
 	dependentsYaml, err := u.ConvertToYAML(dependents)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if dependentsYaml != "" {
+				t.Logf("Dependents:\n%s", dependentsYaml)
+			} else {
+				t.Logf("Dependents (raw): %+v", dependents)
+			}
+		}
+	})
 }

--- a/pkg/describe/describe_stacks_test.go
+++ b/pkg/describe/describe_stacks_test.go
@@ -19,9 +19,17 @@ func TestDescribeStacks(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter1(t *testing.T) {
@@ -35,9 +43,17 @@ func TestDescribeStacksWithFilter1(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, stack, nil, nil, nil, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter2(t *testing.T) {
@@ -52,9 +68,17 @@ func TestDescribeStacksWithFilter2(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, stack, components, nil, nil, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter3(t *testing.T) {
@@ -69,9 +93,17 @@ func TestDescribeStacksWithFilter3(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, stack, nil, nil, sections, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter4(t *testing.T) {
@@ -86,9 +118,17 @@ func TestDescribeStacksWithFilter4(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, "", nil, componentTypes, sections, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter5(t *testing.T) {
@@ -119,7 +159,15 @@ func TestDescribeStacksWithFilter5(t *testing.T) {
 
 	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(stacksYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter6(t *testing.T) {
@@ -146,7 +194,15 @@ func TestDescribeStacksWithFilter6(t *testing.T) {
 
 	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(stacksYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter7(t *testing.T) {
@@ -173,7 +229,15 @@ func TestDescribeStacksWithFilter7(t *testing.T) {
 
 	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(stacksYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithFilter8(t *testing.T) {
@@ -188,9 +252,17 @@ func TestDescribeStacksWithFilter8(t *testing.T) {
 	stacks, err := ExecuteDescribeStacks(atmosConfig, "", nil, componentTypes, sections, false, false)
 	assert.Nil(t, err)
 
-	dependentsYaml, err := u.ConvertToYAML(stacks)
+	stacksYaml, err := u.ConvertToYAML(stacks)
 	assert.Nil(t, err)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if stacksYaml != "" {
+				t.Logf("Stacks:\n%s", stacksYaml)
+			} else {
+				t.Logf("Stacks (raw): %+v", stacks)
+			}
+		}
+	})
 }
 
 func TestDescribeStacksWithEmptyStacks(t *testing.T) {

--- a/pkg/list/list_components_test.go
+++ b/pkg/list/list_components_test.go
@@ -36,7 +36,15 @@ func TestListComponents(t *testing.T) {
 	// Add assertions to validate the output structure
 	assert.NotNil(t, dependentsYaml)
 	assert.Greater(t, len(dependentsYaml), 0)
-	t.Log(dependentsYaml)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if dependentsYaml != "" {
+				t.Logf("Components list:\n%s", dependentsYaml)
+			} else {
+				t.Logf("Components list (raw): %+v", output)
+			}
+		}
+	})
 }
 
 func TestListComponentsWithStack(t *testing.T) {

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -81,7 +81,15 @@ func TestMergeListReplace(t *testing.T) {
 
 	yamlConfig, err := u.ConvertToYAML(result)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Merge result:\n%s", yamlConfig)
+			} else {
+				t.Logf("Merge result (raw): %+v", result)
+			}
+		}
+	})
 }
 
 func TestMergeListAppend(t *testing.T) {
@@ -108,7 +116,15 @@ func TestMergeListAppend(t *testing.T) {
 
 	yamlConfig, err := u.ConvertToYAML(result)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Merge result:\n%s", yamlConfig)
+			} else {
+				t.Logf("Merge result (raw): %+v", result)
+			}
+		}
+	})
 }
 
 func TestMergeListMerge(t *testing.T) {
@@ -162,7 +178,15 @@ func TestMergeListMerge(t *testing.T) {
 
 	yamlConfig, err := u.ConvertToYAML(result)
 	assert.Nil(t, err)
-	t.Log(yamlConfig)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Merge result:\n%s", yamlConfig)
+			} else {
+				t.Logf("Merge result (raw): %+v", result)
+			}
+		}
+	})
 }
 
 func TestMergeWithNilConfig(t *testing.T) {

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -101,7 +101,15 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 
 	yamlSpaceliftStacks, err := u.ConvertToYAML(spaceliftStacks)
 	assert.Nil(t, err)
-	t.Log(yamlSpaceliftStacks)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlSpaceliftStacks != "" {
+				t.Logf("Spacelift stacks:\n%s", yamlSpaceliftStacks)
+			} else {
+				t.Logf("Spacelift stacks (raw): %+v", spaceliftStacks)
+			}
+		}
+	})
 }
 
 func TestLegacySpaceliftStackProcessor(t *testing.T) {
@@ -183,5 +191,13 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 
 	yamlSpaceliftStacks, err := u.ConvertToYAML(spaceliftStacks)
 	assert.Nil(t, err)
-	t.Log(yamlSpaceliftStacks)
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlSpaceliftStacks != "" {
+				t.Logf("Spacelift stacks:\n%s", yamlSpaceliftStacks)
+			} else {
+				t.Logf("Spacelift stacks (raw): %+v", spaceliftStacks)
+			}
+		}
+	})
 }

--- a/pkg/stack/stack_processor_test.go
+++ b/pkg/stack/stack_processor_test.go
@@ -194,7 +194,15 @@ func TestStackProcessor(t *testing.T) {
 
 	yamlConfig, err := u.ConvertToYAML(mapConfig1)
 	assert.Nil(t, err)
-	t.Log(string(yamlConfig))
+	t.Cleanup(func() {
+		if t.Failed() {
+			if yamlConfig != "" {
+				t.Logf("Stack config:\n%s", string(yamlConfig))
+			} else {
+				t.Logf("Stack config (raw): %+v", mapConfig1)
+			}
+		}
+	})
 }
 
 func TestStackProcessorRelativePaths(t *testing.T) {


### PR DESCRIPTION
## what
- Replace unconditional `t.Log()` calls with `t.Cleanup()` handlers that only output verbose YAML/data when tests fail
- Eliminate noisy stderr output during successful test runs while preserving debug information when tests fail
- Add fallback to raw data output (`%+v`) when YAML conversion produces empty strings

## why
- CI test runs were showing verbose YAML dumps to stderr even when tests passed
- This cluttered test output and made it difficult to identify actual issues
- Debug information is still valuable when tests fail, but shouldn't appear during successful runs
- Go's `t.Log()` always outputs to stderr, regardless of test success/failure


## demo

Finally clean output!

```console
go mod download
Running tests with subprocess coverage collection
ok  	github.com/cloudposse/atmos	7.020s	coverage: 14.8% of statements in ./...
ok  	github.com/cloudposse/atmos/cmd	7.581s	coverage: 20.7% of statements in ./...
ok  	github.com/cloudposse/atmos/cmd/about	0.134s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/cmd/internal	0.099s	coverage: 0.1% of statements in ./...
?   	github.com/cloudposse/atmos/cmd/markdown	[no test files]
ok  	github.com/cloudposse/atmos/cmd/version	1.802s	coverage: 1.4% of statements in ./...
ok  	github.com/cloudposse/atmos/errors	0.213s	coverage: 0.4% of statements in ./...
ok  	github.com/cloudposse/atmos/internal/aws_utils	0.120s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/internal/exec	84.175s	coverage: 32.9% of statements in ./...
ok  	github.com/cloudposse/atmos/internal/terraform_backend	32.223s	coverage: 0.9% of statements in ./...
	github.com/cloudposse/atmos/internal/tui/atmos		coverage: 0.0% of statements
	github.com/cloudposse/atmos/internal/tui/components/code_view		coverage: 0.0% of statements
ok  	github.com/cloudposse/atmos/internal/tui/templates	0.125s	coverage: 0.5% of statements in ./...
	github.com/cloudposse/atmos/internal/tui/templates/term		coverage: 0.0% of statements
ok  	github.com/cloudposse/atmos/internal/tui/utils	0.218s	coverage: 0.2% of statements in ./...
	github.com/cloudposse/atmos/internal/tui/workflow		coverage: 0.0% of statements
ok  	github.com/cloudposse/atmos/pkg/atlantis	1.434s	coverage: 10.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth	0.141s	coverage: 2.1% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/cloud/aws	0.113s	coverage: 0.8% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/credentials	0.316s	coverage: 0.9% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/factory	0.141s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/identities/aws	0.139s	coverage: 1.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/list	0.138s	coverage: 1.5% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/providers/aws	0.098s	coverage: 1.6% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/providers/github	0.072s	coverage: 0.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/providers/mock	0.133s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/types	0.075s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/utils	0.099s	coverage: 0.0% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/auth/validation	0.150s	coverage: 0.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/aws	0.199s	coverage: 2.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/component	0.898s	coverage: 10.1% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/component/mock	0.178s	coverage: 0.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/config	3.247s	coverage: 5.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/config/homedir	0.073s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/convert	0.048s	coverage: 0.0% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/datafetcher	0.228s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/describe	29.214s	coverage: 13.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/downloader	1.115s	coverage: 1.6% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/filematch	0.135s	coverage: 0.3% of statements in ./...
	github.com/cloudposse/atmos/pkg/filesystem		coverage: 0.0% of statements
ok  	github.com/cloudposse/atmos/pkg/filetype	0.078s	coverage: 0.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/generate	0.685s	coverage: 7.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/git	0.164s	coverage: 0.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/github	2.462s	coverage: 0.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/hooks	0.264s	coverage: 7.5% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/list	2.193s	coverage: 12.0% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/list/errors	0.073s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/list/flags	0.072s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/list/format	0.119s	coverage: 0.6% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/list/utils	0.187s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/logger	0.161s	coverage: 0.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/merge	0.227s	coverage: 1.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/pager	0.076s	coverage: 0.9% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/perf	1.238s	coverage: 0.5% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/pro	0.177s	coverage: 0.8% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/pro/dtos	0.051s	coverage: 0.0% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/profiler	1.861s	coverage: 0.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/provenance	0.130s	coverage: 1.8% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/retry	0.176s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/schema	0.070s	coverage: 0.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/spacelift	0.787s	coverage: 8.4% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/stack	0.346s	coverage: 4.3% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/store	0.139s	coverage: 1.7% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/telemetry	0.518s	coverage: 2.7% of statements in ./...
	github.com/cloudposse/atmos/pkg/telemetry/mock		coverage: 0.0% of statements
ok  	github.com/cloudposse/atmos/pkg/ui/heatmap	0.129s	coverage: 0.9% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/ui/markdown	0.138s	coverage: 0.4% of statements in ./...
?   	github.com/cloudposse/atmos/pkg/ui/theme	[no test files]
ok  	github.com/cloudposse/atmos/pkg/utils	0.743s	coverage: 4.8% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/validate	1.354s	coverage: 14.5% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/validator	0.116s	coverage: 0.2% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/vender	3.308s	coverage: 3.9% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/version	0.069s	coverage: 0.0% of statements in ./...
ok  	github.com/cloudposse/atmos/pkg/xdg	0.046s	coverage: 0.1% of statements in ./...
ok  	github.com/cloudposse/atmos/tests	174.022s	coverage: 14.3% of statements in ./...
ok  	github.com/cloudposse/atmos/tests/testhelpers	90.419s	coverage: 1.1% of statements in ./...
Coverage report generated: coverage.out
```

## references
- Affects 9 test files with 29 cleanup handlers added
- Modified files:
  - `pkg/component/component_processor_test.go`
  - `pkg/describe/describe_affected_test.go`
  - `pkg/describe/describe_component_test.go`
  - `pkg/describe/describe_dependents_test.go`
  - `pkg/describe/describe_stacks_test.go`
  - `pkg/list/list_components_test.go`
  - `pkg/merge/merge_test.go`
  - `pkg/spacelift/spacelift_stack_processor_test.go`
  - `pkg/stack/stack_processor_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)