### PR TITLE
Fix test output logging to be subtest-aware

### DIFF
--- a/tests/cli_terraform_test.go
+++ b/tests/cli_terraform_test.go
@@ -66,13 +66,9 @@ func runTerraformApply(t *testing.T, environment string) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Logf("Terraform stdout:\n%s", stdout.String())
-			t.Logf("Terraform stderr:\n%s", stderr.String())
-		}
-	})
 	if err != nil {
+		t.Logf("Terraform stdout:\n%s", stdout.String())
+		t.Logf("Terraform stderr:\n%s", stderr.String())
 		t.Fatalf("Failed to run terraform apply mycomponent -s %s: %v", environment, stderr.String())
 	}
 }

--- a/tests/validate_schema_test.go
+++ b/tests/validate_schema_test.go
@@ -195,11 +195,10 @@ version: "1.0.0"
 	require.NoError(t, readErr)
 	output := buf.String()
 
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Logf("Schema validation output:\n%s", output)
-		}
-	})
+	// Log output immediately if there's an error or error output.
+	if err != nil || bytes.Contains([]byte(output), []byte("ERRO")) {
+		t.Logf("Schema validation output:\n%s", output)
+	}
 
 	// Verify validation succeeded.
 	assert.NoError(t, err, "Schema validation should succeed for all valid files")


### PR DESCRIPTION
## Summary

Replace `t.Cleanup()/t.Failed()` pattern with immediate error logging in test helpers. The old approach would log output if ANY part of the test failed, even if the specific operation succeeded. Now we log only when the actual operation fails.

## Changes

- `runTerraformApply()` now logs terraform output immediately on error
- `TestCliValidateSchemaWithMockServer` logs schema output immediately on validation failure

This provides more precise debugging info by showing output only for operations that actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)