### PR TITLE
fix: Pin Helm to v3.19.2 to avoid Helm 4.0 plugin verification issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ on:
 env:
   TERRAFORM_VERSION: "1.9.7"
   OPEN_TOFU_VERSION: "1.9.1"
+  HELM_VERSION: "v3.19.2"
   HELMFILE_VERSION: "v1.1.0"
   PACKER_VERSION: "1.14.2"
 
@@ -159,6 +160,7 @@ jobs:
         uses: helmfile/helmfile-action@v2.0.5
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         with:
+          helm-version: ${{ env.HELM_VERSION }}
           helmfile-version: ${{ env.HELMFILE_VERSION }}
           helmfile-args: version
           helmfile-auto-init: "false"
@@ -364,8 +366,13 @@ jobs:
       - name: Install the Cloud Posse package repository
         run: curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/bash.deb.sh' | sudo bash
 
-      - name: Install kubectl, helmfile, and helm
-        run: sudo apt-get -y install kubectl helmfile helm
+      - name: Install kubectl and helmfile
+        run: sudo apt-get -y install kubectl helmfile
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Install helm-diff plugin
         run: helm plugin install https://github.com/databus23/helm-diff


### PR DESCRIPTION
## what
- Pins Helm to v3.19.2 (latest 3.x version) in CI workflows
- Updates helmfile-action to use pinned helm-version parameter
- Replaces apt-get helm installation with azure/setup-helm action for version control

## why
Helm 4.0 was released with breaking changes to plugin verification that causes the helm-diff plugin installation to fail with "Error: plugin source does not support verification". Pinning to Helm 3.x ensures compatibility with the existing helm-diff plugin until it's updated to support Helm 4.0.

## references
- Closes plugin verification issues in Helm 4.0
- Maintains compatibility with current helm-diff plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to explicitly specify Helm version for improved consistency and reliability in CI/CD testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->