### PR TITLE
docs: PRD for aws/credentials identity with credential_process

### DIFF
--- a/docs/prd/aws-credential-process.md
+++ b/docs/prd/aws-credential-process.md
@@ -486,16 +486,18 @@ EOF
 
 ## Appendix: Example Configurations
 
-### Example 1: aws-sso-cli (Primary Use Case)
+### Example 1: Generic Corporate Credential Helper (Primary Use Case)
 ```yaml
 auth:
   identities:
-    staging:
+    production:
       kind: aws/credentials
       credentials:
-        credential_process: 'aws-sso process --sso staging --arn arn:aws:iam::111111111111:role/DevOps'
+        credential_process: '/usr/local/bin/corporate-credential-helper production'
         region: us-east-1
 ```
+
+**This is the core use case**: Organizations have their own custom credential vending tools that output AWS credentials in the standard format. The examples below show common third-party tools that follow the same pattern.
 
 ### Example 2: Okta AWS CLI
 ```yaml
@@ -508,7 +510,18 @@ auth:
         region: us-east-1
 ```
 
-### Example 3: Custom SAML Script
+### Example 3: aws-sso-cli
+```yaml
+auth:
+  identities:
+    staging:
+      kind: aws/credentials
+      credentials:
+        credential_process: 'aws-sso process --sso staging --arn arn:aws:iam::111111111111:role/DevOps'
+        region: us-east-1
+```
+
+### Example 4: Custom SAML Script
 ```yaml
 auth:
   identities:
@@ -519,14 +532,25 @@ auth:
         region: us-west-2
 ```
 
-### Example 4: Identity Chaining with Role Assumption
+### Example 5: AWS Vault Integration
+```yaml
+auth:
+  identities:
+    my-account:
+      kind: aws/credentials
+      credentials:
+        credential_process: 'aws-vault exec my-profile --json'
+        region: eu-central-1
+```
+
+### Example 6: Identity Chaining with Role Assumption
 ```yaml
 auth:
   identities:
     corp-base:
       kind: aws/credentials
       credentials:
-        credential_process: 'aws-sso process --sso corporate --arn arn:aws:iam::123456789012:role/BaseAccess'
+        credential_process: '/usr/local/bin/corporate-sso-helper'
 
     staging-poweruser:
       kind: aws/assume-role
@@ -543,18 +567,7 @@ auth:
         role_arn: 'arn:aws:iam::111111111111:role/ReadOnly'
 ```
 
-### Example 5: AWS Vault Integration
-```yaml
-auth:
-  identities:
-    my-account:
-      kind: aws/credentials
-      credentials:
-        credential_process: 'aws-vault exec my-profile --json'
-        region: eu-central-1
-```
-
-### Example 6: Comparison with aws/user
+### Example 7: Comparison with aws/user
 ```yaml
 auth:
   identities:
@@ -569,11 +582,11 @@ auth:
       session:
         duration: '12h'  # Atmos calls GetSessionToken with MFA
 
-    # For external credential processes (SSO, SAML, etc.)
-    sso-user:
+    # For external credential processes (corporate SSO, Okta, etc.)
+    corporate-sso:
       kind: aws/credentials
       credentials:
-        credential_process: 'aws-sso process --sso prod --arn arn:aws:iam::123456789012:role/Engineer'
+        credential_process: '/usr/local/bin/corporate-credential-helper prod'
         region: us-east-1
       # No session config - external process determines expiration
 ```


### PR DESCRIPTION
## Summary

Adds comprehensive Product Requirements Document for introducing a new `aws/credentials` identity kind that obtains AWS credentials from external processes using the AWS SDK's `credential_process` standard. Enables seamless integration with external credential helpers (aws-sso-cli, Okta CLI, aws-vault, custom SAML tools, etc.).

## Why a New Identity Kind?

**`aws/credentials` instead of extending `aws/user`:**

The `aws/user` identity kind is semantically tied to IAM Users and performs IAM User-specific operations:
- Takes long-lived credentials (access key + secret key)
- Calls STS `GetSessionToken` to generate temporary credentials
- Prompts for MFA tokens for IAM User MFA devices
- Enforces IAM User session duration limits (12h without MFA, 36h with MFA)

**Semantic mismatch with credential_process:**
- External processes return **already-temporary credentials** from SSO, assumed roles, or other sources
- These credentials already include a session token
- Calling `GetSessionToken` again would fail (can't get session token from session credentials)
- MFA is handled by the external process, not by Atmos

**Solution: New `aws/credentials` identity kind**
- **Semantic meaning**: "I have AWS credentials from an external source"
- **Behavior**: Use credentials as-is without transformation
- **Simpler**: No MFA prompting, no STS calls, just execute process and use credentials
- **Cleaner**: Preserves `aws/user` for its intended purpose (IAM Users with long-lived credentials)

## Identity Kind Comparison

| Feature | `aws/user` (existing) | `aws/credentials` (new) |
|---------|-----------|------------------------|
| **Purpose** | IAM User authentication | External credential processes |
| **Credential source** | Access key + secret key | credential_process output |
| **Transformation** | Calls STS GetSessionToken | Uses credentials as-is |
| **MFA** | Prompts for token | Handled by external process |
| **Session limits** | IAM User limits (12h-36h) | Process-determined |
| **Typical use** | Break-glass IAM users | SSO, SAML, corporate auth |
| **Provider name** | `aws-user` | `aws-credentials` |

## Use Case from GitHub Issue

User's organization sources temporary AWS credentials from an external process and wants to use Atmos's `credential_process` standard to integrate with their existing tooling.

## Configuration Examples

### Generic External Process (GitHub Issue Use Case)

```yaml
auth:
  identities:
    staging:
      kind: aws/credentials
      credentials:
        credential_process: '/home/myuser/.local/bin/external-process staging'
        region: eu-west-1
```

### Comparison with aws/user

```yaml
auth:
  identities:
    # For IAM Users with long-lived credentials
    break-glass-user:
      kind: aws/user
      credentials:
        access_key_id: !env AWS_ACCESS_KEY_ID
        secret_access_key: !env AWS_SECRET_ACCESS_KEY
        mfa_arn: 'arn:aws:iam::123456789012:mfa/emergency-user'
        region: us-east-1
      session:
        duration: '12h'  # Atmos calls GetSessionToken with MFA

    # For external credential processes (SSO, SAML, etc.)
    corporate-sso:
      kind: aws/credentials
      credentials:
        credential_process: '/usr/local/bin/corporate-credential-helper prod'
        region: us-east-1
      # No session config - external process determines expiration
```

### Identity Chaining

```yaml
auth:
  identities:
    corp-base:
      kind: aws/credentials
      credentials:
        credential_process: '/usr/local/bin/corporate-sso-helper'

    staging-poweruser:
      kind: aws/assume-role
      via:
        identity: corp-base
      principal:
        role_arn: 'arn:aws:iam::111111111111:role/PowerUser'
```

## Additional Example Tools

PRD includes examples for common credential helper tools:
- aws-sso-cli
- Okta AWS CLI
- Custom SAML scripts
- aws-vault
- Multi-level identity chaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)