### PR TITLE
Make Cloud Posse watermark clickable

### DIFF
--- a/website/src/components/Watermark/index.css
+++ b/website/src/components/Watermark/index.css
@@ -1,0 +1,47 @@
+/* Cloud Posse Logo - Fixed position in bottom right corner */
+.cloudposse-logo {
+  position: fixed;
+  bottom: 2%;
+  right: 2%;
+  width: 15em;
+  z-index: 100;
+  opacity: 0.5;
+  transition: opacity 0.2s ease-in-out;
+  text-decoration: none;
+}
+
+.cloudposse-logo:hover {
+  opacity: 0.8;
+}
+
+.cloudposse-logo img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Theme-based logo switching */
+/* Light mode: show light logo, hide dark logo */
+.cloudposse-logo__light {
+  display: block;
+}
+
+.cloudposse-logo__dark {
+  display: none;
+}
+
+/* Dark mode: show dark logo, hide light logo */
+html[data-theme='dark'] .cloudposse-logo__light {
+  display: none;
+}
+
+html[data-theme='dark'] .cloudposse-logo__dark {
+  display: block;
+}
+
+/* Hide on mobile to avoid interfering with content */
+@media (max-width: 768px) {
+  .cloudposse-logo {
+    display: none;
+  }
+}

--- a/website/src/components/Watermark/index.tsx
+++ b/website/src/components/Watermark/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import './index.css';
+
+/**
+ * Watermark renders a fixed-position clickable Cloud Posse logo
+ * in the bottom-right corner of the page.
+ *
+ * Theme switching is handled via CSS using [data-theme] selectors.
+ */
+export default function Watermark(): JSX.Element {
+  return (
+    <a
+      href="https://cloudposse.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="cloudposse-logo"
+      aria-label="Cloud Posse - Visit cloudposse.com"
+      title="Cloud Posse"
+    >
+      <img
+        src="/img/cloudposse-light.svg"
+        alt="Cloud Posse"
+        loading="lazy"
+        className="cloudposse-logo__light"
+      />
+      <img
+        src="/img/cloudposse-opaque.svg"
+        alt="Cloud Posse"
+        loading="lazy"
+        className="cloudposse-logo__dark"
+      />
+    </a>
+  );
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -115,17 +115,8 @@ div.atmos__effect::before, html[data-theme='dark'] div.navbar__logo::before {
     color: black;
 }
 
-html[data-theme='dark'] body {
-    background-image: url("/static/img/cloudposse-opaque.svg");
-}
-
 body {
     background-color: var(--ifm-background-color);
-    background-image: url("/static/img/cloudposse-light.svg");
-    background-position: 98% 98%;
-    background-repeat: no-repeat;
-    background-size: 15em;
-    background-attachment: fixed;
     font-family: 'Optimistic Text', -apple-system, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     font-size: 17px;
     line-height: 30px;

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Watermark from '@site/src/components/Watermark';
+
+/**
+ * Root component that wraps the entire site.
+ * Used to add global elements like the watermark.
+ */
+export default function Root({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <>
+      {children}
+      <Watermark />
+    </>
+  );
+}


### PR DESCRIPTION
## What
- Convert the Cloud Posse watermark from a non-interactive CSS background image to a clickable anchor element
- Watermark now links to cloudposse.com and opens in a new tab
- Renamed component from CloudPosseLogo to Watermark for clarity

## Why
- Improve user experience by making the watermark interactive and clickable
- Better maintainability with a React component instead of CSS background properties
- Consistent with modern web practices for branding elements

## How
- Created new Watermark component that renders an anchor tag with two theme-aware images
- Implemented theme switching via CSS using Docusaurus's [data-theme] selector
- Added Root theme component to render watermark on all pages globally
- Removed background-image styling from body element

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cloud Posse watermark/logo positioned in the bottom-right corner with light/dark theme support, hover effects, and click-through functionality.

* **Style**
  * Watermark hidden on mobile devices for improved responsiveness.
  * Removed background imagery from theme styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->