### PR TITLE
Fix Docker build: pin Helm 3.x and helm-diff v3.9.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN set -ex; \
     curl -1sSLf 'https://get.opentofu.org/install-opentofu.sh' | bash -s -- --root-method none --install-method deb; \
     # Install Kustomize binary (required by Helmfile)
     curl -1sSLf "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- /usr/local/bin; \
-    # Install toolchain used with Atmos \
-    apt-get -y install --no-install-recommends terraform kubectl helmfile helm; \
-    # Install the helm-diff plugin required by Helmfile
-    helm plugin install https://github.com/databus23/helm-diff; \
+    # Install toolchain used with Atmos (pin Helm 3.x for consistency)
+    apt-get -y install --no-install-recommends terraform kubectl helmfile helm=3.16.4-1; \
+    # Install the helm-diff plugin required by Helmfile (pin to v3.9.x for Helm 3 compatibility)
+    helm plugin install https://github.com/databus23/helm-diff --version v3.9.14; \
     # Clean up the package lists to keep the image clean
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## what

- Pin Helm to 3.16.4-1 for consistency with the rest of the codebase
- Pin helm-diff plugin to v3.9.14 for Helm 3 compatibility

## why

The Cloud Posse package repository updated Helm to 4.0.1, which broke the Docker build. The latest helm-diff plugin uses a `plugin.yaml` format incompatible with Helm 3.x, and Helm 4.x requires plugin verification that helm-diff doesn't support. Pinning both versions ensures a working build while maintaining consistency with Helm 3 used elsewhere.

## references

- Docker build failure in CI: `Error: plugin source does not support verification`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned dependency versions to specific releases for improved build reproducibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->