### PR TITLE
docs: Enhance YAML reference with null syntax and type tags

### DIFF
--- a/website/docs/reference/yaml-reference.mdx
+++ b/website/docs/reference/yaml-reference.mdx
@@ -460,9 +460,9 @@ vars:
 ```
 </File>
 
-**When to use explicit type tags vs quoting:**
-- ✅ Use quotes (`"value"`) - Simpler, more common, widely understood
-- ✅ Use type tags (`!!str`) - When you need to be explicit about intent, or in generated YAML
+**When to use explicit typing vs quoting:**<br/>
+✅ Use quotes (`"value"`) - Simpler, more common, widely understood<br/>
+✅ Use type tags (`!!str`) - When you need to be explicit about intent, or in generated YAML
 
 :::tip
 Most Atmos users prefer quoting over type tags. Type tags are useful when generating YAML programmatically or when you want to be very explicit about types.
@@ -797,10 +797,10 @@ vars:
 This distinction matters in Terraform where `null` triggers default behavior while `""` is an explicit empty value.
 :::
 
-**When to use `~` vs `null` vs `""`:**
-- ✅ Use `~` for concise configuration when unsetting values
-- ✅ Use `null` when you want to be explicit about the intent
-- ✅ Use `""` when you need an actual empty string (not null)
+**When to use `~` vs `null` vs `""`:**<br/>
+✅ Use `~` for concise configuration when unsetting values<br/>
+✅ Use `null` when you want to be explicit about the intent<br/>
+✅ Use `""` when you need an actual empty string (not null)
 
 **Common use case - Overriding inherited values to null:**
 


### PR DESCRIPTION
## what

- Added comprehensive section on YAML explicit type tags (`!!str`, `!!int`, `!!float`, `!!bool`) as an alternative to quoting
- Expanded null values documentation with detailed explanation of `~` tilde shorthand
- Added prominent warning explaining the semantic difference between `null` and `""` empty string
- Updated quick reference table to include null and type tag entries
- Added practical use case for overriding inherited values to null

## why

The YAML reference guide was missing documentation for explicit type tags and didn't sufficiently emphasize the difference between null and empty string, which is important in Terraform configuration where they have different behaviors.

## references

Related to YAML syntax documentation completeness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on YAML explicit type tags (!!str, !!int, !!float, !!bool) with examples and best practices for when to use them versus quoting
  * Expanded null values section with comprehensive guidance distinguishing null, tilde (~), and empty strings, including Terraform-specific implications
  * Enhanced Quick Reference table with entries for null handling and explicit typing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->