### PR TITLE
Simplify Nerd Fonts installation instructions

### DIFF
--- a/website/docs/quick-start/install-atmos.mdx
+++ b/website/docs/quick-start/install-atmos.mdx
@@ -324,10 +324,6 @@ We recommend the "Fira Code" NerdFont version, which is what all our screenshots
 
     Paste the following into a macOS Terminal window.
 
-    ```shell
-    brew tap homebrew/cask-fonts     # You only need to do this once!
-    brew search nerd-font            # Search for font packages
-
     # Install the NerdFont version of Fira Code
     brew install --cask font-fira-code-nerd-font
     ```


### PR DESCRIPTION
Removed Homebrew tap and search commands from installation instructions. Cask-fonts has been deprecated.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified macOS installation instructions by removing two preparatory commands from the NerdFont setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->