### PR TITLE
Fix markdown code fence in Nerd Fonts installation instructions

### DIFF
--- a/website/docs/quick-start/install-atmos.mdx
+++ b/website/docs/quick-start/install-atmos.mdx
@@ -324,6 +324,7 @@ We recommend the "Fira Code" NerdFont version, which is what all our screenshots
 
     Paste the following into a macOS Terminal window.
 
+    ```shell
     # Install the NerdFont version of Fira Code
     brew install --cask font-fira-code-nerd-font
     ```


### PR DESCRIPTION
## Summary

- Fixes markdown formatting issue introduced in #1913 where the opening code fence was accidentally deleted

## Details

PR #1913 simplified the Nerd Fonts installation instructions by removing deprecated Homebrew tap commands. However, the deletion also removed the opening ` ```shell ` code fence while keeping the closing ` ``` `, breaking the markdown formatting.

This PR adds back the opening code fence.

## Test plan

- [x] Verify the code block renders correctly in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified macOS Nerd Font installation instructions in the quick-start guide for a more straightforward setup experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->