### PR TITLE
fix: Correct Native CI/CD roadmap messaging

### DIFF
--- a/website/src/data/roadmap.js
+++ b/website/src/data/roadmap.js
@@ -96,13 +96,13 @@ export const roadmapConfig = {
       id: 'native-ci',
       icon: 'RiGitBranchLine',
       title: 'Native CI/CD Support',
-      tagline: 'Local = CI, no configuration drift',
-      description: 'PR comments with formatted plans, cost estimates, and approval buttons. Commands behave identically locally and in CI.',
-      benefits: 'PR reviewers see formatted plans directly in GitHub. No clicking through to CI logs. Get started with a few lines of workflow YAML.',
+      tagline: 'Local = CI. Same command, run everywhere',
+      description: 'Rich plan summaries directly in GitHub without wrapper scripts or extra actions. Commands auto-detect CI and produce beautiful output.',
+      benefits: 'Eliminate glue code from your workflows. No bash parsing, no separate actions—just run the same command you use locally. Ships with GitHub Actions support; provider architecture enables future GitLab and Azure DevOps support.',
       status: 'in-progress',
       quarter: 'q1-2026',
       pr: 1891,
-      prd: 'terraform-registry-migration',
+      prd: 'native-ci-integration',
     },
   ],
 
@@ -298,7 +298,7 @@ export const roadmapConfig = {
       milestones: [
         { label: 'Native GitHub OIDC enables automatic role assumptions', status: 'shipped', quarter: 'q3-2025', docs: '/cli/configuration/auth/providers', changelog: 'introducing-atmos-auth', description: 'Secretless CI/CD with native OIDC—no AWS access keys stored in GitHub secrets.', category: 'featured', priority: 'high', benefits: 'No long-lived credentials to rotate. Security posture improves and audit burden decreases.' },
         { label: 'Easily sharing outputs between GitHub Actions steps', status: 'planned', quarter: 'q1-2026', description: 'Pass Terraform outputs between GitHub Actions workflow steps without manual JSON parsing.', category: 'featured', priority: 'high', benefits: 'Use Terraform outputs in subsequent steps naturally. No jq parsing or file juggling.' },
-        { label: 'Simplified GitHub Actions with native CI mode', status: 'in-progress', quarter: 'q1-2026', pr: 1891, docs: '/integrations/github-actions/github-actions', description: 'Pre-built GitHub Actions with automatic CI environment detection, formatted PR comments with plans, and minimal configuration.', category: 'featured', priority: 'high', benefits: 'Get started with a few lines of workflow YAML. Atmos handles CI detection and formatting.' },
+        { label: 'Simplified GitHub Actions with native CI mode', status: 'in-progress', quarter: 'q1-2026', pr: 1891, docs: '/integrations/github-actions/github-actions', description: 'CLI auto-detects CI environments and generates rich job summaries with resource badges, collapsible diffs, and status checks. Replaces separate actions like github-action-atmos-terraform-plan.', category: 'featured', priority: 'high', benefits: 'No wrapper scripts needed. Same command works locally and in CI. Ships with GitHub Actions support; provider architecture enables future GitLab and Azure DevOps support.' },
       ],
       issues: [],
       prs: [


### PR DESCRIPTION
## what

- Removed misleading claims about cost estimates and approval buttons (not part of this feature)
- Updated tagline to "Local = CI. Same command, run everywhere" for clarity
- Refocused description and benefits on eliminating wrapper scripts and glue code
- Fixed PRD reference: terraform-registry-migration → native-ci-integration

## why

The roadmap entry misrepresented the Native CI/CD feature. Per PR #1891's blog post, the core value is replacing separate `github-action-atmos-*` actions with a single CLI that auto-detects CI and behaves identically locally and in CI. Removed unrelated claims about cost estimates and approval buttons.

## references

- PR #1891: Native CI Integration with Summary Templates and Terraform Command Registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Public Roadmap to clarify Native CI/CD Support features, emphasizing environment auto-detection and streamlined CI workflows without wrapper scripts.
  * Expanded GitHub Actions milestone details to highlight native mode capabilities, including enhanced job summaries, resource visualization, and planned multi-provider support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->