### PR TITLE
refactor: Eliminate deep exits in YAML function processing

### DIFF
--- a/internal/exec/describe_component_missing_ref_test.go
+++ b/internal/exec/describe_component_missing_ref_test.go
@@ -1,0 +1,103 @@
+package exec
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	log "github.com/cloudposse/atmos/pkg/logger"
+)
+
+// TestDescribeComponent_MissingComponentReference tests issue #1030:
+// When a component template references a non-existent component via atmos.Component(),
+// it should return a clear error, not fail silently.
+//
+// See: https://github.com/cloudposse/atmos/issues/1030
+func TestDescribeComponent_MissingComponentReference(t *testing.T) {
+	// Clear caches to ensure fresh processing.
+	ClearBaseComponentConfigCache()
+	ClearMergeContexts()
+	ClearLastMergeContext()
+	ClearFileContentCache()
+
+	err := os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+	require.NoError(t, err, "Failed to unset 'ATMOS_CLI_CONFIG_PATH'")
+
+	err = os.Unsetenv("ATMOS_BASE_PATH")
+	require.NoError(t, err, "Failed to unset 'ATMOS_BASE_PATH'")
+
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(os.Stdout)
+
+	// Mock os.Exit to prevent test termination and capture exit code.
+	// Some code paths call CheckErrorPrintAndExit which calls os.Exit.
+	var exitCode int
+	exitCalled := false
+	originalOsExit := errUtils.OsExit
+	errUtils.OsExit = func(code int) {
+		exitCode = code
+		exitCalled = true
+		// Don't actually exit - just record the code.
+	}
+	defer func() {
+		errUtils.OsExit = originalOsExit
+	}()
+
+	// Define the working directory with missing component reference fixture.
+	workDir := "../../tests/fixtures/scenarios/missing-component-reference"
+	t.Chdir(workDir)
+
+	// Set ATMOS_CLI_CONFIG_PATH to CWD to isolate from repo's atmos.yaml.
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", ".")
+
+	// Attempt to describe a component that references a non-existent component.
+	// The template '{{ (atmos.Component "nonexistent" .stack).vars.some_var }}'
+	// should fail because "nonexistent" component doesn't exist.
+	_, err = ExecuteDescribeComponent(&ExecuteDescribeComponentParams{
+		Component:            "component-with-missing-ref",
+		Stack:                "test",
+		ProcessTemplates:     true,
+		ProcessYamlFunctions: true,
+		Skip:                 nil,
+		AuthManager:          nil,
+	})
+
+	// EXPECTED BEHAVIOR (issue #1030 fix):
+	// An error should be returned when atmos.Component() cannot find the referenced component.
+	// The error should wrap ErrInvalidComponent and contain useful information.
+
+	// BUG BEHAVIOR (issue #1030):
+	// err is nil (silent failure) and the template renders as empty or <no value>.
+
+	// Check if os.Exit was called (which indicates error WAS detected, just not returned properly).
+	// If exitCalled is true with exitCode != 0, the error was detected but os.Exit was called
+	// instead of returning the error - this is better than silent failure but still not ideal.
+	if exitCalled {
+		assert.NotEqual(t, 0, exitCode, "os.Exit was called with exit code 0 - this indicates silent success when failure was expected")
+		t.Logf("NOTE: os.Exit(%d) was called instead of returning error. Error WAS detected (issue #1030 silent failure is fixed), "+
+			"but os.Exit is being called instead of returning the error to the caller.", exitCode)
+		// The test passes because the error WAS detected and reported (issue #1030 is about silent failure).
+		return
+	}
+
+	// Assert that an error IS returned (not nil).
+	// If this assertion fails, the bug from issue #1030 still exists.
+	assert.Error(t, err, "Expected error when referencing non-existent component via atmos.Component(), but got nil. "+
+		"This indicates issue #1030 (silent failure) is still present.")
+
+	// If we got an error, verify it's the right kind of error.
+	if err != nil {
+		// The error should wrap ErrInvalidComponent.
+		assert.True(t, errors.Is(err, errUtils.ErrInvalidComponent),
+			"Expected error to wrap ErrInvalidComponent, got: %v", err)
+
+		// The error message should contain useful information.
+		errMsg := err.Error()
+		assert.Contains(t, errMsg, "nonexistent",
+			"Error message should mention the missing component name 'nonexistent'")
+	}
+}

--- a/internal/exec/describe_component_missing_ref_test.go
+++ b/internal/exec/describe_component_missing_ref_test.go
@@ -33,20 +33,6 @@ func TestDescribeComponent_MissingComponentReference(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(os.Stdout)
 
-	// Mock os.Exit to prevent test termination and capture exit code.
-	// Some code paths call CheckErrorPrintAndExit which calls os.Exit.
-	var exitCode int
-	exitCalled := false
-	originalOsExit := errUtils.OsExit
-	errUtils.OsExit = func(code int) {
-		exitCode = code
-		exitCalled = true
-		// Don't actually exit - just record the code.
-	}
-	defer func() {
-		errUtils.OsExit = originalOsExit
-	}()
-
 	// Define the working directory with missing component reference fixture.
 	workDir := "../../tests/fixtures/scenarios/missing-component-reference"
 	t.Chdir(workDir)
@@ -70,34 +56,17 @@ func TestDescribeComponent_MissingComponentReference(t *testing.T) {
 	// An error should be returned when atmos.Component() cannot find the referenced component.
 	// The error should wrap ErrInvalidComponent and contain useful information.
 
-	// BUG BEHAVIOR (issue #1030):
-	// err is nil (silent failure) and the template renders as empty or <no value>.
-
-	// Check if os.Exit was called (which indicates error WAS detected, just not returned properly).
-	// If exitCalled is true with exitCode != 0, the error was detected but os.Exit was called
-	// instead of returning the error - this is better than silent failure but still not ideal.
-	if exitCalled {
-		assert.NotEqual(t, 0, exitCode, "os.Exit was called with exit code 0 - this indicates silent success when failure was expected")
-		t.Logf("NOTE: os.Exit(%d) was called instead of returning error. Error WAS detected (issue #1030 silent failure is fixed), "+
-			"but os.Exit is being called instead of returning the error to the caller.", exitCode)
-		// The test passes because the error WAS detected and reported (issue #1030 is about silent failure).
-		return
-	}
-
 	// Assert that an error IS returned (not nil).
 	// If this assertion fails, the bug from issue #1030 still exists.
-	assert.Error(t, err, "Expected error when referencing non-existent component via atmos.Component(), but got nil. "+
+	require.Error(t, err, "Expected error when referencing non-existent component via atmos.Component(), but got nil. "+
 		"This indicates issue #1030 (silent failure) is still present.")
 
-	// If we got an error, verify it's the right kind of error.
-	if err != nil {
-		// The error should wrap ErrInvalidComponent.
-		assert.True(t, errors.Is(err, errUtils.ErrInvalidComponent),
-			"Expected error to wrap ErrInvalidComponent, got: %v", err)
+	// The error should wrap ErrInvalidComponent.
+	assert.True(t, errors.Is(err, errUtils.ErrInvalidComponent),
+		"Expected error to wrap ErrInvalidComponent, got: %v", err)
 
-		// The error message should contain useful information.
-		errMsg := err.Error()
-		assert.Contains(t, errMsg, "nonexistent",
-			"Error message should mention the missing component name 'nonexistent'")
-	}
+	// The error message should contain useful information about the component.
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "component-with-missing-ref",
+		"Error message should mention the component name that has the missing reference")
 }

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -667,7 +667,7 @@ func ProcessStacks(
 				configAndStacksInfo.Stack,
 				strings.Join(foundStacks, ", "),
 			)
-			errUtils.CheckErrorPrintAndExit(err, "", "")
+			return configAndStacksInfo, err
 		} else {
 			configAndStacksInfo = foundConfigAndStacksInfo
 		}
@@ -741,8 +741,8 @@ func ProcessStacks(
 			true,
 		)
 		if err != nil {
-			// If any error returned from the template processing, log it and exit.
-			errUtils.CheckErrorPrintAndExit(err, "", "")
+			// If any error returned from the template processing, return it.
+			return configAndStacksInfo, err
 		}
 
 		componentSectionConverted, err := u.UnmarshalYAML[schema.AtmosSectionMapType](componentSectionProcessed)
@@ -754,7 +754,7 @@ func ProcessStacks(
 					err = errors.Join(err, errors.New(errorMessage))
 				}
 			}
-			errUtils.CheckErrorPrintAndExit(err, "", "")
+			return configAndStacksInfo, err
 		}
 
 		configAndStacksInfo.ComponentSection = componentSectionConverted

--- a/internal/exec/yaml_func_aws.go
+++ b/internal/exec/yaml_func_aws.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -25,14 +26,13 @@ func processTagAwsValue(
 	expectedTag string,
 	stackInfo *schema.ConfigAndStacksInfo,
 	extractor func(*AWSCallerIdentity) string,
-) any {
+) (any, error) {
 	log.Debug(execAWSYAMLFunction, functionKey, input)
 
 	// Validate the tag matches expected.
 	if input != expectedTag {
 		log.Error(invalidYAMLFunction, functionKey, input, "expected", expectedTag)
-		errUtils.CheckErrorPrintAndExit(errUtils.ErrYamlFuncInvalidArguments, "", "")
-		return nil
+		return nil, fmt.Errorf("%w: expected %s, got %s", errUtils.ErrYamlFuncInvalidArguments, expectedTag, input)
 	}
 
 	// Get auth context from stack info if available.
@@ -46,12 +46,11 @@ func processTagAwsValue(
 	identity, err := getAWSCallerIdentityCached(ctx, atmosConfig, authContext)
 	if err != nil {
 		log.Error(failedGetIdentity, "error", err)
-		errUtils.CheckErrorPrintAndExit(err, "", "")
-		return nil
+		return nil, err
 	}
 
 	// Extract the requested value.
-	return extractor(identity)
+	return extractor(identity), nil
 }
 
 // processTagAwsAccountID processes the !aws.account_id YAML function.
@@ -65,17 +64,20 @@ func processTagAwsAccountID(
 	atmosConfig *schema.AtmosConfiguration,
 	input string,
 	stackInfo *schema.ConfigAndStacksInfo,
-) any {
+) (any, error) {
 	defer perf.Track(atmosConfig, "exec.processTagAwsAccountID")()
 
-	result := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsAccountID, stackInfo, func(id *AWSCallerIdentity) string {
+	result, err := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsAccountID, stackInfo, func(id *AWSCallerIdentity) string {
 		return id.Account
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if result != nil {
 		log.Debug("Resolved !aws.account_id", "account_id", result)
 	}
-	return result
+	return result, nil
 }
 
 // processTagAwsCallerIdentityArn processes the !aws.caller_identity_arn YAML function.
@@ -89,17 +91,20 @@ func processTagAwsCallerIdentityArn(
 	atmosConfig *schema.AtmosConfiguration,
 	input string,
 	stackInfo *schema.ConfigAndStacksInfo,
-) any {
+) (any, error) {
 	defer perf.Track(atmosConfig, "exec.processTagAwsCallerIdentityArn")()
 
-	result := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsCallerIdentityArn, stackInfo, func(id *AWSCallerIdentity) string {
+	result, err := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsCallerIdentityArn, stackInfo, func(id *AWSCallerIdentity) string {
 		return id.Arn
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if result != nil {
 		log.Debug("Resolved !aws.caller_identity_arn", "arn", result)
 	}
-	return result
+	return result, nil
 }
 
 // processTagAwsCallerIdentityUserID processes the !aws.caller_identity_user_id YAML function.
@@ -113,17 +118,20 @@ func processTagAwsCallerIdentityUserID(
 	atmosConfig *schema.AtmosConfiguration,
 	input string,
 	stackInfo *schema.ConfigAndStacksInfo,
-) any {
+) (any, error) {
 	defer perf.Track(atmosConfig, "exec.processTagAwsCallerIdentityUserID")()
 
-	result := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsCallerIdentityUserID, stackInfo, func(id *AWSCallerIdentity) string {
+	result, err := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsCallerIdentityUserID, stackInfo, func(id *AWSCallerIdentity) string {
 		return id.UserID
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if result != nil {
 		log.Debug("Resolved !aws.caller_identity_user_id", "user_id", result)
 	}
-	return result
+	return result, nil
 }
 
 // processTagAwsRegion processes the !aws.region YAML function.
@@ -137,15 +145,18 @@ func processTagAwsRegion(
 	atmosConfig *schema.AtmosConfiguration,
 	input string,
 	stackInfo *schema.ConfigAndStacksInfo,
-) any {
+) (any, error) {
 	defer perf.Track(atmosConfig, "exec.processTagAwsRegion")()
 
-	result := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsRegion, stackInfo, func(id *AWSCallerIdentity) string {
+	result, err := processTagAwsValue(atmosConfig, input, u.AtmosYamlFuncAwsRegion, stackInfo, func(id *AWSCallerIdentity) string {
 		return id.Region
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if result != nil {
 		log.Debug("Resolved !aws.region", "region", result)
 	}
-	return result
+	return result, nil
 }

--- a/internal/exec/yaml_func_store_get_test.go
+++ b/internal/exec/yaml_func_store_get_test.go
@@ -90,13 +90,13 @@ func TestProcessTagStoreGet(t *testing.T) {
 			name:         "Test invalid number of parameters",
 			input:        "!store.get redis",
 			currentStack: "dev",
-			expected:     "invalid YAML function: !store.get redis",
+			expected:     "invalid number of arguments in the Atmos YAML function: !store.get redis: invalid number of parameters: 1",
 		},
 		{
 			name:         "Test invalid number of parameters (too many)",
 			input:        "!store.get redis key1 key2",
 			currentStack: "dev",
-			expected:     "invalid YAML function: !store.get redis key1 key2",
+			expected:     "invalid number of arguments in the Atmos YAML function: !store.get redis key1 key2: invalid number of parameters: 3",
 		},
 		{
 			name:         "Test invalid default format",
@@ -108,8 +108,12 @@ func TestProcessTagStoreGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagStoreGet(&atmosConfig, tt.input, tt.currentStack)
-			assert.Equal(t, tt.expected, result)
+			result, err := processTagStoreGet(&atmosConfig, tt.input, tt.currentStack)
+			if err != nil {
+				assert.Equal(t, tt.expected, err.Error())
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
 		})
 	}
 }

--- a/internal/exec/yaml_func_store_test.go
+++ b/internal/exec/yaml_func_store_test.go
@@ -86,13 +86,13 @@ func TestProcessTagStore(t *testing.T) {
 			name:         "lookup with invalid default format",
 			input:        "!store redis staging vpc cidr | default",
 			currentStack: "dev",
-			expected:     "invalid YAML function: !store redis staging vpc cidr | default",
+			expected:     "invalid number of arguments in the Atmos YAML function: !store redis staging vpc cidr | default: invalid number of parameters after the pipe: 1",
 		},
 		{
 			name:         "lookup with extra parameters after default",
 			input:        "!store redis staging vpc cidr | default 172.20.0.0/16 extra",
 			currentStack: "dev",
-			expected:     "invalid YAML function: !store redis staging vpc cidr | default 172.20.0.0/16 extra",
+			expected:     "invalid number of arguments in the Atmos YAML function: !store redis staging vpc cidr | default 172.20.0.0/16 extra: invalid number of parameters after the pipe: 3",
 		},
 		{
 			name:         "lookup cross-stack and get a value from the result map using a YQ expression",
@@ -110,8 +110,12 @@ func TestProcessTagStore(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagStore(&atmosConfig, tt.input, tt.currentStack)
-			assert.Equal(t, tt.expected, result)
+			result, err := processTagStore(&atmosConfig, tt.input, tt.currentStack)
+			if err != nil {
+				assert.Equal(t, tt.expected, err.Error())
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
 		})
 	}
 }

--- a/internal/exec/yaml_func_store_test.go
+++ b/internal/exec/yaml_func_store_test.go
@@ -119,3 +119,124 @@ func TestProcessTagStore(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessTagStore_ErrorPaths tests error handling paths in processTagStore.
+func TestProcessTagStore_ErrorPaths(t *testing.T) {
+	// Start a new Redis server.
+	s := miniredis.RunT(t)
+	defer s.Close()
+
+	redisUrl := fmt.Sprintf("redis://%s", s.Addr())
+	t.Setenv("ATMOS_REDIS_URL", redisUrl)
+
+	redisStore, err := store.NewRedisStore(store.RedisStoreOptions{
+		URL: &redisUrl,
+	})
+	require.NoError(t, err)
+
+	// Populate store with test data.
+	require.NoError(t, redisStore.Set("dev", "vpc", "cidr", "10.0.0.0/16"))
+
+	tests := []struct {
+		name         string
+		atmosConfig  *schema.AtmosConfiguration
+		input        string
+		currentStack string
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name: "store not found",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{
+					"redis": redisStore,
+				},
+			},
+			input:        "!store nonexistent dev vpc cidr",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "store nonexistent not found",
+		},
+		{
+			name: "invalid identifier after pipe (not default or query)",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{
+					"redis": redisStore,
+				},
+			},
+			input:        "!store redis dev vpc cidr | invalid value",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "invalid identifier after the pipe: invalid",
+		},
+		{
+			name: "too few parameters",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{
+					"redis": redisStore,
+				},
+			},
+			input:        "!store redis vpc",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "invalid number of parameters: 2",
+		},
+		{
+			name: "too many parameters",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{
+					"redis": redisStore,
+				},
+			},
+			input:        "!store redis dev vpc cidr extra",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "invalid number of parameters: 5",
+		},
+		{
+			name: "key not found without default",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{
+					"redis": redisStore,
+				},
+			},
+			input:        "!store redis dev vpc nonexistent",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "failed to get key nonexistent",
+		},
+		{
+			name: "empty stores map",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: map[string]store.Store{},
+			},
+			input:        "!store redis dev vpc cidr",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "store redis not found",
+		},
+		{
+			name: "nil stores map",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stores: nil,
+			},
+			input:        "!store redis dev vpc cidr",
+			currentStack: "dev",
+			wantErr:      true,
+			errContains:  "store redis not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := processTagStore(tt.atmosConfig, tt.input, tt.currentStack)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/exec/yaml_func_template_test.go
+++ b/internal/exec/yaml_func_template_test.go
@@ -291,6 +291,55 @@ func TestProcessTagTemplate_ErrorHandling(t *testing.T) {
 	}
 }
 
+// TestProcessTagTemplate_EmptyInput tests that empty input after the tag returns an error.
+func TestProcessTagTemplate_EmptyInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "empty input after tag",
+			input:       "!template",
+			wantErr:     true,
+			errContains: "invalid Atmos YAML function",
+		},
+		{
+			name:        "only whitespace after tag",
+			input:       "!template   ",
+			wantErr:     true,
+			errContains: "invalid Atmos YAML function",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := processTagTemplate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestProcessTemplateTagsOnly_ErrorPath tests that ProcessTemplateTagsOnly handles errors gracefully.
+func TestProcessTemplateTagsOnly_ErrorPath(t *testing.T) {
+	// Test that an error in processTagTemplate returns the original string.
+	input := map[string]any{
+		"key": "!template", // Empty after tag - would return error from processTagTemplate.
+	}
+
+	result := ProcessTemplateTagsOnly(input)
+
+	// On error, the original string should be preserved.
+	assert.Equal(t, "!template", result["key"])
+}
+
 // TestYamlFuncTemplate_Integration tests the !template function in a real stack context.
 func TestYamlFuncTemplate_Integration(t *testing.T) {
 	err := os.Unsetenv("ATMOS_CLI_CONFIG_PATH")

--- a/internal/exec/yaml_func_template_test.go
+++ b/internal/exec/yaml_func_template_test.go
@@ -166,7 +166,7 @@ func TestProcessTagTemplate_UnitTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagTemplate(tt.input)
+			result, _ := processTagTemplate(tt.input)
 			assert.Equal(t, tt.expected, result, "Result should match expected value")
 		})
 	}
@@ -235,7 +235,7 @@ func TestProcessTagTemplate_TypePreservation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagTemplate(tt.input)
+			result, _ := processTagTemplate(tt.input)
 			tt.validator(t, result)
 		})
 	}
@@ -283,7 +283,7 @@ func TestProcessTagTemplate_ErrorHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagTemplate(tt.input)
+			result, _ := processTagTemplate(tt.input)
 			str, ok := result.(string)
 			assert.True(t, ok, "Result should be a string (graceful degradation)")
 			assert.Equal(t, tt.expectStr, str, tt.description)
@@ -566,7 +566,7 @@ func TestYamlFuncTemplate_ReturnTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processTagTemplate(tt.input)
+			result, _ := processTagTemplate(tt.input)
 			tt.validate(t, result)
 		})
 	}
@@ -577,7 +577,7 @@ func TestYamlFuncTemplate_ReturnTypes(t *testing.T) {
 func TestYamlFuncTemplate_WithSkip(t *testing.T) {
 	// This test verifies that the !template function works when called directly
 	t.Run("direct function call", func(t *testing.T) {
-		result := processTagTemplate(`!template ["a", "b", "c"]`)
+		result, _ := processTagTemplate(`!template ["a", "b", "c"]`)
 		list, ok := result.([]interface{})
 		assert.True(t, ok, "Should be a list")
 		assert.Len(t, list, 3, "List should have 3 items")
@@ -592,7 +592,7 @@ func TestYamlFuncTemplate_Documentation(t *testing.T) {
 	// Test the exact example from the documentation
 	t.Run("documentation example - list output", func(t *testing.T) {
 		input := `!template ["item-1", "item-2", "item-3"]`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 
 		list, ok := result.([]interface{})
 		assert.True(t, ok, "Should decode to list")
@@ -604,7 +604,7 @@ func TestYamlFuncTemplate_Documentation(t *testing.T) {
 
 	t.Run("documentation example - map output", func(t *testing.T) {
 		input := `!template {"key": "value"}`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 
 		m, ok := result.(map[string]interface{})
 		assert.True(t, ok, "Should decode to map")
@@ -616,7 +616,7 @@ func TestYamlFuncTemplate_Documentation(t *testing.T) {
 	t.Run("documentation pattern - simulated result", func(t *testing.T) {
 		// Simulate the result after toJson from atmos.Component() output
 		input := `!template ["subnet-abc", "subnet-def", "subnet-ghi"]`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 
 		// Verify we get a native list, not a JSON string
 		subnetIDs, ok := result.([]interface{})
@@ -633,14 +633,14 @@ func TestYamlFuncTemplate_Regression(t *testing.T) {
 	t.Run("empty JSON string edge case", func(t *testing.T) {
 		// Regression test: Empty JSON string should decode to empty string, not error
 		input := `!template ""`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 		assert.Equal(t, "", result)
 	})
 
 	t.Run("large JSON structure", func(t *testing.T) {
 		// Regression test: Large nested structures should work
 		input := `!template {"a":{"b":{"c":{"d":{"e":{"f":{"g":"deep"}}}}}}}`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 
 		m, ok := result.(map[string]interface{})
 		assert.True(t, ok, "Should decode deep structure")
@@ -676,7 +676,7 @@ func TestYamlFuncTemplate_Regression(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			result := processTagTemplate(tt.input)
+			result, _ := processTagTemplate(tt.input)
 			num, ok := result.(float64)
 			assert.True(t, ok, "Should decode to number")
 			assert.Equal(t, tt.expected, num)
@@ -686,7 +686,7 @@ func TestYamlFuncTemplate_Regression(t *testing.T) {
 	t.Run("special characters in strings", func(t *testing.T) {
 		// Regression test: Special characters should be preserved
 		input := `!template {"special": "!@#$%^&*()_+-=[]{}|;:',.<>?/~"}`
-		result := processTagTemplate(input)
+		result, _ := processTagTemplate(input)
 
 		m, ok := result.(map[string]interface{})
 		assert.True(t, ok)

--- a/internal/exec/yaml_func_utils.go
+++ b/internal/exec/yaml_func_utils.go
@@ -160,7 +160,8 @@ func processSimpleTags(
 	stackInfo *schema.ConfigAndStacksInfo,
 ) (any, bool, error) {
 	if matchesPrefix(input, u.AtmosYamlFuncTemplate, skip) {
-		return processTagTemplate(input), true, nil
+		result, err := processTagTemplate(input)
+		return result, true, err
 	}
 	if matchesPrefix(input, u.AtmosYamlFuncExec, skip) {
 		res, err := u.ProcessTagExec(input)
@@ -170,10 +171,12 @@ func processSimpleTags(
 		return res, true, nil
 	}
 	if matchesPrefix(input, u.AtmosYamlFuncStoreGet, skip) {
-		return processTagStoreGet(atmosConfig, input, currentStack), true, nil
+		result, err := processTagStoreGet(atmosConfig, input, currentStack)
+		return result, true, err
 	}
 	if matchesPrefix(input, u.AtmosYamlFuncStore, skip) {
-		return processTagStore(atmosConfig, input, currentStack), true, nil
+		result, err := processTagStore(atmosConfig, input, currentStack)
+		return result, true, err
 	}
 	if matchesPrefix(input, u.AtmosYamlFuncEnv, skip) {
 		res, err := u.ProcessTagEnv(input, stackInfo)
@@ -184,16 +187,20 @@ func processSimpleTags(
 	}
 	// AWS YAML functions - note these check for exact match since they take no arguments.
 	if input == u.AtmosYamlFuncAwsAccountID && !skipFunc(skip, u.AtmosYamlFuncAwsAccountID) {
-		return processTagAwsAccountID(atmosConfig, input, stackInfo), true, nil
+		result, err := processTagAwsAccountID(atmosConfig, input, stackInfo)
+		return result, true, err
 	}
 	if input == u.AtmosYamlFuncAwsCallerIdentityArn && !skipFunc(skip, u.AtmosYamlFuncAwsCallerIdentityArn) {
-		return processTagAwsCallerIdentityArn(atmosConfig, input, stackInfo), true, nil
+		result, err := processTagAwsCallerIdentityArn(atmosConfig, input, stackInfo)
+		return result, true, err
 	}
 	if input == u.AtmosYamlFuncAwsCallerIdentityUserID && !skipFunc(skip, u.AtmosYamlFuncAwsCallerIdentityUserID) {
-		return processTagAwsCallerIdentityUserID(atmosConfig, input, stackInfo), true, nil
+		result, err := processTagAwsCallerIdentityUserID(atmosConfig, input, stackInfo)
+		return result, true, err
 	}
 	if input == u.AtmosYamlFuncAwsRegion && !skipFunc(skip, u.AtmosYamlFuncAwsRegion) {
-		return processTagAwsRegion(atmosConfig, input, stackInfo), true, nil
+		result, err := processTagAwsRegion(atmosConfig, input, stackInfo)
+		return result, true, err
 	}
 	return nil, false, nil
 }

--- a/tests/fixtures/scenarios/missing-component-reference/atmos.yaml
+++ b/tests/fixtures/scenarios/missing-component-reference/atmos.yaml
@@ -1,0 +1,33 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.stage }}"
+
+logs:
+  file: "/dev/stderr"
+  level: Debug
+
+# Enable Go templates in Atmos manifests.
+templates:
+  settings:
+    enabled: true
+    evaluations: 1
+    sprig:
+      enabled: true
+    gomplate:
+      enabled: true
+      timeout: 10
+      datasources: {}

--- a/tests/fixtures/scenarios/missing-component-reference/components/terraform/mock/main.tf
+++ b/tests/fixtures/scenarios/missing-component-reference/components/terraform/mock/main.tf
@@ -1,0 +1,8 @@
+variable "foo" {
+  type    = string
+  default = ""
+}
+
+output "foo" {
+  value = var.foo
+}

--- a/tests/fixtures/scenarios/missing-component-reference/stacks/deploy/test.yaml
+++ b/tests/fixtures/scenarios/missing-component-reference/stacks/deploy/test.yaml
@@ -1,0 +1,18 @@
+# Stack manifest for testing issue #1030 - silent failure when component is missing.
+# This component references a non-existent component "nonexistent" via atmos.Component().
+
+vars:
+  stage: test
+
+components:
+  terraform:
+    # Component that references a missing component.
+    # This should fail with a clear error, not silently.
+    component-with-missing-ref:
+      metadata:
+        component: mock
+      vars:
+        # This references a component that doesn't exist.
+        # Expected behavior: Error should be returned.
+        # Bug behavior (issue #1030): Silent failure with exit code 1.
+        foo: '{{ (atmos.Component "nonexistent" .stack).vars.some_var }}'


### PR DESCRIPTION
## what

- Refactored YAML function processing to return errors instead of calling `os.Exit()` via `CheckErrorPrintAndExit`
- Changed function signatures to return `(any, error)` instead of just `any`
- Updated callers in `yaml_func_utils.go` to handle errors properly
- Simplified test to verify errors are returned (no longer needs to mock `os.Exit`)

## why

- Follow-up to issue #1030 (silent failure for missing components)
- While the original bug was fixed (errors ARE printed), the code was calling `os.Exit(1)` instead of returning errors to the caller
- This made the code difficult to test and violated Go error handling best practices
- Proper error propagation allows callers to handle errors appropriately

## references

- closes #1030
- Related PR discussion about error handling patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and propagation for configuration validation, AWS functions, and store operations
  * Fixed error detection for missing component references
  * Enhanced error messaging for invalid template and store operations
  
* **Tests**
  * Added comprehensive test coverage for error scenarios in YAML function processing and component validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->