### PR TITLE
fix: announcement bar responsive wrapping

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -279,6 +279,19 @@ article h1 {
     --announcement-bar-text-color: #fff;
 }
 
+/* Fix announcement bar responsive wrapping at mid-range widths */
+/* Override Docusaurus default fixed 30px height on desktop */
+@media (min-width: 997px) {
+    :root {
+        --docusaurus-announcement-bar-height: auto;
+    }
+}
+
+/* Ensure announcement bar content wraps properly */
+div[class*="announcementBarContent"] {
+    line-height: 1.4;
+}
+
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
     --ifm-color-primary: #3578e5;


### PR DESCRIPTION
## what

- Override Docusaurus default fixed 30px height on the announcement bar at desktop widths
- Allow the announcement bar to wrap gracefully to multiple lines at mid-range viewport widths instead of clipping text

## why

- At viewport widths between 997px and ~1400px, the announcement bar was clipping the text to a single 30px line
- Very wide screens displayed correctly (text fit on one line), and mobile displayed correctly (height: auto)
- The fix enables responsive text wrapping at mid-range widths where the message needs multiple lines

## references

- Docusaurus AnnouncementBar default styles: `website/node_modules/@docusaurus/theme-classic/src/theme/AnnouncementBar/styles.module.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved announcement bar layout and text wrapping on desktop viewports (997px and above) for better content visibility and presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->