### PR TITLE
fix(terminal, version): fix ANSI color downgrade and eliminate deep exits

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1640,14 +1640,8 @@ func init() {
 	viper.SetEnvPrefix("ATMOS")
 	viper.AutomaticEnv()
 
-	// Bind ATMOS_FORCE_COLOR to the force-color viper key.
-	// Note: CLICOLOR_FORCE is intentionally NOT bound here. Per the CLICOLOR spec,
-	// CLICOLOR_FORCE means "enable colors even without a TTY" but says nothing about
-	// color depth. Only --force-color / ATMOS_FORCE_COLOR should force TrueColor.
+	// force-color env binding is handled by the global flags registry via WithEnvVars.
 	// CLICOLOR_FORCE is handled separately in pkg/terminal via EnvCLIColorForce.
-	if err := viper.BindEnv("force-color", "ATMOS_FORCE_COLOR"); err != nil {
-		log.Error("Failed to bind ATMOS_FORCE_COLOR environment variable", "error", err)
-	}
 	// Bind mask flag to Viper so viper.GetBool("mask") reads the flag value.
 	if err := viper.BindPFlag("mask", RootCmd.PersistentFlags().Lookup("mask")); err != nil {
 		log.Error("Failed to bind mask flag to Viper", "error", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -479,10 +479,12 @@ var RootCmd = &cobra.Command{
 			// unless an explicit --use-version flag was provided.
 			shouldReexec := explicitVersionRequested || !isVersionManagementCommand(cmd)
 			if shouldReexec {
-				// CheckAndReexec returns true only on successful syscall.Exec, which replaces
-				// the current process entirely. This means true is never returned in practice
-				// since exec doesn't return. We call it for its side effects.
-				_ = pkgversion.CheckAndReexec(&tmpConfig)
+				// CheckAndReexec returns nil on success (exec replaces process) or if no
+				// re-exec was needed. Returns an error for hard failures (PR/SHA/invalid
+				// version install failures, exec failures).
+				if reexecErr := pkgversion.CheckAndReexec(&tmpConfig); reexecErr != nil {
+					errUtils.CheckErrorPrintAndExit(reexecErr, "", "")
+				}
 			}
 		}
 
@@ -1638,9 +1640,13 @@ func init() {
 	viper.SetEnvPrefix("ATMOS")
 	viper.AutomaticEnv()
 
-	// Bind both ATMOS_FORCE_COLOR and CLICOLOR_FORCE to the same viper key (they are equivalent).
-	if err := viper.BindEnv("force-color", "ATMOS_FORCE_COLOR", "CLICOLOR_FORCE"); err != nil {
-		log.Error("Failed to bind ATMOS_FORCE_COLOR/CLICOLOR_FORCE environment variables", "error", err)
+	// Bind ATMOS_FORCE_COLOR to the force-color viper key.
+	// Note: CLICOLOR_FORCE is intentionally NOT bound here. Per the CLICOLOR spec,
+	// CLICOLOR_FORCE means "enable colors even without a TTY" but says nothing about
+	// color depth. Only --force-color / ATMOS_FORCE_COLOR should force TrueColor.
+	// CLICOLOR_FORCE is handled separately in pkg/terminal via EnvCLIColorForce.
+	if err := viper.BindEnv("force-color", "ATMOS_FORCE_COLOR"); err != nil {
+		log.Error("Failed to bind ATMOS_FORCE_COLOR environment variable", "error", err)
 	}
 	// Bind mask flag to Viper so viper.GetBool("mask") reads the flag value.
 	if err := viper.BindPFlag("mask", RootCmd.PersistentFlags().Lookup("mask")); err != nil {

--- a/pkg/flags/global_registry.go
+++ b/pkg/flags/global_registry.go
@@ -346,7 +346,7 @@ func registerTerminalFlags(registry *FlagRegistry) {
 		Shorthand:   "",
 		Default:     false,
 		Description: "Force color output even when not a TTY (useful for screenshots)",
-		EnvVars:     []string{"ATMOS_FORCE_COLOR", "CLICOLOR_FORCE"},
+		EnvVars:     []string{"ATMOS_FORCE_COLOR"},
 	})
 
 	registry.Register(&BoolFlag{

--- a/pkg/flags/standard_builder.go
+++ b/pkg/flags/standard_builder.go
@@ -544,7 +544,7 @@ func (b *StandardOptionsBuilder) WithForceColor() *StandardOptionsBuilder {
 	defer perf.Track(nil, "flags.StandardOptionsBuilder.WithForceColor")()
 
 	b.options = append(b.options, WithBoolFlag("force-color", "", false, "Force color output even when not a TTY (useful for screenshots)"))
-	b.options = append(b.options, WithEnvVars("force-color", "ATMOS_FORCE_COLOR", "CLICOLOR_FORCE"))
+	b.options = append(b.options, WithEnvVars("force-color", "ATMOS_FORCE_COLOR"))
 	return b
 }
 

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -481,29 +481,31 @@ func (c *Config) DetectColorProfile(isTTY bool) ColorProfile {
 		return ColorTrue
 	}
 
-	// If CLICOLOR_FORCE is set, return TrueColor
-	if c.EnvCLIColorForce {
-		return ColorTrue
-	}
-
-	// Check for truecolor support
+	// Check for truecolor support.
 	colorTerm := strings.ToLower(c.EnvColorTerm)
 	if colorTerm == "truecolor" || colorTerm == "24bit" {
 		return ColorTrue
 	}
 
-	// Check TERM for 256 color support
+	// Check TERM for 256 color support.
 	termVar := strings.ToLower(c.EnvTerm)
 	if strings.Contains(termVar, "256color") || strings.Contains(termVar, "256") {
 		return Color256
 	}
 
-	// Check for any color support
+	// Check for any color support.
 	if strings.Contains(termVar, "color") || termVar == "xterm" || termVar == "screen" {
 		return Color16
 	}
 
-	// Default to 16 colors if TTY and color enabled
+	// CLICOLOR_FORCE enables color but does not dictate color depth.
+	// Per the CLICOLOR spec, it means "enable colors even without a TTY".
+	// Use Color16 as a safe minimum when no COLORTERM/TERM hints are available.
+	if c.EnvCLIColorForce {
+		return Color16
+	}
+
+	// Default to 16 colors if TTY and color enabled.
 	if isTTY {
 		return Color16
 	}

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -711,6 +711,45 @@ func TestDetectColorProfile_RespectsTTY(t *testing.T) {
 			expected: ColorNone,
 			reason:   "Should return ColorNone when --no-color is set",
 		},
+		{
+			name: "CLICOLOR_FORCE with COLORTERM=truecolor detects TrueColor",
+			config: Config{
+				EnvCLIColorForce: true,
+				EnvColorTerm:     "truecolor",
+			},
+			isTTY:    false,
+			expected: ColorTrue,
+			reason:   "CLICOLOR_FORCE enables color but COLORTERM determines depth",
+		},
+		{
+			name: "CLICOLOR_FORCE with TERM=xterm-256color detects 256 colors",
+			config: Config{
+				EnvCLIColorForce: true,
+				EnvTerm:          "xterm-256color",
+			},
+			isTTY:    false,
+			expected: Color256,
+			reason:   "CLICOLOR_FORCE enables color but TERM determines depth",
+		},
+		{
+			name: "CLICOLOR_FORCE alone defaults to Color16",
+			config: Config{
+				EnvCLIColorForce: true,
+			},
+			isTTY:    false,
+			expected: Color16,
+			reason:   "CLICOLOR_FORCE without COLORTERM/TERM should default to safe Color16",
+		},
+		{
+			name: "ForceColor overrides TERM to TrueColor",
+			config: Config{
+				ForceColor: true,
+				EnvTerm:    "xterm-256color",
+			},
+			isTTY:    true,
+			expected: ColorTrue,
+			reason:   "--force-color should force TrueColor regardless of TERM",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/version/reexec.go
+++ b/pkg/version/reexec.go
@@ -96,8 +96,9 @@ func (d *defaultInstaller) Install(toolSpec string, force, allowPrereleases bool
 
 // CheckAndReexec checks if version.use is configured and re-executes with the specified version.
 // This should be called after config/profiles are loaded but before command execution.
-// Returns true if re-exec was triggered (caller should exit), false otherwise.
-func CheckAndReexec(atmosConfig *schema.AtmosConfiguration) bool {
+// Returns nil if no re-exec was needed or if re-exec replaced the process (unreachable).
+// Returns an error for hard failures (PR/SHA/invalid version install failures, exec failures).
+func CheckAndReexec(atmosConfig *schema.AtmosConfiguration) error {
 	defer perf.Track(atmosConfig, "version.CheckAndReexec")()
 
 	return CheckAndReexecWithConfig(atmosConfig, DefaultReexecConfig())
@@ -105,16 +106,16 @@ func CheckAndReexec(atmosConfig *schema.AtmosConfiguration) bool {
 
 // CheckAndReexecWithConfig checks if version.use is configured and re-executes with the specified version.
 // This variant accepts a ReexecConfig for testability.
-func CheckAndReexecWithConfig(atmosConfig *schema.AtmosConfiguration, cfg *ReexecConfig) bool {
+func CheckAndReexecWithConfig(atmosConfig *schema.AtmosConfiguration, cfg *ReexecConfig) error {
 	defer perf.Track(atmosConfig, "version.CheckAndReexecWithConfig")()
 
 	requestedVersion := resolveRequestedVersion(atmosConfig, cfg)
 	if requestedVersion == "" {
-		return false
+		return nil
 	}
 
 	if shouldSkipReexec(requestedVersion, cfg) {
-		return false
+		return nil
 	}
 
 	return executeVersionSwitch(requestedVersion, cfg)
@@ -173,9 +174,9 @@ func shouldSkipReexec(requestedVersion string, cfg *ReexecConfig) bool {
 }
 
 // executeVersionSwitch performs the actual version switch.
-//
-//nolint:revive // os.Exit is intentional for hard failures on PR/SHA version errors.
-func executeVersionSwitch(requestedVersion string, cfg *ReexecConfig) bool {
+// Returns an error for hard failures (PR/SHA/invalid version, exec failure).
+// Returns nil for successful exec (unreachable) or graceful fallback to current version.
+func executeVersionSwitch(requestedVersion string, cfg *ReexecConfig) error {
 	targetVersion := strings.TrimPrefix(requestedVersion, "v")
 
 	// Find or install the requested version.
@@ -183,36 +184,30 @@ func executeVersionSwitch(requestedVersion string, cfg *ReexecConfig) bool {
 	if err != nil {
 		// For PR versions, fail hard - don't continue with wrong version.
 		if _, isPR := toolchain.IsPRVersion(requestedVersion); isPR {
-			formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
-			ui.Errorf("%s", formatted)
-			os.Exit(1)
+			return err
 		}
 
 		// For SHA versions, fail hard - don't continue with wrong version.
 		if _, isSHA := toolchain.IsSHAVersion(requestedVersion); isSHA {
-			formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
-			ui.Errorf("%s", formatted)
-			os.Exit(1)
+			return err
 		}
 
 		// Check if this is an invalid version format error - fail hard for those too.
 		_, _, parseErr := toolchain.ParseVersionSpec(requestedVersion)
 		if parseErr != nil {
-			formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
-			ui.Errorf("%s", formatted)
-			os.Exit(1)
+			return err
 		}
 
 		// For regular semver versions, fall back to current (existing behavior).
 		ui.Warningf("Failed to switch to Atmos version %s: %v", requestedVersion, err)
 		ui.Warningf("Continuing with current version %s", Version)
-		return false
+		return nil
 	}
 
 	// Set re-exec guard to prevent loops.
 	if err := cfg.SetEnv(ReexecGuardEnvVar, requestedVersion); err != nil {
 		log.Warn("Failed to set re-exec guard", "error", err)
-		return false
+		return nil
 	}
 
 	// Re-exec with the new binary.
@@ -223,12 +218,11 @@ func executeVersionSwitch(requestedVersion string, cfg *ReexecConfig) bool {
 	args = stripUseVersionFlags(args)
 
 	if err := cfg.ExecFn(binaryPath, args, cfg.Environ()); err != nil {
-		ui.Errorf("Failed to exec %s: %v", binaryPath, err)
-		return false
+		return fmt.Errorf("failed to exec %s: %w", binaryPath, err)
 	}
 
 	// This line is never reached on successful exec.
-	return true
+	return nil
 }
 
 // findOrInstallVersionWithConfig finds the binary for a version, installing if needed.

--- a/pkg/version/reexec.go
+++ b/pkg/version/reexec.go
@@ -218,7 +218,10 @@ func executeVersionSwitch(requestedVersion string, cfg *ReexecConfig) error {
 	args = stripUseVersionFlags(args)
 
 	if err := cfg.ExecFn(binaryPath, args, cfg.Environ()); err != nil {
-		return fmt.Errorf("failed to exec %s: %w", binaryPath, err)
+		return errUtils.Build(errUtils.ErrCommandFailed).
+			WithCause(err).
+			WithExplanationf("failed to exec %s", binaryPath).
+			Err()
 	}
 
 	// This line is never reached on successful exec.

--- a/pkg/version/reexec_test.go
+++ b/pkg/version/reexec_test.go
@@ -316,6 +316,7 @@ func TestCheckAndReexecWithConfig_ExecFails(t *testing.T) {
 	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
 	assert.Error(t, err, "Should return error when exec fails")
+	assert.ErrorIs(t, err, errUtils.ErrCommandFailed, "Should wrap with ErrCommandFailed sentinel")
 }
 
 func TestCheckAndReexecWithConfig_SetEnvFails(t *testing.T) {

--- a/pkg/version/reexec_test.go
+++ b/pkg/version/reexec_test.go
@@ -1339,6 +1339,7 @@ func TestCheckAndReexecWithConfig_ExecFailReturnsError(t *testing.T) {
 
 	assert.Error(t, err, "Should return error when exec fails")
 	assert.Contains(t, err.Error(), "permission denied")
+	assert.ErrorIs(t, err, errUtils.ErrCommandFailed, "Should wrap with ErrCommandFailed sentinel")
 }
 
 func TestDefaultReexecConfig(t *testing.T) {

--- a/pkg/version/reexec_test.go
+++ b/pkg/version/reexec_test.go
@@ -71,9 +71,9 @@ func TestCheckAndReexecWithConfig_NoVersionUse(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when version.use is empty")
+	assert.NoError(t, err, "Should return nil when version.use is empty")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath")
 	assert.Equal(t, 0, installer.callCount, "Should not call Install")
 }
@@ -102,9 +102,9 @@ func TestCheckAndReexecWithConfig_GuardActive(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when guard is active for same version")
+	assert.NoError(t, err, "Should return nil when guard is active for same version")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath when guard active")
 }
 
@@ -124,9 +124,9 @@ func TestCheckAndReexecWithConfig_VersionMatch(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when versions match")
+	assert.NoError(t, err, "Should return nil when versions match")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath when versions match")
 }
 
@@ -146,9 +146,9 @@ func TestCheckAndReexecWithConfig_VersionMatchWithVPrefix(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when versions match (v prefix normalized)")
+	assert.NoError(t, err, "Should return nil when versions match (v prefix normalized)")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath when versions match")
 }
 
@@ -188,9 +188,9 @@ func TestCheckAndReexecWithConfig_VersionMismatchExistingInstall(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath once")
 	assert.Equal(t, 0, installer.callCount, "Should not call Install when binary exists")
 	assert.Equal(t, "/home/user/.atmos/bin/cloudposse/atmos/1.160.0/atmos", execCalledWith)
@@ -243,9 +243,9 @@ func TestCheckAndReexecWithConfig_VersionMismatchNeedsInstall(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	assert.Equal(t, 2, findCallCount, "Should call FindBinaryPath twice (before and after install)")
 	assert.Equal(t, 1, installer.callCount, "Should call Install once")
 	assert.Equal(t, "/home/user/.atmos/bin/cloudposse/atmos/1.160.0/atmos", execCalledWith)
@@ -275,9 +275,9 @@ func TestCheckAndReexecWithConfig_InstallFails(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when install fails")
+	assert.NoError(t, err, "Should return nil when semver install fails (fallback to current)")
 	assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath once")
 	assert.Equal(t, 1, installer.callCount, "Should call Install once")
 }
@@ -313,9 +313,9 @@ func TestCheckAndReexecWithConfig_ExecFails(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when exec fails")
+	assert.Error(t, err, "Should return error when exec fails")
 }
 
 func TestCheckAndReexecWithConfig_SetEnvFails(t *testing.T) {
@@ -347,9 +347,9 @@ func TestCheckAndReexecWithConfig_SetEnvFails(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when SetEnv fails")
+	assert.NoError(t, err, "Should return nil when SetEnv fails (graceful fallback)")
 }
 
 func TestCheckAndReexecWithConfig_GuardIsSet(t *testing.T) {
@@ -445,9 +445,9 @@ func TestCheckAndReexecWithConfig_EnvVarVersions(t *testing.T) {
 				},
 			}
 
-			result := CheckAndReexecWithConfig(atmosConfig, cfg)
+			err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-			assert.True(t, result, "Should return true when re-exec is triggered")
+			assert.NoError(t, err, "Should return nil when re-exec is triggered")
 			assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath")
 		})
 	}
@@ -488,9 +488,9 @@ func TestCheckAndReexecWithConfig_EnvVarPrecedence(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath")
 }
 
@@ -526,9 +526,9 @@ func TestCheckAndReexecWithConfig_EnvVarFallbackToConfig(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath")
 }
 
@@ -567,9 +567,9 @@ func TestCheckAndReexecWithConfig_UseVersionFlagPrecedence(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	assert.Equal(t, 1, finder.callCount, "Should call FindBinaryPath")
 }
 
@@ -752,9 +752,9 @@ func TestCheckAndReexecWithConfig_StripsChdirFlags(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.True(t, result, "Should return true when re-exec is triggered")
+	assert.NoError(t, err, "Should return nil when re-exec is triggered")
 	// Verify both --chdir and --use-version flags were stripped from args.
 	assert.Equal(t, []string{"atmos", "terraform", "plan"}, execCalledWithArgs)
 }
@@ -1043,9 +1043,9 @@ func TestCheckAndReexecWithConfig_PRVersionGuardActive(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when guard is active for PR version")
+	assert.NoError(t, err, "Should return nil when guard is active for PR version")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath when guard active")
 }
 
@@ -1074,9 +1074,9 @@ func TestCheckAndReexecWithConfig_SHAVersionGuardActive(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	assert.False(t, result, "Should return false when guard is active for SHA version")
+	assert.NoError(t, err, "Should return nil when guard is active for SHA version")
 	assert.Equal(t, 0, finder.callCount, "Should not call FindBinaryPath when guard active")
 }
 
@@ -1117,10 +1117,10 @@ func TestCheckAndReexecWithConfig_InvalidVersionFormat(t *testing.T) {
 		},
 	}
 
-	result := CheckAndReexecWithConfig(atmosConfig, cfg)
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
 
-	// Should return false because install fails and it's a semver (fallback to current).
-	assert.False(t, result, "Should return false when install fails for semver version")
+	// Should return nil because install fails and it's a semver (fallback to current).
+	assert.NoError(t, err, "Should return nil when install fails for semver version (fallback to current)")
 }
 
 func TestStripUseVersionFlags_AtEnd(t *testing.T) {
@@ -1265,6 +1265,79 @@ func TestCheckAndReexecWithConfig_SHAVersionReexec(t *testing.T) {
 	// shouldSkipReexec returns false for SHA versions (never skip).
 	result := shouldSkipReexec("sha:ceb7526", cfg)
 	assert.False(t, result, "Should not skip re-exec for SHA version")
+}
+
+func TestCheckAndReexecWithConfig_PRVersionInstallFails(t *testing.T) {
+	// Previously untestable due to os.Exit(1) in executeVersionSwitch.
+	// Now that the API returns error, we can verify PR install failures are propagated.
+	originalVersion := Version
+	Version = "1.150.0"
+	defer func() { Version = originalVersion }()
+
+	t.Setenv("ATMOS_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	finder := &mockVersionFinder{}
+	installer := &mockVersionInstaller{}
+
+	cfg := &ReexecConfig{
+		Finder:    finder,
+		Installer: installer,
+		ExecFn:    func(argv0 string, argv []string, envv []string) error { return nil },
+		GetEnv:    func(key string) string { return "" },
+		SetEnv:    func(key, value string) error { return nil },
+		Args:      []string{"atmos", "version"},
+		Environ:   func() []string { return []string{} },
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{
+		Version: schema.Version{
+			Use: "pr:9999",
+		},
+	}
+
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
+
+	// PR install failure should return an error (not os.Exit).
+	assert.Error(t, err, "Should return error when PR version install fails")
+	assert.ErrorIs(t, err, errUtils.ErrToolInstall)
+}
+
+func TestCheckAndReexecWithConfig_ExecFailReturnsError(t *testing.T) {
+	// Verify that exec failures return an error instead of silently continuing.
+	originalVersion := Version
+	Version = "1.150.0"
+	defer func() { Version = originalVersion }()
+
+	finder := &mockVersionFinder{
+		findBinaryPathFunc: func(owner, repo, version string) (string, error) {
+			return "/path/to/atmos", nil
+		},
+	}
+	installer := &mockVersionInstaller{}
+
+	cfg := &ReexecConfig{
+		Finder:    finder,
+		Installer: installer,
+		ExecFn: func(argv0 string, argv []string, envv []string) error {
+			return errors.New("permission denied")
+		},
+		GetEnv:  func(key string) string { return "" },
+		SetEnv:  func(key, value string) error { return nil },
+		Args:    []string{"atmos", "version"},
+		Environ: func() []string { return []string{} },
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{
+		Version: schema.Version{
+			Use: "1.160.0",
+		},
+	}
+
+	err := CheckAndReexecWithConfig(atmosConfig, cfg)
+
+	assert.Error(t, err, "Should return error when exec fails")
+	assert.Contains(t, err.Error(), "permission denied")
 }
 
 func TestDefaultReexecConfig(t *testing.T) {

--- a/pkg/version/reexec_test.go
+++ b/pkg/version/reexec_test.go
@@ -1153,6 +1153,7 @@ func TestFindOrInstallVersionWithConfig_PRVersion(t *testing.T) {
 
 	// Should fail at the token check or PR install step.
 	assert.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrToolInstall)
 	assert.Empty(t, path)
 	// Should not call the semver finder/installer.
 	assert.Equal(t, 0, finder.callCount, "Should not use semver finder for PR version")


### PR DESCRIPTION
## what

- Fixed ANSI color profile downgrade where `CLICOLOR_FORCE` incorrectly forced TrueColor output, causing raw escape codes to be printed literally on terminals that only support 256 colors
- Decoupled `CLICOLOR_FORCE` (POSIX standard: "enable colors without TTY") from `--force-color` (Atmos-specific: "force TrueColor")
- Eliminated deep exits (`os.Exit`) from `reexec.go` by changing API to return `error` instead of `bool`, improving testability and error handling
- Fixed double markdown rendering where formatted errors were re-rendered through glamour

## why

A user on macOS saw raw ANSI TrueColor escape codes (`[38;2;R;G;Bm`) printed literally when running version switching commands. Root cause: `CLICOLOR_FORCE` environment variable (common in Docker/Geodesic containers) was bound to `viper.BindEnv("force-color")`, conflating two different semantics and forcing TrueColor even when the outer terminal only supports 256 colors.

Eliminating deep exits improves code quality: errors can now be tested at the library boundary rather than being silently swallowed or requiring elaborate mocking to prevent `os.Exit`.

## changes

### Terminal Color Profile Detection
- `pkg/terminal/terminal.go`: Moved `CLICOLOR_FORCE` check to fallback position after `COLORTERM`/`TERM` detection. Now respects terminal capabilities; uses `Color16` as safe minimum if no depth hints available
- `cmd/root.go`: Removed `CLICOLOR_FORCE` from viper binding; only `ATMOS_FORCE_COLOR` binds to `force-color` flag
- `pkg/flags/`: Removed `CLICOLOR_FORCE` from EnvVars in both `global_registry.go` and `standard_builder.go`

### Version Reexecution API
- `pkg/version/reexec.go`: Changed `CheckAndReexec()`, `CheckAndReexecWithConfig()`, `executeVersionSwitch()` signatures from `bool` to `error`
  - Removed all 3 `os.Exit(1)` calls and `//nolint:revive` comment
  - Removed double markdown rendering (`errUtils.Format()` + `ui.Errorf()`)
  - PR/SHA/invalid version install failures now return error instead of exiting
  - Exec failures now return wrapped error instead of silently failing
  - Semver install failures still gracefully fallback to current version (nil)
  - SetEnv failures still gracefully continue (nil)
- `cmd/root.go`: Updated error handling to check returned error and call `CheckErrorPrintAndExit()` at boundary

### Test Coverage
- `pkg/terminal/terminal_test.go`: Added 4 test cases for `CLICOLOR_FORCE` respecting terminal capabilities
- `pkg/version/reexec_test.go`: Updated ~15 assertions from bool to error semantics; added 2 new tests (`PRVersionInstallFails`, `ExecFailReturnsError`) previously untestable due to `os.Exit`

**Note**: Screengrab infrastructure still forces TrueColor via `--force-color`/`ATMOS_FORCE_COLOR` or explicit `COLORTERM=truecolor`, preserving screenshot generation behavior.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-exec/version switching now surfaces failures as errors so issues are reported and cause clean exits.
  * Color detection now falls back to a safe 16-color mode when forcing is requested but terminal hints are absent.

* **Configuration Changes**
  * Simplified color-forcing configuration to resolve via a single pathway/environment variable.

* **Tests**
  * Expanded coverage for color detection and version re-exec error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->