### PR TITLE
Exclude unsupported windows/arm from goreleaser build matrix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ builds:
       # Go 1.24+ dropped support for windows/arm (32-bit ARM).
       # https://go.dev/doc/go1.24#ports
       - goos: windows
-        goarch: arm      
+        goarch: arm
     binary: atmos
     ldflags:
       # Set `atmos` version to the GitHub release tag using Go `ldflags`


### PR DESCRIPTION
## what

- Add `ignore` rule to the shared goreleaser config (`.github/goreleaser.yml`) to exclude the `windows/arm` (32-bit ARM) build target
- Prevents `"unsupported GOOS/GOARCH pair windows/arm"` build failures for any org repo using Go 1.24+

## why

- Go 1.24 (February 2025) deprecated the `windows/arm` port, and Go 1.25+ removed it entirely. Any repo that upgrades past Go 1.23 and uses this shared goreleaser config will fail during the release build after spending ~33 minutes compiling the other 13 targets
- The `ignore` rule is harmless for repos still on Go < 1.24 — goreleaser simply skips a target that would otherwise build successfully. No binaries are lost for any currently-supported platform
- `windows/arm` (32-bit ARM on Windows) had negligible real-world usage — Windows on ARM devices run 64-bit Windows 11 (`windows/arm64`), which remains supported

## references

- [Go 1.24 release notes — Ports](https://go.dev/doc/go1.24#ports): *"Go 1.24 is the last release that supports building for 386 and arm GOOS targets on Windows"*
- [Go issue #67001](https://github.com/golang/go/issues/67001): Remove windows/arm port
- [GoReleaser `ignore` docs](https://goreleaser.com/customization/build/#why-is-there-a-builds-plural-section): filtering unsupported GOOS/GOARCH pairs
- https://github.com/cloudposse/.github/pull/246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded Windows ARM 32-bit builds from release distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->