### PR TITLE
Fix Claude Code plugin marketplace schema and update docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,29 +1,17 @@
 {
   "name": "cloudposse",
+  "version": "1.0.0",
+  "description": "Official Atmos plugins and skills for Claude Code",
   "owner": {
     "name": "Cloud Posse",
     "email": "opensource@cloudposse.com"
   },
-  "metadata": {
-    "description": "Official Atmos plugins and skills for Claude Code",
-    "version": "1.0.0",
-    "pluginRoot": "./agent-skills"
-  },
   "plugins": [
     {
       "name": "atmos",
-      "source": ".",
+      "source": "./agent-skills",
       "description": "Atmos skills for AI coding assistants: Terraform/Helmfile/Packer/Ansible orchestration, stack configuration, components, vendoring, validation, YAML functions, Go templates, authentication, stores, workflows, and design patterns.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Cloud Posse"
-      },
-      "homepage": "https://atmos.tools/integrations/ai/agent-skills",
-      "repository": "https://github.com/cloudposse/atmos",
-      "license": "Apache-2.0",
-      "keywords": ["atmos", "terraform", "infrastructure", "iac", "devops", "cloud"],
-      "category": "integration",
-      "strict": false
+      "category": "development"
     }
   ]
 }

--- a/docs/prd/atmos-agent-skills.md
+++ b/docs/prd/atmos-agent-skills.md
@@ -232,35 +232,26 @@ File: `.claude-plugin/marketplace.json` (repo root)
 ```json
 {
   "name": "cloudposse",
+  "version": "1.0.0",
+  "description": "Official Atmos plugins and skills for Claude Code",
   "owner": {
     "name": "Cloud Posse",
     "email": "opensource@cloudposse.com"
   },
-  "metadata": {
-    "description": "Official Cloud Posse plugins and skills for Claude Code",
-    "version": "1.0.0",
-    "pluginRoot": "./agent-skills"
-  },
   "plugins": [
     {
       "name": "atmos",
-      "source": ".",
-      "description": "Atmos skills for Claude Code: Terraform/Helmfile/Packer/Ansible orchestration, stack configuration, components, vendoring, validation, GitOps, templates, design patterns, and CLI configuration.",
-      "version": "1.0.0",
-      "author": { "name": "Cloud Posse" },
-      "homepage": "https://atmos.tools/integrations/ai/agent-skills",
-      "repository": "https://github.com/cloudposse/atmos",
-      "license": "Apache-2.0",
-      "keywords": ["atmos", "terraform", "helmfile", "packer", "orchestration", "iac", "stacks", "components", "validation", "gitops"],
-      "category": "integration",
-      "strict": false
+      "source": "./agent-skills",
+      "description": "Atmos skills for AI coding assistants: Terraform/Helmfile/Packer/Ansible orchestration, stack configuration, components, vendoring, validation, YAML functions, Go templates, authentication, stores, workflows, and design patterns.",
+      "category": "development"
     }
   ]
 }
 ```
 
-The `pluginRoot` field prepends `./agent-skills` to all relative plugin sources, so
-`"source": "."` resolves to `./agent-skills`.
+The `source` field points to the directory containing the plugin's `.claude-plugin/plugin.json`.
+Plugin-level metadata (`author`, `homepage`, `repository`, `license`, `keywords`) belongs in the
+plugin manifest (`agent-skills/.claude-plugin/plugin.json`), not the marketplace manifest.
 
 ##### Plugin Manifest
 
@@ -270,15 +261,15 @@ The single plugin directory contains `agent-skills/.claude-plugin/plugin.json`:
 {
   "name": "atmos",
   "version": "1.0.0",
-  "description": "Atmos skills for Claude Code: infrastructure orchestration, stack configuration, and design patterns.",
+  "description": "Atmos skills for AI coding assistants: Terraform/Helmfile/Packer/Ansible orchestration, stack configuration, components, vendoring, validation, YAML functions, Go templates, authentication, stores, workflows, and design patterns.",
   "author": {
     "name": "Cloud Posse",
     "url": "https://github.com/cloudposse"
   },
-  "homepage": "https://atmos.tools",
+  "homepage": "https://atmos.tools/integrations/ai/agent-skills",
   "repository": "https://github.com/cloudposse/atmos",
   "license": "Apache-2.0",
-  "keywords": ["atmos", "terraform", "helmfile", "packer", "orchestration", "iac", "stacks", "components", "validation"]
+  "keywords": ["atmos", "terraform", "infrastructure", "iac", "devops", "cloud"]
 }
 ```
 
@@ -294,6 +285,16 @@ The single plugin directory contains `agent-skills/.claude-plugin/plugin.json`:
 
 A single install command provides all 21 Atmos skills.
 
+##### Uninstalling
+
+```bash
+# Remove the plugin
+/plugin uninstall atmos@cloudposse
+
+# Remove the marketplace (optional)
+/plugin marketplace remove cloudposse
+```
+
 ##### Team Auto-Discovery
 
 Teams can auto-configure the marketplace and plugin for all team members by adding
@@ -301,6 +302,14 @@ to the project's `.claude/settings.json`:
 
 ```json
 {
+  "extraKnownMarketplaces": {
+    "cloudposse": {
+      "source": {
+        "source": "github",
+        "repo": "cloudposse/atmos"
+      }
+    }
+  },
   "enabledPlugins": {
     "atmos@cloudposse": true
   }
@@ -654,7 +663,7 @@ Restructure `agent-skills/` for Claude Code plugin compatibility and add marketp
    ```
 
 2. **Create marketplace manifest**: Add `.claude-plugin/marketplace.json` at the repo root
-   with a single plugin entry (`atmos` with `"source": "."`).
+   with a single plugin entry (`atmos` with `"source": "./agent-skills"`).
 
 3. **Create plugin manifest**: Add `agent-skills/.claude-plugin/plugin.json` for the single
    `atmos` plugin.

--- a/website/blog/2026-02-27-ai-agent-skills.mdx
+++ b/website/blog/2026-02-27-ai-agent-skills.mdx
@@ -51,6 +51,16 @@ Install from the Cloud Posse plugin marketplace:
 
 One plugin, one install command, all 21 skills. The `cloudposse/atmos` GitHub repo serves as the marketplace -- Claude Code fetches the plugin manifest directly from the repo. No central registry or approval is involved. Once installed, the plugin is cached locally and skills activate automatically when you ask Atmos-related questions.
 
+To uninstall:
+
+```bash
+# Remove the plugin
+/plugin uninstall atmos@cloudposse
+
+# Remove the marketplace (optional)
+/plugin marketplace remove cloudposse
+```
+
 For Atmos contributors working directly in the repo, skills are also auto-discovered via `.claude/skills/` symlinks.
 
 ### OpenAI Codex

--- a/website/docs/integrations/ai/agent-skills.mdx
+++ b/website/docs/integrations/ai/agent-skills.mdx
@@ -183,6 +183,18 @@ Cross-tool interoperability happens at the **file format level** (`AGENTS.md` an
 directory path. This is why Atmos places skills in a tool-agnostic `agent-skills/` directory and uses symlinks for
 tool-specific discovery.
 
+## Uninstalling Skills
+
+To remove Atmos skills from Claude Code:
+
+```bash
+# Remove the plugin
+/plugin uninstall atmos@cloudposse
+
+# Remove the marketplace (optional)
+/plugin marketplace remove cloudposse
+```
+
 ## Using Skills with AI Tools
 
 For step-by-step instructions on configuring each AI tool, see

--- a/website/docs/projects/setup-editor/ai-assistants.mdx
+++ b/website/docs/projects/setup-editor/ai-assistants.mdx
@@ -103,6 +103,16 @@ Claude Code fetches `.claude-plugin/marketplace.json` directly from the repo via
 install the plugin, Claude Code downloads the skills directory and caches it locally. No central registry or
 approval process is involved -- the GitHub repo IS the marketplace.
 
+#### Uninstalling
+
+```bash
+# Remove the plugin
+/plugin uninstall atmos@cloudposse
+
+# Remove the marketplace (optional)
+/plugin marketplace remove cloudposse
+```
+
 #### Team Auto-Discovery
 
 Teams can auto-configure the marketplace for all team members by adding to the project's `.claude/settings.json`:


### PR DESCRIPTION
## what

- Fix `.claude-plugin/marketplace.json` schema that caused `/plugin marketplace add cloudposse` to fail with `Invalid schema: plugins.0.source: Invalid input`
- Change `source` from `"."` to `"./agent-skills"` — the `source` field must point to the directory containing `.claude-plugin/plugin.json`
- Remove non-standard `metadata.pluginRoot` field — not part of the Claude Code marketplace schema
- Move `version`/`description` to top-level marketplace fields where they belong
- Remove duplicate plugin-level fields (`author`, `homepage`, `repository`, `license`, `keywords`, `strict`) from the marketplace manifest — these already exist in `agent-skills/.claude-plugin/plugin.json`
- Change `category` from `"integration"` to `"development"` — matches the [official Anthropic marketplace](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json) which uses `development`, `productivity`, `learning`, and `security`
- Add `uninstall`/`marketplace remove` commands to all documentation (PRD, blog, agent-skills doc, ai-assistants doc)
- Fix PRD plugin.json example to match the actual `agent-skills/.claude-plugin/plugin.json` file
- Fix PRD Team Auto-Discovery section to include `extraKnownMarketplaces` (was missing, wouldn't work without it)

## why

- The original `marketplace.json` used `"source": "."` with a custom `metadata.pluginRoot` field to resolve the path. This is not part of the Claude Code marketplace schema — Claude Code expects `source` to directly point to the plugin directory containing `.claude-plugin/plugin.json`
- Users running `/plugin marketplace add cloudposse/atmos` got an opaque validation error with no guidance on what was wrong
- Documentation was missing uninstall/remove instructions, and the PRD had stale examples that didn't match the actual manifest files
- Verified fix works locally:
  ```
  /plugin marketplace add cloudposse/atmos   → Successfully added marketplace: cloudposse
  /plugin install atmos@cloudposse           → ✓ Installed atmos
  /plugin uninstall atmos@cloudposse         → ✓ Uninstalled atmos
  /plugin marketplace remove cloudposse      → ✔ Removed 1 marketplace
  ```

## references

- [Claude Code Plugin Marketplaces documentation](https://code.claude.com/docs/en/plugin-marketplaces)
- [Anthropic's official marketplace.json](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json) — reference for valid `category` values and schema structure
- [Official Claude Code plugins directory](https://github.com/anthropics/claude-plugins-official)
- PR #2121 that introduced the original marketplace.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added uninstall instructions for the Atmos plugin across multiple documentation pages.

* **Chores**
  * Updated plugin configuration and restructured marketplace metadata.
  * Added support for additional marketplace sources to streamline plugin discovery and auto-configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->