### PR TITLE
fix: disable YAML function processing in list instances

### DIFF
--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -344,8 +344,11 @@ func processInstancesWithDeps(
 	stacksProcessor e.StacksProcessor,
 	authManager auth.AuthManager,
 ) ([]schema.Instance, error) {
-	// Get all stacks with template processing enabled to render template variables.
-	stacksMap, err := stacksProcessor.ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, authManager)
+	// Get all stacks with template processing but without YAML functions.
+	// Templates are needed because they can create additional stacks and components.
+	// YAML functions (e.g., !terraform.output, atmos.Component()) are disabled to avoid
+	// requiring external binaries like tofu/terraform in $PATH.
+	stacksMap, err := stacksProcessor.ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, authManager)
 	if err != nil {
 		log.Error(errUtils.ErrExecuteDescribeStacks.Error(), "error", err)
 		return nil, errors.Join(errUtils.ErrExecuteDescribeStacks, err)

--- a/pkg/list/list_instances_process_test.go
+++ b/pkg/list/list_instances_process_test.go
@@ -39,7 +39,7 @@ func TestProcessInstancesWithDeps_Success(t *testing.T) {
 	}
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)
@@ -63,7 +63,7 @@ func TestProcessInstancesWithDeps_ExecuteDescribeStacksError(t *testing.T) {
 	expectedErr := errors.New("failed to read stack files")
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(nil, expectedErr)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)
@@ -84,7 +84,7 @@ func TestProcessInstancesWithDeps_EmptyStacksMap(t *testing.T) {
 	stacksMap := map[string]interface{}{}
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)
@@ -133,7 +133,7 @@ func TestProcessInstancesWithDeps_MultipleStacks(t *testing.T) {
 	}
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)
@@ -174,7 +174,7 @@ func TestProcessInstancesWithDeps_AbstractComponentsFiltered(t *testing.T) {
 	}
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)
@@ -210,7 +210,7 @@ func TestProcessInstancesWithDeps_InvalidStackStructure(t *testing.T) {
 	}
 
 	mockStacksProcessor.EXPECT().
-		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, true, false, nil, nil).
+		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
 	instances, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil)


### PR DESCRIPTION
## What

Disable YAML function processing (`processYamlFunctions`) in `atmos list instances` while keeping template processing enabled.

## Why

`atmos list instances` calls `ExecuteDescribeStacks` with `processYamlFunctions: true`, which triggers execution of YAML functions like `!terraform.output` and `atmos.Component()`. These shell out to `tofu`/`terraform`, causing failures when those binaries aren't in `$PATH` — even though listing instances doesn't need to resolve function values.

Template processing is kept enabled because templates can create additional stacks and components that should be included as instances.

## Ref

- Reported in Slack: `atmos list instances` fails with `exec: "tofu": executable file not found in $PATH`
- The tree-format code path in the same file already correctly disables both flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * YAML functions in template processing have been disabled while maintaining support for core template operations and stack handling.
  * Updated how stacks are processed and described to reflect this change.

* **Tests**
  * Updated multiple test cases to reflect the modified template processing behavior and stack validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->