### PR TITLE
fix: use computed workdir path in describe component

### DIFF
--- a/internal/exec/path_utils.go
+++ b/internal/exec/path_utils.go
@@ -10,24 +10,6 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
-// computeWorkdirPathIfEnabled computes the workdir path when provision.workdir.enabled
-// is true but provisioners haven't run yet (e.g., during describe component).
-// Returns the path and true if workdir is enabled, or empty string and false.
-func computeWorkdirPathIfEnabled(atmosConfig *schema.AtmosConfiguration, componentType string, info *schema.ConfigAndStacksInfo) (string, bool) {
-	if !provWorkdir.IsWorkdirEnabled(info.ComponentSection) {
-		return "", false
-	}
-	stack, _ := info.ComponentSection["atmos_stack"].(string)
-	if stack == "" {
-		return "", false
-	}
-	basePath := atmosConfig.BasePath
-	if basePath == "" {
-		basePath = "."
-	}
-	return provWorkdir.BuildPath(basePath, componentType, info.FinalComponent, stack, info.ComponentSection), true
-}
-
 // constructTerraformComponentWorkingDir constructs the working dir for a terraform component in a stack.
 func constructTerraformComponentWorkingDir(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) string {
 	// Check if a provisioner (source or workdir) set a workdir path.
@@ -39,7 +21,7 @@ func constructTerraformComponentWorkingDir(atmosConfig *schema.AtmosConfiguratio
 
 	// If workdir provisioning is enabled but provisioners haven't run yet
 	// (e.g., during describe component), compute the path deterministically.
-	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "terraform", info); ok {
+	if path, ok := provWorkdir.ResolvePath(atmosConfig.BasePath, "terraform", info.FinalComponent, info.ComponentSection); ok {
 		return path
 	}
 
@@ -115,7 +97,7 @@ func constructHelmfileComponentWorkingDir(atmosConfig *schema.AtmosConfiguration
 
 	// If workdir provisioning is enabled but provisioners haven't run yet
 	// (e.g., during describe component), compute the path deterministically.
-	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "helmfile", info); ok {
+	if path, ok := provWorkdir.ResolvePath(atmosConfig.BasePath, "helmfile", info.FinalComponent, info.ComponentSection); ok {
 		return path
 	}
 
@@ -189,7 +171,7 @@ func constructPackerComponentWorkingDir(atmosConfig *schema.AtmosConfiguration, 
 
 	// If workdir provisioning is enabled but provisioners haven't run yet
 	// (e.g., during describe component), compute the path deterministically.
-	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "packer", info); ok {
+	if path, ok := provWorkdir.ResolvePath(atmosConfig.BasePath, "packer", info.FinalComponent, info.ComponentSection); ok {
 		return path
 	}
 

--- a/internal/exec/path_utils.go
+++ b/internal/exec/path_utils.go
@@ -10,6 +10,24 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
+// computeWorkdirPathIfEnabled computes the workdir path when provision.workdir.enabled
+// is true but provisioners haven't run yet (e.g., during describe component).
+// Returns the path and true if workdir is enabled, or empty string and false.
+func computeWorkdirPathIfEnabled(atmosConfig *schema.AtmosConfiguration, componentType string, info *schema.ConfigAndStacksInfo) (string, bool) {
+	if !provWorkdir.IsWorkdirEnabled(info.ComponentSection) {
+		return "", false
+	}
+	stack, _ := info.ComponentSection["atmos_stack"].(string)
+	if stack == "" {
+		return "", false
+	}
+	basePath := atmosConfig.BasePath
+	if basePath == "" {
+		basePath = "."
+	}
+	return provWorkdir.BuildPath(basePath, componentType, info.FinalComponent, stack, info.ComponentSection), true
+}
+
 // constructTerraformComponentWorkingDir constructs the working dir for a terraform component in a stack.
 func constructTerraformComponentWorkingDir(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) string {
 	// Check if a provisioner (source or workdir) set a workdir path.
@@ -17,6 +35,12 @@ func constructTerraformComponentWorkingDir(atmosConfig *schema.AtmosConfiguratio
 	// Use filepath.FromSlash to normalize path separators for cross-platform compatibility.
 	if workdirPath, ok := info.ComponentSection[provWorkdir.WorkdirPathKey].(string); ok && workdirPath != "" {
 		return filepath.FromSlash(workdirPath)
+	}
+
+	// If workdir provisioning is enabled but provisioners haven't run yet
+	// (e.g., during describe component), compute the path deterministically.
+	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "terraform", info); ok {
+		return path
 	}
 
 	// If we have a resolved absolute path, use GetComponentPath.
@@ -89,6 +113,12 @@ func constructHelmfileComponentWorkingDir(atmosConfig *schema.AtmosConfiguration
 		return filepath.FromSlash(workdirPath)
 	}
 
+	// If workdir provisioning is enabled but provisioners haven't run yet
+	// (e.g., during describe component), compute the path deterministically.
+	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "helmfile", info); ok {
+		return path
+	}
+
 	// If we have a resolved absolute path, use GetComponentPath.
 	// Otherwise, just construct the path directly (for tests and simple cases).
 	if atmosConfig.HelmfileDirAbsolutePath != "" {
@@ -155,6 +185,12 @@ func constructPackerComponentWorkingDir(atmosConfig *schema.AtmosConfiguration, 
 	// Use filepath.FromSlash to normalize path separators for cross-platform compatibility.
 	if workdirPath, ok := info.ComponentSection[provWorkdir.WorkdirPathKey].(string); ok && workdirPath != "" {
 		return filepath.FromSlash(workdirPath)
+	}
+
+	// If workdir provisioning is enabled but provisioners haven't run yet
+	// (e.g., during describe component), compute the path deterministically.
+	if path, ok := computeWorkdirPathIfEnabled(atmosConfig, "packer", info); ok {
+		return path
 	}
 
 	// If we have a resolved absolute path, use GetComponentPath.

--- a/internal/exec/path_utils_test.go
+++ b/internal/exec/path_utils_test.go
@@ -117,154 +117,28 @@ func TestConstructPackerComponentWorkingDir_WithWorkdirPath(t *testing.T) {
 	assert.Equal(t, filepath.Join("base", "components", "packer", "ami"), got2)
 }
 
-// TestComputeWorkdirPathIfEnabled tests deterministic workdir path computation
-// when provision.workdir.enabled is true but provisioners haven't run yet.
-// This is the scenario for `atmos describe component` with workdir-enabled components.
-func TestComputeWorkdirPathIfEnabled(t *testing.T) {
+// TestConstructWorkingDir_WorkdirPathKeyPrecedence tests that an explicit _workdir_path
+// takes precedence over the computed workdir path from provision.workdir.enabled.
+func TestConstructWorkingDir_WorkdirPathKeyPrecedence(t *testing.T) {
 	atmosConfig := schema.AtmosConfiguration{
 		BasePath: filepath.Join("project", "root"),
 	}
-
-	tests := []struct {
-		name          string
-		info          schema.ConfigAndStacksInfo
-		componentType string
-		expectedPath  string
-		expectedOk    bool
-	}{
-		{
-			name: "workdir enabled with atmos_component",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "vpc",
-				ComponentSection: map[string]any{
-					"atmos_stack":     "dev-ue2",
-					"atmos_component": "vpc-primary",
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": true,
-						},
-					},
+	info := schema.ConfigAndStacksInfo{
+		FinalComponent: "vpc",
+		ComponentSection: map[string]any{
+			provWorkdir.WorkdirPathKey: filepath.Join("explicit", "workdir", "path"),
+			"atmos_stack":              "dev-ue2",
+			"provision": map[string]any{
+				"workdir": map[string]any{
+					"enabled": true,
 				},
 			},
-			componentType: "terraform",
-			expectedPath:  filepath.Join("project", "root", ".workdir", "terraform", "dev-ue2-vpc-primary"),
-			expectedOk:    true,
-		},
-		{
-			name: "workdir enabled without atmos_component falls back to FinalComponent",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "vpc",
-				ComponentSection: map[string]any{
-					"atmos_stack": "prod-uw2",
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": true,
-						},
-					},
-				},
-			},
-			componentType: "terraform",
-			expectedPath:  filepath.Join("project", "root", ".workdir", "terraform", "prod-uw2-vpc"),
-			expectedOk:    true,
-		},
-		{
-			name: "workdir not enabled",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent:   "vpc",
-				ComponentSection: map[string]any{},
-			},
-			componentType: "terraform",
-			expectedPath:  "",
-			expectedOk:    false,
-		},
-		{
-			name: "workdir enabled but missing atmos_stack",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "vpc",
-				ComponentSection: map[string]any{
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": true,
-						},
-					},
-				},
-			},
-			componentType: "terraform",
-			expectedPath:  "",
-			expectedOk:    false,
-		},
-		{
-			name: "workdir explicitly disabled",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "vpc",
-				ComponentSection: map[string]any{
-					"atmos_stack": "dev-ue2",
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": false,
-						},
-					},
-				},
-			},
-			componentType: "terraform",
-			expectedPath:  "",
-			expectedOk:    false,
-		},
-		{
-			name: "explicit WorkdirPathKey takes precedence over computed path",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "vpc",
-				ComponentSection: map[string]any{
-					provWorkdir.WorkdirPathKey: filepath.Join("explicit", "workdir", "path"),
-					"atmos_stack":              "dev-ue2",
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": true,
-						},
-					},
-				},
-			},
-			componentType: "terraform",
-			// When WorkdirPathKey is set, constructTerraformComponentWorkingDir returns it
-			// before reaching computeWorkdirPathIfEnabled. This test verifies that.
-			expectedPath: filepath.Join("explicit", "workdir", "path"),
-			expectedOk:   true,
-		},
-		{
-			name: "helmfile component type",
-			info: schema.ConfigAndStacksInfo{
-				FinalComponent: "nginx",
-				ComponentSection: map[string]any{
-					"atmos_stack": "staging-ue1",
-					"provision": map[string]any{
-						"workdir": map[string]any{
-							"enabled": true,
-						},
-					},
-				},
-			},
-			componentType: "helmfile",
-			expectedPath:  filepath.Join("project", "root", ".workdir", "helmfile", "staging-ue1-nginx"),
-			expectedOk:    true,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test the helper function directly for most cases.
-			if tt.name != "explicit WorkdirPathKey takes precedence over computed path" {
-				path, ok := computeWorkdirPathIfEnabled(&atmosConfig, tt.componentType, &tt.info)
-				assert.Equal(t, tt.expectedOk, ok)
-				if ok {
-					assert.Equal(t, tt.expectedPath, path)
-				}
-			} else {
-				// For the precedence test, use the full construct function.
-				got := constructTerraformComponentWorkingDir(&atmosConfig, &tt.info)
-				assert.Equal(t, tt.expectedPath, got)
-			}
-		})
-	}
+	// When WorkdirPathKey is set, constructTerraformComponentWorkingDir returns it
+	// before reaching ResolvePath.
+	got := constructTerraformComponentWorkingDir(&atmosConfig, &info)
+	assert.Equal(t, filepath.Join("explicit", "workdir", "path"), got)
 }
 
 // TestConstructWorkingDir_WorkdirEnabledNoProvisioner tests that construct*WorkingDir

--- a/internal/exec/path_utils_test.go
+++ b/internal/exec/path_utils_test.go
@@ -117,6 +117,214 @@ func TestConstructPackerComponentWorkingDir_WithWorkdirPath(t *testing.T) {
 	assert.Equal(t, filepath.Join("base", "components", "packer", "ami"), got2)
 }
 
+// TestComputeWorkdirPathIfEnabled tests deterministic workdir path computation
+// when provision.workdir.enabled is true but provisioners haven't run yet.
+// This is the scenario for `atmos describe component` with workdir-enabled components.
+func TestComputeWorkdirPathIfEnabled(t *testing.T) {
+	atmosConfig := schema.AtmosConfiguration{
+		BasePath: filepath.Join("project", "root"),
+	}
+
+	tests := []struct {
+		name          string
+		info          schema.ConfigAndStacksInfo
+		componentType string
+		expectedPath  string
+		expectedOk    bool
+	}{
+		{
+			name: "workdir enabled with atmos_component",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "vpc",
+				ComponentSection: map[string]any{
+					"atmos_stack":     "dev-ue2",
+					"atmos_component": "vpc-primary",
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			componentType: "terraform",
+			expectedPath:  filepath.Join("project", "root", ".workdir", "terraform", "dev-ue2-vpc-primary"),
+			expectedOk:    true,
+		},
+		{
+			name: "workdir enabled without atmos_component falls back to FinalComponent",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "vpc",
+				ComponentSection: map[string]any{
+					"atmos_stack": "prod-uw2",
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			componentType: "terraform",
+			expectedPath:  filepath.Join("project", "root", ".workdir", "terraform", "prod-uw2-vpc"),
+			expectedOk:    true,
+		},
+		{
+			name: "workdir not enabled",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent:   "vpc",
+				ComponentSection: map[string]any{},
+			},
+			componentType: "terraform",
+			expectedPath:  "",
+			expectedOk:    false,
+		},
+		{
+			name: "workdir enabled but missing atmos_stack",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "vpc",
+				ComponentSection: map[string]any{
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			componentType: "terraform",
+			expectedPath:  "",
+			expectedOk:    false,
+		},
+		{
+			name: "workdir explicitly disabled",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "vpc",
+				ComponentSection: map[string]any{
+					"atmos_stack": "dev-ue2",
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": false,
+						},
+					},
+				},
+			},
+			componentType: "terraform",
+			expectedPath:  "",
+			expectedOk:    false,
+		},
+		{
+			name: "explicit WorkdirPathKey takes precedence over computed path",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "vpc",
+				ComponentSection: map[string]any{
+					provWorkdir.WorkdirPathKey: filepath.Join("explicit", "workdir", "path"),
+					"atmos_stack":              "dev-ue2",
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			componentType: "terraform",
+			// When WorkdirPathKey is set, constructTerraformComponentWorkingDir returns it
+			// before reaching computeWorkdirPathIfEnabled. This test verifies that.
+			expectedPath: filepath.Join("explicit", "workdir", "path"),
+			expectedOk:   true,
+		},
+		{
+			name: "helmfile component type",
+			info: schema.ConfigAndStacksInfo{
+				FinalComponent: "nginx",
+				ComponentSection: map[string]any{
+					"atmos_stack": "staging-ue1",
+					"provision": map[string]any{
+						"workdir": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			componentType: "helmfile",
+			expectedPath:  filepath.Join("project", "root", ".workdir", "helmfile", "staging-ue1-nginx"),
+			expectedOk:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the helper function directly for most cases.
+			if tt.name != "explicit WorkdirPathKey takes precedence over computed path" {
+				path, ok := computeWorkdirPathIfEnabled(&atmosConfig, tt.componentType, &tt.info)
+				assert.Equal(t, tt.expectedOk, ok)
+				if ok {
+					assert.Equal(t, tt.expectedPath, path)
+				}
+			} else {
+				// For the precedence test, use the full construct function.
+				got := constructTerraformComponentWorkingDir(&atmosConfig, &tt.info)
+				assert.Equal(t, tt.expectedPath, got)
+			}
+		})
+	}
+}
+
+// TestConstructWorkingDir_WorkdirEnabledNoProvisioner tests that construct*WorkingDir
+// returns the correct workdir path when provision.workdir.enabled is true
+// but no provisioner has set _workdir_path (the describe component scenario).
+func TestConstructWorkingDir_WorkdirEnabledNoProvisioner(t *testing.T) {
+	// Terraform.
+	atmosConfig := schema.AtmosConfiguration{
+		BasePath: "myproject",
+		Components: schema.Components{
+			Terraform: schema.Terraform{
+				BasePath: filepath.Join("components", "terraform"),
+			},
+			Helmfile: schema.Helmfile{
+				BasePath: filepath.Join("components", "helmfile"),
+			},
+			Packer: schema.Packer{
+				BasePath: filepath.Join("components", "packer"),
+			},
+		},
+	}
+
+	workdirConfig := map[string]any{
+		"atmos_stack":     "dev-ue2",
+		"atmos_component": "vpc",
+		"provision": map[string]any{
+			"workdir": map[string]any{
+				"enabled": true,
+			},
+		},
+	}
+
+	tfInfo := schema.ConfigAndStacksInfo{
+		FinalComponent:   "vpc",
+		ComponentSection: workdirConfig,
+	}
+	assert.Equal(t,
+		filepath.Join("myproject", ".workdir", "terraform", "dev-ue2-vpc"),
+		constructTerraformComponentWorkingDir(&atmosConfig, &tfInfo),
+	)
+
+	hfInfo := schema.ConfigAndStacksInfo{
+		FinalComponent:   "nginx",
+		ComponentSection: workdirConfig,
+	}
+	assert.Equal(t,
+		filepath.Join("myproject", ".workdir", "helmfile", "dev-ue2-vpc"),
+		constructHelmfileComponentWorkingDir(&atmosConfig, &hfInfo),
+	)
+
+	pkInfo := schema.ConfigAndStacksInfo{
+		FinalComponent:   "ami",
+		ComponentSection: workdirConfig,
+	}
+	assert.Equal(t,
+		filepath.Join("myproject", ".workdir", "packer", "dev-ue2-vpc"),
+		constructPackerComponentWorkingDir(&atmosConfig, &pkInfo),
+	)
+}
+
 func TestConstructPackerComponentVarfileName(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/provisioner/source/provision_hook.go
+++ b/pkg/provisioner/source/provision_hook.go
@@ -214,7 +214,7 @@ func determineSourceTargetDirectory(
 	componentConfig map[string]any,
 ) (string, bool, error) {
 	// Check if workdir is enabled.
-	if isWorkdirEnabled(componentConfig) {
+	if workdir.IsWorkdirEnabled(componentConfig) {
 		// Get stack name for workdir path.
 		stack, _ := componentConfig["atmos_stack"].(string)
 		if stack == "" {
@@ -239,22 +239,6 @@ func determineSourceTargetDirectory(
 		return "", false, err
 	}
 	return targetDir, false, nil
-}
-
-// isWorkdirEnabled checks if provision.workdir.enabled is set to true.
-func isWorkdirEnabled(componentConfig map[string]any) bool {
-	provisionConfig, ok := componentConfig["provision"].(map[string]any)
-	if !ok {
-		return false
-	}
-
-	workdirConfig, ok := provisionConfig["workdir"].(map[string]any)
-	if !ok {
-		return false
-	}
-
-	enabled, ok := workdirConfig["enabled"].(bool)
-	return ok && enabled
 }
 
 // needsProvisioning checks if the target directory needs provisioning.

--- a/pkg/provisioner/source/provision_hook.go
+++ b/pkg/provisioner/source/provision_hook.go
@@ -215,22 +215,14 @@ func determineSourceTargetDirectory(
 ) (string, bool, error) {
 	// Check if workdir is enabled.
 	if workdir.IsWorkdirEnabled(componentConfig) {
-		// Get stack name for workdir path.
-		stack, _ := componentConfig["atmos_stack"].(string)
-		if stack == "" {
-			return "", false, errUtils.Build(errUtils.ErrSourceProvision).
-				WithExplanation("Stack name required when workdir is enabled").
-				WithHint("The 'atmos_stack' field is required for workdir provisioning").
-				Err()
+		if workdirPath, ok := workdir.ResolvePath(atmosConfig.BasePath, componentType, component, componentConfig); ok {
+			return workdirPath, true, nil
 		}
-
-		basePath := atmosConfig.BasePath
-		if basePath == "" {
-			basePath = "."
-		}
-
-		workdirPath := workdir.BuildPath(basePath, componentType, component, stack, componentConfig)
-		return workdirPath, true, nil
+		// Workdir is enabled but stack is missing.
+		return "", false, errUtils.Build(errUtils.ErrSourceProvision).
+			WithExplanation("Stack name required when workdir is enabled").
+			WithHint("The 'atmos_stack' field is required for workdir provisioning").
+			Err()
 	}
 
 	// No workdir - use standard component path.

--- a/pkg/provisioner/source/provision_hook_test.go
+++ b/pkg/provisioner/source/provision_hook_test.go
@@ -183,7 +183,7 @@ func TestIsWorkdirEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isWorkdirEnabled(tt.componentConfig)
+			result := workdir.IsWorkdirEnabled(tt.componentConfig)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/provisioner/source/source.go
+++ b/pkg/provisioner/source/source.go
@@ -135,13 +135,24 @@ func DetermineTargetDirectory(
 	defer perf.Track(atmosConfig, "source.DetermineTargetDirectory")()
 
 	// Check for working_directory override in metadata or settings.
-	if workdir := getWorkingDirectoryOverride(componentConfig); workdir != "" {
-		return workdir, nil
+	if wdOverride := getWorkingDirectoryOverride(componentConfig); wdOverride != "" {
+		return wdOverride, nil
 	}
 
 	// Check if workdir is enabled - if so, use workdir path.
 	if workdir.IsWorkdirEnabled(componentConfig) {
-		return buildWorkdirPath(atmosConfig, componentType, component, componentConfig)
+		var basePath string
+		if atmosConfig != nil {
+			basePath = atmosConfig.BasePath
+		}
+		if path, ok := workdir.ResolvePath(basePath, componentType, component, componentConfig); ok {
+			return path, nil
+		}
+		// Workdir is enabled but stack is missing — error rather than silently falling through.
+		return "", errUtils.Build(errUtils.ErrSourceProvision).
+			WithExplanation("Stack name required when workdir is enabled").
+			WithHint("The 'atmos_stack' field must be present in component config for workdir provisioning").
+			Err()
 	}
 
 	// Get component base path using resolved paths from atmosConfig.
@@ -239,28 +250,4 @@ func getComponentBasePath(atmosConfig *schema.AtmosConfiguration, componentType 
 	default:
 		return ""
 	}
-}
-
-// buildWorkdirPath constructs the workdir path: .workdir/<componentType>/<stack>-<component>/.
-func buildWorkdirPath(
-	atmosConfig *schema.AtmosConfiguration,
-	componentType string,
-	component string,
-	componentConfig map[string]any,
-) (string, error) {
-	// Get stack name from component config.
-	stack, _ := componentConfig["atmos_stack"].(string)
-	if stack == "" {
-		return "", errUtils.Build(errUtils.ErrSourceProvision).
-			WithExplanation("Stack name required when workdir is enabled").
-			WithHint("The 'atmos_stack' field must be present in component config for workdir provisioning").
-			Err()
-	}
-
-	basePath := atmosConfig.BasePath
-	if basePath == "" {
-		basePath = "."
-	}
-
-	return workdir.BuildPath(basePath, componentType, component, stack, componentConfig), nil
 }

--- a/pkg/provisioner/source/source.go
+++ b/pkg/provisioner/source/source.go
@@ -140,7 +140,7 @@ func DetermineTargetDirectory(
 	}
 
 	// Check if workdir is enabled - if so, use workdir path.
-	if isWorkdirEnabled(componentConfig) {
+	if workdir.IsWorkdirEnabled(componentConfig) {
 		return buildWorkdirPath(atmosConfig, componentType, component, componentConfig)
 	}
 

--- a/pkg/provisioner/workdir/types.go
+++ b/pkg/provisioner/workdir/types.go
@@ -103,6 +103,26 @@ const (
 	WorkdirPathKey = "_workdir_path"
 )
 
+// ResolvePath checks if workdir provisioning is enabled and returns the computed
+// workdir path. Returns the path and true if workdir is enabled, or empty string
+// and false otherwise. This is the canonical way to determine the workdir path
+// without running provisioners (e.g., during describe component).
+func ResolvePath(basePath, componentType, component string, componentConfig map[string]any) (string, bool) {
+	defer perf.Track(nil, "workdir.ResolvePath")()
+
+	if !IsWorkdirEnabled(componentConfig) {
+		return "", false
+	}
+	stack, _ := componentConfig["atmos_stack"].(string)
+	if stack == "" {
+		return "", false
+	}
+	if basePath == "" {
+		basePath = "."
+	}
+	return BuildPath(basePath, componentType, component, stack, componentConfig), true
+}
+
 // BuildPath constructs the canonical workdir path for a component instance.
 // It uses atmos_component (the instance name) from componentConfig when available,
 // falling back to the provided component name. This ensures all provisioners

--- a/pkg/provisioner/workdir/workdir.go
+++ b/pkg/provisioner/workdir/workdir.go
@@ -80,7 +80,7 @@ func (s *Service) Provision(
 	defer perf.Track(atmosConfig, "workdir.Service.Provision")()
 
 	// Check activation condition.
-	if !isWorkdirEnabled(componentConfig) {
+	if !IsWorkdirEnabled(componentConfig) {
 		// No workdir needed - terraform runs in original directory.
 		return nil
 	}
@@ -312,8 +312,8 @@ func buildLocalMetadata(params *localMetadataParams) *WorkdirMetadata {
 	return metadata
 }
 
-// isWorkdirEnabled checks if provision.workdir.enabled is set to true.
-func isWorkdirEnabled(componentConfig map[string]any) bool {
+// IsWorkdirEnabled checks if provision.workdir.enabled is set to true.
+func IsWorkdirEnabled(componentConfig map[string]any) bool {
 	defer perf.Track(nil, "workdir.isWorkdirEnabled")()
 
 	provisionConfig, ok := componentConfig["provision"].(map[string]any)

--- a/pkg/provisioner/workdir/workdir_test.go
+++ b/pkg/provisioner/workdir/workdir_test.go
@@ -95,7 +95,7 @@ func TestIsWorkdirEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isWorkdirEnabled(tt.config)
+			result := IsWorkdirEnabled(tt.config)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/provisioner/workdir/workdir_test.go
+++ b/pkg/provisioner/workdir/workdir_test.go
@@ -101,6 +101,135 @@ func TestIsWorkdirEnabled(t *testing.T) {
 	}
 }
 
+// TestResolvePath tests deterministic workdir path resolution without running provisioners.
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		basePath     string
+		compType     string
+		component    string
+		config       map[string]any
+		expectedPath string
+		expectedOk   bool
+	}{
+		{
+			name:      "workdir enabled with atmos_component",
+			basePath:  filepath.Join("project", "root"),
+			compType:  "terraform",
+			component: "vpc",
+			config: map[string]any{
+				"atmos_stack":     "dev-ue2",
+				"atmos_component": "vpc-primary",
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			expectedPath: filepath.Join("project", "root", ".workdir", "terraform", "dev-ue2-vpc-primary"),
+			expectedOk:   true,
+		},
+		{
+			name:      "workdir enabled without atmos_component",
+			basePath:  filepath.Join("project", "root"),
+			compType:  "terraform",
+			component: "vpc",
+			config: map[string]any{
+				"atmos_stack": "prod-uw2",
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			expectedPath: filepath.Join("project", "root", ".workdir", "terraform", "prod-uw2-vpc"),
+			expectedOk:   true,
+		},
+		{
+			name:         "workdir not enabled",
+			basePath:     "base",
+			compType:     "terraform",
+			component:    "vpc",
+			config:       map[string]any{},
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name:      "workdir enabled but missing atmos_stack",
+			basePath:  "base",
+			compType:  "terraform",
+			component: "vpc",
+			config: map[string]any{
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name:      "workdir explicitly disabled",
+			basePath:  "base",
+			compType:  "terraform",
+			component: "vpc",
+			config: map[string]any{
+				"atmos_stack": "dev-ue2",
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": false,
+					},
+				},
+			},
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name:      "empty basePath defaults to dot",
+			basePath:  "",
+			compType:  "terraform",
+			component: "vpc",
+			config: map[string]any{
+				"atmos_stack": "dev-ue2",
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			expectedPath: filepath.Join(".", ".workdir", "terraform", "dev-ue2-vpc"),
+			expectedOk:   true,
+		},
+		{
+			name:      "helmfile component type",
+			basePath:  "myproject",
+			compType:  "helmfile",
+			component: "nginx",
+			config: map[string]any{
+				"atmos_stack": "staging-ue1",
+				"provision": map[string]any{
+					"workdir": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			expectedPath: filepath.Join("myproject", ".workdir", "helmfile", "staging-ue1-nginx"),
+			expectedOk:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, ok := ResolvePath(tt.basePath, tt.compType, tt.component, tt.config)
+			assert.Equal(t, tt.expectedOk, ok)
+			if ok {
+				assert.Equal(t, tt.expectedPath, path)
+			}
+		})
+	}
+}
+
 func TestExtractComponentName(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## what

- `atmos describe component` now returns the correct workdir path (`.workdir/<stack>-<component>/`) when `provision.workdir.enabled: true`, instead of the standard component path
- GitHub Actions can now correctly locate plan files when using workdir + source provisioning
- Consolidated duplicate `IsWorkdirEnabled` logic across provisioner packages

## why

When `atmos describe component` is called without provisioners running, it was returning the standard component path. However, when `atmos terraform plan` actually executes, provisioners run and place terraform in the workdir path. This mismatch broke GitHub Actions that use `describe component` output to determine where plan files should be stored.

The fix deterministically computes the workdir path from component config (when `provision.workdir.enabled` is true) using the same logic as provisioners, ensuring consistency between what `describe component` reports and where terraform actually runs.

## references

- Follows PR #2137 which fixed workdir path construction to use `atmos_component` for instance isolation
- Fixes integration with `cloudposse/github-action-atmos-terraform-plan` for workdir-enabled components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deterministic working-directory path resolution for Terraform, Helmfile, and Packer when provisioner-based workdirs haven’t run, and explicit overrides now take precedence.
  * Centralized workdir enablement detection and clearer behavior when a required stack name is missing.

* **Tests**
  * Added comprehensive tests covering workdir resolution, precedence of overrides, and various component/configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->