### PR TITLE
docs: add dedicated tools and settings pages for stack configuration

### DIFF
--- a/website/docs/stacks/components/settings.mdx
+++ b/website/docs/stacks/components/settings.mdx
@@ -1,0 +1,300 @@
+---
+title: Configure Component Settings
+sidebar_position: 6
+sidebar_label: "*.settings"
+sidebar_class_name: command
+description: Use the settings section to configure integrations, validation, templates, and custom metadata for components.
+id: component-settings
+---
+import File from '@site/src/components/File'
+import Intro from '@site/src/components/Intro'
+
+<Intro>
+The `settings` section provides a flexible configuration space for integrations, validation, templates, and custom metadata. Unlike `vars` (which map to Terraform variables) or `metadata` (which control Atmos behavior), settings configure external integrations and tooling.
+</Intro>
+
+## Use Cases
+
+- **Validation Rules:** Configure JSON Schema or OPA policy validation per component
+- **Template Configuration:** Define template engine settings and data sources
+- **CI/CD Integration:** Configure Atlantis projects or other automation tools
+- **Custom Metadata:** Store arbitrary metadata for external tools and dashboards
+- **Component Dependencies (Legacy):** Define component dependencies using `depends_on`
+
+## Configuration Scope
+
+The `settings` section can be defined at three levels. Atmos deep-merges settings from all levels, with more specific levels taking precedence.
+
+### Global Level
+
+Settings defined at the root level apply to all components:
+
+<File title="stacks/orgs/acme/_defaults.yaml">
+```yaml
+settings:
+  templates:
+    settings:
+      gomplate:
+        enabled: true
+  validation:
+    schema:
+      enabled: true
+```
+</File>
+
+### Component-Type Level
+
+Settings defined under `terraform`, `helmfile`, `packer`, or `ansible` apply to all components of that type:
+
+<File title="stacks/orgs/acme/plat/prod/_defaults.yaml">
+```yaml
+terraform:
+  settings:
+    validation:
+      enforce_policies: true
+```
+</File>
+
+### Component Level
+
+Settings defined within a component override all higher-level settings:
+
+<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
+```yaml
+components:
+  terraform:
+    vpc:
+      settings:
+        validation:
+          vpc-schema:
+            schema_type: jsonschema
+            schema_path: "schemas/vpc.json"
+```
+</File>
+
+## Merge Behavior
+
+Settings are deep-merged from the most general to the most specific level:
+
+1. **Global `settings:`** (applies to all components)
+2. **Component-type `terraform.settings:`** (applies to all Terraform components)
+3. **Component `components.terraform.<name>.settings`** (applies to a specific component)
+
+Maps are recursively merged. Lists are **replaced** (not appended).
+
+:::note Relationship to `atmos.yaml` settings
+The `settings` key appears in both stack manifests and [`atmos.yaml`](/cli/configuration). Some keys, like `templates`, work at both levels — stack-level values override `atmos.yaml` values. However, other `atmos.yaml` settings like `list_merge_strategy`, `terminal`, `pro`, and `telemetry` are **global-only** and are silently ignored if set in stack manifests.
+:::
+
+## Recognized Settings Keys
+
+Atmos processes certain settings keys for built-in integrations. All other keys are passed through as-is.
+
+### `validation`
+
+Configure schema and policy validation per component:
+
+```yaml
+settings:
+  validation:
+    vpc-schema:
+      schema_type: jsonschema
+      schema_path: "schemas/vpc.json"
+      description: "Validate VPC configuration"
+    vpc-policy:
+      schema_type: opa
+      schema_path: "policies/vpc.rego"
+      description: "Enforce VPC security policies"
+```
+
+See [Validation](/validation/validating) for full documentation.
+
+### `templates`
+
+Configure the template engine:
+
+```yaml
+settings:
+  templates:
+    settings:
+      gomplate:
+        enabled: true
+        timeout: 5
+        datasources:
+          config:
+            url: "file:///config"
+```
+
+See [Templates](/templates) for full documentation.
+
+### `integrations`
+
+Configure external integrations (e.g., GitHub):
+
+```yaml
+settings:
+  integrations:
+    github:
+      gitops:
+        opentofu-version: "1.8.4"
+        terraform-version: "1.9.8"
+        infracost-enabled: true
+```
+
+Integration settings are deep-merged with the global `integrations` configuration from `atmos.yaml`.
+
+### `atlantis`
+
+Configure [Atlantis](/cli/configuration/integrations/atlantis) for pull request automation:
+
+```yaml
+settings:
+  atlantis:
+    enabled: true
+    config_template_name: atmos-atlantis
+    project_template_name: atmos-project
+    workflow: terraform-workflow
+```
+
+### `depends_on` (Legacy)
+
+Define dependencies between components:
+
+```yaml
+settings:
+  depends_on:
+    1:
+      component: vpc
+    2:
+      component: security-groups
+```
+
+:::tip Recommended
+Use the new [`dependencies.components`](/stacks/dependencies/components) format instead of `settings.depends_on`.
+:::
+
+### Custom Keys
+
+The `settings` section is intentionally freeform. Any keys not recognized by Atmos are stored as-is and available in the component configuration. Use this to pass metadata to external tools:
+
+```yaml
+settings:
+  my_custom_tool:
+    feature_enabled: true
+    config:
+      option_a: value
+      option_b: value
+  team_metadata:
+    owner: platform-team
+    slack_channel: "#platform-alerts"
+```
+
+## Examples
+
+### Multi-Level Merge
+
+<File title="stacks/catalog/terraform/_defaults.yaml">
+```yaml
+# Base Terraform settings
+terraform:
+  settings:
+    validation:
+      enforce_policies: true
+    templates:
+      settings:
+        gomplate:
+          enabled: true
+```
+</File>
+
+<File title="stacks/orgs/acme/plat/prod/_defaults.yaml">
+```yaml
+# Production settings
+import:
+  - catalog/terraform/_defaults
+
+settings:
+  team_metadata:
+    environment: production
+    owner: platform-team
+```
+</File>
+
+<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
+```yaml
+import:
+  - orgs/acme/plat/prod/_defaults
+
+components:
+  terraform:
+    vpc:
+      settings:
+        validation:
+          vpc-schema:
+            schema_type: jsonschema
+            schema_path: "schemas/vpc.json"
+        team_metadata:
+          owner: network-team     # Overrides production default
+```
+</File>
+
+The resulting `settings` for the `vpc` component:
+
+```yaml
+settings:
+  validation:
+    enforce_policies: true           # From catalog defaults
+    vpc-schema:                      # Added at component level
+      schema_type: jsonschema
+      schema_path: "schemas/vpc.json"
+  templates:
+    settings:
+      gomplate:
+        enabled: true                # From catalog defaults
+  team_metadata:
+    environment: production          # From production defaults
+    owner: network-team              # Overridden at component level
+```
+
+### Validation Per Component
+
+<File title="stacks/catalog/vpc.yaml">
+```yaml
+components:
+  terraform:
+    vpc:
+      settings:
+        validation:
+          vpc-schema:
+            schema_type: jsonschema
+            schema_path: "schemas/vpc.json"
+            description: "Validate VPC configuration"
+          vpc-policy:
+            schema_type: opa
+            schema_path: "policies/vpc.rego"
+            description: "Enforce VPC security policies"
+      vars:
+        cidr_block: "10.0.0.0/16"
+```
+</File>
+
+## Best Practices
+
+1. **Use Catalog Defaults** - Define common settings in `stacks/catalog/` and import them to ensure consistency across stacks.
+
+2. **Namespace Custom Settings** - Use meaningful prefixes for custom settings to avoid conflicts with Atmos or integration keys.
+
+3. **Document Custom Settings** - When adding custom settings, document their purpose and expected values for your team.
+
+4. **Validate Settings** - Use JSON Schema validation to enforce required settings and valid values.
+
+5. **Prefer `dependencies.components`** - Use the new `dependencies.components` format instead of `settings.depends_on` for component dependencies.
+
+## Related
+
+- [Settings Overview](/stacks/settings) - Global settings configuration
+- [Variables (vars)](/stacks/vars) - Terraform input variables
+- [Component Metadata (*.metadata)](/stacks/components/component-metadata) - Component behavior and inheritance
+- [Component Dependencies](/stacks/dependencies/components) - Component-to-component dependencies
+- [Validation](/validation/validating) - JSON Schema and OPA validation
+- [Templates](/templates) - Template engine configuration

--- a/website/docs/stacks/dependencies/index.mdx
+++ b/website/docs/stacks/dependencies/index.mdx
@@ -8,216 +8,51 @@ id: index
 ---
 import File from '@site/src/components/File'
 import Intro from '@site/src/components/Intro'
-import Note from '@site/src/components/Note'
 
 <Intro>
-The `dependencies` section defines tool version requirements. Tool dependencies ensure your components use the correct versions of CLI tools like Terraform, kubectl, or helm.
+The `dependencies` section declares tool version requirements and component dependencies. It ensures your components use the correct CLI tool versions and are deployed in the correct order.
 </Intro>
 
 ## Use Cases
 
 - **Tool Version Requirements:** Ensure components use specific Terraform, kubectl, or helm versions
-- **Team Consistency:** Version-control tool requirements for reproducible deployments
-- **CI/CD Reliability:** Guarantee correct tool versions in automated pipelines
+- **Execution Order:** Ensure VPC is created before subnets
+- **CI/CD Orchestration:** Spacelift and other integrations use dependencies to order stack runs
+- **Impact Analysis:** The `atmos describe affected` command uses dependencies to find impacted components
 
 ## Tool Dependencies
 
 The `dependencies.tools` section declares which CLI tool versions a component requires. Atmos automatically installs and uses the specified versions when executing the component.
 
-### Configuration Scopes
+For detailed documentation on tool dependencies including:
+- Configuration scopes (global, component-type, component)
+- Version resolution formats
+- Inheritance and merge behavior
+- Integration with toolchain management
 
-Tool dependencies can be defined at multiple levels, with more specific levels taking precedence.
+See the dedicated [Tool Dependencies](/stacks/dependencies/tools) page.
 
-#### Global Level
-
-Tool versions defined at the root level apply to all components:
-
-<File title="stacks/orgs/acme/_defaults.yaml">
-```yaml
-# Global tool dependencies
-dependencies:
-  tools:
-    terraform: "1.9.8"      # All Terraform components use this version
-    kubectl: "1.28.0"        # All kubectl commands use this version
-```
-</File>
-
-#### Component-Type Level
-
-Tool versions defined under `terraform`, `helmfile`, `packer`, or `ansible` apply to all components of that type:
+### Quick Example
 
 <File title="stacks/orgs/acme/plat/prod/_defaults.yaml">
 ```yaml
-terraform:
-  dependencies:
-    tools:
-      terraform: "1.9.8"     # All Terraform components use 1.9.8
-      tflint: "0.44.1"       # All Terraform components use tflint 0.44.1
-
-helmfile:
-  dependencies:
-    tools:
-      helm: "3.13.0"         # All Helmfile releases use helm 3.13.0
-      kubectl: "1.28.0"      # All Helmfile releases use kubectl 1.28.0
-
-ansible:
-  dependencies:
-    tools:
-      ansible: "2.16.0"      # All Ansible components use ansible 2.16.0
-```
-</File>
-
-#### Component Level
-
-Tool versions defined within a component override all higher-level settings:
-
-<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
-```yaml
-components:
-  terraform:
-    vpc:
-      dependencies:
-        tools:
-          terraform: "1.8.5"   # This component uses older Terraform version
-          aws-cli: "2.13.0"    # Component-specific AWS CLI version
-```
-</File>
-
-### Version Resolution
-
-Tool dependencies support multiple version formats:
-
-<dl>
-  <dt>Exact version</dt>
-  <dd>
-    Use a specific version: `"1.9.8"`
-  </dd>
-
-  <dt>Latest version</dt>
-  <dd>
-    Use the latest available version: `"latest"`
-  </dd>
-
-  <dt>Semver constraint (planned)</dt>
-  <dd>
-    Use semantic version ranges: `">=1.8.0"`, `"~>1.9.0"`
-  </dd>
-</dl>
-
-### Inheritance and Merge Behavior
-
-Tool dependencies are merged from the most general to the most specific level:
-
-1. **Global `dependencies.tools`** (applies to all components)
-2. **Component-type `terraform.dependencies.tools`** (applies to all components of that type)
-3. **Component `components.terraform.<name>.dependencies.tools`** (applies to specific component)
-
-More specific levels override less specific levels. For example:
-
-<File title="Example: Version Override">
-```yaml
-# Global default
-dependencies:
-  tools:
-    terraform: "1.9.8"
-
-# Component-type override
-terraform:
-  dependencies:
-    tools:
-      terraform: "1.9.8"
-      tflint: "0.44.1"     # Added for all Terraform components
-
-# Component-specific override
-components:
-  terraform:
-    legacy-vpc:
-      dependencies:
-        tools:
-          terraform: "1.5.0"  # This component uses older version
-          tflint: "0.44.1"    # Inherited from component-type level
-```
-</File>
-
-Result:
-- Most Terraform components use Terraform 1.9.8
-- `legacy-vpc` component uses Terraform 1.5.0
-- All Terraform components use tflint 0.44.1
-
-### Integration with Toolchain
-
-Tool dependencies integrate seamlessly with the [toolchain management system](/cli/commands/toolchain/usage):
-
-1. **Automatic Installation:** When you run a component, Atmos installs the required tool versions automatically
-2. **Version Isolation:** Each component uses its declared versions, isolated from other components
-3. **Cache Efficiency:** Tools are cached and reused across components with the same version requirements
-
-Example workflow:
-
-```bash
-# Component declares terraform: "1.9.8"
-atmos terraform plan vpc -s prod
-
-# Atmos automatically:
-# 1. Checks if terraform 1.9.8 is installed
-# 2. Installs it if missing (from toolchain registries)
-# 3. Executes: terraform plan (using 1.9.8)
-```
-
-### Complete Tool Dependencies Example
-
-<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
-```yaml
-# Global tool dependencies (all components)
 dependencies:
   tools:
     terraform: "1.9.8"
     kubectl: "1.28.0"
 
-# Component-type dependencies (all Terraform components)
-terraform:
-  dependencies:
-    tools:
-      terraform: "1.9.8"      # Override global if needed
-      tflint: "0.44.1"        # Terraform-specific tool
-      tfsec: "1.28.0"         # Security scanning
-      aws-cli: "latest"       # Use latest AWS CLI
-
-# Component-type dependencies (all Helmfile releases)
-helmfile:
-  dependencies:
-    tools:
-      helm: "3.13.0"
-      kubectl: "1.28.0"
-      helmfile: "0.157.0"
-
-# Component-specific dependencies
 components:
   terraform:
-    vpc:
+    legacy-vpc:
       dependencies:
         tools:
-          terraform: "1.9.8"    # Use default
-          aws-cli: "2.13.0"     # Component needs specific AWS CLI version
-
-    legacy-app:
-      dependencies:
-        tools:
-          terraform: "1.5.0"    # Legacy component requires older version
-          aws-cli: "2.10.0"
-
-  helmfile:
-    monitoring:
-      dependencies:
-        tools:
-          helm: "3.13.0"
-          kubectl: "1.28.0"
+          terraform: "1.5.0"   # Override for this component only
 ```
 </File>
 
 ## Component Dependencies
 
-The `dependencies` section also supports component dependencies for commands and integrations that honor dependency metadata. In those flows, this helps components run in the correct sequence.
+The `dependencies.components` section defines relationships between components, ensuring they are deployed in the correct order.
 
 For detailed documentation on component dependencies including:
 - Cross-stack dependencies
@@ -246,18 +81,10 @@ components:
 ```
 </File>
 
-## Best Practices
-
-1. **Pin Versions Explicitly** - Use exact versions (`"1.9.8"`) instead of `"latest"` for production
-2. **Consistent Team Standards** - Define global defaults in `_defaults.yaml` files
-3. **Component-Specific Overrides** - Only override when necessary (legacy code, compatibility)
-4. **Document Reasons** - Add comments explaining why a component uses a different version
-5. **Test Before Upgrading** - Test tool version changes in dev/staging before production
-
 ## Related Documentation
 
-- [Component Dependencies](/stacks/dependencies/components) - Detailed component dependency configuration
+- [Tool Dependencies](/stacks/dependencies/tools) - Tool version requirements
+- [Component Dependencies](/stacks/dependencies/components) - Component-to-component dependencies
 - [Toolchain Management](/cli/commands/toolchain/usage) - Installing and managing CLI tools
 - [Toolchain Configuration](/cli/configuration/toolchain/) - Configuring toolchain behavior
-- [Component Dependencies](/stacks/settings/depends_on) - Configure dependencies between components
 - [YAML Functions](/functions/yaml) - Using `!terraform.output` and other functions for cross-component dependencies

--- a/website/docs/stacks/dependencies/tools.mdx
+++ b/website/docs/stacks/dependencies/tools.mdx
@@ -1,0 +1,219 @@
+---
+title: Tool Dependencies
+sidebar_position: 3
+sidebar_label: tools
+sidebar_class_name: command
+description: Declare tool version requirements so Atmos automatically installs the correct CLI tool versions for each component.
+id: tools
+---
+import File from '@site/src/components/File'
+import Intro from '@site/src/components/Intro'
+
+<Intro>
+The `dependencies.tools` section declares which CLI tool versions a component requires. Atmos automatically installs and uses the specified versions when executing the component.
+</Intro>
+
+## Use Cases
+
+- **Tool Version Requirements:** Ensure components use specific Terraform, kubectl, or helm versions
+- **Team Consistency:** Version-control tool requirements for reproducible deployments
+- **CI/CD Reliability:** Guarantee correct tool versions in automated pipelines
+
+## Configuration
+
+The `dependencies.tools` section is a map of tool names to version constraints.
+
+### Schema
+
+<dl>
+  <dt>tool name <em>(string key)</em></dt>
+  <dd>The CLI tool name as registered in the <a href="/cli/commands/toolchain/usage">toolchain</a> (e.g., <code>terraform</code>, <code>kubectl</code>, <code>helm</code>, <code>aws-cli</code>).</dd>
+
+  <dt>version constraint <em>(string value)</em></dt>
+  <dd>The required version. Supported formats: exact version (<code>"1.9.8"</code>), latest (<code>"latest"</code>), or semver constraint (planned: <code>"&gt;=1.8.0"</code>, <code>"~&gt;1.9.0"</code>).</dd>
+</dl>
+
+### Configuration Scopes
+
+Tool dependencies can be defined at multiple levels, with more specific levels taking precedence.
+
+#### Global Level
+
+Tool versions defined at the root level apply to all components:
+
+<File title="stacks/orgs/acme/_defaults.yaml">
+```yaml
+# Global tool dependencies
+dependencies:
+  tools:
+    terraform: "1.9.8"      # All Terraform components use this version
+    kubectl: "1.28.0"        # All kubectl commands use this version
+```
+</File>
+
+#### Component-Type Level
+
+Tool versions defined under `terraform`, `helmfile`, `packer`, or `ansible` apply to all components of that type:
+
+<File title="stacks/orgs/acme/plat/prod/_defaults.yaml">
+```yaml
+terraform:
+  dependencies:
+    tools:
+      terraform: "1.9.8"     # All Terraform components use 1.9.8
+      tflint: "0.44.1"       # All Terraform components use tflint 0.44.1
+
+helmfile:
+  dependencies:
+    tools:
+      helm: "3.13.0"         # All Helmfile releases use helm 3.13.0
+      kubectl: "1.28.0"      # All Helmfile releases use kubectl 1.28.0
+
+ansible:
+  dependencies:
+    tools:
+      ansible: "2.16.0"      # All Ansible components use ansible 2.16.0
+```
+</File>
+
+#### Component Level
+
+Tool versions defined within a component override all higher-level settings:
+
+<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
+```yaml
+components:
+  terraform:
+    vpc:
+      dependencies:
+        tools:
+          terraform: "1.8.5"   # This component uses older Terraform version
+          aws-cli: "2.13.0"    # Component-specific AWS CLI version
+```
+</File>
+
+## Inheritance and Merge Behavior
+
+Tool dependencies are merged from the most general to the most specific level:
+
+1. **Global `dependencies.tools`** (applies to all components)
+2. **Component-type `terraform.dependencies.tools`** (applies to all components of that type)
+3. **Component `components.terraform.<name>.dependencies.tools`** (applies to specific component)
+
+More specific levels override less specific levels. For example:
+
+<File title="Example: Version Override">
+```yaml
+# Global default
+dependencies:
+  tools:
+    terraform: "1.9.8"
+
+# Component-type override
+terraform:
+  dependencies:
+    tools:
+      terraform: "1.9.8"
+      tflint: "0.44.1"     # Added for all Terraform components
+
+# Component-specific override
+components:
+  terraform:
+    legacy-vpc:
+      dependencies:
+        tools:
+          terraform: "1.5.0"  # This component uses older version
+          tflint: "0.44.1"    # Inherited from component-type level
+```
+</File>
+
+Result:
+- Most Terraform components use Terraform 1.9.8
+- `legacy-vpc` component uses Terraform 1.5.0
+- All Terraform components use tflint 0.44.1
+
+## Integration with Toolchain
+
+Tool dependencies integrate seamlessly with the [toolchain management system](/cli/commands/toolchain/usage):
+
+1. **Automatic Installation:** When you run a component, Atmos installs the required tool versions automatically
+2. **Version Isolation:** Each component uses its declared versions, isolated from other components
+3. **Cache Efficiency:** Tools are cached and reused across components with the same version requirements
+
+Example workflow:
+
+```bash
+# Component declares terraform: "1.9.8"
+atmos terraform plan vpc -s prod
+
+# Atmos automatically:
+# 1. Checks if terraform 1.9.8 is installed
+# 2. Installs it if missing (from toolchain registries)
+# 3. Executes: terraform plan (using 1.9.8)
+```
+
+## Complete Example
+
+<File title="stacks/orgs/acme/plat/prod/us-east-1.yaml">
+```yaml
+# Global tool dependencies (all components)
+dependencies:
+  tools:
+    terraform: "1.9.8"
+    kubectl: "1.28.0"
+
+# Component-type dependencies (all Terraform components)
+terraform:
+  dependencies:
+    tools:
+      terraform: "1.9.8"      # Override global if needed
+      tflint: "0.44.1"        # Terraform-specific tool
+      tfsec: "1.28.0"         # Security scanning
+      aws-cli: "latest"       # Use latest AWS CLI
+
+# Component-type dependencies (all Helmfile releases)
+helmfile:
+  dependencies:
+    tools:
+      helm: "3.13.0"
+      kubectl: "1.28.0"
+      helmfile: "0.157.0"
+
+# Component-specific dependencies
+components:
+  terraform:
+    vpc:
+      dependencies:
+        tools:
+          terraform: "1.9.8"    # Use default
+          aws-cli: "2.13.0"     # Component needs specific AWS CLI version
+
+    legacy-app:
+      dependencies:
+        tools:
+          terraform: "1.5.0"    # Legacy component requires older version
+          aws-cli: "2.10.0"
+
+  helmfile:
+    monitoring:
+      dependencies:
+        tools:
+          helm: "3.13.0"
+          kubectl: "1.28.0"
+```
+</File>
+
+## Best Practices
+
+1. **Pin Versions Explicitly** - Use exact versions (`"1.9.8"`) instead of `"latest"` for production
+2. **Consistent Team Standards** - Define global defaults in `_defaults.yaml` files
+3. **Component-Specific Overrides** - Only override when necessary (legacy code, compatibility)
+4. **Document Reasons** - Add comments explaining why a component uses a different version
+5. **Test Before Upgrading** - Test tool version changes in dev/staging before production
+
+## Related
+
+- [Dependencies Overview](/stacks/dependencies) - Tool and component dependencies overview
+- [Component Dependencies](/stacks/dependencies/components) - Component-to-component dependencies
+- [Toolchain Management](/cli/commands/toolchain/usage) - Installing and managing CLI tools
+- [Toolchain Configuration](/cli/configuration/toolchain/) - Configuring toolchain behavior


### PR DESCRIPTION
## what

- Added `website/docs/stacks/dependencies/tools.mdx` — dedicated page for `dependencies.tools` configuration (version constraints, scopes, merge behavior, toolchain integration)
- Added `website/docs/stacks/components/settings.mdx` — dedicated page for `*.settings` configuration (validation, templates, integrations, atlantis, depends_on, custom keys)
- Slimmed `website/docs/stacks/dependencies/index.mdx` to an overview with quick examples linking to the dedicated tools and components pages

## why

- The dependencies sidebar had `components` but no `tools` page — tool dependency docs were inlined in the overview
- The components sidebar had `*.metadata` but no `*.settings` page — settings docs were scattered across integration pages
- Adds parity so both dependency types and both component config sections have dedicated reference pages
- Clarifies the relationship between `atmos.yaml` settings and stack-level settings (some keys like `templates` work at both levels, others like `list_merge_strategy` are global-only)

## references

- Follows patterns from existing `components.mdx` and `metadata.mdx` pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for configuring component settings in Atmos manifests, including use cases, scope levels, and merge behavior
  * Added dedicated documentation for tool dependencies configuration and management
  * Reorganized dependencies overview to clarify component vs. tool dependencies with improved cross-references and examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->