### PR TITLE
fix: include component name and file location in terraform load errors

### DIFF
--- a/internal/exec/describe_affected_optimizations_test.go
+++ b/internal/exec/describe_affected_optimizations_test.go
@@ -539,6 +539,23 @@ module "remote_module" {
 		require.NoError(t, err)
 		assert.Empty(t, patterns)
 	})
+
+	t.Run("invalid HCL includes component name and location in error", func(t *testing.T) {
+		badPath := filepath.Join(tempDir, "components", "terraform", "broken")
+		err := os.MkdirAll(badPath, 0o755)
+		require.NoError(t, err)
+
+		invalidHCL := `variable "name" { default = var.other }`
+		err = os.WriteFile(filepath.Join(badPath, "main.tf"), []byte(invalidHCL), 0o644)
+		require.NoError(t, err)
+
+		freshCache := newComponentPathPatternCache()
+		_, err = freshCache.getTerraformModulePatterns("broken", atmosConfig)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errUtils.ErrFailedToLoadTerraformComponent)
+		assert.Contains(t, err.Error(), "'broken'", "error should include the component name")
+		assert.Contains(t, err.Error(), "main.tf:", "error should include the file name")
+	})
 }
 
 func TestComponentPathPatternCache_ModulePatternsThreadSafety(t *testing.T) {
@@ -2221,6 +2238,25 @@ module "security" {
 		changed, err := areTerraformComponentModulesChanged("multi", atmosConfig, changedFiles)
 		require.NoError(t, err)
 		assert.True(t, changed)
+	})
+
+	t.Run("invalid HCL includes component name and location in error", func(t *testing.T) {
+		componentPath := filepath.Join(tempDir, "components", "terraform", "bad-hcl")
+		err := os.MkdirAll(componentPath, 0o755)
+		require.NoError(t, err)
+
+		// Write syntactically invalid HCL.
+		invalidHCL := `variable "name" { default = var.other }`
+		err = os.WriteFile(filepath.Join(componentPath, "main.tf"), []byte(invalidHCL), 0o644)
+		require.NoError(t, err)
+
+		changedFiles := []string{filepath.Join(componentPath, "main.tf")}
+
+		_, err = areTerraformComponentModulesChanged("bad-hcl", atmosConfig, changedFiles)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errUtils.ErrFailedToLoadTerraformComponent)
+		assert.Contains(t, err.Error(), "'bad-hcl'", "error should include the component name")
+		assert.Contains(t, err.Error(), "main.tf:", "error should include the file name")
 	})
 }
 

--- a/internal/exec/describe_affected_pattern_cache.go
+++ b/internal/exec/describe_affected_pattern_cache.go
@@ -106,7 +106,7 @@ func (c *componentPathPatternCache) getTerraformModulePatterns(
 			c.cacheEmptyPatterns(component)
 			return []string{}, nil
 		}
-		return nil, errors.Join(errUtils.ErrFailedToLoadTerraformComponent, diags.Err())
+		return nil, componentLoadError(component, diags)
 	}
 
 	if terraformConfiguration == nil {
@@ -124,6 +124,25 @@ func (c *componentPathPatternCache) getTerraformModulePatterns(
 	c.mu.Unlock()
 
 	return patterns, nil
+}
+
+// diagFileLocation extracts the first file:line location from tfconfig diagnostics, or returns "".
+func diagFileLocation(diags tfconfig.Diagnostics) string {
+	for _, diag := range diags {
+		if diag.Pos != nil {
+			return fmt.Sprintf("%s:%d", diag.Pos.Filename, diag.Pos.Line)
+		}
+	}
+	return ""
+}
+
+// componentLoadError builds an error for a failed component load, including file location when available.
+func componentLoadError(component string, diags tfconfig.Diagnostics) error {
+	loc := diagFileLocation(diags)
+	if loc != "" {
+		return fmt.Errorf("%w '%s' at %s: %w", errUtils.ErrFailedToLoadTerraformComponent, component, loc, diags.Err())
+	}
+	return fmt.Errorf("%w '%s': %w", errUtils.ErrFailedToLoadTerraformComponent, component, diags.Err())
 }
 
 // shouldCacheEmptyPatterns determines if the error indicates a missing directory that should cache empty patterns.

--- a/internal/exec/describe_affected_utils_2.go
+++ b/internal/exec/describe_affected_utils_2.go
@@ -335,7 +335,7 @@ func areTerraformComponentModulesChanged(
 		}
 
 		// For other errors (syntax errors, permission issues, etc.), return error.
-		return false, errors.Join(errUtils.ErrFailedToLoadTerraformComponent, diagErr)
+		return false, componentLoadError(component, diags)
 	}
 
 	// If no configuration, there are no modules to check.


### PR DESCRIPTION
## what

- When `atmos describe affected` fails to load a terraform component (e.g. HCL syntax errors), the error now includes the component name and file:line location
- Previously the error was generic: `failed to load terraform component Variables not allowed...`
- Now it reads: `failed to load terraform component 'vpc' at main.tf:3: Variables not allowed...`

## why

- The generic error gave no indication of which component failed, making debugging difficult in repos with many components
- The `describe affected` code path used simple `errors.Join` without context, while the `describe component` path already had rich error reporting via the error builder

## references

- Follows the same diagnostic extraction pattern already used in `internal/exec/utils.go` for `ProcessComponentConfig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when configuration parsing fails, now including component names and file location details for faster troubleshooting.

* **Tests**
  * Added test coverage for configuration parsing error scenarios to validate error reporting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->