### PR TITLE
fix: preserve deleted and deletion_type fields in upload strip

### DIFF
--- a/internal/exec/describe_affected_upload.go
+++ b/internal/exec/describe_affected_upload.go
@@ -14,8 +14,8 @@ import (
 //   - included_in_dependents: Used in filtering logic
 //   - dependents: Nested stack processing (recursively stripped)
 //   - settings.pro: Workflow dispatch configuration
-//   - deleted: Marks components removed in HEAD
-//   - deletion_type: Whether a component or entire stack was deleted
+//   - deleted: Marks components removed in HEAD.
+//   - deletion_type: Whether a component or entire stack was deleted.
 //
 // Fields removed:
 //   - settings.depends_on: Dependency graph (largest contributor to size)


### PR DESCRIPTION
## What

Preserve `deleted` and `deletion_type` fields in `StripAffectedForUpload` so they reach Atmos Pro when using `--upload`.

## Why

`StripAffectedForUpload` constructs a new `schema.Affected` with only the fields needed by Atmos Pro, but it was missing `Deleted` and `DeletionType`. This caused deleted components to arrive at Atmos Pro without their deletion metadata, making them appear as "disabled" instead of "deleted".

## References

- Previous fix (dependents crash): #2237
- Atmos Pro PR: [cloudposse-corp/apps#933](https://github.com/cloudposse-corp/apps/pull/933)
- Linear: [AP-161](https://linear.app/cloudposse/issue/AP-161/support-deleting-components-and-stacks-in-atmos-pro-ops)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deletion-related information was not being properly preserved during the data upload process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->