### PR TITLE
fix: Atmos Auth stack-level default identity resolution

### DIFF
--- a/cmd/describe_affected.go
+++ b/cmd/describe_affected.go
@@ -84,7 +84,11 @@ func getRunnableDescribeAffectedCmd(
 		identityName := GetIdentityFromFlags(cmd, os.Args)
 		identityExplicit := cmd.Flags().Changed(IdentityFlagName)
 		if props.ProcessYamlFunctions || identityExplicit {
-			authManager, authErr := CreateAuthManagerFromIdentityWithAtmosConfig(identityName, &props.CLIConfig.Auth, props.CLIConfig)
+			// Category B: describe affected operates on multiple affected components across stacks
+			// with no single target (component, stack) pair. Use the SCAN wrapper to discover
+			// stack-level defaults (including imported _defaults.yaml). See
+			// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
+			authManager, authErr := CreateAuthManagerFromIdentityWithStackScan(identityName, &props.CLIConfig.Auth, props.CLIConfig)
 			if authErr != nil {
 				return authErr
 			}

--- a/cmd/describe_dependents.go
+++ b/cmd/describe_dependents.go
@@ -62,7 +62,9 @@ func getRunnableDescribeDependentsCmd(
 		identityName := GetIdentityFromFlags(cmd, os.Args)
 		identityExplicit := cmd.Flags().Changed(IdentityFlagName)
 		if describe.ProcessYamlFunctions || identityExplicit {
-			authManager, authErr := CreateAuthManagerFromIdentityWithAtmosConfig(identityName, &atmosConfig.Auth, &atmosConfig)
+			// Category B: describe dependents has no single target (component, stack) pair.
+			// Use the SCAN wrapper to discover stack-level defaults.
+			authManager, authErr := CreateAuthManagerFromIdentityWithStackScan(identityName, &atmosConfig.Auth, &atmosConfig)
 			if authErr != nil {
 				return authErr
 			}

--- a/cmd/describe_stacks.go
+++ b/cmd/describe_stacks.go
@@ -77,7 +77,11 @@ func getRunnableDescribeStacksCmd(
 		identityName := GetIdentityFromFlags(cmd, os.Args)
 		identityExplicit := cmd.Flags().Changed(IdentityFlagName)
 		if describe.ProcessYamlFunctions || identityExplicit {
-			authManager, authErr := CreateAuthManagerFromIdentityWithAtmosConfig(identityName, &atmosConfig.Auth, &atmosConfig)
+			// Category B: describe stacks operates on multiple stacks/components with no single
+			// target (component, stack) pair. Use the SCAN wrapper so stack-level default identities
+			// (including those declared in imported _defaults.yaml files) are discovered. See
+			// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
+			authManager, authErr := CreateAuthManagerFromIdentityWithStackScan(identityName, &atmosConfig.Auth, &atmosConfig)
 			if authErr != nil {
 				return authErr
 			}

--- a/cmd/identity_flag.go
+++ b/cmd/identity_flag.go
@@ -132,22 +132,48 @@ func CreateAuthManagerFromIdentity(
 	return auth.CreateAndAuthenticateManager(identityName, authConfig, IdentityFlagSelectValue)
 }
 
-// CreateAuthManagerFromIdentityWithAtmosConfig creates and authenticates an AuthManager from an identity name.
-// This version accepts the full atmosConfig to enable loading stack configs for default identities.
+// CreateAuthManagerFromIdentityWithAtmosConfig creates and authenticates an AuthManager from an
+// identity name using a pre-merged auth config.
 //
-// When identityName is empty and atmosConfig is provided:
-//   - Loads stack configuration files for auth identity defaults
-//   - Applies stack-level defaults on top of atmos.yaml defaults
-//   - When stack defaults are present, they override atmos.yaml identity defaults (stack > atmos.yaml)
+// **This is the NO-SCAN wrapper** — it delegates to `auth.CreateAndAuthenticateManagerWithAtmosConfig`
+// and never runs the global stack-file pre-scanner. Use this for Category A callers that have
+// already merged the target stack's auth section via `ExecuteDescribeComponent` /
+// `MergeComponentAuthFromConfig` (e.g. `atmos describe component`).
 //
-// This solves the chicken-and-egg problem where:
-//   - We need to know the default identity to authenticate
-//   - But stack configs are only loaded after authentication is configured
-//   - Stack-level defaults (auth.identities.*.default: true) would otherwise be ignored
+// For Category B callers (multi-stack commands with no specific target), use
+// `CreateAuthManagerFromIdentityWithStackScan` instead. Using the scan variant on a Category A
+// caller would reintroduce the Discussion #122 cross-stack leak. See
+// `docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md` for the full design rationale.
 func CreateAuthManagerFromIdentityWithAtmosConfig(
 	identityName string,
 	authConfig *schema.AuthConfig,
 	atmosConfig *schema.AtmosConfiguration,
 ) (auth.AuthManager, error) {
 	return auth.CreateAndAuthenticateManagerWithAtmosConfig(identityName, authConfig, IdentityFlagSelectValue, atmosConfig)
+}
+
+// CreateAuthManagerFromIdentityWithStackScan creates and authenticates an AuthManager, first
+// running the global stack-file pre-scanner (Approach 2) to discover stack-level default
+// identities declared in `auth.identities.<name>.default: true`.
+//
+// **This is the SCAN wrapper** — it delegates to `auth.CreateAndAuthenticateManagerWithStackScan`.
+// Use it for Category B commands that legitimately have no target `(component, stack)` pair and
+// therefore cannot use the exec-layer merge path: `atmos describe stacks`,
+// `atmos describe affected`, `atmos describe dependents`, `atmos list affected`,
+// `atmos list instances`, `atmos aws security`, `atmos aws compliance`, and workflow execution.
+//
+// The scanner now follows `import:` chains, so stack-level defaults declared inside an imported
+// `_defaults.yaml` are visible even when that file is listed under `excluded_paths` — fixing
+// Issue #2293 for multi-stack commands. Conflict handling is unchanged: when two stacks declare
+// different defaults, both are discarded (matches Issue #2072's `allAgree` behavior).
+//
+// Category A callers (terraform/helmfile/describe component/nested auth) must NOT use this
+// variant. Running the scanner on top of a stack-scoped merged config reintroduces Discussion
+// #122's cross-stack leak.
+func CreateAuthManagerFromIdentityWithStackScan(
+	identityName string,
+	authConfig *schema.AuthConfig,
+	atmosConfig *schema.AtmosConfiguration,
+) (auth.AuthManager, error) {
+	return auth.CreateAndAuthenticateManagerWithStackScan(identityName, authConfig, IdentityFlagSelectValue, atmosConfig)
 }

--- a/cmd/list/utils.go
+++ b/cmd/list/utils.go
@@ -181,14 +181,19 @@ func normalizeIdentityValue(value string) string {
 
 // createAuthManagerForList creates an AuthManager for list commands.
 // It uses the identity from --identity flag or ATMOS_IDENTITY env var.
-// If no identity is specified, it loads stack configs for default identity.
+// If no identity is specified, it loads stack configs for default identity via the SCAN variant.
 // Returns nil AuthManager if no auth is configured (which is valid for many use cases).
+//
+// Category B: list commands operate across multiple stacks/components without a single target
+// (component, stack) pair, so they use the SCAN variant to discover stack-level defaults
+// (including defaults declared in imported _defaults.yaml). See
+// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
 func createAuthManagerForList(cmd *cobra.Command, atmosConfig *schema.AtmosConfiguration) (auth.AuthManager, error) {
 	identityName := getIdentityFromCommand(cmd)
 
-	// Create AuthManager with stack-level default identity loading.
-	// When identityName is empty, this loads stack configs for auth.identities.*.default: true.
-	authManager, err := auth.CreateAndAuthenticateManagerWithAtmosConfig(
+	// Scan variant: follows import: chains, discards conflicting defaults, isolates the scan
+	// into a copy of the auth config (no mutation of atmosConfig.Auth).
+	authManager, err := auth.CreateAndAuthenticateManagerWithStackScan(
 		identityName,
 		&atmosConfig.Auth,
 		cfg.IdentityFlagSelectValue,

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -502,17 +502,17 @@ reinforces Category A, which was already fixed via the exec-layer merge).
 
 ## Coverage matrix
 
-| Scenario | Pre-fix main | Option (a) | Option (b) | **Option (d+)** |
-|---|---|---|---|---|
-| **#2293** imported default, `terraform plan -s acme-dev` (Category A) | ❌ broken | ✅ exec-layer merge | ✅ exec-layer merge | ✅ exec-layer merge |
-| **#2293** imported default, `describe stacks` / `describe affected` (Category B) | ❌ broken | ❌ broken | ❌ broken | ✅ **scanner follows imports** |
-| **#2293** imported default, `list affected` / workflows / `aws security` (Category B) | ❌ broken | ❌ broken | ❌ broken | ✅ **scanner follows imports** |
-| **#122** single-stack default leaks to `terraform plan -s other` (Category A) | ❌ leak | ✅ scanner removed | ❌ leak still (gating fails) | ✅ Category A never runs scanner |
-| **#122** repo-wide consistent default, `describe stacks` (Category B) | ✅ works (scanner picks it up) | ❌ regression | ✅ works | ✅ works (scanner still runs) |
-| Existing `describe stacks` / `describe affected` / `list affected` multi-stack identity resolution | ✅ works | ❌ **regression** | ❌ **regression** | ✅ preserved bit-for-bit |
-| 2026-03-25 describe-affected AuthManager threading (Bugs 1-4) | ✅ works | ❌ regression | ❌ regression | ✅ preserved |
-| Issue #2072 conflicting-defaults discard across stacks | ✅ works | N/A (scanner gone) | ✅ works | ✅ preserved (same `allAgree` logic) |
-| Workflow execution stack-level default loading | ✅ works | ❌ regression | ❌ regression | ✅ restored |
+| Scenario                                                                                           | Pre-fix main                  | Option (a)         | Option (b)                  | **Option (d+)**                     |
+|----------------------------------------------------------------------------------------------------|-------------------------------|--------------------|-----------------------------|-------------------------------------|
+| **#2293** imported default, `terraform plan -s acme-dev` (Category A)                              | ❌ broken                      | ✅ exec-layer merge | ✅ exec-layer merge          | ✅ exec-layer merge                  |
+| **#2293** imported default, `describe stacks` / `describe affected` (Category B)                   | ❌ broken                      | ❌ broken           | ❌ broken                    | ✅ **scanner follows imports**       |
+| **#2293** imported default, `list affected` / workflows / `aws security` (Category B)              | ❌ broken                      | ❌ broken           | ❌ broken                    | ✅ **scanner follows imports**       |
+| **#122** single-stack default leaks to `terraform plan -s other` (Category A)                      | ❌ leak                        | ✅ scanner removed  | ❌ leak still (gating fails) | ✅ Category A never runs scanner     |
+| **#122** repo-wide consistent default, `describe stacks` (Category B)                              | ✅ works (scanner picks it up) | ❌ regression       | ✅ works                     | ✅ works (scanner still runs)        |
+| Existing `describe stacks` / `describe affected` / `list affected` multi-stack identity resolution | ✅ works                       | ❌ **regression**   | ❌ **regression**            | ✅ preserved bit-for-bit             |
+| 2026-03-25 describe-affected AuthManager threading (Bugs 1-4)                                      | ✅ works                       | ❌ regression       | ❌ regression                | ✅ preserved                         |
+| Issue #2072 conflicting-defaults discard across stacks                                             | ✅ works                       | N/A (scanner gone) | ✅ works                     | ✅ preserved (same `allAgree` logic) |
+| Workflow execution stack-level default loading                                                     | ✅ works                       | ❌ regression       | ❌ regression                | ✅ restored                          |
 
 ---
 

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -697,7 +697,26 @@ single-word change at each call site.
   caller), and now gets the import-following benefit for free since
   `LoadStackAuthDefaults` was rewritten to follow imports.
 
-### 4. Fixed flows
+### 4. Clear global defaults during component auth merge (Issue #3)
+
+**`pkg/auth/config_helpers.go`**
+
+- `MergeComponentAuthConfig` now copies `globalAuthConfig` internally via
+  `CopyGlobalAuthConfig` before any mutation, making it safe for direct
+  callers (not just those that go through the `MergeComponentAuthFromConfig`
+  wrapper).
+- Added `componentAuthHasDefault` — checks whether the component-level
+  auth section (raw `map[string]any` from the stack processor) contains any
+  identity with `default: true`.
+- Added `clearExistingIdentityDefaults` — clears all `Default` flags from
+  an `AuthConfig` struct's identities.
+- When `componentAuthHasDefault` returns true, `clearExistingIdentityDefaults`
+  runs on the working copy before the deep merge. The component-level
+  default then wins cleanly, producing exactly one default in the merged
+  result. This matches the precedence pattern already used by
+  `MergeStackAuthDefaults` in `pkg/config/stack_auth_loader.go`.
+
+### 5. Fixed flows
 
 **Category A — `atmos terraform plan my-component -s acme-dev` with imported `_defaults.yaml`:**
 
@@ -748,6 +767,21 @@ single-word change at each call site.
 2. allAgree → false → defaults map returned empty.
 3. Approach 2 falls back to `atmos.yaml`-level default only.
 4. Issue #2072 behavior preserved exactly.
+```
+
+**Issue #3 — `atmos terraform apply my-component -s dev` where component overrides global default:**
+
+```text
+1. getMergedAuthConfigWithFetcher → ExecuteDescribeComponent for my-component.
+2. Component's stack config has auth.identities.deploy-role.default: true.
+3. MergeComponentAuthFromConfig → CopyGlobalAuthConfig → MergeComponentAuthConfig:
+   → componentAuthHasDefault returns true (deploy-role has default: true).
+   → clearExistingIdentityDefaults clears tf-state-role.default on the copy.
+   → merge.Merge deep-merges: deploy-role.default: true survives, tf-state-role
+     exists but with default: false.
+4. CreateAndAuthenticateManagerWithAtmosConfig (NO-SCAN) resolves the single
+   default (deploy-role) without prompting.
+5. Auth manager authenticates as deploy-role. No "multiple defaults" prompt.
 ```
 
 ---

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -791,22 +791,25 @@ Stack names resolve to `data-staging` and `plat-staging` respectively.
 ### CLI regression tests
 
 `tests/test-cases/auth-identity-resolution-bugs.yaml` wires the fixtures
-into assertions that guard the exec-layer merge path and the non-leak
-guarantee for Category A callers. All three scenarios run through the full
-auth-manager path (no `--identity off`) using mock/aws credentials:
+into three assertions:
 
-- **`describe component mycomponent -s acme-dev`** (Issue #2293) — asserts
-  the imported `_defaults.yaml` default is present in the exec-layer merged
-  output (`auth.identities.dev-identity.default: true`).
+- **`describe component mycomponent -s acme-dev --identity off`**
+  (Issue #2293) — uses `--identity off` to disable auth and queries the
+  exec-layer merged output directly. Asserts
+  `auth.identities.dev-identity.default: true` is present, proving the
+  stack processor followed the `import:` chain into the excluded
+  `_defaults.yaml`. This test guards the exec-layer merge path only (not
+  the auth-manager scan variant).
 - **`describe component monitoring -s data-staging`** (Discussion #122
-  happy path) — asserts data-staging correctly sees its own default via the
-  full NO-SCAN auth-manager path.
+  happy path) — runs through the full NO-SCAN auth-manager path (no
+  `--identity off`). Asserts data-staging correctly sees its own default.
 - **`describe component eks -s plat-staging`** (Discussion #122 non-leak)
-  — asserts `data-default.default` is `null`, not `true`. This is the core
+  — runs through the full NO-SCAN auth-manager path (no `--identity off`).
+  Asserts `data-default.default` is `null`, not `true`. This is the core
   regression guard: if the scanner were still running inside the NO-SCAN
-  variant, it would pick up the `data-default.default: true` from the
-  foreign `data-staging` stack file and inject it here. The `null` assertion
-  proves the NO-SCAN variant never consults other stack files.
+  variant, it would pick up `data-default.default: true` from the foreign
+  `data-staging` stack file. The `null` assertion proves the NO-SCAN
+  variant never consults other stack files.
 
 ### Go unit tests
 
@@ -824,9 +827,10 @@ auth-manager path (no `--identity off`) using mock/aws credentials:
   glob; scanner must expand.
 - `TestLoadStackAuthDefaults_TemplatedImportSkipped` — Go-template import
   path; scanner must skip gracefully (same as today).
-- `TestLoadStackAuthDefaults_CurrentFileWinsOverImport` — when both the
-  importing file and the imported file declare defaults, the importing
-  file's default takes precedence.
+- `TestLoadStackAuthDefaults_ConflictingDefaultsAcrossImportAndFileDiscarded`
+  — when the importing file and the imported file declare defaults for
+  different identities, the merged view has two competing defaults; the
+  `allAgree` check detects the conflict and discards both (Issue #2072).
 - `TestLoadStackAuthDefaults_ImportedDefaultAgreesAcrossStacks` — two
   stacks import the same `_defaults.yaml`; `allAgree` passes.
 - `TestLoadStackAuthDefaults_RelativeImports` — `./` imports resolve

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -5,12 +5,15 @@
 **Issues:**
 - [#2293](https://github.com/cloudposse/atmos/issues/2293) — `auth.identities.<name>.default: true` in imported stack files not recognized during identity resolution
 - [Discussion #122](https://github.com/orgs/cloudposse/discussions/122) — Auth inheritance not scoping to stack (a default identity declared in one stack manifest leaks to every other stack across all OUs)
+- Component-level identity override — when a component declares its own `auth.identities.<name>.default: true`, the global default from `atmos.yaml` should be overridden for that component; instead both defaults survive the merge and the user is prompted to choose
 
 ## Status
 
-**Two related bugs fixed without breaking any existing auth functionality.**
-Both originate from the same global raw-YAML pre-scanner in
-`pkg/config/stack_auth_loader.go`. The chosen fix is a **two-part change**:
+**Three related bugs fixed without breaking any existing auth functionality.**
+Issues 1 and 2 originate from the global raw-YAML pre-scanner in
+`pkg/config/stack_auth_loader.go`. Issue 3 is in the exec-layer
+component auth merge in `pkg/auth/config_helpers.go`. The fix is a
+**three-part change**:
 
 1. **Split the auth manager entry points** into a "scan" variant (for
    multi-stack commands that legitimately have no target stack) and a
@@ -24,6 +27,12 @@ Both originate from the same global raw-YAML pre-scanner in
    commands (`describe stacks`, `describe affected`, `list affected`,
    workflows, `aws security`, `aws compliance`). This closes Issue #2293
    across *all* command categories.
+3. **Clear global defaults when a component declares its own** in
+   `MergeComponentAuthConfig`. When the component-level auth section has
+   any identity with `default: true`, all existing global defaults are
+   cleared before the deep merge, so the component-level default wins
+   cleanly. This matches the precedence pattern already used by
+   `MergeStackAuthDefaults`.
 
 The multi-stack "Approach 2" code path (documented in
 `stack-level-default-auth-identity.md`) is preserved. No existing auth
@@ -238,6 +247,95 @@ behavior reproduces on all three.
 `default: true` under `auth.identities.<name>` should only apply to the
 stack(s) that actually import or declare that `auth:` block. Unrelated
 stacks in other OUs, tenants, or environments should be unaffected.
+
+---
+
+## Issue 3 — Component-level identity override does not clear global default
+
+### Problem
+
+When `atmos.yaml` declares a global default identity (e.g. for Terraform
+state access) and a component overrides it with a different identity via
+`auth.identities.<name>.default: true` in the stack config, **both**
+defaults survive the exec-layer merge. The user is then prompted to choose
+between multiple defaults (interactive mode) or gets an error (CI/non-
+interactive mode).
+
+### Reproduction
+
+Global auth config (`atmos.yaml`):
+
+```yaml
+auth:
+  identities:
+    tf-state-role:
+      default: true
+      kind: aws/permission-set
+      via.provider: company-sso
+      principal:
+        name: role-for-tf-state
+        account.id: "11111111111"
+
+    deploy-role:
+      kind: aws/permission-set
+      via.provider: company-sso
+      principal:
+        name: role-for-deploy
+        account.id: "22222222222"
+```
+
+Stack manifest with component-level override:
+
+```yaml
+components:
+  terraform:
+    my-component:
+      auth:
+        identities:
+          deploy-role:
+            default: true
+```
+
+Running `atmos terraform apply my-component -s dev` prompts:
+
+```text
+┃ Multiple default identities found. Please choose:
+┃ > tf-state-role
+┃   deploy-role
+```
+
+### Expected behavior
+
+The component-level `default: true` should override the global default for
+that component. The user should not be prompted — `deploy-role` should be
+used automatically.
+
+### Root cause
+
+`pkg/auth/config_helpers.go:MergeComponentAuthConfig` does a raw deep merge
+via `merge.Merge(atmosConfig, []map[string]any{globalAuthMap, componentAuth})`.
+The component's `deploy-role.default: true` is added to the merged map, but
+the global `tf-state-role.default: true` is **not cleared**. The result has
+two identities with `default: true`.
+
+Compare with `MergeStackAuthDefaults` in `pkg/config/stack_auth_loader.go`
+which **does** clear existing defaults before applying stack-level ones:
+
+```go
+if hasAnyDefault(stackDefaults) {
+    clearExistingDefaults(authConfig)
+}
+```
+
+`MergeComponentAuthConfig` was missing this equivalent logic.
+
+### Fix
+
+Added `componentAuthHasDefault` check and `clearExistingIdentityDefaults`
+call before the deep merge in `MergeComponentAuthConfig`. When the component
+auth section has any identity with `default: true`, all existing `Default`
+flags in the global auth config are cleared first, so the component-level
+default wins cleanly.
 
 ---
 

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -35,7 +35,7 @@ functionality is removed.
 - [x] Caller audit — categorized every call site of
       `CreateAndAuthenticateManagerWithAtmosConfig` into Category A
       (target-stack context) vs Category B (multi-stack / no target).
-- [x] Identified regression risk: earlier draft (option "c" below) removed
+- [x] Identified regression risk: earlier draft (option "a" below) removed
       the pre-scanner entirely and broke the intentional Approach 2 code
       path for `describe stacks` / `describe affected` / `list affected` /
       workflows / `aws security`.
@@ -67,14 +67,18 @@ functionality is removed.
 - [x] `internal/exec/workflow_utils.go:checkAndMergeDefaultIdentity` —
       unchanged on this branch. Already calls `config.LoadStackAuthDefaults`
       directly, and now gets the import-following benefit for free.
-- [x] Scenario coverage for Issue #2293 via `describe stacks` added to
-      `tests/test-cases/auth-identity-resolution-bugs.yaml`. Uses the
-      `auth-imported-defaults/` fixture and exercises the new scan variant
-      end-to-end.
-- [x] Go unit tests: 12 new scanner tests in
-      `pkg/config/stack_auth_loader_test.go`, 5 new auth-helper regression
-      tests in `pkg/auth/manager_helpers_test.go`, plus isolation tests for
-      `copyAuthConfigForScan`.
+- [x] CLI regression test cases in
+      `tests/test-cases/auth-identity-resolution-bugs.yaml` (3 scenarios:
+      imported default via `describe component`, data-staging happy path,
+      plat-staging non-leak). The Category B scan variant is covered at the
+      Go unit level only — a CLI test for the scan path would require real
+      authentication, which is out of scope for mock/aws fixtures.
+- [x] Go unit tests: 22 new scanner tests in
+      `pkg/config/stack_auth_loader_test.go` and 14 new auth-helper tests in
+      `pkg/auth/manager_helpers_test.go` (regression tests for the no-scan /
+      scan split, isolation tests for `copyAuthConfigForScan`,
+      `scanStackFilesForDefaults` behavior, and Category A non-leak /
+      Category B import-discovery paths).
 - [x] Full regression suite passes: `pkg/auth/`, `pkg/config/`,
       `internal/exec/`, `cmd/`, `pkg/list/`, `cmd/list/`, CLI scenarios
       under `tests/`.
@@ -298,8 +302,8 @@ identity as the default.
 
 ### Why the approach is structurally wrong
 
-The code comment above `CreateAndAuthenticateManagerWithAtmosConfig` framed
-this as a chicken-and-egg problem:
+The code comment above `CreateAndAuthenticateManagerWithAtmosConfig` (before
+this fix) framed this as a chicken-and-egg problem:
 
 > - We need to know the default identity to authenticate
 > - But stack configs are only loaded after authentication is configured
@@ -369,9 +373,9 @@ no single `(component, stack)` pair upfront. They were *intentionally*
 designed to use the pre-scanner as "Approach 2" in
 `docs/fixes/stack-level-default-auth-identity.md`:
 
-- `atmos describe stacks` — `cmd/describe_stacks.go:80`
+- `atmos describe stacks` — `cmd/describe_stacks.go`
   (gated on `ProcessYamlFunctions || identityExplicit`)
-- `atmos describe affected` — `cmd/describe_affected.go:87`
+- `atmos describe affected` — `cmd/describe_affected.go`
   (same gate; plus 2026-03-25 fix threads the AuthManager through the
   entire affected/graph pipeline)
 - `atmos describe dependents` — `cmd/describe_dependents.go`
@@ -512,7 +516,7 @@ reinforces Category A, which was already fixed via the exec-layer merge).
 | Existing `describe stacks` / `describe affected` / `list affected` multi-stack identity resolution | ✅ works                       | ❌ **regression**   | ❌ **regression**            | ✅ preserved bit-for-bit             |
 | 2026-03-25 describe-affected AuthManager threading (Bugs 1-4)                                      | ✅ works                       | ❌ regression       | ❌ regression                | ✅ preserved                         |
 | Issue #2072 conflicting-defaults discard across stacks                                             | ✅ works                       | N/A (scanner gone) | ✅ works                     | ✅ preserved (same `allAgree` logic) |
-| Workflow execution stack-level default loading                                                     | ✅ works                       | ❌ regression       | ❌ regression                | ✅ restored                          |
+| Workflow execution stack-level default loading                                                     | ✅ works                       | ❌ regression       | ❌ regression                | ✅ preserved (unchanged from main)   |
 
 ---
 
@@ -520,8 +524,9 @@ reinforces Category A, which was already fixed via the exec-layer merge).
 
 ### 1. Teach the scanner to follow imports
 
-**`pkg/config/stack_auth_loader.go`** — replace the flat per-file
-`loadFileForAuthDefaults` with a recursive `loadAuthWithImports` that:
+**`pkg/config/stack_auth_loader.go`** — add a new recursive
+`loadAuthWithImports` (used by `LoadStackAuthDefaults` instead of the flat
+`loadFileForAuthDefaults`, which is kept for backward compatibility) that:
 
 - Reads each stack file's top-level `import:` list and `auth:` block via
   a minimal `yaml.Unmarshal` (no template rendering, no full stack
@@ -573,22 +578,26 @@ single-word change at each call site.
 - **Category A** — no change. Already uses
   `CreateAndAuthenticateManagerWithAtmosConfig` (no scan).
 - **Category B** — switch to `CreateAndAuthenticateManagerWithStackScan`
-  (or, for most of them, update the thin wrapper they go through):
-  - `cmd/identity_flag.go:CreateAuthManagerFromIdentityWithAtmosConfig`
-    → switch its inner call to the scan variant. This single change
-    auto-updates `describe stacks`, `describe affected`, and
-    `describe dependents` because they all go through the wrapper.
+  (or, for callers that go through the `cmd/identity_flag.go` wrappers,
+  switch to the new `CreateAuthManagerFromIdentityWithStackScan` wrapper):
+  - `cmd/identity_flag.go` — a **new** wrapper
+    `CreateAuthManagerFromIdentityWithStackScan` was added; the existing
+    `CreateAuthManagerFromIdentityWithAtmosConfig` was **kept as NO-SCAN**.
+    `describe stacks`, `describe affected`, and `describe dependents`
+    were each updated to call the new scan wrapper directly.
   - `cmd/list/utils.go:createAuthManagerForList` → scan variant.
   - `pkg/list/list_affected.go` → scan variant.
   - `cmd/list/instances.go` → scan variant (if it currently calls the
     auth helper).
-  - `cmd/aws/security/security.go` → scan variant.
-  - `cmd/aws/compliance/compliance.go` → scan variant.
+  - `pkg/auth/manager_env_overrides.go` → scan variant (MCP scoped auth).
+  - `cmd/aws/security/security.go` and `cmd/aws/compliance/compliance.go`
+    — **unchanged**. These bail out when `identityName == ""`, so the
+    scan would be a no-op; they remain on the no-scan variant.
 - **`internal/exec/workflow_utils.go:checkAndMergeDefaultIdentity`** —
-  restore the `config.LoadStackAuthDefaults` +
-  `config.MergeStackAuthDefaults` calls that the earlier draft
-  simplified away. This is equivalent to calling the scan variant and
-  matches the pre-fix behavior exactly.
+  unchanged on this branch. Already calls `config.LoadStackAuthDefaults` +
+  `config.MergeStackAuthDefaults` directly (pre-existing Approach 2
+  caller), and now gets the import-following benefit for free since
+  `LoadStackAuthDefaults` was rewritten to follow imports.
 
 ### 4. Fixed flows
 
@@ -621,7 +630,7 @@ single-word change at each call site.
 **Category B — `atmos describe stacks` with imported `_defaults.yaml`:**
 
 ```text
-1. cmd/describe_stacks.go → CreateAuthManagerFromIdentityWithAtmosConfig
+1. cmd/describe_stacks.go → CreateAuthManagerFromIdentityWithStackScan
    → CreateAndAuthenticateManagerWithStackScan(identityName="", …)
 2. Scan variant calls LoadStackAuthDefaults:
    → scanner walks each top-level stack file, recursively following
@@ -684,26 +693,26 @@ Stack names resolve to `data-staging` and `plat-staging` respectively.
 ### CLI regression tests
 
 `tests/test-cases/auth-identity-resolution-bugs.yaml` wires the fixtures
-into assertions that guard both the Category A exec-layer merge path AND
-the Category B scan-variant path:
+into assertions that guard the exec-layer merge path and the non-leak
+guarantee for Category A callers. All three scenarios run through the full
+auth-manager path (no `--identity off`) using mock/aws credentials:
 
-- **`describe component -s acme-dev`** (Category A) asserts the imported
-  `_defaults.yaml` default is present in the merged output.
-- **`describe stacks -s acme-dev --process-functions=true`** (Category B)
-  asserts the scan variant surfaces the imported default — new coverage
-  for #2293 against multi-stack commands.
-- **`describe component -s data-staging`** asserts data-staging sees its
-  own default identity (happy path).
-- **`describe component -s plat-staging`** asserts plat-staging does NOT
-  inherit data-staging's default (the Category A non-leak — Discussion
-  #122).
-- **`describe stacks` across the auth-stack-scoping fixture** asserts the
-  scan variant still behaves correctly under the `allAgree` conflict
-  logic (Issue #2072 preserved).
+- **`describe component mycomponent -s acme-dev`** (Issue #2293) — asserts
+  the imported `_defaults.yaml` default is present in the exec-layer merged
+  output (`auth.identities.dev-identity.default: true`).
+- **`describe component monitoring -s data-staging`** (Discussion #122
+  happy path) — asserts data-staging correctly sees its own default via the
+  full NO-SCAN auth-manager path.
+- **`describe component eks -s plat-staging`** (Discussion #122 non-leak)
+  — asserts `data-default.default` is `null`, not `true`. This is the core
+  regression guard: if the scanner were still running inside the NO-SCAN
+  variant, it would pick up the `data-default.default: true` from the
+  foreign `data-staging` stack file and inject it here. The `null` assertion
+  proves the NO-SCAN variant never consults other stack files.
 
 ### Go unit tests
 
-**`pkg/config/stack_auth_loader_test.go`** (new / updated)
+**`pkg/config/stack_auth_loader_test.go`** (22 new tests, key highlights)
 
 - `TestLoadStackAuthDefaults_FollowsImports` — stack file imports a
   `_defaults.yaml` that declares `default: true`; scanner must see it.
@@ -715,54 +724,78 @@ the Category B scan-variant path:
   import each other; scanner must terminate and return a sensible result.
 - `TestLoadStackAuthDefaults_GlobImports` — `import:` list contains a
   glob; scanner must expand.
-- `TestLoadStackAuthDefaults_TemplatedImportSkipped` — map-form import
-  with a Go-template path; scanner must skip gracefully (same as today).
-- `TestLoadStackAuthDefaults_ConflictingDefaultsDiscarded` — preserves
-  Issue #2072 `allAgree` behavior unchanged.
+- `TestLoadStackAuthDefaults_TemplatedImportSkipped` — Go-template import
+  path; scanner must skip gracefully (same as today).
 - `TestLoadStackAuthDefaults_CurrentFileWinsOverImport` — when both the
   importing file and the imported file declare defaults, the importing
   file's default takes precedence.
+- `TestLoadStackAuthDefaults_ImportedDefaultAgreesAcrossStacks` — two
+  stacks import the same `_defaults.yaml`; `allAgree` passes.
+- `TestLoadStackAuthDefaults_RelativeImports` — `./` imports resolve
+  against the importing file's directory.
+- `TestLoadStackAuthDefaults_ExplicitFalseRevokesImportedDefault` — an
+  imported `default: true` is overridden by `default: false` in the
+  importing file. Uses `*bool` three-state semantics to distinguish
+  "not mentioned" from "explicitly false".
+- `TestLoadStackAuthDefaults_IdentityWithoutDefaultFieldLeavesImportedDefault`
+  — complementary test: mentioning the identity without a `default` field
+  (nil) preserves the imported `true`.
+- Plus 12 additional tests for `resolveAuthImportPaths` (map form, unknown
+  types, empty stacksBasePath, .yml fallback, non-existent candidate, glob
+  no-matches), `extractImportPathString` (`map[any]any`, non-string path,
+  empty string), and `loadAuthWithImports` (non-YAML extension,
+  nonexistent file).
 
 **`pkg/auth/manager_helpers_test.go`** (new regression tests)
 
 Category A (no-scan variant):
 
-- `TestCreateAndAuthenticateManagerWithAtmosConfig_HonorsMergedConfigDefault`
-  — when the merged `authConfig` already carries a default (produced by
-  the exec-layer stack processor for a target stack that imports
-  `_defaults.yaml`), that default is resolved correctly.
-- `TestCreateAndAuthenticateManagerWithAtmosConfig_DoesNotLeakCrossStackDefault`
-  — when the merged `authConfig` has NO default (simulating a target
-  stack like `plat-staging` with no auth block), the no-scan variant
-  never consults unrelated stack files; no leak possible.
-- `TestCreateAndAuthenticateManagerWithAtmosConfig_IgnoresStackFilesWithLeakingDefault`
-  — end-to-end: a real stack file on disk declares `default: true`; the
-  no-scan variant must not pick it up even with a full `atmosConfig`.
-- `TestCreateAndAuthenticateManagerWithAtmosConfig_ExplicitIdentityNotOverriddenByStackFiles`
-  — `--identity` flag passed explicitly wins over any stack file
-  defaults.
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_NoScanVariant_DoesNotLeakCrossStackDefault`
+  — Discussion #122 regression test: a real stack file on disk declares
+  `default: true`; the no-scan variant must not pick it up.
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_NoScanVariant_IgnoresStackFilesEntirely`
+  — even with an empty `authConfig` and stack files on disk, the no-scan
+  variant returns nil (no authentication) rather than auto-discovering
+  identities from unrelated stack files.
 
 Category B (scan variant):
 
-- `TestCreateAndAuthenticateManagerWithStackScan_PicksUpImportedDefault`
-  — scan variant finds an imported `_defaults.yaml` default that the
-  no-scan variant cannot see. Primary Category B #2293 test.
-- `TestCreateAndAuthenticateManagerWithStackScan_HonorsExplicitIdentity`
-  — explicit `identityName` bypasses the scan.
-- `TestCreateAndAuthenticateManagerWithStackScan_DiscardsConflictingDefaults`
+- `TestCreateAndAuthenticateManagerWithStackScan_FollowsImportedDefaultFromExcludedPath`
+  — Issue #2293 regression test: scan variant finds an imported
+  `_defaults.yaml` default (in `excluded_paths`) that the no-scan variant
+  cannot see. Verifies isolation: caller's original `authConfig` remains
+  untouched.
+- `TestCreateAndAuthenticateManagerWithStackScan_ExplicitIdentitySkipsScan`
+  — explicit `identityName` bypasses the scan entirely.
+- `TestCreateAndAuthenticateManagerWithStackScan_DelegatesAfterSuccessfulScan`
+  — end-to-end: scan runs, finds a default, delegates to the no-scan
+  variant with the scanned copy. Verifies the caller's `authConfig` is
+  not mutated.
+- `TestCreateAndAuthenticateManagerWithStackScan_NilAtmosConfig`
+  — nil `atmosConfig` skips the scan; delegates straight to the no-scan
+  variant.
+- `TestCreateAndAuthenticateManagerWithStackScan_UnconfiguredAuthSkipsScan`
+  — when auth is not configured (no identities), scan is skipped.
+- `TestCreateAndAuthenticateManagerWithStackScan_ConflictingDefaultsDiscarded`
   — two stacks declare different defaults; scan returns empty; falls
   back to `atmos.yaml`-level default. Issue #2072 preserved.
-- `TestCreateAndAuthenticateManagerWithStackScan_NoMutationOfInputConfig`
-  — scan variant must operate on a copy of `authConfig`; caller's
-  original must remain untouched.
 
-**`internal/exec/workflow_utils_test.go`** (restored)
+Isolation and copy helpers:
 
-- Restore the stack-loading tests that the earlier draft deleted:
-  `TestCheckAndMergeDefaultIdentity_WithStackLoading`, `_LoadError`,
-  `_LoadErrorNoDefault`, `_StackNoDefaults`, `_EmptyStackDefaults`. The
-  function's pre-fix behavior is restored, so these tests become valid
-  again.
+- `TestScanStackFilesForDefaults_*` — 4 tests covering the private
+  `scanStackFilesForDefaults` helper's behavior for existing defaults,
+  no defaults, stack files on disk, and load errors.
+- `TestCopyAuthConfigForScan_IsolationBothDirections` — verifies deep-copy
+  semantics: mutating the copy does not leak into the original, and vice
+  versa.
+- `TestCopyAuthConfigForScan_Nil` — nil input returns nil.
+
+**`internal/exec/workflow_utils_test.go`** (unchanged)
+
+- Unchanged on this branch. `checkAndMergeDefaultIdentity` and its tests
+  were never modified — the function already calls
+  `config.LoadStackAuthDefaults` directly, and now benefits from the
+  import-following scanner automatically.
 
 ### Regression run (required before merge)
 

--- a/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+++ b/docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
@@ -1,0 +1,802 @@
+# Fix: Atmos Auth stack-level default identity resolution
+
+**Date:** 2026-04-08
+
+**Issues:**
+- [#2293](https://github.com/cloudposse/atmos/issues/2293) — `auth.identities.<name>.default: true` in imported stack files not recognized during identity resolution
+- [Discussion #122](https://github.com/orgs/cloudposse/discussions/122) — Auth inheritance not scoping to stack (a default identity declared in one stack manifest leaks to every other stack across all OUs)
+
+## Status
+
+**Two related bugs fixed without breaking any existing auth functionality.**
+Both originate from the same global raw-YAML pre-scanner in
+`pkg/config/stack_auth_loader.go`. The chosen fix is a **two-part change**:
+
+1. **Split the auth manager entry points** into a "scan" variant (for
+   multi-stack commands that legitimately have no target stack) and a
+   "no-scan" variant (for commands that have already done an exec-layer
+   merge against a specific target stack). This closes the Discussion #122
+   leak at the source — the scanner can no longer contaminate merged
+   configs.
+2. **Teach the pre-scanner to follow `import:` chains** so that
+   `auth.identities.<name>.default: true` declared inside an imported
+   `_defaults.yaml` is visible everywhere — including for multi-stack
+   commands (`describe stacks`, `describe affected`, `list affected`,
+   workflows, `aws security`, `aws compliance`). This closes Issue #2293
+   across *all* command categories.
+
+The multi-stack "Approach 2" code path (documented in
+`stack-level-default-auth-identity.md`) is preserved. No existing auth
+functionality is removed.
+
+### Progress checklist
+
+- [x] Root-cause analysis.
+- [x] Caller audit — categorized every call site of
+      `CreateAndAuthenticateManagerWithAtmosConfig` into Category A
+      (target-stack context) vs Category B (multi-stack / no target).
+- [x] Identified regression risk: earlier draft (option "c" below) removed
+      the pre-scanner entirely and broke the intentional Approach 2 code
+      path for `describe stacks` / `describe affected` / `list affected` /
+      workflows / `aws security`.
+- [x] Two scenario fixtures under `tests/fixtures/scenarios/` using
+      `mock/aws`.
+- [x] CLI regression test cases in
+      `tests/test-cases/auth-identity-resolution-bugs.yaml`.
+- [x] Go unit tests at the function boundary and the auth-manager boundary.
+- [x] Option (d+) implemented on fresh branch `aknysh/atmos-auth-fixes-3`
+      off `main` — split entry points plus import-following scanner.
+- [x] `pkg/config/stack_auth_loader.go` — added `loadAuthWithImports`
+      (recursive, cycle-protected), `resolveAuthImportPaths`, and
+      `extractImportPathString`. `LoadStackAuthDefaults` now follows
+      `import:` chains. `allAgree` conflict detection (Issue #2072) preserved.
+- [x] `pkg/auth/manager_helpers.go` — `CreateAndAuthenticateManagerWithAtmosConfig`
+      is now the NO-SCAN variant; added `CreateAndAuthenticateManagerWithStackScan`
+      for Category B. `scanStackFilesForDefaults` operates on a COPY via
+      `copyAuthConfigForScan` so Category B invocations cannot leak into
+      Category A reuses of the same `atmosConfig.Auth`.
+- [x] `cmd/identity_flag.go` — added `CreateAuthManagerFromIdentityWithStackScan`
+      wrapper. `CreateAuthManagerFromIdentityWithAtmosConfig` remains NO-SCAN.
+- [x] Category B callers routed to the scan variant:
+      `cmd/describe_stacks.go`, `cmd/describe_affected.go`,
+      `cmd/describe_dependents.go`, `cmd/list/utils.go`,
+      `pkg/list/list_affected.go`, and `pkg/auth/manager_env_overrides.go`
+      (MCP scoped auth). `cmd/describe_component.go` kept on the NO-SCAN
+      wrapper (Category A). `aws security` / `aws compliance` untouched —
+      they bail out when `identityName == ""` so the scan is a no-op.
+- [x] `internal/exec/workflow_utils.go:checkAndMergeDefaultIdentity` —
+      unchanged on this branch. Already calls `config.LoadStackAuthDefaults`
+      directly, and now gets the import-following benefit for free.
+- [x] Scenario coverage for Issue #2293 via `describe stacks` added to
+      `tests/test-cases/auth-identity-resolution-bugs.yaml`. Uses the
+      `auth-imported-defaults/` fixture and exercises the new scan variant
+      end-to-end.
+- [x] Go unit tests: 12 new scanner tests in
+      `pkg/config/stack_auth_loader_test.go`, 5 new auth-helper regression
+      tests in `pkg/auth/manager_helpers_test.go`, plus isolation tests for
+      `copyAuthConfigForScan`.
+- [x] Full regression suite passes: `pkg/auth/`, `pkg/config/`,
+      `internal/exec/`, `cmd/`, `pkg/list/`, `cmd/list/`, CLI scenarios
+      under `tests/`.
+
+---
+
+## Relationship summary (TL;DR)
+
+**Both issues share the same root cause.** They originate from
+`pkg/config/stack_auth_loader.go:LoadStackAuthDefaults`, a shortcut that
+scans every stack file globally *before* the target stack is known and tries
+to discover "the" default identity from raw YAML parsing. That shortcut is
+structurally wrong in two ways:
+
+1. It reads files with `yaml.Unmarshal` against a minimal struct — it does
+   **not** follow `import:` directives, so any `auth:` block declared in an
+   imported `_defaults.yaml` is invisible (**#2293**). In a typical Cloud
+   Posse layout `_defaults.yaml` files are even listed under
+   `stacks.excluded_paths`, so they never reach the glob at all.
+
+2. It aggregates every `default: true` flag it finds into a **global** pool
+   and applies the result to every subsequent command regardless of target
+   stack. The existing "conflict detection" only handles the case where
+   *multiple different* identities are flagged as default; if exactly one
+   stack file declares a default, that default silently leaks to every
+   other stack, OU, and tenant (**Discussion #122**).
+
+---
+
+## Issue 1 — Default identity declared in an imported stack file is not recognized
+
+**Source:** [#2293](https://github.com/cloudposse/atmos/issues/2293)
+
+### Problem
+
+When `auth.identities.<name>.default: true` is declared in an imported stack
+file (for example `_defaults.yaml` that a stack manifest imports via
+`import:`), Atmos does not pick it up during the pre-scanner identity
+resolution. Instead, Atmos prompts the user to select an identity
+interactively even though a default is configured — and in non-interactive
+contexts this surfaces as "no default identity configured."
+
+### Reproduction
+
+Defaults file declaring the default identity:
+
+```yaml
+# stacks/orgs/acme/dev/_defaults.yaml
+import:
+  - ../_defaults
+
+vars:
+  stage: dev
+
+auth:
+  identities:
+    acme-dev:
+      default: true
+```
+
+Stack manifest that imports it:
+
+```yaml
+# stacks/orgs/acme/dev/us-east-1/foundation.yaml
+import:
+  - ../_defaults
+  - mixins/region/us-east-1
+```
+
+Running any component command in that stack with the debug log enabled
+shows the pre-scanner missing the imported defaults file:
+
+```text
+DEBU  Loading stack configs for auth identity defaults
+DEBU  Loading stack files for auth defaults count=16
+DEBU  No default identities found in stack configs
+```
+
+### Expected behavior
+
+Atmos should resolve the default identity from the **merged** stack config,
+honoring the same `import:` / `_defaults.yaml` inheritance semantics that
+`vars:` and `components:` already obey. Placing `auth:` in a defaults file
+should not require duplication in every manifest that imports it.
+
+---
+
+## Issue 2 — Default identity declared in one stack manifest leaks to all stacks across all OUs
+
+**Source:** [Discussion #122 — "Auth inheritance not scoping to stack"](https://github.com/orgs/cloudposse/discussions/122)
+
+### Problem
+
+When a stack manifest declares:
+
+```yaml
+auth:
+  identities:
+    <org>-<tenant>/terraform:
+      default: true
+```
+
+…that `default: true` assignment is treated as **global** rather than
+scoped to the stack that declared it. Every subsequent `atmos terraform
+plan/apply` invocation — regardless of which stack the user selects —
+loads that same identity as the default, even for stacks in a completely
+different OU, tenant, or environment.
+
+The user tested this across Atmos `1.210`, `1.211`, and `1.213`; the
+behavior reproduces on all three.
+
+### Reproduction
+
+1. Stack tree with multiple tenants, e.g.
+
+   ```text
+   stacks/orgs/acme/
+     data/staging/us-east-1/monitoring-agent.yaml
+     plat/staging/us-east-1/eks-cluster.yaml
+     plat/prod/us-east-1/eks-cluster.yaml
+   ```
+
+2. Add a default-identity `auth:` block to **one** manifest, e.g.
+
+   ```yaml
+   # stacks/orgs/acme/data/staging/us-east-1/monitoring-agent.yaml
+   auth:
+     identities:
+       data-staging/terraform:
+         default: true
+   ```
+
+3. Run any terraform command against a **different** stack:
+
+   ```bash
+   $ atmos terraform plan eks/test-eks-agent -s plat-use1-staging
+   ```
+
+4. Atmos loads the `data-staging/terraform` identity for the
+   `plat-use1-staging` stack command. Debug output (trimmed):
+
+   ```text
+   Found component 'eks/test-eks-agent' in the stack 'plat-use1-staging'
+     in the stack manifest 'orgs/acme/plat/staging/us-east-1/monitoring-test'
+   CreateAndAuthenticateManager called identityName="" hasAuthConfig=true
+   Loading stack configs for auth identity defaults
+   Loading stack files for auth defaults count=284
+   Found default identity in stack config identity=data-staging/terraform
+     file=/…/stacks/orgs/acme/data/staging/us-east-1/monitoring-test.yaml
+   ```
+
+   The file Atmos picks the default from belongs to a completely
+   unrelated stack (`data-staging` vs the requested `plat-use1-staging`).
+
+### Expected behavior
+
+`default: true` under `auth.identities.<name>` should only apply to the
+stack(s) that actually import or declare that `auth:` block. Unrelated
+stacks in other OUs, tenants, or environments should be unaffected.
+
+---
+
+## Root Cause Analysis
+
+### Where the bug lives
+
+- `pkg/config/stack_auth_loader.go` — the `LoadStackAuthDefaults` function
+  and its helpers `getAllStackFiles` / `loadFileForAuthDefaults`.
+- `pkg/auth/manager_helpers.go` — `loadAndMergeStackAuthDefaults` was the
+  caller: inside `CreateAndAuthenticateManagerWithAtmosConfig`, when
+  `identityName == ""` and auth was configured, it called out to the loader
+  to "discover the default" before the target stack was known.
+
+### Why it fails
+
+`LoadStackAuthDefaults` does a raw `yaml.Unmarshal` against a minimal
+struct that contains only the top-level `auth:` section. There is no
+import-following, no template processing, no deep-merge with imports.
+
+```go
+stackFiles := getAllStackFiles(
+    atmosConfig.IncludeStackAbsolutePaths,
+    atmosConfig.ExcludeStackAbsolutePaths,
+)
+for _, filePath := range stackFiles {
+    fileDefaults, err := loadFileForAuthDefaults(filePath)   // raw yaml.Unmarshal
+    for identity, isDefault := range fileDefaults {
+        if isDefault {
+            allDefaults = append(allDefaults, defaultSource{identity, filePath})
+        }
+    }
+}
+firstIdentity := allDefaults[0].identity
+allAgree := true
+for _, d := range allDefaults[1:] {
+    if d.identity != firstIdentity {
+        allAgree = false
+        break
+    }
+}
+if allAgree {
+    defaults[firstIdentity] = true   // <-- global default applied here
+}
+```
+
+**Why Issue 1 fails:** `_defaults.yaml` is typically listed in
+`stacks.excluded_paths` because those files are meant to be **imported** by
+stack manifests, not processed as standalone stacks. As a result,
+`getAllStackFiles` filters them out entirely — their `auth:` block is never
+even seen by the raw YAML parser. Even if a `_defaults.yaml` file is not
+excluded, `loadFileForAuthDefaults` does not follow its `import:`
+directive.
+
+**Why Issue 2 fails:** The conflict-detection loop only handles *different*
+default identities colliding across stack files. When only one stack
+declares a default, the loop over `allDefaults[1:]` is empty, `allAgree`
+stays true, and the identity is added to a global map. `MergeStackAuthDefaults`
+then clears any existing defaults in the merged auth config and applies
+this global one, so every command in the repo resolves to the leaked
+identity as the default.
+
+### Why the approach is structurally wrong
+
+The code comment above `CreateAndAuthenticateManagerWithAtmosConfig` framed
+this as a chicken-and-egg problem:
+
+> - We need to know the default identity to authenticate
+> - But stack configs are only loaded after authentication is configured
+
+This is **not** actually a chicken-and-egg. For every command where a
+stack-scoped default identity could matter (`atmos terraform *`,
+`atmos helmfile *`, etc.), the target stack is either:
+
+1. Passed explicitly on the command line via `-s <stack>`, OR
+2. Interactively selected by the user, OR
+3. Derived from the `atmos.yaml` `stacks.name_pattern` /
+   `stacks.name_template` after component/context resolution.
+
+In every case the target stack is knowable **before** the auth manager
+needs to exist. The only exception is `atmos auth login` (or `auth whoami`
+/ `auth env` / etc.) invoked with no stack context, in which case the only
+meaningful default is the `atmos.yaml`-level default — no stack scan needed.
+
+So the correct layering is:
+
+```text
+1. Parse CLI args → know the target stack (or know there isn't one).
+2. If there is a target stack:
+      load its merged config through the normal stack processor
+      (which correctly follows import: chains and honors stack scope)
+   Else:
+      use the atmos.yaml auth defaults only.
+3. Resolve the default identity from the merged auth config (global ∪ stack ∪ component).
+4. Build and authenticate the auth manager.
+```
+
+The pre-scanner tried to compress steps 1-3 into a single pre-stack scan
+and in doing so broke the scoping model entirely.
+
+---
+
+## Caller audit — who calls the auth manager, and how?
+
+Before picking a fix, we categorized every call site of
+`CreateAndAuthenticateManagerWithAtmosConfig` (and the thin
+`cmd/identity_flag.go:CreateAuthManagerFromIdentityWithAtmosConfig` wrapper
+that sits in front of it). This matters because the right fix depends on
+whether the caller already has a specific target stack or not.
+
+### Category A — target-stack callers (exec-layer merge owns identity resolution)
+
+These commands have a specific `(component, stack)` pair known *before*
+auth manager creation. They go through
+`internal/exec/utils_auth.go:getMergedAuthConfigWithFetcher` →
+`ExecuteDescribeComponent`, which correctly follows `import:` chains,
+template rendering, and deep merge against that specific stack:
+
+- `atmos terraform *` (all subcommands) — `internal/exec/utils_auth.go`
+- `atmos helmfile *`
+- `atmos terraform query` — `internal/exec/terraform_query.go`
+- Nested component auth — `internal/exec/terraform_nested_auth_helper.go`
+- `atmos describe component` — `cmd/describe_component.go`
+
+For Category A callers, the pre-scanner is **actively harmful**: it can
+only contaminate an already-correct merged config. This is the mechanism
+behind Discussion #122's cross-stack leak.
+
+### Category B — multi-stack callers (no specific target stack)
+
+These commands legitimately operate across many stacks/components and have
+no single `(component, stack)` pair upfront. They were *intentionally*
+designed to use the pre-scanner as "Approach 2" in
+`docs/fixes/stack-level-default-auth-identity.md`:
+
+- `atmos describe stacks` — `cmd/describe_stacks.go:80`
+  (gated on `ProcessYamlFunctions || identityExplicit`)
+- `atmos describe affected` — `cmd/describe_affected.go:87`
+  (same gate; plus 2026-03-25 fix threads the AuthManager through the
+  entire affected/graph pipeline)
+- `atmos describe dependents` — `cmd/describe_dependents.go`
+- `atmos list affected` — `pkg/list/list_affected.go`
+  (cmd/list/affected.go reads `--identity`; 2026-03-25 fix Bug 4)
+- `atmos list instances`
+- `atmos list <various>` — `cmd/list/utils.go:createAuthManagerForList`
+  (comment literally says *"it loads stack configs for default identity"*)
+- `atmos aws security` — `cmd/aws/security/security.go`
+- `atmos aws compliance` — `cmd/aws/compliance/compliance.go`
+- Workflow execution — `internal/exec/workflow_utils.go:checkAndMergeDefaultIdentity`
+
+For Category B callers, removing the pre-scanner entirely is a **real
+regression**. These commands have no target stack to scope against, so
+their only options are (1) scan all stacks for a unanimous default
+(today's pre-scanner behavior, already hardened against conflicts by
+Issue #2072), or (2) refuse to resolve a default identity for any
+non-`atmos.yaml`-level config.
+
+### Category C — no atmosConfig (never used the pre-scanner)
+
+These commands call the simpler `CreateAndAuthenticateManager` variant
+without passing `atmosConfig`, so they never ran the pre-scanner to begin
+with. Unaffected by every option below:
+
+- `cmd/terraform/backend/backend_helpers.go`
+- `cmd/terraform/utils.go`
+- `cmd/identity_flag.go` (simpler variant)
+- `cmd/list/sources.go`
+- `pkg/provisioner/source/cmd/helpers.go`
+
+---
+
+## Options considered
+
+Four options were evaluated against two hard constraints:
+
+1. **Must fix Issue #2293 and Discussion #122** across all commands where
+   they were reported.
+2. **Must not regress any existing auth functionality.** Atmos has a long
+   history of auth fixes (`docs/fixes/stack-level-default-auth-identity.md`,
+   `2026-02-12-auth-realm-isolation-issues.md`,
+   `2026-03-25-describe-affected-auth-identity-not-used.md`, etc.) — any
+   behavior change that breaks existing Category B users would undo that
+   work.
+
+### Option (a) — Remove pre-scanner entirely. ❌ Rejected.
+
+The initial draft of this fix deleted all pre-scanner calls from the auth
+flow. It cleanly fixes both bugs for Category A but **regresses every
+Category B command**. In particular:
+
+- `atmos describe stacks` / `describe affected` / `list affected` /
+  `list instances` / `aws security` / `aws compliance` / workflows would
+  silently lose the ability to resolve stack-level default identities.
+- The 2026-03-25 describe-affected fix that went to great lengths to
+  thread an AuthManager through the entire affected/graph pipeline would
+  stop working when users relied on stack-level defaults.
+- Users with a single-tenant repo who declared `default: true` in a stack
+  manifest would start hitting "no default identity" errors on multi-stack
+  commands.
+
+**Verdict:** unacceptable per constraint (2). Rejected even though it was
+the smallest diff.
+
+### Option (b) — Conditional fallback in a single helper. ❌ Insufficient.
+
+Keep a single `CreateAndAuthenticateManagerWithAtmosConfig` helper, and
+run the pre-scanner as a fallback only when both:
+
+1. `identityName == ""`, AND
+2. The incoming `authConfig` already has no default identity flagged.
+
+**Why it fails:** the gating signal "authConfig has no default" cannot
+distinguish the two cases that need opposite treatment:
+
+- **Category A, target stack with no auth block** (e.g.,
+  `atmos terraform plan eks -s plat-staging`): merged authConfig has no
+  default — **correctly**, because `plat-staging` truly has no auth. The
+  fallback should NOT fire.
+- **Category B, no target stack** (e.g., `atmos describe stacks`):
+  authConfig has no default because no per-stack merge happened. The
+  fallback SHOULD fire.
+
+Both look identical to the helper, so any single-helper fallback either
+leaks (Discussion #122 reproduced against `plat-staging`) or regresses
+Category B. Rejected.
+
+### Option (c) — Lazy / deferred auth manager creation. ⚠️ Too big for this PR.
+
+Create an "unresolved" auth manager wrapper and defer real resolution
+until after the first stack processing pass. For `describe stacks` etc.
+this is correct because the auth manager is only actually *used* when
+YAML functions are evaluated — which happens after stack processing.
+
+**Why not now:** this requires threading a lazy-AuthManager abstraction
+through every callsite that currently expects a ready-to-use manager, plus
+careful design of error reporting (what if identity resolution fails
+mid-stack-processing?). It is the cleanest long-term architecture but out
+of scope for a point fix. Tracked as a follow-up.
+
+### Option (d+) — Split entry points + import-following scanner. ✅ Chosen.
+
+Two changes, neither of which removes any existing behavior:
+
+1. **Split the pkg/auth entry points.** Introduce
+   `CreateAndAuthenticateManagerWithStackScan` alongside the existing
+   `CreateAndAuthenticateManagerWithAtmosConfig`. The scan variant is a
+   thin wrapper that runs the pre-scanner first, then delegates to the
+   no-scan variant. Category A callers use the no-scan variant (no more
+   contamination of their merged config). Category B callers use the
+   scan variant (existing Approach 2 behavior preserved exactly).
+
+2. **Teach the pre-scanner to follow `import:` chains.** Rewrite
+   `pkg/config/stack_auth_loader.go` so `LoadStackAuthDefaults`
+   recursively reads imported files' `auth:` sections — including
+   `_defaults.yaml` files listed in `excluded_paths`, because the
+   `excluded_paths` filter only prevents files from being processed as
+   standalone stacks, not from being imported. Uses the same
+   `allAgree` conflict-detection logic introduced by Issue #2072, so
+   conflicting defaults across stacks are still discarded.
+
+The split fully isolates Category A from Discussion #122. The
+import-following scanner fully fixes Issue #2293 for Category B (and
+reinforces Category A, which was already fixed via the exec-layer merge).
+
+---
+
+## Coverage matrix
+
+| Scenario | Pre-fix main | Option (a) | Option (b) | **Option (d+)** |
+|---|---|---|---|---|
+| **#2293** imported default, `terraform plan -s acme-dev` (Category A) | ❌ broken | ✅ exec-layer merge | ✅ exec-layer merge | ✅ exec-layer merge |
+| **#2293** imported default, `describe stacks` / `describe affected` (Category B) | ❌ broken | ❌ broken | ❌ broken | ✅ **scanner follows imports** |
+| **#2293** imported default, `list affected` / workflows / `aws security` (Category B) | ❌ broken | ❌ broken | ❌ broken | ✅ **scanner follows imports** |
+| **#122** single-stack default leaks to `terraform plan -s other` (Category A) | ❌ leak | ✅ scanner removed | ❌ leak still (gating fails) | ✅ Category A never runs scanner |
+| **#122** repo-wide consistent default, `describe stacks` (Category B) | ✅ works (scanner picks it up) | ❌ regression | ✅ works | ✅ works (scanner still runs) |
+| Existing `describe stacks` / `describe affected` / `list affected` multi-stack identity resolution | ✅ works | ❌ **regression** | ❌ **regression** | ✅ preserved bit-for-bit |
+| 2026-03-25 describe-affected AuthManager threading (Bugs 1-4) | ✅ works | ❌ regression | ❌ regression | ✅ preserved |
+| Issue #2072 conflicting-defaults discard across stacks | ✅ works | N/A (scanner gone) | ✅ works | ✅ preserved (same `allAgree` logic) |
+| Workflow execution stack-level default loading | ✅ works | ❌ regression | ❌ regression | ✅ restored |
+
+---
+
+## Fix — Option (d+) implementation
+
+### 1. Teach the scanner to follow imports
+
+**`pkg/config/stack_auth_loader.go`** — replace the flat per-file
+`loadFileForAuthDefaults` with a recursive `loadAuthWithImports` that:
+
+- Reads each stack file's top-level `import:` list and `auth:` block via
+  a minimal `yaml.Unmarshal` (no template rendering, no full stack
+  processing).
+- For each import entry, resolves it to absolute file paths, handling the
+  three Atmos import forms: plain string, glob string, map form with
+  `path`. Imports are resolved relative to the importing file first, then
+  relative to `atmosConfig.StacksBaseAbsolutePath`. Adds `.yaml` extension
+  if missing.
+- Recursively loads imported files — crucially, **including files inside
+  `excluded_paths`** when referenced via `import:`. The `excluded_paths`
+  filter only prevents direct processing as a standalone stack; imports
+  must still resolve them.
+- Deep-merges imported auth sections with the current file's auth
+  section, with the current file winning on conflict (matches Atmos
+  import semantics).
+- Uses a `visited` map for cycle protection.
+- Templated imports whose path cannot be resolved without running Go
+  templates fall back to being skipped (same graceful-degrade behavior as
+  today). Document the limitation; rare in practice.
+
+`LoadStackAuthDefaults` then aggregates results across all top-level
+stack files and keeps the existing `allAgree` conflict-detection logic
+from Issue #2072 unchanged.
+
+### 2. Split the auth manager entry points
+
+**`pkg/auth/manager_helpers.go`**
+
+- `CreateAndAuthenticateManagerWithAtmosConfig` (existing name, reworked
+  body): **does not run the pre-scanner.** Takes an already-merged
+  `authConfig` and resolves an identity from it. This is what Category A
+  callers want: their `authConfig` was already merged by
+  `ExecuteDescribeComponent` against the correct target stack, and
+  running the scanner on top would only reintroduce the Discussion #122
+  leak.
+- `CreateAndAuthenticateManagerWithStackScan` (**new**): thin wrapper
+  that, when `identityName == ""`, calls
+  `config.LoadStackAuthDefaults` + `config.MergeStackAuthDefaults` on a
+  *copy* of `authConfig`, then delegates to
+  `CreateAndAuthenticateManagerWithAtmosConfig`. This preserves the
+  Approach 2 pre-scan behavior for Category B callers.
+
+Both helpers share identical signatures; switching between them is a
+single-word change at each call site.
+
+### 3. Route callers
+
+- **Category A** — no change. Already uses
+  `CreateAndAuthenticateManagerWithAtmosConfig` (no scan).
+- **Category B** — switch to `CreateAndAuthenticateManagerWithStackScan`
+  (or, for most of them, update the thin wrapper they go through):
+  - `cmd/identity_flag.go:CreateAuthManagerFromIdentityWithAtmosConfig`
+    → switch its inner call to the scan variant. This single change
+    auto-updates `describe stacks`, `describe affected`, and
+    `describe dependents` because they all go through the wrapper.
+  - `cmd/list/utils.go:createAuthManagerForList` → scan variant.
+  - `pkg/list/list_affected.go` → scan variant.
+  - `cmd/list/instances.go` → scan variant (if it currently calls the
+    auth helper).
+  - `cmd/aws/security/security.go` → scan variant.
+  - `cmd/aws/compliance/compliance.go` → scan variant.
+- **`internal/exec/workflow_utils.go:checkAndMergeDefaultIdentity`** —
+  restore the `config.LoadStackAuthDefaults` +
+  `config.MergeStackAuthDefaults` calls that the earlier draft
+  simplified away. This is equivalent to calling the scan variant and
+  matches the pre-fix behavior exactly.
+
+### 4. Fixed flows
+
+**Category A — `atmos terraform plan my-component -s acme-dev` with imported `_defaults.yaml`:**
+
+```text
+1. ExecuteTerraform → createAndAuthenticateAuthManager(atmosConfig, info)
+2. getMergedAuthConfigWithFetcher(atmosConfig, info, …)
+   → ExecuteDescribeComponent (follows import: chains correctly)
+   → mergedAuthConfig carries `dev-identity.default: true` from the
+     imported _defaults.yaml — correctly scoped to this stack only.
+3. CreateAndAuthenticateManagerWithAtmosConfig(
+     identityName="", mergedAuthConfig, …)  ← NO-SCAN variant.
+   → no pre-scanner clobbering the merged config.
+   → resolveIdentityName finds the default from mergedAuthConfig.
+4. Auth manager constructed with dev-identity. No leak into other stacks.
+```
+
+**Category A — `atmos terraform plan eks -s plat-staging` against unrelated stack:**
+
+```text
+1. getMergedAuthConfigWithFetcher returns mergedAuthConfig with NO default
+   (plat-staging's stack has no auth block; global atmos.yaml has no
+   default).
+2. resolveIdentityName returns the empty string → no auth.
+   → no cross-stack leak, because the NO-SCAN variant never consults any
+     other stack file.
+```
+
+**Category B — `atmos describe stacks` with imported `_defaults.yaml`:**
+
+```text
+1. cmd/describe_stacks.go → CreateAuthManagerFromIdentityWithAtmosConfig
+   → CreateAndAuthenticateManagerWithStackScan(identityName="", …)
+2. Scan variant calls LoadStackAuthDefaults:
+   → scanner walks each top-level stack file, recursively following
+     `import:` entries (including into `_defaults.yaml` files in
+     excluded_paths).
+   → merged per-file auth section contains `dev-identity.default: true`.
+   → allAgree across stacks → applied to merged authConfig.
+3. Delegates to no-scan variant with the populated authConfig.
+4. Auth manager constructed with dev-identity. Approach 2 behavior
+   preserved; Issue #2293 now fixed for this command too.
+```
+
+**Category B — `atmos describe stacks` with conflicting defaults across stacks:**
+
+```text
+1. Scanner finds two DIFFERENT identities flagged `default: true`.
+2. allAgree → false → defaults map returned empty.
+3. Approach 2 falls back to `atmos.yaml`-level default only.
+4. Issue #2072 behavior preserved exactly.
+```
+
+---
+
+## Test fixtures and regression tests
+
+All fixtures use `mock/aws` identities so they authenticate end-to-end in
+CI without real cloud credentials.
+
+### `tests/fixtures/scenarios/auth-imported-defaults/` — Issue #2293
+
+Mirrors the real-world Cloud Posse reference architecture layout:
+
+```text
+atmos.yaml                                        # name_template,
+                                                  # excluded_paths: ['**/_defaults.yaml']
+stacks/orgs/acme/dev/
+├── _defaults.yaml                                # auth.identities.dev-identity.default: true
+└── us-east-1/foundation.yaml                     # import: orgs/acme/dev/_defaults
+```
+
+The key detail: `_defaults.yaml` is listed under `stacks.excluded_paths`,
+so `getAllStackFiles` filters it out before the raw-YAML pre-scanner ever
+sees it. The stack name resolves to `acme-dev` via
+`name_template: "{{ .vars.tenant }}-{{ .vars.stage }}"`.
+
+### `tests/fixtures/scenarios/auth-stack-scoping/` — Discussion #122
+
+Two unrelated stacks under `stacks/orgs/acme/`, using tenant names `data`
+and `plat` (acme is a placeholder; real customer namespace is redacted):
+
+```text
+atmos.yaml                                        # NO global default
+stacks/orgs/acme/
+├── data/staging/us-east-1/monitoring.yaml        # auth.identities.data-default.default: true
+└── plat/staging/us-east-1/eks.yaml               # NO auth block at all
+```
+
+Stack names resolve to `data-staging` and `plat-staging` respectively.
+
+### CLI regression tests
+
+`tests/test-cases/auth-identity-resolution-bugs.yaml` wires the fixtures
+into assertions that guard both the Category A exec-layer merge path AND
+the Category B scan-variant path:
+
+- **`describe component -s acme-dev`** (Category A) asserts the imported
+  `_defaults.yaml` default is present in the merged output.
+- **`describe stacks -s acme-dev --process-functions=true`** (Category B)
+  asserts the scan variant surfaces the imported default — new coverage
+  for #2293 against multi-stack commands.
+- **`describe component -s data-staging`** asserts data-staging sees its
+  own default identity (happy path).
+- **`describe component -s plat-staging`** asserts plat-staging does NOT
+  inherit data-staging's default (the Category A non-leak — Discussion
+  #122).
+- **`describe stacks` across the auth-stack-scoping fixture** asserts the
+  scan variant still behaves correctly under the `allAgree` conflict
+  logic (Issue #2072 preserved).
+
+### Go unit tests
+
+**`pkg/config/stack_auth_loader_test.go`** (new / updated)
+
+- `TestLoadStackAuthDefaults_FollowsImports` — stack file imports a
+  `_defaults.yaml` that declares `default: true`; scanner must see it.
+- `TestLoadStackAuthDefaults_FollowsImportsFromExcludedPath` — same as
+  above but `_defaults.yaml` is listed in `excluded_paths`. Scanner must
+  still follow the import (excluded_paths only filters standalone
+  processing, not import resolution).
+- `TestLoadStackAuthDefaults_ImportCycleProtection` — two files that
+  import each other; scanner must terminate and return a sensible result.
+- `TestLoadStackAuthDefaults_GlobImports` — `import:` list contains a
+  glob; scanner must expand.
+- `TestLoadStackAuthDefaults_TemplatedImportSkipped` — map-form import
+  with a Go-template path; scanner must skip gracefully (same as today).
+- `TestLoadStackAuthDefaults_ConflictingDefaultsDiscarded` — preserves
+  Issue #2072 `allAgree` behavior unchanged.
+- `TestLoadStackAuthDefaults_CurrentFileWinsOverImport` — when both the
+  importing file and the imported file declare defaults, the importing
+  file's default takes precedence.
+
+**`pkg/auth/manager_helpers_test.go`** (new regression tests)
+
+Category A (no-scan variant):
+
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_HonorsMergedConfigDefault`
+  — when the merged `authConfig` already carries a default (produced by
+  the exec-layer stack processor for a target stack that imports
+  `_defaults.yaml`), that default is resolved correctly.
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_DoesNotLeakCrossStackDefault`
+  — when the merged `authConfig` has NO default (simulating a target
+  stack like `plat-staging` with no auth block), the no-scan variant
+  never consults unrelated stack files; no leak possible.
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_IgnoresStackFilesWithLeakingDefault`
+  — end-to-end: a real stack file on disk declares `default: true`; the
+  no-scan variant must not pick it up even with a full `atmosConfig`.
+- `TestCreateAndAuthenticateManagerWithAtmosConfig_ExplicitIdentityNotOverriddenByStackFiles`
+  — `--identity` flag passed explicitly wins over any stack file
+  defaults.
+
+Category B (scan variant):
+
+- `TestCreateAndAuthenticateManagerWithStackScan_PicksUpImportedDefault`
+  — scan variant finds an imported `_defaults.yaml` default that the
+  no-scan variant cannot see. Primary Category B #2293 test.
+- `TestCreateAndAuthenticateManagerWithStackScan_HonorsExplicitIdentity`
+  — explicit `identityName` bypasses the scan.
+- `TestCreateAndAuthenticateManagerWithStackScan_DiscardsConflictingDefaults`
+  — two stacks declare different defaults; scan returns empty; falls
+  back to `atmos.yaml`-level default. Issue #2072 preserved.
+- `TestCreateAndAuthenticateManagerWithStackScan_NoMutationOfInputConfig`
+  — scan variant must operate on a copy of `authConfig`; caller's
+  original must remain untouched.
+
+**`internal/exec/workflow_utils_test.go`** (restored)
+
+- Restore the stack-loading tests that the earlier draft deleted:
+  `TestCheckAndMergeDefaultIdentity_WithStackLoading`, `_LoadError`,
+  `_LoadErrorNoDefault`, `_StackNoDefaults`, `_EmptyStackDefaults`. The
+  function's pre-fix behavior is restored, so these tests become valid
+  again.
+
+### Regression run (required before merge)
+
+```text
+go test ./pkg/auth/ ./pkg/config/ ./internal/exec/ -count=1        → all PASS
+go test ./tests -run 'TestCLICommands/atmos_describe'              → all PASS
+go test ./tests -run 'TestCLICommands/atmos_list'                  → all PASS
+go test ./pkg/auth/ ./pkg/config/ -count=1 -race                   → PASS
+```
+
+Special attention to:
+
+- `TestCLICommands/describe_affected_*` — 2026-03-25 fix's end-to-end
+  coverage for AuthManager threading through the affected pipeline.
+- `TestCLICommands/list_affected_*` — 2026-03-25 fix Bug 4.
+- Workflow tests that exercise `checkAndMergeDefaultIdentity`.
+- `pkg/config/auth_realm_issues_test.go` — Issue #2072 conflicting
+  defaults coverage.
+
+---
+
+## Related
+
+- `docs/fixes/stack-level-default-auth-identity.md` — the original
+  Approach 1 / Approach 2 design that this fix preserves and extends.
+  Approach 2 is the multi-stack scanner code path that option (d+) keeps
+  alive for Category B commands.
+- `docs/fixes/2026-02-12-auth-realm-isolation-issues.md` — Issue #2072
+  introduced the `allAgree` conflict-detection logic in the scanner.
+  Option (d+) preserves that logic unchanged.
+- `docs/fixes/2026-03-25-describe-affected-auth-identity-not-used.md` —
+  threaded an AuthManager through the entire describe-affected pipeline.
+  Option (d+) preserves that plumbing; Category B callers still get a
+  working AuthManager with stack-level defaults resolved via the scan
+  variant.
+- `docs/fixes/2026-04-06-mcp-server-env-not-applied-to-auth-setup.md` —
+  another auth-context propagation fix in a different code path.

--- a/pkg/auth/config_helpers.go
+++ b/pkg/auth/config_helpers.go
@@ -88,16 +88,21 @@ func MergeComponentAuthConfig(
 	globalAuthConfig *schema.AuthConfig,
 	componentAuthSection map[string]any,
 ) (*schema.AuthConfig, error) {
+	// Work on a copy so the caller's globalAuthConfig is never mutated.
+	// MergeComponentAuthFromConfig already passes a copy, but copying here
+	// makes MergeComponentAuthConfig safe for any future direct caller too.
+	workingGlobalAuth := CopyGlobalAuthConfig(globalAuthConfig)
+
 	// If the component declares its own default identity, clear any existing
-	// defaults from the global config so the component-level default wins.
+	// defaults from the working copy so the component-level default wins.
 	// This matches the precedence pattern used by MergeStackAuthDefaults in
 	// pkg/config/stack_auth_loader.go.
 	if componentAuthHasDefault(componentAuthSection) {
-		clearExistingIdentityDefaults(globalAuthConfig)
+		clearExistingIdentityDefaults(workingGlobalAuth)
 	}
 
 	// Convert global auth config to map for deep merging.
-	globalAuthMap, err := AuthConfigToMap(globalAuthConfig)
+	globalAuthMap, err := AuthConfigToMap(workingGlobalAuth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/config_helpers.go
+++ b/pkg/auth/config_helpers.go
@@ -75,11 +75,27 @@ func AuthConfigToMap(authConfig *schema.AuthConfig) (map[string]any, error) {
 
 // MergeComponentAuthConfig merges component-level auth config with global auth config.
 // Returns the merged AuthConfig with component overrides applied.
+//
+// When the component auth section declares any identity with `default: true`,
+// all existing `default: true` flags in the global auth config are cleared
+// before merging. This ensures the component-level default wins over the
+// global default (matching Atmos inheritance semantics: more specific config
+// overrides more general). Without this step, a global default and a
+// component-level default would both survive the deep merge, causing
+// "multiple default identities" prompts or errors.
 func MergeComponentAuthConfig(
 	atmosConfig *schema.AtmosConfiguration,
 	globalAuthConfig *schema.AuthConfig,
 	componentAuthSection map[string]any,
 ) (*schema.AuthConfig, error) {
+	// If the component declares its own default identity, clear any existing
+	// defaults from the global config so the component-level default wins.
+	// This matches the precedence pattern used by MergeStackAuthDefaults in
+	// pkg/config/stack_auth_loader.go.
+	if componentAuthHasDefault(componentAuthSection) {
+		clearExistingIdentityDefaults(globalAuthConfig)
+	}
+
 	// Convert global auth config to map for deep merging.
 	globalAuthMap, err := AuthConfigToMap(globalAuthConfig)
 	if err != nil {
@@ -159,4 +175,41 @@ func MergeComponentAuthFromConfig(
 
 	// Merge component auth with global auth.
 	return MergeComponentAuthConfig(atmosConfig, mergedAuthConfig, componentAuthSection)
+}
+
+// componentAuthHasDefault checks whether a component-level auth section
+// (as a raw map from the stack processor) contains any identity with
+// `default: true`. This is used to decide whether to clear global defaults
+// before merging.
+func componentAuthHasDefault(componentAuth map[string]any) bool {
+	identities, ok := componentAuth["identities"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, identity := range identities {
+		identityMap, ok := identity.(map[string]any)
+		if !ok {
+			continue
+		}
+		if d, ok := identityMap["default"]; ok && d == true {
+			return true
+		}
+	}
+	return false
+}
+
+// clearExistingIdentityDefaults removes the `Default` flag from all
+// identities in an AuthConfig struct. Called before merging when the
+// component-level auth declares its own default, so the component-level
+// default wins cleanly without producing "multiple defaults" conflicts.
+func clearExistingIdentityDefaults(authConfig *schema.AuthConfig) {
+	if authConfig == nil {
+		return
+	}
+	for name, identity := range authConfig.Identities {
+		if identity.Default {
+			identity.Default = false
+			authConfig.Identities[name] = identity
+		}
+	}
 }

--- a/pkg/auth/config_helpers_test.go
+++ b/pkg/auth/config_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -493,4 +494,193 @@ func TestAuthConfigToMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ============================================================================
+// Issue #3 — component-level default does not override global default.
+//
+// When a component declares auth.identities.<name>.default: true in its stack
+// config, and the global atmos.yaml also has a different identity with
+// default: true, the raw deep merge preserves BOTH defaults. The user then
+// gets prompted to choose (interactive) or errors out (CI). The fix clears
+// global defaults before merging when the component declares its own.
+// ============================================================================
+
+func TestMergeComponentAuthConfig_ComponentDefaultOverridesGlobalDefault(t *testing.T) {
+	// The core Issue #3 scenario: global has `tf-state.default: true`,
+	// component declares `create-resources.default: true`. After merge,
+	// only `create-resources` should be default.
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"tf-state": {
+				Kind:    "aws/permission-set",
+				Default: true,
+			},
+			"create-resources": {
+				Kind:    "aws/permission-set",
+				Default: false,
+			},
+		},
+	}
+
+	componentAuth := map[string]any{
+		"identities": map[string]any{
+			"create-resources": map[string]any{
+				"default": true,
+			},
+		},
+	}
+
+	result, err := MergeComponentAuthConfig(&schema.AtmosConfiguration{}, globalAuth, componentAuth)
+	require.NoError(t, err)
+
+	// Component default wins — global default must be cleared.
+	assert.False(t, result.Identities["tf-state"].Default,
+		"global default must be cleared when component declares its own default")
+	assert.True(t, result.Identities["create-resources"].Default,
+		"component-level default must survive the merge")
+}
+
+func TestMergeComponentAuthConfig_NoComponentDefault_PreservesGlobalDefault(t *testing.T) {
+	// When the component auth section does NOT declare any default, the
+	// global default must be preserved unchanged.
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"tf-state": {
+				Kind:    "aws/permission-set",
+				Default: true,
+			},
+		},
+	}
+
+	// Component adds an identity but without default: true.
+	componentAuth := map[string]any{
+		"identities": map[string]any{
+			"deploy": map[string]any{
+				"kind": "aws/assume-role",
+			},
+		},
+	}
+
+	result, err := MergeComponentAuthConfig(&schema.AtmosConfiguration{}, globalAuth, componentAuth)
+	require.NoError(t, err)
+
+	assert.True(t, result.Identities["tf-state"].Default,
+		"global default must be preserved when component has no default")
+}
+
+func TestMergeComponentAuthConfig_ComponentDefaultForSameIdentity(t *testing.T) {
+	// Edge case: global has `foo.default: true`, component also declares
+	// `foo.default: true` (same identity). Should still work — no conflict.
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"foo": {Kind: "aws/assume-role", Default: true},
+		},
+	}
+
+	componentAuth := map[string]any{
+		"identities": map[string]any{
+			"foo": map[string]any{
+				"default": true,
+			},
+		},
+	}
+
+	result, err := MergeComponentAuthConfig(&schema.AtmosConfiguration{}, globalAuth, componentAuth)
+	require.NoError(t, err)
+
+	assert.True(t, result.Identities["foo"].Default,
+		"same identity declared as default in both global and component — should stay default")
+}
+
+func TestMergeComponentAuthFromConfig_ComponentDefaultOverridesGlobal(t *testing.T) {
+	// End-to-end via MergeComponentAuthFromConfig (the wrapper used by
+	// the exec-layer in getMergedAuthConfigWithFetcher). Verifies the fix
+	// flows through the full call chain.
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"global-default": {Kind: "aws/assume-role", Default: true},
+			"component-id":   {Kind: "aws/assume-role", Default: false},
+		},
+	}
+
+	componentConfig := map[string]any{
+		"auth": map[string]any{
+			"identities": map[string]any{
+				"component-id": map[string]any{
+					"default": true,
+				},
+			},
+		},
+	}
+
+	result, err := MergeComponentAuthFromConfig(globalAuth, componentConfig, &schema.AtmosConfiguration{}, "auth")
+	require.NoError(t, err)
+
+	assert.False(t, result.Identities["global-default"].Default,
+		"global default cleared by component-level override")
+	assert.True(t, result.Identities["component-id"].Default,
+		"component-level default must win")
+}
+
+func TestComponentAuthHasDefault_True(t *testing.T) {
+	section := map[string]any{
+		"identities": map[string]any{
+			"foo": map[string]any{"default": true},
+		},
+	}
+	assert.True(t, componentAuthHasDefault(section))
+}
+
+func TestComponentAuthHasDefault_False(t *testing.T) {
+	section := map[string]any{
+		"identities": map[string]any{
+			"foo": map[string]any{"kind": "aws/assume-role"},
+		},
+	}
+	assert.False(t, componentAuthHasDefault(section))
+}
+
+func TestComponentAuthHasDefault_NoIdentities(t *testing.T) {
+	assert.False(t, componentAuthHasDefault(map[string]any{}))
+	assert.False(t, componentAuthHasDefault(map[string]any{"identities": "invalid"}))
+}
+
+func TestComponentAuthHasDefault_InvalidIdentityType(t *testing.T) {
+	// Identity value is not a map — must return false gracefully.
+	section := map[string]any{
+		"identities": map[string]any{
+			"foo": "invalid-string-instead-of-map",
+		},
+	}
+	assert.False(t, componentAuthHasDefault(section))
+}
+
+func TestComponentAuthHasDefault_ExplicitFalse(t *testing.T) {
+	// default: false is NOT a "has default" — it's an explicit opt-out.
+	section := map[string]any{
+		"identities": map[string]any{
+			"foo": map[string]any{"default": false},
+		},
+	}
+	assert.False(t, componentAuthHasDefault(section))
+}
+
+func TestClearExistingIdentityDefaults_Nil(t *testing.T) {
+	// Must not panic on nil.
+	clearExistingIdentityDefaults(nil)
+}
+
+func TestClearExistingIdentityDefaults_ClearsAll(t *testing.T) {
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"a": {Kind: "aws/assume-role", Default: true},
+			"b": {Kind: "aws/assume-role", Default: true},
+			"c": {Kind: "aws/assume-role", Default: false},
+		},
+	}
+	clearExistingIdentityDefaults(authConfig)
+	assert.False(t, authConfig.Identities["a"].Default)
+	assert.False(t, authConfig.Identities["b"].Default)
+	assert.False(t, authConfig.Identities["c"].Default)
 }

--- a/pkg/auth/config_helpers_test.go
+++ b/pkg/auth/config_helpers_test.go
@@ -621,6 +621,50 @@ func TestMergeComponentAuthFromConfig_ComponentDefaultOverridesGlobal(t *testing
 		"global default cleared by component-level override")
 	assert.True(t, result.Identities["component-id"].Default,
 		"component-level default must win")
+
+	// Isolation: the original globalAuth must NOT be mutated.
+	// MergeComponentAuthFromConfig copies via CopyGlobalAuthConfig before
+	// passing to MergeComponentAuthConfig, so clearExistingIdentityDefaults
+	// operates on the copy, not the caller's original.
+	assert.True(t, globalAuth.Identities["global-default"].Default,
+		"original globalAuth must remain untouched after merge (result→src isolation)")
+
+	// Reverse isolation: mutating the result must not affect globalAuth.
+	mutated := result.Identities["component-id"]
+	mutated.Kind = "MUTATED"
+	result.Identities["component-id"] = mutated
+	assert.Equal(t, "aws/assume-role", globalAuth.Identities["component-id"].Kind,
+		"mutating result must not leak back into globalAuth (src→result isolation)")
+}
+
+func TestMergeComponentAuthConfig_DoesNotMutateInput(t *testing.T) {
+	// MergeComponentAuthConfig copies globalAuthConfig internally, so the
+	// caller's original must remain untouched — even when called directly
+	// (not through the MergeComponentAuthFromConfig wrapper).
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"global-default": {Kind: "aws/assume-role", Default: true},
+		},
+	}
+
+	componentAuth := map[string]any{
+		"identities": map[string]any{
+			"comp-default": map[string]any{"default": true},
+		},
+	}
+
+	result, err := MergeComponentAuthConfig(&schema.AtmosConfiguration{}, globalAuth, componentAuth)
+	require.NoError(t, err)
+
+	// Input must NOT be mutated.
+	assert.True(t, globalAuth.Identities["global-default"].Default,
+		"MergeComponentAuthConfig must not mutate its input globalAuthConfig")
+
+	// Result must have the component default applied.
+	assert.True(t, result.Identities["comp-default"].Default,
+		"component-level default must be applied in the result")
+	assert.False(t, result.Identities["global-default"].Default,
+		"global default must be cleared in the result when component declares its own")
 }
 
 func TestComponentAuthHasDefault_True(t *testing.T) {

--- a/pkg/auth/manager_env_overrides.go
+++ b/pkg/auth/manager_env_overrides.go
@@ -17,9 +17,16 @@ import (
 // They are variables (not constants) only so tests can substitute fakes
 // without needing real atmos config fixtures or simulating os.Setenv
 // failures. Production code always uses the real defaults.
+//
+// Category B: the env-override entry point is used by the MCP server's scoped
+// auth flow, which has no specific (component, stack) target. We route it
+// through the SCAN variant so stack-level default identities (including those
+// declared in imported _defaults.yaml files) are discovered after the env
+// overrides trigger a fresh cfg.InitCliConfig. See
+// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
 var (
 	initCliConfigFn     = cfg.InitCliConfig
-	createAuthManager   = CreateAndAuthenticateManagerWithAtmosConfig
+	createAuthManager   = CreateAndAuthenticateManagerWithStackScan
 	setEnvWithRestoreFn = env.SetWithRestore
 )
 

--- a/pkg/auth/manager_helpers.go
+++ b/pkg/auth/manager_helpers.go
@@ -193,25 +193,33 @@ func CreateAndAuthenticateManager(
 	return CreateAndAuthenticateManagerWithAtmosConfig(identityName, authConfig, selectValue, nil)
 }
 
-// CreateAndAuthenticateManagerWithAtmosConfig creates and authenticates an AuthManager from an identity name.
-// This is the full implementation that supports loading stack configs for default identities.
+// CreateAndAuthenticateManagerWithAtmosConfig creates and authenticates an AuthManager from an identity
+// name using a pre-merged auth config.
 //
-// When atmosConfig is provided and identityName is empty:
-//   - Loads stack configuration files for auth identity defaults
-//   - Merges stack-level defaults with atmos.yaml defaults
-//   - Stack defaults take precedence over atmos.yaml defaults
+// **This is the NO-SCAN variant.** It trusts the incoming `authConfig` to already be correct for the
+// target scope and never runs the global stack-file pre-scanner. Use this for Category A callers that
+// have a specific (component, stack) pair and have already merged the target stack's auth section via
+// `ExecuteDescribeComponent` / `getMergedAuthConfigWithFetcher` (e.g. all `atmos terraform *` flows,
+// `atmos helmfile *`, `atmos describe component`, nested component auth).
 //
-// This solves the chicken-and-egg problem where:
-//   - We need to know the default identity to authenticate
-//   - But stack configs are only loaded after authentication is configured
-//   - Stack-level defaults (auth.identities.*.default: true) would otherwise be ignored
+// Running the global pre-scanner on top of a stack-scoped merged config would reintroduce the
+// Discussion #122 leak (a default identity declared in one stack manifest silently propagating to
+// terraform commands targeting completely unrelated stacks). Category A callers must stay on this
+// no-scan path.
+//
+// For Category B callers (`describe stacks`, `describe affected`, `list affected`, `list instances`,
+// `aws security`, `aws compliance`, workflows, etc.) that legitimately have no target stack and need
+// the Approach 2 stack-file pre-scan, use `CreateAndAuthenticateManagerWithStackScan` instead.
+//
+// See docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md for the full design rationale
+// (option d+).
 //
 // Parameters:
 //   - identityName: The identity to authenticate (can be "__SELECT__" for interactive selection,
 //     "__DISABLED__" to disable auth, or empty for auto-detection)
-//   - authConfig: The auth configuration from atmos.yaml and stack configs
+//   - authConfig: The auth configuration, already merged against the target stack by the caller
 //   - selectValue: The special value that triggers interactive identity selection (typically "__SELECT__")
-//   - atmosConfig: The full atmos configuration (optional, enables stack auth loading)
+//   - atmosConfig: The full atmos configuration (optional; used only for cliConfigPath and perf tracking)
 //
 // Returns:
 //   - AuthManager with populated AuthContext after successful authentication
@@ -231,12 +239,6 @@ func CreateAndAuthenticateManagerWithAtmosConfig(
 	if shouldDisableAuth(identityName) {
 		log.Debug("Authentication explicitly disabled")
 		return nil, nil
-	}
-
-	// If no identity specified and auth is configured, load stack configs for defaults.
-	// This solves the chicken-and-egg problem where stack-level defaults are not yet loaded.
-	if identityName == "" && isAuthConfigured(authConfig) && atmosConfig != nil {
-		loadAndMergeStackAuthDefaults(authConfig, atmosConfig)
 	}
 
 	// Get cliConfigPath from atmosConfig if available, otherwise use empty string.
@@ -276,27 +278,106 @@ func CreateAndAuthenticateManagerWithAtmosConfig(
 	return authManager, nil
 }
 
-// loadAndMergeStackAuthDefaults loads stack configs for auth defaults and merges them into authConfig.
-// This is a helper function that handles the stack auth loading logic.
-// Stack defaults take precedence over atmos.yaml defaults (following Atmos inheritance model).
-func loadAndMergeStackAuthDefaults(authConfig *schema.AuthConfig, atmosConfig *schema.AtmosConfiguration) {
-	defer perf.Track(atmosConfig, "auth.loadAndMergeStackAuthDefaults")()
+// CreateAndAuthenticateManagerWithStackScan creates and authenticates an AuthManager, first running
+// the global stack-file pre-scanner (Approach 2) to discover stack-level default identities.
+//
+// **This is the SCAN variant.** It is the correct choice for Category B commands that legitimately
+// have no target (component, stack) pair and therefore cannot rely on the exec-layer merge path. These
+// commands include `atmos describe stacks`, `atmos describe affected`, `atmos describe dependents`,
+// `atmos list affected`, `atmos list instances`, `atmos aws security`, `atmos aws compliance`, and
+// workflow execution.
+//
+// Behavior:
+//   - When `identityName` is empty and `atmosConfig` is provided, loads stack configuration files
+//     via `config.LoadStackAuthDefaults` (which now follows `import:` chains and correctly sees
+//     defaults declared in imported `_defaults.yaml` files, even when those files are in
+//     `excluded_paths` — fixing Issue #2293 for multi-stack commands).
+//   - Merges the discovered defaults into a **copy** of `authConfig` (never mutates the caller's
+//     original config) before delegating to `CreateAndAuthenticateManagerWithAtmosConfig`.
+//   - When the caller passes an explicit `identityName`, the scan is skipped — the explicit flag
+//     always wins.
+//
+// Category A callers (terraform/helmfile/describe component/nested auth) must NOT use this variant.
+// Running the scanner on top of a stack-scoped merged config reintroduces the Discussion #122 leak
+// across stacks. Those callers must use `CreateAndAuthenticateManagerWithAtmosConfig` directly.
+//
+// See docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md for the full design rationale
+// (option d+).
+//
+// Parameters:
+//   - identityName: The identity to authenticate (can be "__SELECT__" for interactive selection,
+//     "__DISABLED__" to disable auth, or empty for auto-detection via stack scan)
+//   - authConfig: The base auth configuration from atmos.yaml + profile (NOT stack-scoped)
+//   - selectValue: The special value that triggers interactive identity selection
+//   - atmosConfig: The full atmos configuration (required for stack loading; nil skips the scan)
+//
+// Returns: same contract as `CreateAndAuthenticateManagerWithAtmosConfig`.
+func CreateAndAuthenticateManagerWithStackScan(
+	identityName string,
+	authConfig *schema.AuthConfig,
+	selectValue string,
+	atmosConfig *schema.AtmosConfiguration,
+) (AuthManager, error) {
+	defer perf.Track(atmosConfig, "auth.CreateAndAuthenticateManagerWithStackScan")()
 
-	// Always load stack configs - stack defaults take precedence over atmos.yaml.
-	// This follows the Atmos inheritance model where more specific config overrides global.
-	log.Debug("Loading stack configs for auth identity defaults")
+	// Only run the scanner when we actually need to auto-detect a default identity.
+	// If the caller passed an explicit identityName, or auth is not configured, or we have
+	// no atmosConfig to scan, skip straight to the no-scan helper.
+	if identityName == "" && isAuthConfigured(authConfig) && atmosConfig != nil {
+		scannedConfig := scanStackFilesForDefaults(authConfig, atmosConfig)
+		if scannedConfig != nil {
+			authConfig = scannedConfig
+		}
+	}
+
+	return CreateAndAuthenticateManagerWithAtmosConfig(identityName, authConfig, selectValue, atmosConfig)
+}
+
+// scanStackFilesForDefaults runs the Approach 2 pre-scanner and returns a COPY of `authConfig` with
+// any discovered stack-level defaults merged in. The caller's original `authConfig` is never mutated,
+// which matters because Category B callers (e.g. `describe stacks`) reuse the same `atmosConfig.Auth`
+// across multiple command invocations.
+//
+// Returns nil if no defaults were found or the scan errored — the caller then uses the original
+// `authConfig` unchanged.
+func scanStackFilesForDefaults(authConfig *schema.AuthConfig, atmosConfig *schema.AtmosConfiguration) *schema.AuthConfig {
+	defer perf.Track(atmosConfig, "auth.scanStackFilesForDefaults")()
+
+	log.Debug("Loading stack configs for auth identity defaults (scan variant)")
 	stackDefaults, err := cfg.LoadStackAuthDefaults(atmosConfig)
 	if err != nil {
 		log.Debug("Failed to load stack auth defaults", "error", err)
-		return
+		return nil
 	}
 
 	if len(stackDefaults) == 0 {
 		log.Debug("No default identities found in stack configs")
-		return
+		return nil
 	}
 
-	// Merge stack defaults into auth config (stack takes precedence over atmos.yaml).
-	cfg.MergeStackAuthDefaults(authConfig, stackDefaults)
+	// Merge into a COPY so we don't mutate the caller's original auth config.
+	copied := copyAuthConfigForScan(authConfig)
+	cfg.MergeStackAuthDefaults(copied, stackDefaults)
 	log.Debug("Merged stack auth defaults", "count", len(stackDefaults))
+
+	return copied
+}
+
+// copyAuthConfigForScan creates a shallow-struct + deep-identities copy of an AuthConfig suitable for
+// mutation by MergeStackAuthDefaults. Only the `Identities` map is deep-copied because that is the
+// only field MergeStackAuthDefaults touches — it toggles the `Default` bool on individual identity
+// entries and nothing else. Other fields (providers, realm, etc.) are shared by pointer/value; the
+// scanner never modifies them.
+func copyAuthConfigForScan(src *schema.AuthConfig) *schema.AuthConfig {
+	if src == nil {
+		return nil
+	}
+	dup := *src // Shallow struct copy.
+	if src.Identities != nil {
+		dup.Identities = make(map[string]schema.Identity, len(src.Identities))
+		for k, v := range src.Identities {
+			dup.Identities[k] = v
+		}
+	}
+	return &dup
 }

--- a/pkg/auth/manager_helpers_test.go
+++ b/pkg/auth/manager_helpers_test.go
@@ -1333,14 +1333,15 @@ func TestCreateAndAuthenticateManagerWithStackScan_FollowsImportedDefaultFromExc
 }
 
 func TestCreateAndAuthenticateManagerWithStackScan_ExplicitIdentitySkipsScan(t *testing.T) {
-	// When the caller passes a non-empty identityName, the scan variant must
-	// skip the scanner entirely — no need to hit disk when the user has already
-	// told us which identity to use.
+	// When the caller passes a real non-empty identityName (not __DISABLED__),
+	// the scan guard `identityName == ""` is false, so the pre-scanner never
+	// runs. We verify this by checking that a stack file on disk declaring a
+	// different default does NOT mutate the caller's authConfig.
 	tmpDir := t.TempDir()
 
-	// Create a stack file that would normally trigger a scan hit. Since we're
-	// passing an explicit identityName, the scanner should never run, and
-	// `scan-me-identity` should never be examined.
+	// Create a stack file that would normally trigger a scan hit if the scanner
+	// ran. Since we're passing an explicit identityName, the scanner must be
+	// skipped entirely.
 	writeTestStackFile(t, tmpDir, "foreign-stack.yaml", `auth:
   identities:
     scan-me-identity:
@@ -1359,10 +1360,12 @@ func TestCreateAndAuthenticateManagerWithStackScan_ExplicitIdentitySkipsScan(t *
 		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
 	}
 
-	// Verify the scan short-circuits when identityName is explicit. We can't
-	// assert "scanner didn't run" directly, but we CAN assert the original
-	// authConfig is unchanged (no Default flags flipped by a stray scan).
-	_, _ = CreateAndAuthenticateManagerWithStackScan("__DISABLED__", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+	// Pass "explicit-identity" — a real identity name, not __DISABLED__. This
+	// exercises the `identityName == ""` guard in the scan variant (which should
+	// be false → skip scan → delegate to no-scan variant). The downstream
+	// authentication will fail (no real provider), but we only care that the
+	// scan was skipped and the caller's authConfig remained untouched.
+	_, _ = CreateAndAuthenticateManagerWithStackScan("explicit-identity", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
 	assert.False(t, authConfig.Identities["scan-me-identity"].Default,
 		"scan must short-circuit when identityName is non-empty; original authConfig must remain untouched")
 }

--- a/pkg/auth/manager_helpers_test.go
+++ b/pkg/auth/manager_helpers_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -973,8 +974,17 @@ func TestCreateAndAuthenticateManagerWithAtmosConfig_SkipsWhenAtmosConfigDefault
 	}
 }
 
-func TestLoadAndMergeStackAuthDefaults_ExistingDefault_NoStackFiles(t *testing.T) {
-	// When authConfig has a default and no stack files exist, default should be preserved.
+// TestScanStackFilesForDefaults_* exercises the private scanStackFilesForDefaults helper that
+// backs CreateAndAuthenticateManagerWithStackScan (Category B callers). It is the direct
+// successor of the old loadAndMergeStackAuthDefaults helper, with one behavioral change: it
+// returns a COPY rather than mutating the caller's authConfig (so Category A callers that share
+// an atmosConfig.Auth across multiple invocations cannot leak defaults across stacks).
+//
+// See docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md for the design rationale.
+
+func TestScanStackFilesForDefaults_ExistingDefault_NoStackFiles(t *testing.T) {
+	// When authConfig has a default and no stack files exist, the scan finds no defaults and
+	// returns nil (meaning "no changes, use the original"). The caller keeps its original.
 	authConfig := &schema.AuthConfig{
 		Identities: map[string]schema.Identity{
 			"test-identity": {Kind: "aws/assume-role", Default: true},
@@ -985,44 +995,43 @@ func TestLoadAndMergeStackAuthDefaults_ExistingDefault_NoStackFiles(t *testing.T
 		IncludeStackAbsolutePaths: []string{"/nonexistent/path/*.yaml"},
 	}
 
-	// Should scan but find no files, so atmos.yaml default is preserved
-	loadAndMergeStackAuthDefaults(authConfig, atmosConfig)
+	result := scanStackFilesForDefaults(authConfig, atmosConfig)
 
-	// Identity should still have default: true (no stack files to override)
-	assert.True(t, authConfig.Identities["test-identity"].Default)
+	// No defaults found in any stack file -> nil returned, original untouched.
+	assert.Nil(t, result, "scan should return nil when no defaults are found")
+	assert.True(t, authConfig.Identities["test-identity"].Default, "caller's original must remain untouched")
 }
 
-func TestLoadAndMergeStackAuthDefaults_NoExistingDefault(t *testing.T) {
-	// When authConfig has no default, loadAndMergeStackAuthDefaults should scan.
+func TestScanStackFilesForDefaults_NoExistingDefault(t *testing.T) {
+	// When authConfig has no default and there are no stack files, scan returns nil.
 	authConfig := &schema.AuthConfig{
 		Identities: map[string]schema.Identity{
 			"test-identity": {Kind: "aws/assume-role", Default: false},
 		},
 	}
 
-	// Empty paths - no files to scan
 	atmosConfig := &schema.AtmosConfiguration{
 		IncludeStackAbsolutePaths: []string{},
 	}
 
-	// Should not error, just find no defaults
-	loadAndMergeStackAuthDefaults(authConfig, atmosConfig)
+	result := scanStackFilesForDefaults(authConfig, atmosConfig)
 
-	// Identity should still not have default set (no stack defaults found)
+	assert.Nil(t, result)
 	assert.False(t, authConfig.Identities["test-identity"].Default)
 }
 
-func TestLoadAndMergeStackAuthDefaults_WithStackFiles(t *testing.T) {
-	// Create a temporary directory with stack files.
+func TestScanStackFilesForDefaults_WithStackFiles(t *testing.T) {
+	// When the scan finds a stack-level default, it returns a COPY of authConfig with the
+	// default flag applied. The caller's original authConfig must remain untouched —
+	// this is the Discussion #122 non-leak guarantee.
 	tmpDir := t.TempDir()
 
-	// Create a stack file with default identity.
 	stackContent := `auth:
   identities:
     stack-identity:
       default: true
 `
-	err := os.WriteFile(tmpDir+"/stack.yaml", []byte(stackContent), 0o644)
+	err := os.WriteFile(filepath.Join(tmpDir, "stack.yaml"), []byte(stackContent), 0o644)
 	require.NoError(t, err)
 
 	authConfig := &schema.AuthConfig{
@@ -1033,34 +1042,69 @@ func TestLoadAndMergeStackAuthDefaults_WithStackFiles(t *testing.T) {
 
 	atmosConfig := &schema.AtmosConfiguration{
 		BasePath:                  tmpDir,
-		IncludeStackAbsolutePaths: []string{tmpDir + "/*.yaml"},
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
 	}
 
-	// Should scan and find the default
-	loadAndMergeStackAuthDefaults(authConfig, atmosConfig)
+	result := scanStackFilesForDefaults(authConfig, atmosConfig)
 
-	// Identity should now have default set from stack config
-	assert.True(t, authConfig.Identities["stack-identity"].Default)
+	// Copy returned with the default applied.
+	require.NotNil(t, result, "scan should return a populated copy when a default is found")
+	assert.True(t, result.Identities["stack-identity"].Default, "scanned copy must reflect the discovered default")
+
+	// Original must NOT be mutated — this is the key isolation invariant.
+	assert.False(t, authConfig.Identities["stack-identity"].Default,
+		"caller's original authConfig must remain untouched; otherwise a Category B scan could leak into a Category A reuse of the same atmosConfig.Auth")
 }
 
-func TestLoadAndMergeStackAuthDefaults_LoadError(t *testing.T) {
-	// When loading fails, should gracefully handle the error.
+func TestScanStackFilesForDefaults_LoadError(t *testing.T) {
+	// When loading fails (invalid glob), the scan returns nil. Caller keeps its original.
 	authConfig := &schema.AuthConfig{
 		Identities: map[string]schema.Identity{
 			"test-identity": {Kind: "aws/assume-role", Default: true},
 		},
 	}
 
-	// Invalid glob pattern - should fail gracefully
 	atmosConfig := &schema.AtmosConfiguration{
 		IncludeStackAbsolutePaths: []string{"/nonexistent/path/[invalid/glob"},
 	}
 
-	// Should not panic, should gracefully return after logging error
-	loadAndMergeStackAuthDefaults(authConfig, atmosConfig)
+	result := scanStackFilesForDefaults(authConfig, atmosConfig)
 
-	// Default should be preserved (scan failed, so no change)
+	// No usable defaults -> nil returned. Original unchanged.
+	assert.Nil(t, result)
 	assert.True(t, authConfig.Identities["test-identity"].Default)
+}
+
+func TestCopyAuthConfigForScan_IsolationBothDirections(t *testing.T) {
+	// Verify that copyAuthConfigForScan produces a deep-enough copy that mutating Default on
+	// the copy does not leak into the original, and vice versa.
+	src := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"id-a": {Kind: "aws/assume-role", Default: false},
+			"id-b": {Kind: "aws/user", Default: true},
+		},
+	}
+
+	dup := copyAuthConfigForScan(src)
+	require.NotNil(t, dup)
+	require.NotSame(t, src, dup, "copy must be a distinct struct, not the same pointer")
+
+	// Mutate the copy's Identities map — original must not change.
+	mutated := dup.Identities["id-a"]
+	mutated.Default = true
+	dup.Identities["id-a"] = mutated
+	assert.False(t, src.Identities["id-a"].Default, "original id-a.Default must not change after mutating the copy")
+
+	// Mutate the original — copy must not change.
+	mutatedSrc := src.Identities["id-b"]
+	mutatedSrc.Default = false
+	src.Identities["id-b"] = mutatedSrc
+	assert.True(t, dup.Identities["id-b"].Default, "copy id-b.Default must remain true after mutating the original")
+}
+
+func TestCopyAuthConfigForScan_Nil(t *testing.T) {
+	assert.Nil(t, copyAuthConfigForScan(nil))
 }
 
 func TestAuthenticateWithIdentity_SelectValue(t *testing.T) {
@@ -1138,4 +1182,281 @@ func TestResolveIdentityName_EmptyWithAuth(t *testing.T) {
 	resolved, err := resolveIdentityName("", authConfig, "")
 	require.NoError(t, err)
 	assert.Equal(t, "default-identity", resolved)
+}
+
+// ============================================================================
+// Regression tests for PR #2302 / docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md
+//
+// These tests guard the two bugs at the pkg/auth boundary:
+//
+//   - Issue #2293: `auth.identities.<name>.default: true` declared in an
+//     imported _defaults.yaml (which is typically in `excluded_paths`) must be
+//     discoverable by the SCAN variant through the import-following scanner.
+//
+//   - Discussion #122: a default identity declared in one stack manifest must
+//     NOT leak to unrelated stacks. The NO-SCAN variant never consults stack
+//     files on disk, so contamination from pkg/config/stack_auth_loader.go is
+//     structurally impossible for Category A callers (terraform/helmfile/
+//     describe component/nested auth).
+// ============================================================================
+
+// writeTestStackFile is a helper that writes a YAML file into a nested directory,
+// creating any required parent directories.
+func writeTestStackFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestCreateAndAuthenticateManagerWithAtmosConfig_NoScanVariant_DoesNotLeakCrossStackDefault(t *testing.T) {
+	// Discussion #122 — Category A non-leak guarantee.
+	//
+	// Setup: simulate a terraform command targeting `plat-staging` (no auth block
+	// in its stack). A completely unrelated stack file declares
+	// `leaked-identity.default: true`. Before the fix, the NO-SCAN variant
+	// would run the scanner, find the unrelated default, and apply it to the
+	// plat-staging command — leaking across stacks.
+	//
+	// After the fix: the NO-SCAN variant never consults stack files on disk.
+	// The `leaked-identity` file is present but invisible to this helper. The
+	// caller's (already-merged) authConfig wins.
+	tmpDir := t.TempDir()
+
+	// Write a real stack file on disk with a default identity — this simulates a
+	// foreign stack whose default we must NOT pick up.
+	writeTestStackFile(t, tmpDir, "foreign-stack.yaml", `auth:
+  identities:
+    leaked-identity:
+      default: true
+`)
+
+	// The caller (e.g. terraform exec-layer) passes a pre-merged authConfig that
+	// has NO default — correctly scoped to its target stack.
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"leaked-identity":       {Kind: "aws/assume-role", Default: false},
+			"plat-staging-identity": {Kind: "aws/assume-role", Default: false},
+		},
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
+	}
+
+	// Call the NO-SCAN variant with identityName="" — auto-detect should find nothing.
+	manager, err := CreateAndAuthenticateManagerWithAtmosConfig("", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+
+	// Expect: no leak. The scanner never ran, so leaked-identity stays Default:false.
+	require.NoError(t, err)
+	assert.Nil(t, manager, "no-scan variant must return nil when no default is in the merged config, regardless of foreign stack files")
+	assert.False(t, authConfig.Identities["leaked-identity"].Default, "no-scan variant must not mutate authConfig from disk")
+}
+
+func TestCreateAndAuthenticateManagerWithAtmosConfig_NoScanVariant_IgnoresStackFilesEntirely(t *testing.T) {
+	// Companion to the above: even when the caller passes an authConfig with
+	// NO identities at all, the no-scan variant returns nil (no authentication)
+	// instead of auto-discovering identities from stack files on disk.
+	tmpDir := t.TempDir()
+	writeTestStackFile(t, tmpDir, "some-stack.yaml", `auth:
+  identities:
+    discovered-identity:
+      default: true
+`)
+
+	// Empty authConfig — no identities configured.
+	authConfig := &schema.AuthConfig{Identities: map[string]schema.Identity{}}
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
+	}
+
+	manager, err := CreateAndAuthenticateManagerWithAtmosConfig("", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+	require.NoError(t, err)
+	assert.Nil(t, manager, "no-scan variant must not consult stack files to discover identities")
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_FollowsImportedDefaultFromExcludedPath(t *testing.T) {
+	// Issue #2293 — SCAN variant must surface defaults declared in imported
+	// _defaults.yaml, even when the _defaults.yaml is in `excluded_paths`.
+	//
+	// This is the primary Category B end-to-end test for the fix. If it fails,
+	// describe stacks / list affected / workflows will not see imported defaults.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+
+	// Imported _defaults.yaml declaring the default — this file is in excluded_paths.
+	defaultsContent := `auth:
+  identities:
+    imported-default-identity:
+      default: true
+`
+	defaultsPath := writeTestStackFile(t, filepath.Join(stacksDir, "orgs", "acme", "dev"), "_defaults.yaml", defaultsContent)
+
+	// Top-level stack manifest that imports _defaults via a relative path.
+	manifestContent := `import:
+  - ./_defaults
+`
+	writeTestStackFile(t, filepath.Join(stacksDir, "orgs", "acme", "dev"), "manifest.yaml", manifestContent)
+
+	// authConfig lists the identity but with Default:false. The scan variant
+	// should follow the import, see `default: true` in the imported file, and
+	// apply the flag to a COPY of authConfig before resolving.
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"imported-default-identity": {Kind: "aws/assume-role", Default: false},
+		},
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "orgs", "acme", "dev", "manifest.yaml")},
+		ExcludeStackAbsolutePaths: []string{defaultsPath},
+	}
+
+	// Before attempting the full end-to-end call (which would try to actually
+	// authenticate and fail without real credentials), verify at the scanner
+	// level that the default is discovered.
+	scannedCopy := scanStackFilesForDefaults(authConfig, atmosConfig)
+	require.NotNil(t, scannedCopy, "scan must discover the imported default even when the file is in excluded_paths")
+	assert.True(t, scannedCopy.Identities["imported-default-identity"].Default,
+		"imported-default-identity.Default must be true in the scanned copy — this is the Issue #2293 fix for Category B commands")
+
+	// And verify isolation: the caller's original authConfig is NOT mutated.
+	assert.False(t, authConfig.Identities["imported-default-identity"].Default,
+		"caller's original authConfig must remain untouched — Discussion #122 non-leak guarantee extended to the scan variant")
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_ExplicitIdentitySkipsScan(t *testing.T) {
+	// When the caller passes a non-empty identityName, the scan variant must
+	// skip the scanner entirely — no need to hit disk when the user has already
+	// told us which identity to use.
+	tmpDir := t.TempDir()
+
+	// Create a stack file that would normally trigger a scan hit. Since we're
+	// passing an explicit identityName, the scanner should never run, and
+	// `scan-me-identity` should never be examined.
+	writeTestStackFile(t, tmpDir, "foreign-stack.yaml", `auth:
+  identities:
+    scan-me-identity:
+      default: true
+`)
+
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"explicit-identity": {Kind: "aws/assume-role", Default: false},
+			"scan-me-identity":  {Kind: "aws/assume-role", Default: false},
+		},
+	}
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
+	}
+
+	// Verify the scan short-circuits when identityName is explicit. We can't
+	// assert "scanner didn't run" directly, but we CAN assert the original
+	// authConfig is unchanged (no Default flags flipped by a stray scan).
+	_, _ = CreateAndAuthenticateManagerWithStackScan("__DISABLED__", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+	assert.False(t, authConfig.Identities["scan-me-identity"].Default,
+		"scan must short-circuit when identityName is non-empty; original authConfig must remain untouched")
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_DelegatesAfterSuccessfulScan(t *testing.T) {
+	// End-to-end path: scan runs, finds a default, and the helper delegates
+	// to the no-scan variant with the scanned copy. This exercises the "scan
+	// found something → use copy → delegate" branch that the short-circuit
+	// tests skip.
+	tmpDir := t.TempDir()
+	writeTestStackFile(t, tmpDir, "stack.yaml", `auth:
+  identities:
+    scan-target:
+      default: true
+`)
+
+	// Identity exists in atmos.yaml-level config but not marked as default.
+	// The scanner should find the default in the file and flip it on the copy.
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"scan-target": {Kind: "aws/assume-role", Default: false},
+		},
+	}
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
+	}
+
+	// Full call — not expected to succeed authentication (no real provider),
+	// but we want coverage of the delegate path. We don't care about the manager
+	// or the error; we care that the scan ran and the call reached the no-scan
+	// helper, and that the caller's original authConfig remained untouched.
+	_, _ = CreateAndAuthenticateManagerWithStackScan("", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+
+	// Isolation guarantee: caller's original authConfig must remain untouched
+	// (the scan writes into a copy only).
+	assert.False(t, authConfig.Identities["scan-target"].Default,
+		"caller's authConfig must not be mutated by the scan variant — Discussion #122 non-leak guarantee")
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_NilAtmosConfig(t *testing.T) {
+	// When atmosConfig is nil, the scan is skipped entirely and the helper
+	// delegates straight to the no-scan variant.
+	authConfig := &schema.AuthConfig{Identities: map[string]schema.Identity{}}
+	// Empty auth + no atmosConfig → no identities, returns nil manager with no error.
+	mgr, err := CreateAndAuthenticateManagerWithStackScan("", authConfig, cfg.IdentityFlagSelectValue, nil)
+	require.NoError(t, err)
+	assert.Nil(t, mgr)
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_UnconfiguredAuthSkipsScan(t *testing.T) {
+	// When auth is not configured (no identities), the scan is skipped.
+	authConfig := &schema.AuthConfig{Identities: map[string]schema.Identity{}}
+	atmosConfig := &schema.AtmosConfiguration{
+		IncludeStackAbsolutePaths: []string{"/nonexistent/*.yaml"},
+	}
+	mgr, err := CreateAndAuthenticateManagerWithStackScan("", authConfig, cfg.IdentityFlagSelectValue, atmosConfig)
+	require.NoError(t, err)
+	assert.Nil(t, mgr)
+}
+
+func TestCreateAndAuthenticateManagerWithStackScan_ConflictingDefaultsDiscarded(t *testing.T) {
+	// Issue #2072 (allAgree) must continue to work through the scan variant.
+	// When two stacks declare different defaults, both are discarded and the
+	// scanner returns empty — falls back to atmos.yaml-level defaults only.
+	tmpDir := t.TempDir()
+	writeTestStackFile(t, tmpDir, "stack-a.yaml", `auth:
+  identities:
+    identity-a:
+      default: true
+`)
+	writeTestStackFile(t, tmpDir, "stack-b.yaml", `auth:
+  identities:
+    identity-b:
+      default: true
+`)
+
+	authConfig := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"identity-a":         {Kind: "aws/assume-role", Default: false},
+			"identity-b":         {Kind: "aws/assume-role", Default: false},
+			"atmos-yaml-default": {Kind: "aws/assume-role", Default: true},
+		},
+	}
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:                  tmpDir,
+		StacksBaseAbsolutePath:    tmpDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(tmpDir, "*.yaml")},
+	}
+
+	// The scanner finds conflicting defaults → returns nothing → scanStackFilesForDefaults
+	// returns nil → caller uses original authConfig unchanged.
+	scannedCopy := scanStackFilesForDefaults(authConfig, atmosConfig)
+	assert.Nil(t, scannedCopy, "scan must return nil when stacks disagree on default identity (Issue #2072 allAgree preserved)")
+	assert.True(t, authConfig.Identities["atmos-yaml-default"].Default, "atmos.yaml-level default must remain intact")
 }

--- a/pkg/config/stack_auth_helpers_test.go
+++ b/pkg/config/stack_auth_helpers_test.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Table-driven edge-case tests for the import-resolution and path-extraction
+// helpers used by loadAuthWithImports. Split from stack_auth_loader_test.go
+// to keep that file under the 600-line guideline.
+
+func TestResolveAuthImportPaths(t *testing.T) {
+	// Create a temp dir with a .yml file for the fallback test.
+	tmpDir := t.TempDir()
+	ymlPath := filepath.Join(tmpDir, "defaults.yml")
+	require.NoError(t, os.WriteFile(ymlPath, []byte(""), 0o644))
+	targetPath := filepath.Join(tmpDir, "target.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte(""), 0o644))
+
+	tests := []struct {
+		name          string
+		imp           any
+		importingFile string
+		stacksBase    string
+		wantLen       int
+		wantFirst     string // expected first result (empty = nil expected).
+	}{
+		{
+			name:          "map form with path key",
+			imp:           map[string]any{"path": "target", "context": map[string]any{"k": "v"}},
+			importingFile: filepath.Join(tmpDir, "importer.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       1,
+			wantFirst:     targetPath,
+		},
+		{
+			name:          "unknown type integer",
+			imp:           42,
+			importingFile: filepath.Join(tmpDir, "x.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       0,
+		},
+		{
+			name:          "unknown type nil",
+			imp:           nil,
+			importingFile: filepath.Join(tmpDir, "x.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       0,
+		},
+		{
+			name:          "unknown type slice",
+			imp:           []string{"a", "b"},
+			importingFile: filepath.Join(tmpDir, "x.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       0,
+		},
+		{
+			name:          "empty stacksBasePath for non-relative import",
+			imp:           "orgs/acme/_defaults",
+			importingFile: filepath.Join(tmpDir, "importer.yaml"),
+			stacksBase:    "",
+			wantLen:       0,
+		},
+		{
+			name:          "fallback to .yml extension",
+			imp:           "defaults",
+			importingFile: filepath.Join(tmpDir, "importer.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       1,
+			wantFirst:     ymlPath,
+		},
+		{
+			name:          "non-existent candidate",
+			imp:           "nonexistent-import",
+			importingFile: filepath.Join(tmpDir, "importer.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       0,
+		},
+		{
+			name:          "glob with no matches",
+			imp:           "mixins/*",
+			importingFile: filepath.Join(tmpDir, "importer.yaml"),
+			stacksBase:    tmpDir,
+			wantLen:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveAuthImportPaths(tt.imp, tt.importingFile, tt.stacksBase)
+			if tt.wantLen == 0 {
+				assert.Nil(t, result)
+			} else {
+				require.Len(t, result, tt.wantLen)
+				assert.Equal(t, tt.wantFirst, result[0])
+			}
+		})
+	}
+}
+
+func TestExtractImportPathString(t *testing.T) {
+	tests := []struct {
+		name string
+		imp  any
+		want string
+	}{
+		{
+			name: "plain string",
+			imp:  "orgs/acme/_defaults",
+			want: "orgs/acme/_defaults",
+		},
+		{
+			name: "empty string",
+			imp:  "",
+			want: "",
+		},
+		{
+			name: "map[string]any with path",
+			imp:  map[string]any{"path": "target"},
+			want: "target",
+		},
+		{
+			name: "map[string]any with non-string path",
+			imp:  map[string]any{"path": 42},
+			want: "",
+		},
+		{
+			name: "map[string]any without path key",
+			imp:  map[string]any{"context": "value"},
+			want: "",
+		},
+		{
+			name: "map[any]any with path",
+			imp:  map[any]any{"path": "target"},
+			want: "target",
+		},
+		{
+			name: "map[any]any with non-string path",
+			imp:  map[any]any{"path": 42},
+			want: "",
+		},
+		{
+			name: "nil",
+			imp:  nil,
+			want: "",
+		},
+		{
+			name: "integer",
+			imp:  42,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractImportPathString(tt.imp))
+		})
+	}
+}
+
+func TestLoadAuthWithImports_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		basePath string
+		wantNil  bool
+	}{
+		{
+			name:     "non-YAML extension",
+			filePath: "/tmp/readme.md",
+			basePath: "/tmp",
+			wantNil:  true,
+		},
+		{
+			name:     "nonexistent file",
+			filePath: "/nonexistent/path/file.yaml",
+			basePath: "/tmp",
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := loadAuthWithImports(tt.filePath, tt.basePath, map[string]bool{})
+			if tt.wantNil {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}

--- a/pkg/config/stack_auth_helpers_test.go
+++ b/pkg/config/stack_auth_helpers_test.go
@@ -163,6 +163,11 @@ func TestExtractImportPathString(t *testing.T) {
 }
 
 func TestLoadAuthWithImports_EdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	readmePath := filepath.Join(tmpDir, "readme.md")
+	require.NoError(t, os.WriteFile(readmePath, []byte(""), 0o644))
+	missingYAMLPath := filepath.Join(tmpDir, "nonexistent", "file.yaml")
+
 	tests := []struct {
 		name     string
 		filePath string
@@ -171,14 +176,14 @@ func TestLoadAuthWithImports_EdgeCases(t *testing.T) {
 	}{
 		{
 			name:     "non-YAML extension",
-			filePath: "/tmp/readme.md",
-			basePath: "/tmp",
+			filePath: readmePath,
+			basePath: tmpDir,
 			wantNil:  true,
 		},
 		{
 			name:     "nonexistent file",
-			filePath: "/nonexistent/path/file.yaml",
-			basePath: "/tmp",
+			filePath: missingYAMLPath,
+			basePath: tmpDir,
 			wantNil:  true,
 		},
 	}

--- a/pkg/config/stack_auth_loader.go
+++ b/pkg/config/stack_auth_loader.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -18,6 +19,18 @@ const logKeyIdentity = "identity"
 // stackAuthSection represents the minimal auth section structure for loading.
 type stackAuthSection struct {
 	Auth struct {
+		Identities map[string]struct {
+			Default bool `yaml:"default"`
+		} `yaml:"identities"`
+	} `yaml:"auth"`
+}
+
+// stackAuthFileWithImports parses the top of a stack file to extract both the
+// `import:` list and the `auth:` block. Used by the recursive scanner that
+// follows import chains when looking for default identities.
+type stackAuthFileWithImports struct {
+	Import []any `yaml:"import"`
+	Auth   struct {
 		Identities map[string]struct {
 			Default bool `yaml:"default"`
 		} `yaml:"identities"`
@@ -68,12 +81,16 @@ func LoadStackAuthDefaults(atmosConfig *schema.AtmosConfiguration) (map[string]b
 	var allDefaults []defaultSource
 
 	// Load each file for auth defaults.
+	// Uses the recursive import-following scanner so defaults declared in
+	// imported `_defaults.yaml` files are visible even when those files are
+	// listed in `excluded_paths` (the excluded-paths filter only prevents
+	// standalone processing, not import resolution). This fixes Issue #2293
+	// for multi-stack commands that cannot use the exec-layer merge path.
 	for _, filePath := range stackFiles {
-		fileDefaults, err := loadFileForAuthDefaults(filePath)
-		if err != nil {
-			log.Debug("Failed to load file for auth defaults", "file", filePath, "error", err)
-			continue // Non-fatal: skip this file.
-		}
+		// Each top-level stack file gets its own visited set so import cycles
+		// in one file tree don't poison another.
+		visited := make(map[string]bool)
+		fileDefaults := loadAuthWithImports(filePath, atmosConfig.StacksBaseAbsolutePath, visited)
 
 		for identity, isDefault := range fileDefaults {
 			if isDefault {
@@ -190,6 +207,231 @@ func loadFileForAuthDefaults(filePath string) (map[string]bool, error) {
 	}
 
 	return defaults, nil
+}
+
+// yamlExt / ymlExt are the two stack-file extensions the scanner understands.
+// They match the conventions used throughout the Atmos stack processor.
+const (
+	yamlExt = ".yaml"
+	ymlExt  = ".yml"
+)
+
+// loadAuthWithImports recursively reads a stack file and its imports, extracting
+// auth.identities.*.default markers. The importing file's auth section takes
+// precedence over imported files' auth sections when identity names conflict,
+// matching Atmos inheritance semantics (more specific wins over more general).
+//
+// The `visited` map tracks absolute file paths already processed to protect
+// against import cycles. `stacksBasePath` is `atmosConfig.StacksBaseAbsolutePath`
+// — the root that non-relative imports are resolved against. Relative imports
+// (`./foo`, `../bar`) are resolved against the importing file's directory.
+//
+// Returns nil on any unrecoverable error (unreadable file, YAML parse failure,
+// non-YAML extension). Errors are swallowed intentionally — the scanner's
+// contract is best-effort discovery, not strict validation.
+func loadAuthWithImports(filePath, stacksBasePath string, visited map[string]bool) map[string]bool {
+	defer perf.Track(nil, "config.loadAuthWithImports")()
+
+	absPath, ok := markVisited(filePath, visited)
+	if !ok {
+		return nil
+	}
+
+	parsed, ok := readStackAuthFile(absPath)
+	if !ok {
+		return nil
+	}
+
+	result := make(map[string]bool)
+	mergeImportedAuthDefaults(parsed.Import, absPath, stacksBasePath, visited, result)
+	applyCurrentFileAuthDefaults(parsed, result)
+	return result
+}
+
+// markVisited returns the absolute path of filePath and true if it is not yet
+// in the visited set (marking it in-place), or returns false if the file has
+// already been processed (cycle) or the path cannot be resolved.
+func markVisited(filePath string, visited map[string]bool) (string, bool) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", false
+	}
+	if visited[absPath] {
+		return "", false
+	}
+	visited[absPath] = true
+	return absPath, true
+}
+
+// readStackAuthFile reads a YAML stack file and parses its top-level `import:`
+// and `auth:` sections. Returns the parsed struct and true on success, or zero
+// value and false for non-YAML extensions, unreadable files, or parse errors
+// (which often just mean the file contains Go templates).
+func readStackAuthFile(absPath string) (stackAuthFileWithImports, bool) {
+	var zero stackAuthFileWithImports
+
+	ext := filepath.Ext(absPath)
+	if ext != yamlExt && ext != ymlExt {
+		return zero, false
+	}
+
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return zero, false
+	}
+
+	var parsed stackAuthFileWithImports
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
+		// Non-fatal: file may contain Go templates that prevent raw YAML parsing.
+		return zero, false
+	}
+	return parsed, true
+}
+
+// mergeImportedAuthDefaults walks each entry in an `import:` list, recursively
+// loads the imported files' auth defaults, and merges them into `result`.
+// Matches Atmos inheritance order: imported defaults are applied first, then
+// the current file overrides via applyCurrentFileAuthDefaults.
+func mergeImportedAuthDefaults(
+	imports []any,
+	importingFile, stacksBasePath string,
+	visited map[string]bool,
+	result map[string]bool,
+) {
+	for _, imp := range imports {
+		importedFiles := resolveAuthImportPaths(imp, importingFile, stacksBasePath)
+		for _, impFile := range importedFiles {
+			for name, isDefault := range loadAuthWithImports(impFile, stacksBasePath, visited) {
+				if isDefault {
+					result[name] = true
+				}
+			}
+		}
+	}
+}
+
+// applyCurrentFileAuthDefaults applies the default flags declared in the
+// current file's `auth.identities` section to `result`. These override any
+// imported defaults by virtue of being processed after
+// mergeImportedAuthDefaults.
+func applyCurrentFileAuthDefaults(parsed stackAuthFileWithImports, result map[string]bool) {
+	for name, identity := range parsed.Auth.Identities {
+		if identity.Default {
+			result[name] = true
+		}
+	}
+}
+
+// resolveAuthImportPaths resolves a single `import:` list entry to absolute file
+// paths on disk. Handles the three Atmos import forms:
+//
+//  1. Plain string: "orgs/acme/_defaults" — resolved against `stacksBasePath`.
+//  2. Glob string:  "mixins/region/*"    — resolved against `stacksBasePath`,
+//     then glob-expanded via `GetGlobMatches` (supports doublestar `**`).
+//  3. Map form with `path:` field:
+//     `- path: orgs/acme/_defaults` — the `path` value is treated as a string.
+//
+// Relative paths (`./foo`, `../bar`) are resolved against the importing file's
+// directory instead of `stacksBasePath`.
+//
+// Returns nil for import forms that cannot be resolved without running Go
+// templates (e.g., `path: "{{ .something }}"`), for paths that do not exist
+// on disk, or for any other error. This is intentional graceful degradation —
+// the scanner is best-effort and never blocks the auth flow on a malformed or
+// templated import.
+func resolveAuthImportPaths(imp any, importingFile, stacksBasePath string) []string {
+	defer perf.Track(nil, "config.resolveAuthImportPaths")()
+
+	importPath := normalizeImportPath(extractImportPathString(imp))
+	if importPath == "" {
+		return nil
+	}
+
+	candidate, ok := buildImportCandidatePath(importPath, importingFile, stacksBasePath)
+	if !ok {
+		return nil
+	}
+
+	return matchImportCandidate(candidate)
+}
+
+// normalizeImportPath returns the raw import path with a `.yaml` extension
+// appended if missing, or empty string if the input is empty or contains a Go
+// template expression (which cannot be resolved without template context).
+func normalizeImportPath(rawPath string) string {
+	if rawPath == "" {
+		return ""
+	}
+	if strings.Contains(rawPath, "{{") {
+		return ""
+	}
+	if filepath.Ext(rawPath) == "" {
+		rawPath += yamlExt
+	}
+	return rawPath
+}
+
+// buildImportCandidatePath joins the normalized import path against either the
+// importing file's directory (for `./` / `../` relative imports) or the stacks
+// base path (for everything else). Returns the candidate path and true, or
+// empty/false if the base path required for resolution is missing.
+func buildImportCandidatePath(importPath, importingFile, stacksBasePath string) (string, bool) {
+	normalized := filepath.FromSlash(importPath)
+	if strings.HasPrefix(importPath, "./") || strings.HasPrefix(importPath, "../") {
+		return filepath.Join(filepath.Dir(importingFile), normalized), true
+	}
+	if stacksBasePath == "" {
+		return "", false
+	}
+	return filepath.Join(stacksBasePath, normalized), true
+}
+
+// matchImportCandidate returns matching file paths for a candidate. For glob
+// patterns it uses doublestar; for plain paths it uses a direct stat, with a
+// `.yml` fallback when the original `.yaml` candidate does not exist.
+func matchImportCandidate(candidate string) []string {
+	if strings.ContainsAny(candidate, "*?[") {
+		matches, err := u.GetGlobMatches(candidate)
+		if err != nil || len(matches) == 0 {
+			return nil
+		}
+		return matches
+	}
+
+	if _, err := os.Stat(candidate); err == nil {
+		return []string{candidate}
+	}
+
+	// Fall back to .yml if .yaml did not exist.
+	if strings.HasSuffix(candidate, yamlExt) {
+		alt := strings.TrimSuffix(candidate, yamlExt) + ymlExt
+		if _, err := os.Stat(alt); err == nil {
+			return []string{alt}
+		}
+	}
+
+	return nil
+}
+
+// extractImportPathString extracts the path string from an import list entry.
+// Supports plain string imports and map-form imports with a `path` key.
+// Returns empty string for unrecognized forms — the caller treats that as
+// unresolvable and skips the import gracefully.
+func extractImportPathString(imp any) string {
+	switch v := imp.(type) {
+	case string:
+		return v
+	case map[string]any:
+		if p, ok := v["path"].(string); ok {
+			return p
+		}
+	case map[any]any:
+		// yaml.v3 sometimes decodes into map[any]any depending on tag state.
+		if p, ok := v["path"].(string); ok {
+			return p
+		}
+	}
+	return ""
 }
 
 // MergeStackAuthDefaults merges stack-level auth defaults into the auth config.

--- a/pkg/config/stack_auth_loader.go
+++ b/pkg/config/stack_auth_loader.go
@@ -28,11 +28,20 @@ type stackAuthSection struct {
 // stackAuthFileWithImports parses the top of a stack file to extract both the
 // `import:` list and the `auth:` block. Used by the recursive scanner that
 // follows import chains when looking for default identities.
+//
+// `Default` is a *bool to distinguish three states:
+//   - nil:   identity listed without a `default` field → do not touch result.
+//   - true:  explicitly `default: true` → mark as default.
+//   - false: explicitly `default: false` → revoke any imported default.
+//
+// This matters because an importing file may override an imported default with
+// `default: false`. Without a pointer, that override would be indistinguishable
+// from "not mentioned" and the imported `true` would leak through.
 type stackAuthFileWithImports struct {
 	Import []any `yaml:"import"`
 	Auth   struct {
 		Identities map[string]struct {
-			Default bool `yaml:"default"`
+			Default *bool `yaml:"default"`
 		} `yaml:"identities"`
 	} `yaml:"auth"`
 }
@@ -314,11 +323,22 @@ func mergeImportedAuthDefaults(
 // current file's `auth.identities` section to `result`. These override any
 // imported defaults by virtue of being processed after
 // mergeImportedAuthDefaults.
+//
+// Three-state logic via *bool:
+//   - nil:   identity listed without `default` field → leave result unchanged.
+//   - true:  `default: true` → mark as default.
+//   - false: `default: false` → revoke any imported default (delete from result).
 func applyCurrentFileAuthDefaults(parsed stackAuthFileWithImports, result map[string]bool) {
 	for name, identity := range parsed.Auth.Identities {
-		if identity.Default {
-			result[name] = true
+		if identity.Default == nil {
+			continue
 		}
+		if *identity.Default {
+			result[name] = true
+			continue
+		}
+		// Explicit `default: false` revokes any default inherited from imports.
+		delete(result, name)
 	}
 }
 

--- a/pkg/config/stack_auth_loader_test.go
+++ b/pkg/config/stack_auth_loader_test.go
@@ -731,6 +731,87 @@ auth:
 	assert.Empty(t, defaults, "when the merged view of a single file shows two competing defaults, allAgree discards them per Issue #2072")
 }
 
+func TestLoadStackAuthDefaults_ExplicitFalseRevokesImportedDefault(t *testing.T) {
+	// An imported _defaults.yaml sets `foo.default: true`. The importing file
+	// overrides it with `foo.default: false`. The scanner must honor the
+	// explicit `false` and NOT report `foo` as a default.
+	//
+	// Before the *bool fix, `default: false` was indistinguishable from "not
+	// mentioned" (both decoded as Go's zero value `false`), so the imported
+	// `true` leaked through — the wrong identity was selected for the stack.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    imported-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "_defaults.yaml"), []byte(defaultsContent), 0o644))
+
+	// The importing file explicitly revokes the imported default.
+	manifestContent := `
+import:
+  - _defaults
+auth:
+  identities:
+    imported-identity:
+      default: false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.Empty(t, defaults, "explicit default: false in the importing file must revoke the imported default: true")
+}
+
+func TestLoadStackAuthDefaults_IdentityWithoutDefaultFieldLeavesImportedDefault(t *testing.T) {
+	// An imported _defaults.yaml sets `foo.default: true`. The importing file
+	// mentions `foo` but without a `default` field at all. The scanner must
+	// treat the nil `default` as "not mentioned" and preserve the imported
+	// default. This is the complementary test to
+	// ExplicitFalseRevokesImportedDefault — it verifies the three-state
+	// distinction between nil (preserve), false (revoke), and true (set).
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    imported-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "_defaults.yaml"), []byte(defaultsContent), 0o644))
+
+	// The importing file mentions the identity but does NOT set `default` at all.
+	manifestContent := `
+import:
+  - _defaults
+auth:
+  identities:
+    imported-identity:
+      kind: aws/assume-role
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["imported-identity"], "identity mentioned without default field must preserve the imported default: true")
+}
+
 func TestLoadStackAuthDefaults_ImportedDefaultAgreesAcrossStacks(t *testing.T) {
 	// Two top-level stacks import the SAME _defaults.yaml that declares a
 	// default. Both should report the same identity, allAgree passes, and

--- a/pkg/config/stack_auth_loader_test.go
+++ b/pkg/config/stack_auth_loader_test.go
@@ -504,3 +504,397 @@ auth:
 	// Should have found the default from the valid file.
 	assert.True(t, defaults["valid-identity"])
 }
+
+// ============================================================================
+// Import-following scanner tests — Issue #2293 for Category B commands.
+//
+// These tests cover the new recursive loadAuthWithImports helper that makes
+// LoadStackAuthDefaults follow `import:` chains when scanning for
+// `auth.identities.*.default: true`. Before this fix, the scanner only looked
+// at each top-level stack file's own auth section and missed defaults declared
+// in imported `_defaults.yaml` files — including files that were explicitly
+// excluded from standalone processing via `excluded_paths`.
+//
+// See docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md for the
+// full design rationale (option d+).
+// ============================================================================
+
+func TestLoadStackAuthDefaults_FollowsImports(t *testing.T) {
+	// Top-level stack manifest imports a _defaults.yaml that declares the default.
+	// The scanner must follow the import and surface the default to the loader.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    imported-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "_defaults.yaml"), []byte(defaultsContent), 0o644))
+
+	manifestContent := `
+import:
+  - _defaults
+vars:
+  stage: dev
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["imported-identity"], "scanner should follow the import: chain and surface the imported default")
+}
+
+func TestLoadStackAuthDefaults_FollowsImportsFromExcludedPath(t *testing.T) {
+	// The real-world Issue #2293 layout: _defaults.yaml is in `excluded_paths`
+	// so `getAllStackFiles` filters it out, but it is still referenced via
+	// `import:` from a top-level manifest. The scanner must resolve that import
+	// through the excluded file's path despite the exclusion.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    excluded-imported-identity:
+      default: true
+`
+	defaultsPath := filepath.Join(stacksDir, "_defaults.yaml")
+	require.NoError(t, os.WriteFile(defaultsPath, []byte(defaultsContent), 0o644))
+
+	manifestContent := `
+import:
+  - _defaults
+`
+	manifestPath := filepath.Join(stacksDir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "*.yaml")},
+		// _defaults.yaml is explicitly excluded from standalone processing.
+		ExcludeStackAbsolutePaths: []string{defaultsPath},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["excluded-imported-identity"],
+		"scanner must follow imports into excluded_paths files — excluded_paths filters standalone processing, not import resolution")
+}
+
+func TestLoadStackAuthDefaults_ImportCycleProtection(t *testing.T) {
+	// Two files that import each other. The recursive scanner must terminate
+	// and return a sensible result without infinite recursion.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	aContent := `
+import:
+  - b
+auth:
+  identities:
+    a-identity:
+      default: true
+`
+	bContent := `
+import:
+  - a
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "a.yaml"), []byte(aContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "b.yaml"), []byte(bContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "a.yaml")},
+	}
+
+	// Must terminate (if cycle protection fails this test hangs / stack-overflows).
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["a-identity"], "default from the top-level file must still be returned despite the cycle")
+}
+
+func TestLoadStackAuthDefaults_GlobImports(t *testing.T) {
+	// Glob import should expand and be followed.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	mixinsDir := filepath.Join(stacksDir, "mixins")
+	require.NoError(t, os.MkdirAll(mixinsDir, 0o755))
+
+	mixinContent := `
+auth:
+  identities:
+    mixin-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(mixinsDir, "region.yaml"), []byte(mixinContent), 0o644))
+
+	manifestContent := `
+import:
+  - mixins/*
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["mixin-identity"], "scanner should glob-expand import paths and follow the matches")
+}
+
+func TestLoadStackAuthDefaults_TemplatedImportSkipped(t *testing.T) {
+	// Go-template imports cannot be resolved without template context — the
+	// scanner must skip them gracefully rather than erroring.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	// The manifest imports a templated path AND declares its own default, so
+	// we can verify: (1) scanner does not crash, (2) scanner still picks up
+	// the static default from the manifest itself.
+	manifestContent := `
+import:
+  - '{{ .stage }}/_defaults'
+auth:
+  identities:
+    manifest-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["manifest-identity"], "scanner must skip templated imports gracefully and still surface static defaults from the same file")
+}
+
+func TestLoadStackAuthDefaults_CurrentFileWinsOverImport(t *testing.T) {
+	// When both the importing file and an imported file declare defaults for
+	// DIFFERENT identities, the importing file's default should win for the
+	// purpose of what the scanner reports for that file. (Matches Atmos
+	// inheritance: more specific overrides more general.)
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    imported-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "_defaults.yaml"), []byte(defaultsContent), 0o644))
+
+	manifestContent := `
+import:
+  - _defaults
+auth:
+  identities:
+    manifest-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stacksDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
+	}
+
+	// Both identities are in the file's merged view, which means TWO defaults
+	// were found. The allAgree check sees a conflict (two different identities)
+	// and discards both — correct pre-existing behavior from Issue #2072 for
+	// the case where a stack pair genuinely disagrees.
+	//
+	// The important assertion here is that the scanner DID see both (import
+	// was followed AND current file was read).
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	// The allAgree discard kicks in — the scanner correctly detects the conflict
+	// between manifest-identity and imported-identity within the merged view of
+	// the single file and returns empty.
+	assert.Empty(t, defaults, "when the merged view of a single file shows two competing defaults, allAgree discards them per Issue #2072")
+}
+
+func TestLoadStackAuthDefaults_ImportedDefaultAgreesAcrossStacks(t *testing.T) {
+	// Two top-level stacks import the SAME _defaults.yaml that declares a
+	// default. Both should report the same identity, allAgree passes, and
+	// the default is returned. This is the positive happy-path companion to
+	// TestLoadStackAuthDefaults_FollowsImports.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    shared-identity:
+      default: true
+`
+	defaultsPath := filepath.Join(stacksDir, "_defaults.yaml")
+	require.NoError(t, os.WriteFile(defaultsPath, []byte(defaultsContent), 0o644))
+
+	for _, name := range []string{"stack-a.yaml", "stack-b.yaml"} {
+		content := `
+import:
+  - _defaults
+`
+		require.NoError(t, os.WriteFile(filepath.Join(stacksDir, name), []byte(content), 0o644))
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "stack-*.yaml")},
+		ExcludeStackAbsolutePaths: []string{defaultsPath},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["shared-identity"], "both stacks agree on the imported default, so allAgree passes and the default is returned")
+}
+
+func TestLoadStackAuthDefaults_RelativeImports(t *testing.T) {
+	// `./` and `../` imports must resolve against the importing file's dir,
+	// not the stacks base path.
+	tmpDir := t.TempDir()
+	stacksDir := filepath.Join(tmpDir, "stacks")
+	subDir := filepath.Join(stacksDir, "orgs", "acme", "dev")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	defaultsContent := `
+auth:
+  identities:
+    relative-identity:
+      default: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "_defaults.yaml"), []byte(defaultsContent), 0o644))
+
+	manifestContent := `
+import:
+  - ./_defaults
+`
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "manifest.yaml"), []byte(manifestContent), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		StacksBaseAbsolutePath:    stacksDir,
+		IncludeStackAbsolutePaths: []string{filepath.Join(subDir, "manifest.yaml")},
+	}
+
+	defaults, err := LoadStackAuthDefaults(atmosConfig)
+	require.NoError(t, err)
+	assert.True(t, defaults["relative-identity"], "./ imports must resolve against the importing file's directory")
+}
+
+func TestResolveAuthImportPaths_MapFormWithPath(t *testing.T) {
+	// Map-form imports (used for context-carrying imports) specify the path
+	// via a `path:` key. The scanner should extract that.
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "target.yaml"), []byte(""), 0o644))
+
+	imp := map[string]any{
+		"path":    "target",
+		"context": map[string]any{"key": "value"},
+	}
+	result := resolveAuthImportPaths(imp, filepath.Join(tmpDir, "importer.yaml"), tmpDir)
+	require.Len(t, result, 1)
+	assert.Equal(t, filepath.Join(tmpDir, "target.yaml"), result[0])
+}
+
+func TestResolveAuthImportPaths_UnknownType(t *testing.T) {
+	// Integer / nil / unrecognized types must return nil (skip gracefully).
+	assert.Nil(t, resolveAuthImportPaths(42, "/tmp/x.yaml", "/tmp"))
+	assert.Nil(t, resolveAuthImportPaths(nil, "/tmp/x.yaml", "/tmp"))
+	assert.Nil(t, resolveAuthImportPaths([]string{"a", "b"}, "/tmp/x.yaml", "/tmp"))
+}
+
+func TestLoadAuthWithImports_NonYAMLExtension(t *testing.T) {
+	// Non-YAML files should return nil without reading.
+	result := loadAuthWithImports("/tmp/readme.md", "/tmp", map[string]bool{})
+	assert.Nil(t, result)
+}
+
+func TestLoadAuthWithImports_NonexistentFile(t *testing.T) {
+	// Unreadable files return nil.
+	result := loadAuthWithImports("/nonexistent/path/file.yaml", "/tmp", map[string]bool{})
+	assert.Nil(t, result)
+}
+
+func TestResolveAuthImportPaths_EmptyStacksBasePathForNonRelative(t *testing.T) {
+	// Non-relative import with empty stacksBasePath cannot be resolved.
+	// This branch guards against tests/callers that forget to set StacksBaseAbsolutePath.
+	result := resolveAuthImportPaths("orgs/acme/_defaults", "/tmp/importer.yaml", "")
+	assert.Nil(t, result, "non-relative imports require a non-empty stacksBasePath")
+}
+
+func TestResolveAuthImportPaths_FallbackToYmlExtension(t *testing.T) {
+	// If the .yaml candidate does not exist, the resolver should fall back to .yml
+	// before giving up. This matches the two-extension convention Atmos stacks use.
+	tmpDir := t.TempDir()
+	// Write a .yml file (NOT .yaml) and try to import it without an extension.
+	ymlPath := filepath.Join(tmpDir, "defaults.yml")
+	require.NoError(t, os.WriteFile(ymlPath, []byte(""), 0o644))
+
+	result := resolveAuthImportPaths("defaults", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
+	require.Len(t, result, 1, "resolver should fall back to .yml when .yaml is absent")
+	assert.Equal(t, ymlPath, result[0])
+}
+
+func TestResolveAuthImportPaths_NonExistentCandidate(t *testing.T) {
+	// Non-glob candidate that does not exist on disk, AND has no .yml fallback,
+	// should return nil. Exercises both the os.Stat miss and the fallback miss.
+	tmpDir := t.TempDir()
+	result := resolveAuthImportPaths("nonexistent-import", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
+	assert.Nil(t, result)
+}
+
+func TestResolveAuthImportPaths_GlobNoMatches(t *testing.T) {
+	// A glob that matches nothing should return nil (not error).
+	tmpDir := t.TempDir()
+	result := resolveAuthImportPaths("mixins/*", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
+	assert.Nil(t, result)
+}
+
+func TestExtractImportPathString_MapAnyAny(t *testing.T) {
+	// yaml.v3 may produce map[any]any for some tag states. The extractor must
+	// handle that variant in addition to map[string]any.
+	imp := map[any]any{
+		"path":    "target",
+		"context": map[any]any{"key": "value"},
+	}
+	assert.Equal(t, "target", extractImportPathString(imp))
+}
+
+func TestExtractImportPathString_MapAnyAnyNonStringPath(t *testing.T) {
+	// map[any]any with a non-string `path` value must return empty string.
+	imp := map[any]any{
+		"path": 42,
+	}
+	assert.Empty(t, extractImportPathString(imp))
+}
+
+func TestExtractImportPathString_MapStringAnyNonStringPath(t *testing.T) {
+	// map[string]any with a non-string `path` value must return empty string.
+	imp := map[string]any{
+		"path": 42,
+	}
+	assert.Empty(t, extractImportPathString(imp))
+}
+
+func TestExtractImportPathString_EmptyString(t *testing.T) {
+	assert.Empty(t, extractImportPathString(""))
+}

--- a/pkg/config/stack_auth_loader_test.go
+++ b/pkg/config/stack_auth_loader_test.go
@@ -684,11 +684,16 @@ auth:
 	assert.True(t, defaults["manifest-identity"], "scanner must skip templated imports gracefully and still surface static defaults from the same file")
 }
 
-func TestLoadStackAuthDefaults_CurrentFileWinsOverImport(t *testing.T) {
-	// When both the importing file and an imported file declare defaults for
-	// DIFFERENT identities, the importing file's default should win for the
-	// purpose of what the scanner reports for that file. (Matches Atmos
-	// inheritance: more specific overrides more general.)
+func TestLoadStackAuthDefaults_ConflictingDefaultsAcrossImportAndFileDiscarded(t *testing.T) {
+	// When the importing file and its imported file declare defaults for
+	// DIFFERENT identities, the merged view of that file contains two
+	// competing defaults. The top-level allAgree check detects the conflict
+	// and discards both — matching Issue #2072 behavior.
+	//
+	// This also serves as a proof that the import WAS followed: if the
+	// scanner had not seen the imported file, only `manifest-identity`
+	// would appear and allAgree would pass (returning a single default).
+	// The empty result proves both were seen and conflicted.
 	tmpDir := t.TempDir()
 	stacksDir := filepath.Join(tmpDir, "stacks")
 	require.NoError(t, os.MkdirAll(stacksDir, 0o755))
@@ -716,19 +721,9 @@ auth:
 		IncludeStackAbsolutePaths: []string{filepath.Join(stacksDir, "manifest.yaml")},
 	}
 
-	// Both identities are in the file's merged view, which means TWO defaults
-	// were found. The allAgree check sees a conflict (two different identities)
-	// and discards both — correct pre-existing behavior from Issue #2072 for
-	// the case where a stack pair genuinely disagrees.
-	//
-	// The important assertion here is that the scanner DID see both (import
-	// was followed AND current file was read).
 	defaults, err := LoadStackAuthDefaults(atmosConfig)
 	require.NoError(t, err)
-	// The allAgree discard kicks in — the scanner correctly detects the conflict
-	// between manifest-identity and imported-identity within the merged view of
-	// the single file and returns empty.
-	assert.Empty(t, defaults, "when the merged view of a single file shows two competing defaults, allAgree discards them per Issue #2072")
+	assert.Empty(t, defaults, "two competing defaults from import + file must be discarded by allAgree (Issue #2072)")
 }
 
 func TestLoadStackAuthDefaults_ExplicitFalseRevokesImportedDefault(t *testing.T) {
@@ -881,101 +876,5 @@ import:
 	assert.True(t, defaults["relative-identity"], "./ imports must resolve against the importing file's directory")
 }
 
-func TestResolveAuthImportPaths_MapFormWithPath(t *testing.T) {
-	// Map-form imports (used for context-carrying imports) specify the path
-	// via a `path:` key. The scanner should extract that.
-	tmpDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "target.yaml"), []byte(""), 0o644))
-
-	imp := map[string]any{
-		"path":    "target",
-		"context": map[string]any{"key": "value"},
-	}
-	result := resolveAuthImportPaths(imp, filepath.Join(tmpDir, "importer.yaml"), tmpDir)
-	require.Len(t, result, 1)
-	assert.Equal(t, filepath.Join(tmpDir, "target.yaml"), result[0])
-}
-
-func TestResolveAuthImportPaths_UnknownType(t *testing.T) {
-	// Integer / nil / unrecognized types must return nil (skip gracefully).
-	assert.Nil(t, resolveAuthImportPaths(42, "/tmp/x.yaml", "/tmp"))
-	assert.Nil(t, resolveAuthImportPaths(nil, "/tmp/x.yaml", "/tmp"))
-	assert.Nil(t, resolveAuthImportPaths([]string{"a", "b"}, "/tmp/x.yaml", "/tmp"))
-}
-
-func TestLoadAuthWithImports_NonYAMLExtension(t *testing.T) {
-	// Non-YAML files should return nil without reading.
-	result := loadAuthWithImports("/tmp/readme.md", "/tmp", map[string]bool{})
-	assert.Nil(t, result)
-}
-
-func TestLoadAuthWithImports_NonexistentFile(t *testing.T) {
-	// Unreadable files return nil.
-	result := loadAuthWithImports("/nonexistent/path/file.yaml", "/tmp", map[string]bool{})
-	assert.Nil(t, result)
-}
-
-func TestResolveAuthImportPaths_EmptyStacksBasePathForNonRelative(t *testing.T) {
-	// Non-relative import with empty stacksBasePath cannot be resolved.
-	// This branch guards against tests/callers that forget to set StacksBaseAbsolutePath.
-	result := resolveAuthImportPaths("orgs/acme/_defaults", "/tmp/importer.yaml", "")
-	assert.Nil(t, result, "non-relative imports require a non-empty stacksBasePath")
-}
-
-func TestResolveAuthImportPaths_FallbackToYmlExtension(t *testing.T) {
-	// If the .yaml candidate does not exist, the resolver should fall back to .yml
-	// before giving up. This matches the two-extension convention Atmos stacks use.
-	tmpDir := t.TempDir()
-	// Write a .yml file (NOT .yaml) and try to import it without an extension.
-	ymlPath := filepath.Join(tmpDir, "defaults.yml")
-	require.NoError(t, os.WriteFile(ymlPath, []byte(""), 0o644))
-
-	result := resolveAuthImportPaths("defaults", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
-	require.Len(t, result, 1, "resolver should fall back to .yml when .yaml is absent")
-	assert.Equal(t, ymlPath, result[0])
-}
-
-func TestResolveAuthImportPaths_NonExistentCandidate(t *testing.T) {
-	// Non-glob candidate that does not exist on disk, AND has no .yml fallback,
-	// should return nil. Exercises both the os.Stat miss and the fallback miss.
-	tmpDir := t.TempDir()
-	result := resolveAuthImportPaths("nonexistent-import", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
-	assert.Nil(t, result)
-}
-
-func TestResolveAuthImportPaths_GlobNoMatches(t *testing.T) {
-	// A glob that matches nothing should return nil (not error).
-	tmpDir := t.TempDir()
-	result := resolveAuthImportPaths("mixins/*", filepath.Join(tmpDir, "importer.yaml"), tmpDir)
-	assert.Nil(t, result)
-}
-
-func TestExtractImportPathString_MapAnyAny(t *testing.T) {
-	// yaml.v3 may produce map[any]any for some tag states. The extractor must
-	// handle that variant in addition to map[string]any.
-	imp := map[any]any{
-		"path":    "target",
-		"context": map[any]any{"key": "value"},
-	}
-	assert.Equal(t, "target", extractImportPathString(imp))
-}
-
-func TestExtractImportPathString_MapAnyAnyNonStringPath(t *testing.T) {
-	// map[any]any with a non-string `path` value must return empty string.
-	imp := map[any]any{
-		"path": 42,
-	}
-	assert.Empty(t, extractImportPathString(imp))
-}
-
-func TestExtractImportPathString_MapStringAnyNonStringPath(t *testing.T) {
-	// map[string]any with a non-string `path` value must return empty string.
-	imp := map[string]any{
-		"path": 42,
-	}
-	assert.Empty(t, extractImportPathString(imp))
-}
-
-func TestExtractImportPathString_EmptyString(t *testing.T) {
-	assert.Empty(t, extractImportPathString(""))
-}
+// Helper edge-case tests for resolveAuthImportPaths, extractImportPathString,
+// and loadAuthWithImports are in stack_auth_helpers_test.go (table-driven).

--- a/pkg/list/list_affected.go
+++ b/pkg/list/list_affected.go
@@ -87,16 +87,22 @@ func ExecuteListAffectedCmd(opts *AffectedCommandOptions) error {
 		return fmt.Errorf("failed to initialize config: %w", err)
 	}
 
-	// Create AuthManager from identity flag if provided.
-	// Category B: list affected operates on multiple affected components across stacks without a
-	// single target (component, stack) pair. Use the SCAN variant so stack-level defaults
-	// (including defaults declared in imported _defaults.yaml) are discovered. See
-	// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
-	authManager, err := auth.CreateAndAuthenticateManagerWithStackScan(
-		opts.IdentityName, &atmosConfig.Auth, cfg.IdentityFlagSelectValue, &atmosConfig,
-	)
-	if err != nil {
-		return err
+	// Only create auth manager when YAML functions are enabled or identity is explicitly requested.
+	// When functions are disabled (--process-functions=false), there are no YAML functions
+	// (like !terraform.state) that need auth credentials, so identity resolution is unnecessary.
+	// This matches the gating pattern used by describe stacks/affected/dependents.
+	var authManager auth.AuthManager
+	if opts.ProcessFunctions || opts.IdentityName != "" {
+		// Category B: list affected operates on multiple affected components across stacks without a
+		// single target (component, stack) pair. Use the SCAN variant so stack-level defaults
+		// (including defaults declared in imported _defaults.yaml) are discovered. See
+		// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
+		authManager, err = auth.CreateAndAuthenticateManagerWithStackScan(
+			opts.IdentityName, &atmosConfig.Auth, cfg.IdentityFlagSelectValue, &atmosConfig,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Get format flag.

--- a/pkg/list/list_affected.go
+++ b/pkg/list/list_affected.go
@@ -88,7 +88,11 @@ func ExecuteListAffectedCmd(opts *AffectedCommandOptions) error {
 	}
 
 	// Create AuthManager from identity flag if provided.
-	authManager, err := auth.CreateAndAuthenticateManagerWithAtmosConfig(
+	// Category B: list affected operates on multiple affected components across stacks without a
+	// single target (component, stack) pair. Use the SCAN variant so stack-level defaults
+	// (including defaults declared in imported _defaults.yaml) are discovered. See
+	// docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md.
+	authManager, err := auth.CreateAndAuthenticateManagerWithStackScan(
 		opts.IdentityName, &atmosConfig.Auth, cfg.IdentityFlagSelectValue, &atmosConfig,
 	)
 	if err != nil {

--- a/tests/fixtures/scenarios/auth-imported-defaults/atmos.yaml
+++ b/tests/fixtures/scenarios/auth-imported-defaults/atmos.yaml
@@ -1,0 +1,66 @@
+# Test fixture for issue #2293:
+# "auth.identities.<name>.default: true in imported stack files not recognized
+#  during identity resolution"
+#
+# This fixture reproduces the real-world Cloud Posse layout where `_defaults.yaml`
+# files are in the `excluded_paths` list (they are meant to be imported by stack
+# manifests, not processed as standalone stacks). When the default identity is
+# declared inside such an imported defaults file, the current
+# pkg/config/stack_auth_loader.go pre-scanner never sees it because:
+#
+#   1. getAllStackFiles filters out _defaults.yaml per excluded_paths.
+#   2. loadFileForAuthDefaults does a raw yaml.Unmarshal on each surviving file
+#      — it does NOT follow `import:` directives.
+#
+# Expected current (buggy) behavior:
+#   atmos auth whoami -s acme-dev  → "No default identity configured"
+#
+# Expected behavior after the fix:
+#   Same command resolves the default from the merged stack config (which DOES
+#   follow imports) and authenticates as `dev-identity`.
+
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "../../components/terraform"
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "orgs/**/us-east-1/*"
+  # _defaults.yaml files are excluded from stack processing — they are import
+  # targets, not standalone stacks. This matches the Cloud Posse reference
+  # architecture layout and is the configuration where issue #2293 manifests.
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.tenant }}-{{ .vars.stage }}"
+
+# Global auth config: two mock identities, NEITHER of them marked as default.
+# The default must come from the imported _defaults.yaml in the stack tree.
+auth:
+  providers:
+    mock-provider:
+      kind: mock/aws
+      config:
+        description: "Mock AWS provider for issue #2293 tests"
+
+  identities:
+    dev-identity:
+      kind: mock/aws
+      via:
+        provider: mock-provider
+      principal:
+        account:
+          id: "111111111111"
+
+    prod-identity:
+      kind: mock/aws
+      via:
+        provider: mock-provider
+      principal:
+        account:
+          id: "222222222222"
+
+logs:
+  level: Info

--- a/tests/fixtures/scenarios/auth-imported-defaults/stacks/orgs/acme/dev/_defaults.yaml
+++ b/tests/fixtures/scenarios/auth-imported-defaults/stacks/orgs/acme/dev/_defaults.yaml
@@ -1,0 +1,20 @@
+# Defaults file for the acme/dev environment.
+#
+# This file is listed under `stacks.excluded_paths` in atmos.yaml so it is
+# NOT processed as a standalone stack. It is only reachable via `import:` from
+# stack manifests below this directory.
+#
+# The `auth:` block here declares the default identity that every stack under
+# acme/dev/** should authenticate as. Per issue #2293, the current
+# pre-scanner in pkg/config/stack_auth_loader.go cannot see this block because
+# it never opens this file (it is filtered out by the exclude glob), and it
+# does not follow `import:` chains from the files it does open.
+
+vars:
+  tenant: acme
+  stage: dev
+
+auth:
+  identities:
+    dev-identity:
+      default: true

--- a/tests/fixtures/scenarios/auth-imported-defaults/stacks/orgs/acme/dev/us-east-1/foundation.yaml
+++ b/tests/fixtures/scenarios/auth-imported-defaults/stacks/orgs/acme/dev/us-east-1/foundation.yaml
@@ -1,0 +1,20 @@
+# Top-level stack manifest for acme-dev-ue1.
+#
+# It imports `orgs/acme/dev/_defaults.yaml` which declares the default identity.
+# After full stack processing, the merged config for this stack should contain
+# `auth.identities.dev-identity.default: true` — but the current auth
+# pre-scanner runs BEFORE this merge and does not see the imported file.
+
+import:
+  - orgs/acme/dev/_defaults
+
+vars:
+  region: us-east-1
+
+components:
+  terraform:
+    mycomponent:
+      metadata:
+        component: mock_caller_identity
+      vars:
+        enabled: true

--- a/tests/fixtures/scenarios/auth-stack-scoping/atmos.yaml
+++ b/tests/fixtures/scenarios/auth-stack-scoping/atmos.yaml
@@ -1,0 +1,69 @@
+# Test fixture for cloudposse/community discussion #122:
+# "Auth inheritance not scoping to stack"
+#
+# Scenario: a repo has many stacks across multiple tenants/OUs. ONE stack file
+# declares `auth.identities.<name>.default: true`. Currently, that single
+# declaration is picked up by the global pre-scanner in
+# pkg/config/stack_auth_loader.go and applied as THE default for every
+# subsequent `atmos terraform plan/apply` invocation — regardless of which
+# stack the user targeted.
+#
+# This is because LoadStackAuthDefaults:
+#   1. Reads every stack file in the include glob.
+#   2. Collects all `default: true` flags into a single global slice.
+#   3. Only discards them when DIFFERENT identities are flagged (the
+#      "conflict" branch). When exactly ONE stack flags a default, the
+#      `allAgree` loop sees 0 dissenting entries and the default is applied
+#      globally.
+#
+# Expected current (buggy) behavior:
+#   atmos auth whoami -s plat-staging → authenticates as `data-default`
+#   (the default declared in the unrelated data-staging monitoring stack).
+#
+# Expected behavior after the fix:
+#   Same command returns "no default identity configured" because the
+#   plat-staging stack has no auth block and should not inherit anything from
+#   the data stack.
+
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "../../components/terraform"
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "orgs/**/us-east-1/*"
+  excluded_paths: []
+  name_template: "{{ .vars.tenant }}-{{ .vars.stage }}"
+
+# Global auth config: TWO mock identities, NEITHER of them globally default.
+# Any default must come from a specific stack — and should be scoped to that
+# stack only.
+auth:
+  providers:
+    mock-provider:
+      kind: mock/aws
+      config:
+        description: "Mock AWS provider for discussion #122 tests"
+
+  identities:
+    data-default:
+      kind: mock/aws
+      via:
+        provider: mock-provider
+      principal:
+        account:
+          id: "111111111111"
+
+    plat-default:
+      kind: mock/aws
+      via:
+        provider: mock-provider
+      principal:
+        account:
+          id: "222222222222"
+
+logs:
+  level: Info

--- a/tests/fixtures/scenarios/auth-stack-scoping/stacks/orgs/acme/data/staging/us-east-1/monitoring.yaml
+++ b/tests/fixtures/scenarios/auth-stack-scoping/stacks/orgs/acme/data/staging/us-east-1/monitoring.yaml
@@ -1,0 +1,21 @@
+# data-staging monitoring stack — declares `data-default` as the default
+# identity FOR THIS STACK ONLY. Per discussion #122, that scoping is not
+# currently honored: the default leaks to every other stack in the repo.
+
+vars:
+  tenant: data
+  stage: staging
+  region: us-east-1
+
+auth:
+  identities:
+    data-default:
+      default: true
+
+components:
+  terraform:
+    monitoring:
+      metadata:
+        component: mock_caller_identity
+      vars:
+        enabled: true

--- a/tests/fixtures/scenarios/auth-stack-scoping/stacks/orgs/acme/plat/staging/us-east-1/eks.yaml
+++ b/tests/fixtures/scenarios/auth-stack-scoping/stacks/orgs/acme/plat/staging/us-east-1/eks.yaml
@@ -1,0 +1,16 @@
+# plat-staging EKS stack — has NO auth block at all. It should NOT inherit
+# anything from the data-staging monitoring stack (which is in a completely
+# unrelated OU). Per discussion #122, it currently does inherit the leak.
+
+vars:
+  tenant: plat
+  stage: staging
+  region: us-east-1
+
+components:
+  terraform:
+    eks:
+      metadata:
+        component: mock_caller_identity
+      vars:
+        enabled: true

--- a/tests/test-cases/auth-identity-resolution-bugs.yaml
+++ b/tests/test-cases/auth-identity-resolution-bugs.yaml
@@ -1,0 +1,163 @@
+# yaml-language-server: $schema=schema.json
+
+# Regression test cases for Atmos Auth identity-resolution bugs.
+# See docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md for the
+# full analysis and fix rationale.
+#
+# All fixtures use `mock/aws` providers/identities so they run end-to-end in
+# CI without real cloud credentials.
+
+tests:
+
+  # ============================================================================
+  # Issue #2293 — default identity declared in an imported _defaults.yaml is
+  # invisible to LoadStackAuthDefaults because the pre-scanner filters out
+  # _defaults.yaml via `excluded_paths` and does not follow `import:` chains.
+  # ============================================================================
+
+  - name: atmos describe component — imported default identity is visible in merged map
+    enabled: true
+    snapshot: false
+    description: >
+      CURRENT BEHAVIOR (OK): when ExecuteDescribeComponent processes a stack
+      that imports _defaults.yaml, the merged auth section correctly contains
+      `dev-identity.default: true`. The exec-layer stack processor follows
+      imports properly. This assertion guards that path so we notice if a
+      future change regresses it.
+    workdir: "fixtures/scenarios/auth-imported-defaults/"
+    command: "atmos"
+    env:
+      ATMOS_KEYRING_TYPE: "memory"
+      ATMOS_AUTH_REALM: "test-realm"
+    args:
+      - "describe"
+      - "component"
+      - "mycomponent"
+      - "-s"
+      - "acme-dev"
+      - "--identity"
+      - "off"
+      - "-q"
+      - ".auth.identities.dev-identity.default"
+    expect:
+      diff: []
+      stdout:
+        - "true"
+      exit_code: 0
+
+  # Note: there is no CLI-layer assertion that LoadStackAuthDefaults returns
+  # empty — that is a pre-scanner internal, covered by the Go unit test
+  # `TestLoadStackAuthDefaults_ExcludedDefaultsFile_BugIssue2293` in
+  # pkg/config/stack_auth_loader_test.go.
+
+  - name: atmos describe stacks — Category B scan variant surfaces the imported default identity (Issue #2293)
+    enabled: true
+    snapshot: false
+    description: >
+      Category B coverage for Issue #2293. `atmos describe stacks` uses the
+      scan variant (cmd/identity_flag.go:CreateAuthManagerFromIdentityWithStackScan)
+      which invokes pkg/config/stack_auth_loader.go:LoadStackAuthDefaults. With
+      the import-following scanner introduced in this fix, defaults declared
+      inside imported `_defaults.yaml` files are now visible even when those
+      files are listed in `stacks.excluded_paths`. Before the fix this test
+      would fail with "No default identities found in stack configs".
+
+      The assertion queries the merged stack output for the `dev-identity`
+      default flag — which is what the scan variant populates into the merged
+      config before resolving the identity name.
+    workdir: "fixtures/scenarios/auth-imported-defaults/"
+    command: "atmos"
+    env:
+      ATMOS_KEYRING_TYPE: "memory"
+      ATMOS_AUTH_REALM: "test-realm"
+    args:
+      - "describe"
+      - "stacks"
+      - "--stack"
+      - "acme-dev"
+      - "--identity"
+      - "off"
+      - "--process-functions=false"
+      - "--sections"
+      - "vars"
+    expect:
+      diff: []
+      stdout:
+        - "acme-dev"
+        - "tenant: acme"
+        - "stage: dev"
+      exit_code: 0
+
+  # ============================================================================
+  # Discussion #122 — a default identity declared in ONE stack file leaks to
+  # EVERY other stack because LoadStackAuthDefaults runs globally before the
+  # target stack is known.
+  # ============================================================================
+
+  - name: atmos describe component — data-staging correctly sees its own default identity
+    enabled: true
+    snapshot: false
+    description: >
+      CURRENT BEHAVIOR (OK): the stack that actually declares
+      `data-default.default: true` should see it as its default. This is the
+      happy path for discussion #122 — we want to verify it still works after
+      the fix.
+    workdir: "fixtures/scenarios/auth-stack-scoping/"
+    command: "atmos"
+    env:
+      ATMOS_KEYRING_TYPE: "memory"
+      ATMOS_AUTH_REALM: "test-realm"
+    args:
+      - "describe"
+      - "component"
+      - "monitoring"
+      - "-s"
+      - "data-staging"
+      - "--identity"
+      - "off"
+      - "-q"
+      - ".auth.identities.data-default.default"
+    expect:
+      diff: []
+      stdout:
+        - "true"
+      exit_code: 0
+
+  - name: atmos describe component — plat-staging has NO default in the merged config
+    enabled: true
+    snapshot: false
+    description: >
+      CURRENT BEHAVIOR (OK at the exec-layer): when the stack processor merges
+      plat-staging's config, it does NOT see the data-staging stack's auth
+      block (correctly scoped). The LEAK happens elsewhere — in the auth
+      manager's global pre-scanner. This assertion guards the correct
+      exec-layer scoping.
+    workdir: "fixtures/scenarios/auth-stack-scoping/"
+    command: "atmos"
+    env:
+      ATMOS_KEYRING_TYPE: "memory"
+      ATMOS_AUTH_REALM: "test-realm"
+    args:
+      - "describe"
+      - "component"
+      - "eks"
+      - "-s"
+      - "plat-staging"
+      - "--identity"
+      - "off"
+      - "-q"
+      - ".auth.identities"
+    expect:
+      diff: []
+      # Both identities from atmos.yaml are present. Crucially, NEITHER has
+      # `default: true` in the exec-layer merged output for this stack.
+      stdout:
+        - "data-default"
+        - "plat-default"
+      # The leak happened at a different layer (the global pre-scanner,
+      # which was exercised at auth time, not describe time). The Go unit
+      # test `TestLoadStackAuthDefaults_SingleDefaultIsReturnedGlobally`
+      # in pkg/config/auth_defaults_test.go characterizes the loader's
+      # standalone behavior; the auth flow no longer consumes it.
+      exit_code: 0
+

--- a/tests/test-cases/auth-identity-resolution-bugs.yaml
+++ b/tests/test-cases/auth-identity-resolution-bugs.yaml
@@ -50,43 +50,14 @@ tests:
   # `TestLoadStackAuthDefaults_ExcludedDefaultsFile_BugIssue2293` in
   # pkg/config/stack_auth_loader_test.go.
 
-  - name: atmos describe stacks — Category B scan variant surfaces the imported default identity (Issue #2293)
-    enabled: true
-    snapshot: false
-    description: >
-      Category B coverage for Issue #2293. `atmos describe stacks` uses the
-      scan variant (cmd/identity_flag.go:CreateAuthManagerFromIdentityWithStackScan)
-      which invokes pkg/config/stack_auth_loader.go:LoadStackAuthDefaults. With
-      the import-following scanner introduced in this fix, defaults declared
-      inside imported `_defaults.yaml` files are now visible even when those
-      files are listed in `stacks.excluded_paths`. Before the fix this test
-      would fail with "No default identities found in stack configs".
-
-      The assertion queries the merged stack output for the `dev-identity`
-      default flag — which is what the scan variant populates into the merged
-      config before resolving the identity name.
-    workdir: "fixtures/scenarios/auth-imported-defaults/"
-    command: "atmos"
-    env:
-      ATMOS_KEYRING_TYPE: "memory"
-      ATMOS_AUTH_REALM: "test-realm"
-    args:
-      - "describe"
-      - "stacks"
-      - "--stack"
-      - "acme-dev"
-      - "--identity"
-      - "off"
-      - "--process-functions=false"
-      - "--sections"
-      - "vars"
-    expect:
-      diff: []
-      stdout:
-        - "acme-dev"
-        - "tenant: acme"
-        - "stage: dev"
-      exit_code: 0
+  # Note: The Category B scan variant (CreateAndAuthenticateManagerWithStackScan) is
+  # tested at the Go unit level in pkg/auth/manager_helpers_test.go
+  # (TestCreateAndAuthenticateManagerWithStackScan_FollowsImportedDefaultFromExcludedPath)
+  # and pkg/config/stack_auth_loader_test.go
+  # (TestLoadStackAuthDefaults_FollowsImportsFromExcludedPath). A CLI-level
+  # test for the scan path would require real authentication (or a mock that
+  # exercises the full auth chain), which is out of scope for these scenario
+  # fixtures.
 
   # ============================================================================
   # Discussion #122 — a default identity declared in ONE stack file leaks to
@@ -98,10 +69,11 @@ tests:
     enabled: true
     snapshot: false
     description: >
-      CURRENT BEHAVIOR (OK): the stack that actually declares
-      `data-default.default: true` should see it as its default. This is the
-      happy path for discussion #122 — we want to verify it still works after
-      the fix.
+      Happy path for Discussion #122: the stack that actually declares
+      `data-default.default: true` should see it as its default. Auth runs
+      through the full NO-SCAN describe-component path (no --identity off)
+      so we exercise the exec-layer merged auth config end-to-end with mock
+      credentials.
     workdir: "fixtures/scenarios/auth-stack-scoping/"
     command: "atmos"
     env:
@@ -113,8 +85,7 @@ tests:
       - "monitoring"
       - "-s"
       - "data-staging"
-      - "--identity"
-      - "off"
+      - "--process-functions=false"
       - "-q"
       - ".auth.identities.data-default.default"
     expect:
@@ -123,15 +94,18 @@ tests:
         - "true"
       exit_code: 0
 
-  - name: atmos describe component — plat-staging has NO default in the merged config
+  - name: atmos describe component — plat-staging does NOT inherit data-staging default
     enabled: true
     snapshot: false
     description: >
-      CURRENT BEHAVIOR (OK at the exec-layer): when the stack processor merges
-      plat-staging's config, it does NOT see the data-staging stack's auth
-      block (correctly scoped). The LEAK happens elsewhere — in the auth
-      manager's global pre-scanner. This assertion guards the correct
-      exec-layer scoping.
+      Discussion #122 regression guard — the core non-leak assertion. Auth
+      runs through the full NO-SCAN describe-component path (no --identity
+      off) so we exercise the actual auth-manager identity resolution. Before
+      the fix, the global pre-scanner would pick up data-staging's default
+      and inject it here. After the fix, the NO-SCAN variant never consults
+      stack files on disk; it trusts the exec-layer merged config, which
+      correctly shows no default for plat-staging. The `.default` field must
+      be `null` (absent), not `true`.
     workdir: "fixtures/scenarios/auth-stack-scoping/"
     command: "atmos"
     env:
@@ -143,21 +117,14 @@ tests:
       - "eks"
       - "-s"
       - "plat-staging"
-      - "--identity"
-      - "off"
+      - "--process-functions=false"
       - "-q"
-      - ".auth.identities"
+      - ".auth.identities.data-default.default"
     expect:
       diff: []
-      # Both identities from atmos.yaml are present. Crucially, NEITHER has
-      # `default: true` in the exec-layer merged output for this stack.
+      # data-default.default must be null (not true) — proving the leak
+      # from data-staging's stack file does NOT reach plat-staging.
       stdout:
-        - "data-default"
-        - "plat-default"
-      # The leak happened at a different layer (the global pre-scanner,
-      # which was exercised at auth time, not describe time). The Go unit
-      # test `TestLoadStackAuthDefaults_SingleDefaultIsReturnedGlobally`
-      # in pkg/config/auth_defaults_test.go characterizes the loader's
-      # standalone behavior; the auth flow no longer consumes it.
+        - "null"
       exit_code: 0
 


### PR DESCRIPTION
## what

- Fixes three related bugs in Atmos Auth identity resolution without breaking any existing auth functionality.
- **Issue #2293**: Teaches the stack auth scanner to follow `import:` chains recursively, so `auth.identities.<name>.default: true` declared in an imported `_defaults.yaml` is visible to every command — including multi-stack commands like `describe stacks` / `describe affected` / `list affected`.
- **Discussion https://github.com/orgs/cloudposse/discussions/122%7C#122**: Splits the `pkg/auth` entry points into a NO-SCAN variant (for commands with a stack-scoped merged auth config) and a SCAN variant (for multi-stack commands). The split makes the cross-stack default-identity leak structurally impossible for terraform/helmfile/describe-component flows.
- **Issue 3 (component-level default override)**: When a component declares its own `auth.identities.<name>.default: true` and the global `atmos.yaml` also has a different default, the component-level default now wins cleanly instead of producing "multiple default identities" prompts.
- Keeps every previous auth fix intact, including the Approach 1 / Approach 2 design, the `allAgree` conflict-detection, the describe-affected AuthManager threading, and the MCP scoped-auth env-override flow.
- Adds two scenario fixtures (using mock AWS identities for CI), three CLI regression test cases, and extensive unit tests covering every new code path.

## why

- **Issue #2293 — imported defaults invisible**: when `auth.identities.<name>.default: true` was declared in an imported `_defaults.yaml` (especially one listed under `stacks.excluded_paths`, which is the common reference-architecture layout), the pre-scanner never saw it. Users hit "No default identity configured" on commands that should have auto-authenticated. The exec-layer merge path already handled this correctly for terraform/helmfile/describe-component, but multi-stack commands (`describe stacks`, `describe affected`, `list affected`, workflows, `aws security`/`compliance`, MCP scoped auth) all failed.
- **Discussion https://github.com/orgs/cloudposse/discussions/122%7C#122 — single stack default leaks globally**: when a single stack manifest declared `default: true`, that identity silently propagated to every other stack across all tenants. Running `atmos terraform plan eks -s plat-staging` would pick up the `data-staging` default declared in an unrelated stack file. Reported to reproduce against Atmos 1.210, 1.211, and 1.213.
- **Issue 3 — component-level default doesn't override global**: when a component in a stack config declares a different identity as `default: true` than the global `atmos.yaml` default, both defaults survived the exec-layer deep merge in `MergeComponentAuthConfig`. Users were prompted to choose between multiple defaults (interactive) or got errors (CI). This broke the expected Atmos inheritance semantics where more-specific config overrides more-general.
- **No regressions allowed**: an earlier draft removed the pre-scanner entirely. That fixed Issues 1 and 2 for `terraform *` but regressed `describe stacks`, `describe affected`, `list affected`, `list instances`, `aws security`, `aws compliance`, and workflow execution — all of which were documented in `docs/fixes/stack-level-default-auth-identity.md` as intentionally using the pre-scanner (Approach 2). This PR preserves that Approach 2 code path while fixing all three bugs, so no existing user-visible functionality is removed.

## references

- closes #2293
- design doc: `docs/fixes/2026-04-08-atmos-auth-identity-resolution-fixes.md` (full caller audit, rejected alternatives, coverage matrix)
- related: `docs/fixes/stack-level-default-auth-identity.md` (Approach 1 / Approach 2 design this PR preserves and extends)
- related: `docs/fixes/2026-02-12-auth-realm-isolation-issues.md` (Issue #2072 `allAgree` conflict-detection preserved unchanged)
- related: `docs/fixes/2026-03-25-describe-affected-auth-identity-not-used.md` (AuthManager threading through describe/list-affected preserved unchanged)
- related: `docs/fixes/2026-04-06-mcp-server-env-not-applied-to-auth-setup.md` (MCP scoped-auth flow now routes through the scan variant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Identity resolution now discovers defaults from imported stack files, prevents defaults leaking across stacks/commands, and ensures component-level defaults override global defaults.
* **Refactor**
  * Split auth manager flow into SCAN vs NO-SCAN paths and switched relevant commands to the SCAN variant for multi-stack/no-target contexts.
* **Documentation**
  * Added a detailed guide describing the identity-resolution fixes and routing.
* **Tests**
  * Added extensive unit, integration and CLI regression tests plus fixtures covering import-following, isolation, conflicts, and non-leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->