### PR TITLE
fix: Add ATMOS_CI_GITHUB_TOKEN for separate CI token override

### DIFF
--- a/pkg/ci/artifact/github/store.go
+++ b/pkg/ci/artifact/github/store.go
@@ -163,8 +163,12 @@ func NewStore(opts artifact.StoreOptions) (artifact.Backend, error) {
 }
 
 // getGitHubToken returns the GitHub token from environment variables.
+// Token precedence: ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
 func getGitHubToken() string {
-	token := os.Getenv("GITHUB_TOKEN")
+	token := os.Getenv("ATMOS_CI_GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
 	if token == "" {
 		token = os.Getenv("GH_TOKEN")
 	}

--- a/pkg/ci/artifact/github/store_test.go
+++ b/pkg/ci/artifact/github/store_test.go
@@ -471,54 +471,63 @@ func TestFillRepoFromEnv(t *testing.T) {
 func TestGetGitHubToken(t *testing.T) {
 	tests := []struct {
 		name        string
+		ciToken     string
 		githubToken string
 		ghToken     string
-		expectedLen int
-		expectEmpty bool
+		expected    string
 	}{
 		{
-			name:        "GITHUB_TOKEN set",
+			name:        "ATMOS_CI_GITHUB_TOKEN takes highest precedence",
+			ciToken:     "ci-token-value",
+			githubToken: "github-token-value",
+			ghToken:     "gh-token-value",
+			expected:    "ci-token-value",
+		},
+		{
+			name:        "ATMOS_CI_GITHUB_TOKEN alone",
+			ciToken:     "ci-token-value",
+			githubToken: "",
+			ghToken:     "",
+			expected:    "ci-token-value",
+		},
+		{
+			name:        "GITHUB_TOKEN fallback",
+			ciToken:     "",
 			githubToken: "github-token-value",
 			ghToken:     "",
-			expectEmpty: false,
+			expected:    "github-token-value",
 		},
 		{
 			name:        "GH_TOKEN fallback",
+			ciToken:     "",
 			githubToken: "",
 			ghToken:     "gh-token-value",
-			expectEmpty: false,
+			expected:    "gh-token-value",
 		},
 		{
-			name:        "GITHUB_TOKEN takes precedence",
+			name:        "GITHUB_TOKEN takes precedence over GH_TOKEN",
+			ciToken:     "",
 			githubToken: "github-token-value",
 			ghToken:     "gh-token-value",
-			expectEmpty: false,
+			expected:    "github-token-value",
 		},
 		{
 			name:        "no token",
+			ciToken:     "",
 			githubToken: "",
 			ghToken:     "",
-			expectEmpty: true,
+			expected:    "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ATMOS_CI_GITHUB_TOKEN", tt.ciToken)
 			t.Setenv("GITHUB_TOKEN", tt.githubToken)
 			t.Setenv("GH_TOKEN", tt.ghToken)
 
 			result := getGitHubToken()
-			if tt.expectEmpty {
-				assert.Empty(t, result)
-			} else {
-				assert.NotEmpty(t, result)
-				// If GITHUB_TOKEN is set, it should be returned.
-				if tt.githubToken != "" {
-					assert.Equal(t, tt.githubToken, result)
-				} else {
-					assert.Equal(t, tt.ghToken, result)
-				}
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/ci/providers/github/checks.go
+++ b/pkg/ci/providers/github/checks.go
@@ -2,7 +2,8 @@ package github
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"net/http"
 	"unicode/utf8"
 
 	"github.com/google/go-github/v59/github"
@@ -35,7 +36,35 @@ func (p *Provider) setCommitStatus(ctx context.Context, owner, repo, sha, status
 	}
 
 	status, _, err := p.client.GitHub().Repositories.CreateStatus(ctx, owner, repo, sha, repoStatus)
-	return status, err
+	if err != nil {
+		return nil, wrapGitHubAPIError(err)
+	}
+	return status, nil
+}
+
+// wrapGitHubAPIError wraps GitHub API errors with actionable hints for common
+// permission-related failures (404, 403).
+func wrapGitHubAPIError(err error) error {
+	var ghErr *github.ErrorResponse
+	if !errors.As(err, &ghErr) || ghErr.Response == nil {
+		return err
+	}
+
+	switch ghErr.Response.StatusCode {
+	case http.StatusNotFound:
+		return errUtils.Build(err).
+			WithHint("A 404 from the GitHub Status API usually means the token lacks permission to create commit statuses.").
+			WithHint("If GITHUB_TOKEN is a GitHub App token, the App must have 'Commit statuses: Read and write' permission. The workflow-level 'permissions: statuses: write' only applies to the default GITHUB_TOKEN.").
+			WithHint("Set ATMOS_CI_GITHUB_TOKEN to use a separate token for CI operations (e.g., the workflow's default token) while keeping GITHUB_TOKEN for Terraform.").
+			Err()
+	case http.StatusForbidden:
+		return errUtils.Build(err).
+			WithHint("The token does not have permission to create commit statuses on this repository.").
+			WithHint("Set ATMOS_CI_GITHUB_TOKEN to use a separate token with 'statuses: write' permission for CI operations.").
+			Err()
+	default:
+		return err
+	}
 }
 
 // createCheckRun sets a commit status on a commit.
@@ -44,7 +73,7 @@ func (p *Provider) createCheckRun(ctx context.Context, opts *provider.CreateChec
 
 	status, err := p.setCommitStatus(ctx, opts.Owner, opts.Repo, opts.SHA, opts.Name, state, opts.Title, opts.DetailsURL)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errUtils.ErrCICheckRunCreateFailed, err)
+		return nil, errUtils.Build(errUtils.ErrCICheckRunCreateFailed).WithCause(err).Err()
 	}
 
 	return &provider.CheckRun{
@@ -62,7 +91,7 @@ func (p *Provider) updateCheckRun(ctx context.Context, opts *provider.UpdateChec
 
 	status, err := p.setCommitStatus(ctx, opts.Owner, opts.Repo, opts.SHA, opts.Name, state, opts.Title, opts.DetailsURL)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errUtils.ErrCICheckRunUpdateFailed, err)
+		return nil, errUtils.Build(errUtils.ErrCICheckRunUpdateFailed).WithCause(err).Err()
 	}
 
 	return &provider.CheckRun{

--- a/pkg/ci/providers/github/checks_test.go
+++ b/pkg/ci/providers/github/checks_test.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v59/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -317,4 +319,64 @@ func TestProvider_UpdateCheckRun(t *testing.T) {
 
 		assert.Equal(t, "failure", capturedRequest["state"])
 	})
+}
+
+// newErrorServer creates a test server that returns the given HTTP status code
+// for all status API requests. Returns the server and a Provider connected to it.
+func newErrorServer(t *testing.T, statusCode int, message string) *Provider {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/statuses/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": message})
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	ghClient := github.NewClient(nil)
+	ghClient.BaseURL = serverURL
+
+	return NewProviderWithClient(&Client{client: ghClient})
+}
+
+func TestUpdateCheckRun_ErrorHints(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+		expectHint bool
+	}{
+		{"404 includes permission hint", http.StatusNotFound, "Not Found", true},
+		{"403 includes permission hint", http.StatusForbidden, "Forbidden", true},
+		{"500 has no permission hint", http.StatusInternalServerError, "Internal Server Error", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newErrorServer(t, tt.statusCode, tt.message)
+
+			_, err := p.UpdateCheckRun(context.Background(), &provider.UpdateCheckRunOptions{
+				Owner:  "owner",
+				Repo:   "repo",
+				SHA:    "abc123",
+				Name:   "atmos/plan/dev/vpc",
+				Status: provider.CheckRunStateSuccess,
+				Title:  "Done",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), strconv.Itoa(tt.statusCode))
+
+			hints := errors.GetAllHints(err)
+			allHints := strings.Join(hints, " ")
+			if tt.expectHint {
+				assert.Contains(t, allHints, "ATMOS_CI_GITHUB_TOKEN")
+			} else {
+				assert.NotContains(t, allHints, "ATMOS_CI_GITHUB_TOKEN")
+			}
+		})
+	}
 }

--- a/pkg/ci/providers/github/client.go
+++ b/pkg/ci/providers/github/client.go
@@ -19,11 +19,16 @@ type Client struct {
 }
 
 // NewClient creates a new GitHub API client.
-// It uses the GITHUB_TOKEN environment variable for authentication.
+// Token precedence: ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
+// ATMOS_CI_GITHUB_TOKEN allows using a separate token for CI operations
+// (e.g., commit statuses) while GITHUB_TOKEN is used by Terraform.
 func NewClient() (*Client, error) {
 	defer perf.Track(nil, "github.NewClient")()
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := os.Getenv("ATMOS_CI_GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
 	if token == "" {
 		// Also check GH_TOKEN (used by gh CLI).
 		token = os.Getenv("GH_TOKEN")

--- a/pkg/ci/providers/github/provider_test.go
+++ b/pkg/ci/providers/github/provider_test.go
@@ -107,7 +107,28 @@ func TestResolveGitSHA(t *testing.T) {
 }
 
 func TestProvider_EnsureClient(t *testing.T) {
+	t.Run("succeeds when ATMOS_CI_GITHUB_TOKEN is set", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "ci-token")
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "")
+		p := NewProvider()
+		err := p.ensureClient()
+		require.NoError(t, err)
+		assert.NotNil(t, p.client)
+	})
+
+	t.Run("ATMOS_CI_GITHUB_TOKEN takes precedence over GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "ci-token")
+		t.Setenv("GITHUB_TOKEN", "github-token")
+		t.Setenv("GH_TOKEN", "gh-token")
+		p := NewProvider()
+		err := p.ensureClient()
+		require.NoError(t, err)
+		assert.NotNil(t, p.client)
+	})
+
 	t.Run("succeeds when GITHUB_TOKEN is set", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
 		t.Setenv("GITHUB_TOKEN", "test-token")
 		p := NewProvider()
 		err := p.ensureClient()
@@ -116,7 +137,8 @@ func TestProvider_EnsureClient(t *testing.T) {
 	})
 
 	t.Run("succeeds when GH_TOKEN is set", func(t *testing.T) {
-		// Clear GITHUB_TOKEN to ensure GH_TOKEN fallback works.
+		// Clear higher-priority tokens to ensure GH_TOKEN fallback works.
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
 		t.Setenv("GITHUB_TOKEN", "")
 		t.Setenv("GH_TOKEN", "test-token")
 		p := NewProvider()
@@ -126,6 +148,7 @@ func TestProvider_EnsureClient(t *testing.T) {
 	})
 
 	t.Run("fails when no token is available", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
 		t.Setenv("GITHUB_TOKEN", "")
 		t.Setenv("GH_TOKEN", "")
 		p := NewProvider()

--- a/pkg/ci/providers/github/provider_test.go
+++ b/pkg/ci/providers/github/provider_test.go
@@ -1,6 +1,10 @@
 package github
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -118,13 +122,30 @@ func TestProvider_EnsureClient(t *testing.T) {
 	})
 
 	t.Run("ATMOS_CI_GITHUB_TOKEN takes precedence over GITHUB_TOKEN", func(t *testing.T) {
+		// Verify the CI token is actually used by checking the Authorization header.
+		var capturedAuth string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"login":"test"}`))
+		}))
+		defer server.Close()
+
 		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "ci-token")
 		t.Setenv("GITHUB_TOKEN", "github-token")
 		t.Setenv("GH_TOKEN", "gh-token")
 		p := NewProvider()
 		err := p.ensureClient()
 		require.NoError(t, err)
-		assert.NotNil(t, p.client)
+
+		// Point the client at our test server and make a request.
+		serverURL, err := url.Parse(server.URL + "/")
+		require.NoError(t, err)
+		p.client.GitHub().BaseURL = serverURL
+		_, _, _ = p.client.GitHub().Users.Get(context.Background(), "")
+
+		assert.Equal(t, "Bearer ci-token", capturedAuth, "should use ATMOS_CI_GITHUB_TOKEN, not GITHUB_TOKEN")
 	})
 
 	t.Run("succeeds when GITHUB_TOKEN is set", func(t *testing.T) {

--- a/website/blog/2026-04-09-ci-github-token-override.mdx
+++ b/website/blog/2026-04-09-ci-github-token-override.mdx
@@ -1,0 +1,42 @@
+---
+slug: ci-github-token-override
+title: "Separate Token for CI Commit Statuses"
+authors: [osterman]
+tags: [enhancement]
+date: 2026-04-09T00:00:00.000Z
+---
+
+Atmos now supports `ATMOS_CI_GITHUB_TOKEN` to use a dedicated token for CI operations like commit statuses, independent of the `GITHUB_TOKEN` used by Terraform.
+
+<!--truncate-->
+
+## What Changed
+
+A new environment variable `ATMOS_CI_GITHUB_TOKEN` takes the highest priority when resolving the GitHub token for CI operations. The full precedence is:
+
+```
+ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
+```
+
+When the GitHub Status API returns a 404 or 403 error, Atmos now provides actionable hints explaining the likely cause and suggesting `ATMOS_CI_GITHUB_TOKEN` as a solution.
+
+## Why This Matters
+
+Organizations commonly use a **GitHub App token** as `GITHUB_TOKEN` because Terraform needs elevated permissions (e.g., managing GitHub repositories). However, GitHub App tokens may not have `statuses: write` permission, causing CI commit status updates to fail with a cryptic 404 error.
+
+The workflow-level `permissions: statuses: write` block only applies to the **default** `GITHUB_TOKEN`, not to tokens minted by GitHub Apps. Previously, there was no way to use one token for Terraform and a different token for Atmos CI operations.
+
+## How to Use It
+
+In your GitHub Actions workflow, set `ATMOS_CI_GITHUB_TOKEN` to the workflow's default token while keeping `GITHUB_TOKEN` for Terraform:
+
+```yaml
+- name: atmos terraform plan
+  env:
+    ATMOS_CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+  run: |
+    atmos terraform plan "$COMPONENT" --stack "$STACK"
+```
+
+This follows the existing `ATMOS_CI_*` naming convention used by `ATMOS_CI_OUTPUT`, `ATMOS_CI_SUMMARY`, `ATMOS_CI_SHA`, and other CI-specific environment variables.

--- a/website/blog/2026-04-09-ci-github-token-override.mdx
+++ b/website/blog/2026-04-09-ci-github-token-override.mdx
@@ -1,34 +1,34 @@
 ---
 slug: ci-github-token-override
-title: "Separate Token for CI Commit Statuses"
+title: "Use Multiple GitHub Tokens in CI Workflows"
 authors: [osterman]
 tags: [enhancement]
 date: 2026-04-09T00:00:00.000Z
 ---
 
-Atmos now supports `ATMOS_CI_GITHUB_TOKEN` to use a dedicated token for CI operations like commit statuses, independent of the `GITHUB_TOKEN` used by Terraform.
+When you're using a GitHub App token to manage GitHub resources with Terraform, you probably still want CI commit statuses to use the workflow's own token. Now you can — just set `ATMOS_CI_GITHUB_TOKEN`.
 
 <!--truncate-->
 
 ## What Changed
 
-A new environment variable `ATMOS_CI_GITHUB_TOKEN` takes the highest priority when resolving the GitHub token for CI operations. The full precedence is:
+A new `ATMOS_CI_GITHUB_TOKEN` environment variable lets you use a separate token for Atmos CI operations (commit statuses, artifacts) while keeping `GITHUB_TOKEN` for Terraform. Token precedence:
 
 ```
 ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
 ```
 
-When the GitHub Status API returns a 404 or 403 error, Atmos now provides actionable hints explaining the likely cause and suggesting `ATMOS_CI_GITHUB_TOKEN` as a solution.
+Atmos also now gives you actionable hints when the GitHub Status API returns a 404 or 403, instead of a cryptic error with no guidance.
 
 ## Why This Matters
 
-Organizations commonly use a **GitHub App token** as `GITHUB_TOKEN` because Terraform needs elevated permissions (e.g., managing GitHub repositories). However, GitHub App tokens may not have `statuses: write` permission, causing CI commit status updates to fail with a cryptic 404 error.
+If you're Terraforming GitHub repositories, you probably mint a GitHub App token with repo management permissions and set it as `GITHUB_TOKEN`. That works great for Terraform — but that App token likely doesn't have `statuses: write` permission, so CI commit status updates fail with a mysterious 404.
 
-The workflow-level `permissions: statuses: write` block only applies to the **default** `GITHUB_TOKEN`, not to tokens minted by GitHub Apps. Previously, there was no way to use one token for Terraform and a different token for Atmos CI operations.
+You might think adding `permissions: statuses: write` to your workflow fixes it, but that only applies to the **default** workflow token — not your GitHub App token. Until now, there was no way to use both tokens concurrently: one for Terraform, one for CI.
 
 ## How to Use It
 
-In your GitHub Actions workflow, set `ATMOS_CI_GITHUB_TOKEN` to the workflow's default token while keeping `GITHUB_TOKEN` for Terraform:
+Set `ATMOS_CI_GITHUB_TOKEN` to the workflow's default token, and let `GITHUB_TOKEN` stay as your App token for Terraform:
 
 ```yaml
 - name: atmos terraform plan
@@ -39,4 +39,4 @@ In your GitHub Actions workflow, set `ATMOS_CI_GITHUB_TOKEN` to the workflow's d
     atmos terraform plan "$COMPONENT" --stack "$STACK"
 ```
 
-This follows the existing `ATMOS_CI_*` naming convention used by `ATMOS_CI_OUTPUT`, `ATMOS_CI_SUMMARY`, `ATMOS_CI_SHA`, and other CI-specific environment variables.
+Terraform uses `GITHUB_TOKEN` (the App token with repo permissions), and Atmos CI uses `ATMOS_CI_GITHUB_TOKEN` (the workflow token with `statuses: write`). Both work concurrently without conflict.

--- a/website/src/data/roadmap.js
+++ b/website/src/data/roadmap.js
@@ -392,7 +392,7 @@ export const roadmapConfig = {
       tagline: 'Native CI/CD support — local = CI',
       description:
         'CI pipelines shouldn\'t require complicated workflows, custom actions, and shell commands just to run what should be a one liner. They should just work. What works locally should work identically in CI with minimal configuration.',
-      progress: 85,
+      progress: 88,
       status: 'in-progress',
       milestones: [
         { label: 'Native GitHub OIDC enables automatic role assumptions', status: 'shipped', quarter: 'q3-2025', docs: '/cli/configuration/auth/providers', changelog: 'introducing-atmos-auth', version: 'v1.196.0', description: 'Secretless CI/CD with native OIDC—no AWS access keys stored in GitHub secrets.', category: 'featured', priority: 'high', benefits: 'No long-lived credentials to rotate. Security posture improves and audit burden decreases.' },
@@ -402,6 +402,7 @@ export const roadmapConfig = {
         { label: 'Simplified GitHub Actions with native CI mode', status: 'in-progress', quarter: 'q1-2026', pr: 1891, docs: '/integrations/github-actions/github-actions', description: 'CLI auto-detects CI environments and generates rich job summaries with resource badges, collapsible diffs, and status checks. Replaces separate actions like github-action-atmos-terraform-plan.', category: 'featured', priority: 'high', benefits: 'No wrapper scripts needed. Same command works locally and in CI. Ships with GitHub Actions support; provider architecture enables future GitLab and Azure DevOps support.' },
         { label: 'Detect deleted components in affected stacks', status: 'shipped', quarter: 'q1-2026', pr: 2063, docs: '/cli/commands/describe/affected', changelog: 'describe-affected-deleted-detection', description: 'Automatically detect components and stacks that have been deleted in the current branch compared to the target branch. Enables CI/CD pipelines to trigger terraform destroy workflows for removed infrastructure.', category: 'featured', priority: 'high', benefits: 'CI/CD pipelines can now separate apply and destroy workflows automatically. No more orphaned cloud resources from removed components.' },
         { label: 'Zero-config CI base detection for describe affected', status: 'shipped', quarter: 'q1-2026', pr: 2241, docs: '/cli/commands/describe/affected', changelog: 'describe-affected-auto-detection', description: 'Automatic base commit resolution from CI environment variables. The --base flag replaces --ref/--sha, and CI providers auto-detect the comparison point for pull requests, pushes, and merge groups.', category: 'featured', priority: 'high', benefits: 'No more shell expression gymnastics in CI workflows. Just run atmos describe affected and it does the right thing.' },
+        { label: 'Separate CI token for commit statuses (ATMOS_CI_GITHUB_TOKEN)', status: 'shipped', quarter: 'q2-2026', pr: 2304, changelog: 'ci-github-token-override', description: 'New ATMOS_CI_GITHUB_TOKEN environment variable allows using a dedicated token for CI operations (commit statuses, artifacts) while keeping GITHUB_TOKEN for Terraform. Includes actionable error hints for 404/403 permission failures.', benefits: 'Use GitHub App tokens for Terraform without breaking CI commit statuses. Clear error messages guide users to the fix.' },
       ],
       issues: [],
       prs: [


### PR DESCRIPTION
## what

- Added `ATMOS_CI_GITHUB_TOKEN` environment variable with highest priority in CI token resolution (`ATMOS_CI_GITHUB_TOKEN` > `GITHUB_TOKEN` > `GH_TOKEN`)
- Added actionable error hints when GitHub Status API returns 404 or 403, explaining token permission requirements and suggesting `ATMOS_CI_GITHUB_TOKEN`
- Switched `createCheckRun`/`updateCheckRun` error wrapping from `fmt.Errorf` to the error builder pattern to preserve hint metadata through the error chain

## why

- Users running Atmos in GitHub Actions with a GitHub App token (e.g., for Terraform managing GitHub repos) get 404 errors on commit status updates because the App token lacks `statuses: write` permission
- The workflow's default `GITHUB_TOKEN` has the right permission via the `permissions:` block, but there was no way to use a separate token for CI operations vs Terraform
- The raw 404 error gave no guidance on what went wrong or how to fix it — users with `statuses: write` in their workflow were confused why it wasn't working

## references

- Follows existing `ATMOS_CI_*` naming convention (`ATMOS_CI_OUTPUT`, `ATMOS_CI_SUMMARY`, `ATMOS_CI_SHA`, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated CI GitHub token (ATMOS_CI_GITHUB_TOKEN) with highest precedence over GITHUB_TOKEN and GH_TOKEN.

* **Bug Fixes**
  * Improved GitHub API error reporting to include actionable hints for permission/authentication failures (notably 403/404).

* **Documentation**
  * Published blog post and updated roadmap describing the new CI token and guidance.

* **Tests**
  * Expanded coverage to validate token precedence and error-hint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->