### PR TITLE
fix: Ensure terraform plan-diff processes yaml and skips init properly

### DIFF
--- a/cmd/terraform/plan_diff.go
+++ b/cmd/terraform/plan_diff.go
@@ -46,6 +46,9 @@ Example usage:
 			return err
 		}
 
+		// Parse base terraform options.
+		opts := ParseTerraformRunOptions(v)
+
 		// Get flag values from Viper
 		stack := v.GetString("stack")
 		orig := v.GetString("orig")
@@ -71,6 +74,9 @@ Example usage:
 			Stack:            stack,
 			SubCommand:       "plan-diff",
 			ComponentType:    cfg.TerraformComponentType,
+			ProcessTemplates: opts.ProcessTemplates,
+			ProcessFunctions: opts.ProcessFunctions,
+			SkipInit:         opts.SkipInit,
 		}
 
 		// Store plan file paths in AdditionalArgsAndFlags for backward compatibility


### PR DESCRIPTION
## what

- Fixes a bug where `atmos terraform plan-diff` would not properly process templates, functions, or respect the `--skip-init` flag.
- **Issue #2258**

## why

- **Issue #2258**

## references

* closes #2258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `plan-diff` command now accepts additional configuration options for controlling Terraform template processing, function execution, and initialization behavior during plan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->