### PR TITLE
Consolidate CI GitHub token resolution and document ATMOS_CI_* env vars

### DIFF
--- a/pkg/ci/artifact/github/store.go
+++ b/pkg/ci/artifact/github/store.go
@@ -19,6 +19,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/ci/artifact"
+	pkgGitHub "github.com/cloudposse/atmos/pkg/github"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
@@ -126,7 +127,7 @@ type Store struct {
 func NewStore(opts artifact.StoreOptions) (artifact.Backend, error) {
 	defer perf.Track(opts.AtmosConfig, "github.NewStore")()
 
-	token := getGitHubToken()
+	token := pkgGitHub.GetCIGitHubToken()
 	if token == "" {
 		return nil, errUtils.ErrGitHubTokenNotFound
 	}
@@ -160,19 +161,6 @@ func NewStore(opts artifact.StoreOptions) (artifact.Backend, error) {
 		prefix:        prefix,
 		retentionDays: retentionDays,
 	}, nil
-}
-
-// getGitHubToken returns the GitHub token from environment variables.
-// Token precedence: ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
-func getGitHubToken() string {
-	token := os.Getenv("ATMOS_CI_GITHUB_TOKEN")
-	if token == "" {
-		token = os.Getenv("GITHUB_TOKEN")
-	}
-	if token == "" {
-		token = os.Getenv("GH_TOKEN")
-	}
-	return token
 }
 
 // getRepoInfo extracts owner and repo from options or environment.

--- a/pkg/ci/artifact/github/store_test.go
+++ b/pkg/ci/artifact/github/store_test.go
@@ -468,74 +468,14 @@ func TestFillRepoFromEnv(t *testing.T) {
 	}
 }
 
-func TestGetGitHubToken(t *testing.T) {
-	tests := []struct {
-		name        string
-		ciToken     string
-		githubToken string
-		ghToken     string
-		expected    string
-	}{
-		{
-			name:        "ATMOS_CI_GITHUB_TOKEN takes highest precedence",
-			ciToken:     "ci-token-value",
-			githubToken: "github-token-value",
-			ghToken:     "gh-token-value",
-			expected:    "ci-token-value",
-		},
-		{
-			name:        "ATMOS_CI_GITHUB_TOKEN alone",
-			ciToken:     "ci-token-value",
-			githubToken: "",
-			ghToken:     "",
-			expected:    "ci-token-value",
-		},
-		{
-			name:        "GITHUB_TOKEN fallback",
-			ciToken:     "",
-			githubToken: "github-token-value",
-			ghToken:     "",
-			expected:    "github-token-value",
-		},
-		{
-			name:        "GH_TOKEN fallback",
-			ciToken:     "",
-			githubToken: "",
-			ghToken:     "gh-token-value",
-			expected:    "gh-token-value",
-		},
-		{
-			name:        "GITHUB_TOKEN takes precedence over GH_TOKEN",
-			ciToken:     "",
-			githubToken: "github-token-value",
-			ghToken:     "gh-token-value",
-			expected:    "github-token-value",
-		},
-		{
-			name:        "no token",
-			ciToken:     "",
-			githubToken: "",
-			ghToken:     "",
-			expected:    "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("ATMOS_CI_GITHUB_TOKEN", tt.ciToken)
-			t.Setenv("GITHUB_TOKEN", tt.githubToken)
-			t.Setenv("GH_TOKEN", tt.ghToken)
-
-			result := getGitHubToken()
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestNewStore(t *testing.T) {
 	t.Run("missing token", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
+		t.Setenv("ATMOS_GITHUB_TOKEN", "")
 		t.Setenv("GITHUB_TOKEN", "")
 		t.Setenv("GH_TOKEN", "")
+		// Override PATH to prevent gh CLI fallback from finding a token.
+		t.Setenv("PATH", t.TempDir())
 
 		_, err := NewStore(artifact.StoreOptions{
 			Options: map[string]any{

--- a/pkg/ci/providers/github/client.go
+++ b/pkg/ci/providers/github/client.go
@@ -4,12 +4,11 @@ package github
 import (
 	"context"
 	"net/http"
-	"os"
 
 	"github.com/google/go-github/v59/github"
 	"golang.org/x/oauth2"
 
-	errUtils "github.com/cloudposse/atmos/errors"
+	pkgGitHub "github.com/cloudposse/atmos/pkg/github"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
@@ -18,23 +17,14 @@ type Client struct {
 	client *github.Client
 }
 
-// NewClient creates a new GitHub API client.
-// Token precedence: ATMOS_CI_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
-// ATMOS_CI_GITHUB_TOKEN allows using a separate token for CI operations
-// (e.g., commit statuses) while GITHUB_TOKEN is used by Terraform.
+// NewClient creates a new GitHub API client using the CI token resolution chain.
+// See pkgGitHub.GetCIGitHubToken for the full detection order.
 func NewClient() (*Client, error) {
 	defer perf.Track(nil, "github.NewClient")()
 
-	token := os.Getenv("ATMOS_CI_GITHUB_TOKEN")
-	if token == "" {
-		token = os.Getenv("GITHUB_TOKEN")
-	}
-	if token == "" {
-		// Also check GH_TOKEN (used by gh CLI).
-		token = os.Getenv("GH_TOKEN")
-	}
-	if token == "" {
-		return nil, errUtils.ErrGitHubTokenNotFound
+	token, err := pkgGitHub.GetCIGitHubTokenOrError()
+	if err != nil {
+		return nil, err
 	}
 
 	return NewClientWithToken(token), nil

--- a/pkg/ci/providers/github/provider_test.go
+++ b/pkg/ci/providers/github/provider_test.go
@@ -170,8 +170,11 @@ func TestProvider_EnsureClient(t *testing.T) {
 
 	t.Run("fails when no token is available", func(t *testing.T) {
 		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
+		t.Setenv("ATMOS_GITHUB_TOKEN", "")
 		t.Setenv("GITHUB_TOKEN", "")
 		t.Setenv("GH_TOKEN", "")
+		// Override PATH to prevent gh CLI fallback from finding a token.
+		t.Setenv("PATH", t.TempDir())
 		p := NewProvider()
 		err := p.ensureClient()
 		require.Error(t, err)
@@ -207,8 +210,12 @@ func TestProvider_EnsureClient(t *testing.T) {
 func TestProvider_DetectIndependentOfToken(t *testing.T) {
 	// This is the key test: detection works without GITHUB_TOKEN.
 	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
+	t.Setenv("ATMOS_GITHUB_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
+	// Override PATH to prevent gh CLI fallback from finding a token.
+	t.Setenv("PATH", t.TempDir())
 
 	p := NewProvider()
 	assert.True(t, p.Detect(), "detection should succeed without token")
@@ -229,6 +236,8 @@ func TestProvider_DetectIndependentOfToken(t *testing.T) {
 
 func TestProvider_OutputWriter_IndependentOfToken(t *testing.T) {
 	// OutputWriter should work without a GitHub API client.
+	t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
+	t.Setenv("ATMOS_GITHUB_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
 	t.Setenv("GITHUB_OUTPUT", os.DevNull)

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -3,10 +3,12 @@ package github
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	httpClient "github.com/cloudposse/atmos/pkg/http"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
@@ -57,6 +59,39 @@ func GetGitHubTokenOrError() (string, error) {
 	if token == "" {
 		return "", ErrGitHubTokenRequired
 	}
+	return token, nil
+}
+
+// GetCIGitHubToken retrieves a GitHub token for CI operations (commit statuses, artifacts).
+// It checks ATMOS_CI_GITHUB_TOKEN first, then falls back to the standard GetGitHubToken chain.
+// This allows CI operations to use a dedicated token while Terraform uses a different one.
+//
+// Detection order:
+//  1. ATMOS_CI_GITHUB_TOKEN environment variable (CI-specific override)
+//  2. Standard GetGitHubToken chain (--github-token flag, ATMOS_GITHUB_TOKEN, GITHUB_TOKEN, gh auth token)
+//
+// Returns the token if found, or an empty string if no token is available.
+func GetCIGitHubToken() string {
+	defer perf.Track(nil, "github.GetCIGitHubToken")()
+
+	//nolint:forbidigo // Direct env lookup required for CI-specific token override.
+	if token := os.Getenv("ATMOS_CI_GITHUB_TOKEN"); token != "" {
+		return token
+	}
+
+	return GetGitHubToken()
+}
+
+// GetCIGitHubTokenOrError retrieves a CI GitHub token or returns an error if none is found.
+// Use this when authentication is required for CI operations.
+func GetCIGitHubTokenOrError() (string, error) {
+	defer perf.Track(nil, "github.GetCIGitHubTokenOrError")()
+
+	token := GetCIGitHubToken()
+	if token == "" {
+		return "", errUtils.ErrGitHubTokenNotFound
+	}
+
 	return token, nil
 }
 

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 func TestGetGitHubToken(t *testing.T) {
@@ -84,6 +86,83 @@ func TestGetGitHubTokenOrError(t *testing.T) {
 			assert.Empty(t, token)
 		} else {
 			// gh CLI returned a token.
+			assert.NotEmpty(t, token)
+		}
+	})
+}
+
+func TestGetCIGitHubToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		ciToken     string
+		atmosToken  string
+		githubToken string
+		expected    string
+	}{
+		{
+			name:        "ATMOS_CI_GITHUB_TOKEN takes highest precedence",
+			ciToken:     "ci-token-value",
+			atmosToken:  "atmos-token-value",
+			githubToken: "github-token-value",
+			expected:    "ci-token-value",
+		},
+		{
+			name:        "ATMOS_CI_GITHUB_TOKEN alone",
+			ciToken:     "ci-token-value",
+			atmosToken:  "",
+			githubToken: "",
+			expected:    "ci-token-value",
+		},
+		{
+			name:        "falls back to ATMOS_GITHUB_TOKEN",
+			ciToken:     "",
+			atmosToken:  "atmos-token-value",
+			githubToken: "github-token-value",
+			expected:    "atmos-token-value",
+		},
+		{
+			name:        "falls back to GITHUB_TOKEN",
+			ciToken:     "",
+			atmosToken:  "",
+			githubToken: "github-token-value",
+			expected:    "github-token-value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ATMOS_CI_GITHUB_TOKEN", tt.ciToken)
+			t.Setenv("ATMOS_GITHUB_TOKEN", tt.atmosToken)
+			t.Setenv("GITHUB_TOKEN", tt.githubToken)
+
+			result := GetCIGitHubToken()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetCIGitHubTokenOrError(t *testing.T) {
+	t.Run("with CI token", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "ci-test-token")
+		t.Setenv("ATMOS_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		token, err := GetCIGitHubTokenOrError()
+		assert.NoError(t, err)
+		assert.Equal(t, "ci-test-token", token)
+	})
+
+	t.Run("without token and no gh CLI", func(t *testing.T) {
+		t.Setenv("ATMOS_CI_GITHUB_TOKEN", "")
+		t.Setenv("ATMOS_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		token, err := GetCIGitHubTokenOrError()
+		// If gh CLI is installed, this will succeed.
+		if err != nil {
+			assert.ErrorIs(t, err, errUtils.ErrGitHubTokenNotFound)
+			assert.Empty(t, token)
+		} else {
 			assert.NotEmpty(t, token)
 		}
 	})

--- a/website/docs/cli/configuration/ci/index.mdx
+++ b/website/docs/cli/configuration/ci/index.mdx
@@ -113,6 +113,14 @@ Override with the `--ci` flag or `ci.enabled` configuration.
 | Variable | Description |
 |----------|-------------|
 | `ATMOS_CI` | Explicitly enable CI mode (`true`/`false`) |
+| `ATMOS_CI_GITHUB_TOKEN` | Dedicated token for CI operations (statuses, artifacts), separate from Terraform's token |
+| `ATMOS_CI_SHA` | Override commit SHA for planfile resolution and CI context |
+| `ATMOS_CI_BRANCH` | Override branch name for CI context |
+| `ATMOS_CI_REPOSITORY` | Override repository name (`owner/repo`) |
+| `ATMOS_CI_ACTOR` | Override CI actor/username |
+| `ATMOS_CI_BASE_REF` | Override base ref for diff/affected detection |
+| `ATMOS_CI_OUTPUT` | File path for CI output variables (overrides `GITHUB_OUTPUT`) |
+| `ATMOS_CI_SUMMARY` | File path for CI job summaries (overrides `GITHUB_STEP_SUMMARY`) |
 | `CI` | Standard CI environment variable (set by most CI providers) |
 | `GITHUB_ACTIONS` | Set by GitHub Actions runner |
 | `GITHUB_TOKEN` / `GH_TOKEN` | GitHub API token (required for status checks and PR comments) |

--- a/website/docs/cli/environment-variables.mdx
+++ b/website/docs/cli/environment-variables.mdx
@@ -414,6 +414,68 @@ These environment variables configure Atmos behavior and can override settings i
   </dd>
 </dl>
 
+## CI / CD
+
+<dl>
+  <dt>`ATMOS_CI`</dt>
+  <dd>
+    Explicitly enable or disable CI mode. When `true`, activates CI features such as commit statuses,
+    job summaries, and planfile storage. Auto-detected when `CI=true` or `GITHUB_ACTIONS=true` is set.
+  </dd>
+
+  <dt>`ATMOS_CI_GITHUB_TOKEN`</dt>
+  <dd>
+    Dedicated GitHub token for CI operations (commit statuses, artifact storage).
+    When set, CI operations use this token instead of `GITHUB_TOKEN`, allowing Terraform
+    to use a GitHub App token with elevated permissions while CI uses a standard token
+    with `statuses:write` scope.
+
+    **Precedence:** `ATMOS_CI_GITHUB_TOKEN` > `ATMOS_GITHUB_TOKEN` > `GITHUB_TOKEN` > `gh auth token`
+  </dd>
+
+  <dt>`ATMOS_CI_SHA`</dt>
+  <dd>
+    Override the commit SHA used for planfile resolution and CI context.
+    Falls back to `GIT_COMMIT`, `CI_COMMIT_SHA`, `COMMIT_SHA`, then git HEAD.
+  </dd>
+
+  <dt>`ATMOS_CI_BRANCH`</dt>
+  <dd>
+    Override the branch name used for CI context.
+    Falls back to `GIT_BRANCH`, `CI_COMMIT_REF_NAME`, `BRANCH_NAME`, then git detection.
+  </dd>
+
+  <dt>`ATMOS_CI_REPOSITORY`</dt>
+  <dd>
+    Override the repository name (`owner/repo`) used for CI context.
+    Falls back to `CI_PROJECT_PATH`.
+  </dd>
+
+  <dt>`ATMOS_CI_ACTOR`</dt>
+  <dd>
+    Override the CI actor/username.
+    Falls back to `CI_COMMIT_AUTHOR`, then `USER`.
+  </dd>
+
+  <dt>`ATMOS_CI_BASE_REF`</dt>
+  <dd>
+    Override the base ref for diff and affected-component detection.
+    Accepts a branch name or full commit SHA.
+  </dd>
+
+  <dt>`ATMOS_CI_OUTPUT`</dt>
+  <dd>
+    File path for CI output variables (key=value pairs).
+    On GitHub Actions, defaults to `GITHUB_OUTPUT`.
+  </dd>
+
+  <dt>`ATMOS_CI_SUMMARY`</dt>
+  <dd>
+    File path for CI job summaries (Markdown).
+    On GitHub Actions, defaults to `GITHUB_STEP_SUMMARY`.
+  </dd>
+</dl>
+
 ## AI Integration
 
 <dl>


### PR DESCRIPTION
## Summary

- Consolidate duplicate `getGitHubToken()` implementations from `pkg/ci/artifact/github/` and `pkg/ci/providers/github/` into a single `GetCIGitHubToken()` in `pkg/github/token.go`
- The new function checks `ATMOS_CI_GITHUB_TOKEN` first, then delegates to the existing `GetGitHubToken()` chain (`ATMOS_GITHUB_TOKEN` > `GITHUB_TOKEN` > `gh auth token`)
- Document all 9 `ATMOS_CI_*` environment variables in the global env var reference and CI configuration page

## What

**Code**: Two identical private token functions existed in separate CI packages. Both are replaced by a single exported function in the shared `pkg/github/` package, eliminating duplication and ensuring consistent token precedence across all CI operations.

**Docs**: `ATMOS_CI_GITHUB_TOKEN`, `ATMOS_CI_SHA`, `ATMOS_CI_BRANCH`, `ATMOS_CI_REPOSITORY`, `ATMOS_CI_ACTOR`, `ATMOS_CI_BASE_REF`, `ATMOS_CI_OUTPUT`, `ATMOS_CI_SUMMARY`, and `ATMOS_CI` were all undocumented in the environment variables reference.

## Why

Follow-up to #2304 which introduced `ATMOS_CI_GITHUB_TOKEN` but placed the token resolution logic in a package-private function buried inside the artifact store. The CI provider had its own identical copy. Neither was documented.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./pkg/github/... ./pkg/ci/...` all pass
- [x] `cd website && npm run build` succeeds
- [x] No remaining duplicate token logic in `pkg/ci/` (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ATMOS_CI_GITHUB_TOKEN` for dedicated CI authentication separate from Terraform operations.
  * Introduced CI environment variables to override commit context: branch, SHA, repository, actor, and base reference.
  * Custom output path configuration via `ATMOS_CI_OUTPUT` and `ATMOS_CI_SUMMARY` for CI workflows.

* **Documentation**
  * Documented new CI/CD environment variables with full precedence and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->