### PR TITLE
fix: Replace symlink strategy with plain directory for SAML browser storage

### DIFF
--- a/docs/fixes/2026-04-10-auth-windows-path-issues.md
+++ b/docs/fixes/2026-04-10-auth-windows-path-issues.md
@@ -1,0 +1,319 @@
+# Fix: Atmos Auth path issues on Windows
+
+**Date:** 2026-04-10
+
+**Issues:**
+
+- SAML browser storage state fails to save on Windows due to mixed path
+  separators (`C:\Users\user/.aws/saml2aws/storageState.json`)
+- Storage strategy should prefer XDG paths directly instead of symlink
+  workarounds that break on Windows
+
+## Status
+
+**Fixed.** Both issues share the same root cause: `saml2aws` hardcodes the
+storage path with `fmt.Sprintf` and forward slashes. The fix replaces the
+symlink strategy with a plain `os.MkdirAll` for the directory `saml2aws`
+expects.
+
+### Progress checklist
+
+- [x] Root-cause analysis.
+- [x] Chose approach: create `~/.aws/saml2aws/` as a real directory on
+  all platforms. Drop the symlink strategy entirely.
+- [x] Rewrite `setupBrowserStorageDir` to use `os.MkdirAll`.
+- [x] Remove dead symlink code: `ensureStorageSymlink`,
+  `isCorrectSymlink`, `stageExistingPath`, `restoreStagedPath`.
+- [x] Update tests — removed all symlink-dependent tests, added
+  cross-platform directory-creation tests (idempotent, preserves
+  existing state, handles `.aws` as file, verifies not-a-symlink).
+  `setupBrowserStorageDir` at 88.9% (only `homedir.Dir()` error
+  path uncovered). `setupBrowserAutomation` at 100%.
+- [ ] Full regression suite passes.
+
+---
+
+## Issue 1 — SAML browser storage state path broken on Windows
+
+### Problem
+
+After successful SAML authentication on Windows, `saml2aws` fails to save the
+browser storage state file with the error:
+
+```text
+Error saving storage stateopen C:\\Users\\user/.aws/saml2aws/storageState.json:
+The system cannot find the path specified.
+```
+
+Authentication itself succeeds (credentials are obtained), but the storage
+state (which enables session reuse for subsequent logins) is lost. The next
+`atmos auth login` requires a full interactive browser flow instead of
+reusing the saved session.
+
+### Root Cause
+
+**Upstream bug in saml2aws** (`github.com/versent/saml2aws/v2`).
+
+In `pkg/provider/browser/browser.go:118`, `saml2aws` constructs the storage
+state path using `fmt.Sprintf` with hardcoded forward slashes:
+
+```go
+userHomeDir, err := os.UserHomeDir()
+storageStatePath := fmt.Sprintf("%s/.aws/saml2aws/storageState.json", userHomeDir)
+```
+
+On Windows, `os.UserHomeDir()` returns a path with backslashes
+(`C:\Users\user`), and the format string appends `/.aws/saml2aws/...`
+with forward slashes. The resulting mixed-separator path
+`C:\Users\user/.aws/saml2aws/storageState.json` cannot be resolved by
+the Windows filesystem.
+
+### Why the current symlink workaround doesn't help
+
+Atmos creates `~/.aws/saml2aws` as a symlink to an XDG-compliant cache
+directory via `setupBrowserStorageDir()`. This symlink is created using
+`filepath.Join` (correct backslashes on Windows). However:
+
+1. On Windows, `os.Symlink` requires Developer Mode or admin privileges.
+   Without these, the symlink creation fails silently (our staging code
+   restores the original directory).
+2. Even if the symlink is created, `saml2aws's` mixed-separator path
+   construction means the OS receives a path it cannot parse — the
+   symlink is never reached.
+
+### Fix options
+
+**Option A — Create a plain directory instead of symlink on Windows.**
+
+On Windows, skip the symlink strategy entirely and create
+`%USERPROFILE%\.aws\saml2aws` as a regular directory. This ensures:
+
+- The directory exists at the path `saml2aws` will look for.
+- No symlink privilege requirements.
+- `saml2aws's` forward-slash path still works because Windows `os.Stat`
+  and file operations DO accept forward slashes in some contexts — the
+  issue is specifically with the mixed-separator path through a parent
+  directory that uses backslashes.
+
+Actually, the real question is: does `os.OpenFile` on Windows accept
+`C:\Users\user/.aws/saml2aws/storageState.json`? Testing shows that Go's
+`os` package normalizes forward slashes on Windows for basic file
+operations. The issue may be specifically with Playwright's `StorageState`
+method which may use native Windows APIs that don't normalize.
+
+**Option B — Ensure the directory exists at both path variants.**
+
+Create `%USERPROFILE%\.aws\saml2aws\` using `filepath.Join` (backslashes)
+AND verify the directory exists. Since Go's `os.MkdirAll` normalizes
+paths, the directory should be accessible regardless of separator style.
+The key insight is that the directory must exist as a real directory (not
+a symlink) for `saml2aws's` mixed-separator path to resolve.
+
+**Option C — Patch saml2aws upstream.**
+
+Submit a PR to `github.com/versent/saml2aws` to use `filepath.Join`
+instead of `fmt.Sprintf`. This is the correct long-term fix but doesn't
+help users on current versions.
+
+### Recommended approach
+
+**Option B for immediate fix + Option C for upstream.** On Windows:
+
+- Skip the symlink strategy in `setupBrowserStorageDir`.
+- Create `%USERPROFILE%\.aws\saml2aws\` as a regular directory using
+  `os.MkdirAll(filepath.Join(homeDir, ".aws", "saml2aws"), 0o700)`.
+- The XDG-compliant cache location is still used on Linux/macOS where
+  symlinks work reliably.
+- File an upstream PR against `saml2aws` for the `filepath.Join` fix.
+
+---
+
+## Issue 2 — Storage strategy should use XDG paths directly, not symlinks
+
+### Problem
+
+The current `setupBrowserStorageDir` creates an XDG-compliant cache
+directory (`~/.cache/atmos/aws-saml/<provider>`) and then symlinks
+`~/.aws/saml2aws` to it. This is an indirect workaround for `saml2aws's`
+hardcoded `~/.aws/saml2aws/storageState.json` path.
+
+This symlink strategy is problematic:
+
+1. **Windows:** `os.Symlink` requires Developer Mode or admin privileges.
+   Most users don't have this. The staging/restore code handles the failure
+   gracefully, but the result is that the storage directory doesn't exist
+   at the path `saml2aws` expects → storage state is lost every session.
+
+2. **Conceptual layering:** the symlink exists only to satisfy `saml2aws's`
+   hardcoded path. Atmos should own its own storage locations (XDG) and
+   work around `saml2aws's` limitations at the integration boundary — not by
+   mutating the user's `~/.aws` directory with symlinks.
+
+3. **Multi-provider conflicts:** the symlink points to ONE provider's
+   directory. If a user has multiple SAML providers, the symlink gets
+   replaced on each `atmos auth login`, losing the previous provider's
+   storage state.
+
+### Why we can't use XDG for saml2aws storage
+
+XDG itself works fine on all platforms — `pkg/xdg` resolves to proper
+paths like `%LOCALAPPDATA%\atmos\aws-saml\` on Windows. The problem is
+that **saml2aws doesn't expose a configurable storage path**. The path
+`~/.aws/saml2aws/storageState.json` is hardcoded in
+`pkg/provider/browser/browser.go:118` with no way to override it.
+
+The symlink strategy was an attempt to redirect `saml2aws's` hardcoded
+path to an XDG-compliant location, but symlinks require elevated
+privileges on Windows and the mixed-separator path construction in
+`saml2aws` breaks even when the symlink exists.
+
+XDG remains the right choice for **Atmos-owned data** (Playwright driver
+cache detection, config, etc.) — it just can't be used for `saml2aws's`
+storage state until upstream supports a configurable path.
+
+### Recommended approach
+
+**On all platforms:**
+
+1. **Create `~/.aws/saml2aws/` as a real directory** (not a symlink).
+   This is the path `saml2aws` hardcodes. `os.MkdirAll` works on all
+   platforms without privilege requirements.
+
+2. **Drop the symlink strategy entirely.** Remove `ensureStorageSymlink`,
+   `isCorrectSymlink`, `stageExistingPath`, and `restoreStagedPath`.
+
+3. **Accept that saml2aws owns `storageState.json`** — the filename and
+   location are not ours to control. Multi-provider state sharing is an
+   upstream limitation.
+
+4. **Long-term: upstream PR** to `saml2aws` to:
+  - Use `filepath.Join` instead of `fmt.Sprintf` (fixes Windows).
+  - Accept a configurable storage path (enables XDG integration).
+
+### Implementation
+
+Rewrite `setupBrowserStorageDir` to:
+
+```go
+func (p *samlProvider) setupBrowserStorageDir() error {
+  homeDir, err := homedir.Dir()
+  if err != nil {
+    return fmt.Errorf("failed to get user home directory: %w", err)
+  }
+}
+
+// Create ~/.aws/saml2aws/ as a real directory.
+// saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
+  saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+  if err := os.MkdirAll(saml2awsDir, 0o700); err != nil {
+      return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
+  }
+
+  return nil
+}
+```
+
+Remove `ensureStorageSymlink`, `isCorrectSymlink`, `stageExistingPath`,
+and `restoreStagedPath` — they become dead code.
+
+---
+
+## End-to-end auth flow analysis: storageState.json vs AWS credentials
+
+### Two separate storage systems
+
+Atmos Auth uses two independent storage mechanisms. The Windows path
+issue only affects one of them.
+
+**1. AWS credentials (NOT affected by the Windows path issue)**
+
+```text
+atmos auth login
+  → saml2aws browser login (Playwright opens browser, user authenticates)
+  → saml2aws returns SAML assertion (base64-encoded XML)
+  → Atmos calls AWS STS AssumeRoleWithSAML
+    → returns AccessKeyID, SecretAccessKey, SessionToken, Expiration
+  → PostAuthenticate() writes credentials to INI files:
+      ~/.config/atmos/aws/{provider}/credentials
+      (uses filepath.Join — correct separators on all platforms)
+  → Credentials also stored in keyring (system keyring or file-based)
+```
+
+All credential paths use `filepath.Join` and Go's `os` package, which
+normalizes separators on Windows. This pipeline works correctly on all
+platforms.
+
+**2. Playwright browser session state (AFFECTED by the Windows path issue)**
+
+```text
+saml2aws browser provider (after authentication completes):
+  → context.StorageState(storageStatePath)
+    → storageStatePath = fmt.Sprintf("%s/.aws/saml2aws/storageState.json", userHomeDir)
+    → on Windows: "C:\Users\user/.aws/saml2aws/storageState.json" (mixed separators)
+    → Windows cannot resolve this path → save fails
+    → error logged: "Error saving storage state"
+```
+
+`storageState.json` contains Playwright browser session data (cookies,
+localStorage). It is used exclusively for **browser session reuse** — so
+the next `atmos auth login` can skip the interactive browser flow by
+replaying saved cookies/session.
+
+### Impact assessment
+
+| What                                       | Affected? | Why                                                                              |
+|--------------------------------------------|-----------|----------------------------------------------------------------------------------|
+| `atmos auth login` (authentication itself) | No        | SAML assertion and STS call succeed regardless of storageState.json              |
+| `atmos terraform plan/apply`               | No        | Reads credentials from INI files via `AWS_SHARED_CREDENTIALS_FILE` env var       |
+| `atmos describe stacks`                    | No        | Uses credentials from INI files / keyring via AuthManager                        |
+| `atmos auth whoami`                        | No        | Reads credential metadata from keyring / INI files                               |
+| Browser session reuse on next login        | **Yes**   | Without saved storageState.json, user must re-authenticate in browser every time |
+
+### How `atmos terraform plan` uses stored credentials
+
+When a user runs `atmos terraform plan -s my-stack`:
+
+1. `TerraformPreHook()` (`pkg/auth/hooks.go`) decodes the stack's auth
+   config and creates an AuthManager.
+2. The AuthManager loads previously stored credentials from:
+  - INI files: `~/.config/atmos/aws/{provider}/credentials`
+  - Keyring: system keyring or file-based fallback
+3. `PrepareShellEnvironment()` returns environment variables:
+  - `AWS_SHARED_CREDENTIALS_FILE` → path to the INI credentials file
+  - `AWS_CONFIG_FILE` → path to the INI config file
+  - `AWS_PROFILE` → identity name as profile section
+  - `AWS_SDK_LOAD_CONFIG=1` / `AWS_EC2_METADATA_DISABLED=true`
+4. These env vars are passed to terraform's subprocess. Terraform reads
+   credentials via standard AWS SDK env vars pointing to Atmos-managed
+   INI files — NOT via `AWS_ACCESS_KEY_ID` directly.
+
+### Why our fix is correct
+
+The `setupBrowserStorageDir` fix (creating `~/.aws/saml2aws/` as a real
+directory via `os.MkdirAll`) ensures the directory exists at the path
+`saml2aws` expects. Go's `os.MkdirAll` normalizes forward slashes on
+Windows, so the directory creation succeeds. When `saml2aws` later writes
+`storageState.json` using its mixed-separator path, Go's `os` package
+handles the normalization internally — so the file write also succeeds.
+
+The credential storage pipeline (`PostAuthenticate` → INI files →
+`TerraformPreHook`) uses `filepath.Join` throughout and is unaffected
+by this fix. It already works correctly on Windows.
+
+---
+
+## Related
+
+- `docs/prd/saml-browser-driver-integration.md` — SAML browser driver
+  integration PRD (covers Playwright driver download, XDG storage, and
+  the original symlink strategy).
+- `saml-driver-install` branch / PR #1747 — the branch where the symlink
+  strategy was originally implemented.
+- `pkg/auth/providers/aws/saml.go:setupBrowserStorageDir` — the function
+  that now creates a plain directory (was previously a symlink).
+- `pkg/auth/providers/aws/saml.go:Authenticate` — the SAML auth entry
+  point that calls `setupBrowserAutomation` → `setupBrowserStorageDir`.
+- `pkg/auth/cloud/aws/files.go:WriteCredentials` — writes AWS
+  credentials to INI files (uses `filepath.Join` — correct on Windows).
+- `pkg/auth/hooks.go:TerraformPreHook` — sets up env vars for terraform
+  subprocess from stored credentials.

--- a/docs/fixes/2026-04-10-auth-windows-path-issues.md
+++ b/docs/fixes/2026-04-10-auth-windows-path-issues.md
@@ -65,8 +65,10 @@ storageStatePath := fmt.Sprintf("%s/.aws/saml2aws/storageState.json", userHomeDi
 On Windows, `os.UserHomeDir()` returns a path with backslashes
 (`C:\Users\user`), and the format string appends `/.aws/saml2aws/...`
 with forward slashes. The resulting mixed-separator path
-`C:\Users\user/.aws/saml2aws/storageState.json` cannot be resolved by
-the Windows filesystem.
+`C:\Users\user/.aws/saml2aws/storageState.json` fails when the
+intermediate directories do not exist — Go's `os` package normalizes
+the separators internally, but `os.Create` cannot create parent
+directories that are missing.
 
 ### Why the current symlink workaround doesn't help
 
@@ -76,10 +78,10 @@ directory via `setupBrowserStorageDir()`. This symlink is created using
 
 1. On Windows, `os.Symlink` requires Developer Mode or admin privileges.
    Without these, the symlink creation fails silently (our staging code
-   restores the original directory).
-2. Even if the symlink is created, `saml2aws's` mixed-separator path
-   construction means the OS receives a path it cannot parse — the
-   symlink is never reached.
+   restores the original directory — but if there was no original
+   directory, the path is simply absent).
+2. The directory does not exist at the path saml2aws expects, so the
+   file write fails with "The system cannot find the path specified."
 
 ### Fix options
 
@@ -88,18 +90,15 @@ directory via `setupBrowserStorageDir()`. This symlink is created using
 On Windows, skip the symlink strategy entirely and create
 `%USERPROFILE%\.aws\saml2aws` as a regular directory. This ensures:
 
-- The directory exists at the path `saml2aws` will look for.
+- The directory exists at the path saml2aws will look for.
 - No symlink privilege requirements.
-- `saml2aws's` forward-slash path still works because Windows `os.Stat`
-  and file operations DO accept forward slashes in some contexts — the
-  issue is specifically with the mixed-separator path through a parent
-  directory that uses backslashes.
 
-Actually, the real question is: does `os.OpenFile` on Windows accept
-`C:\Users\user/.aws/saml2aws/storageState.json`? Testing shows that Go's
-`os` package normalizes forward slashes on Windows for basic file
-operations. The issue may be specifically with Playwright's `StorageState`
-method which may use native Windows APIs that don't normalize.
+The user's error log confirms the root cause is a missing directory, not
+a path separator issue: `"The system cannot find the path specified."`
+The symlink creation failed (no Developer Mode), so the directory didn't
+exist at all. Go's `os` package normalizes forward slashes to backslashes
+on Windows internally (via `syscall.UTF16PtrFromString`), so once the
+directory exists, the mixed-separator path resolves correctly.
 
 **Option B — Ensure the directory exists at both path variants.**
 
@@ -117,14 +116,15 @@ help users on current versions.
 
 ### Recommended approach
 
-**Option B for immediate fix + Option C for upstream.** On Windows:
+**Option A on all platforms + Option C for upstream.**
 
-- Skip the symlink strategy in `setupBrowserStorageDir`.
-- Create `%USERPROFILE%\.aws\saml2aws\` as a regular directory using
+- Drop the symlink strategy on ALL platforms (not just Windows). The
+  symlink added complexity for no user-visible benefit since saml2aws
+  ignores the XDG path regardless.
+- Create `~/.aws/saml2aws/` as a regular directory using
   `os.MkdirAll(filepath.Join(homeDir, ".aws", "saml2aws"), 0o700)`.
-- The XDG-compliant cache location is still used on Linux/macOS where
-  symlinks work reliably.
-- File an upstream PR against `saml2aws` for the `filepath.Join` fix.
+- File an upstream PR against saml2aws for the `filepath.Join` fix and
+  configurable storage path.
 
 ---
 
@@ -250,8 +250,9 @@ saml2aws browser provider (after authentication completes):
   → context.StorageState(storageStatePath)
     → storageStatePath = fmt.Sprintf("%s/.aws/saml2aws/storageState.json", userHomeDir)
     → on Windows: "C:\Users\user/.aws/saml2aws/storageState.json" (mixed separators)
-    → Windows cannot resolve this path → save fails
-    → error logged: "Error saving storage state"
+    → Go normalizes the separators internally, but the directory must exist
+    → if ~/.aws/saml2aws/ is missing (symlink creation failed) → save fails
+    → error logged: "Error saving storage state... The system cannot find the path specified."
 ```
 
 `storageState.json` contains Playwright browser session data (cookies,
@@ -291,10 +292,13 @@ When a user runs `atmos terraform plan -s my-stack`:
 
 The `setupBrowserStorageDir` fix (creating `~/.aws/saml2aws/` as a real
 directory via `os.MkdirAll`) ensures the directory exists at the path
-`saml2aws` expects. Go's `os.MkdirAll` normalizes forward slashes on
-Windows, so the directory creation succeeds. When `saml2aws` later writes
-`storageState.json` using its mixed-separator path, Go's `os` package
-handles the normalization internally — so the file write also succeeds.
+saml2aws expects. The user's error log confirmed the failure was "The
+system cannot find the path specified" — meaning the directory was missing
+(symlink creation had failed silently), not that Go couldn't parse the
+mixed separators. Go's `os` package normalizes forward slashes on Windows
+internally (via `syscall.UTF16PtrFromString`), so once the directory
+exists, saml2aws's mixed-separator path resolves correctly for both
+reading and writing `storageState.json`.
 
 The credential storage pipeline (`PostAuthenticate` → INI files →
 `TerraformPreHook`) uses `filepath.Join` throughout and is unaffected

--- a/docs/fixes/2026-04-10-auth-windows-path-issues.md
+++ b/docs/fixes/2026-04-10-auth-windows-path-issues.md
@@ -4,10 +4,10 @@
 
 **Issues:**
 
-- SAML browser storage state fails to save on Windows due to mixed path
-  separators (`C:\Users\user/.aws/saml2aws/storageState.json`)
-- Storage strategy should prefer XDG paths directly instead of symlink
-  workarounds that break on Windows
+- SAML browser storage state fails to save on Windows — the directory
+  at `~/.aws/saml2aws/` is missing because the previous symlink-based
+  strategy requires privileges most Windows users don't have
+- Replace symlink strategy with plain directory creation on all platforms
 
 ## Status
 
@@ -128,13 +128,13 @@ help users on current versions.
 
 ---
 
-## Issue 2 — Storage strategy should use XDG paths directly, not symlinks
+## Issue 2 — Replace symlink strategy with plain directory creation
 
 ### Problem
 
-The current `setupBrowserStorageDir` creates an XDG-compliant cache
-directory (`~/.cache/atmos/aws-saml/<provider>`) and then symlinks
-`~/.aws/saml2aws` to it. This is an indirect workaround for `saml2aws's`
+The previous `setupBrowserStorageDir` created an XDG-compliant cache
+directory (`~/.cache/atmos/aws-saml/<provider>`) and then symlinked
+`~/.aws/saml2aws` to it. This was an indirect workaround for saml2aws's
 hardcoded `~/.aws/saml2aws/storageState.json` path.
 
 This symlink strategy is problematic:
@@ -196,20 +196,19 @@ Rewrite `setupBrowserStorageDir` to:
 
 ```go
 func (p *samlProvider) setupBrowserStorageDir() error {
-  homeDir, err := homedir.Dir()
-  if err != nil {
-    return fmt.Errorf("failed to get user home directory: %w", err)
-  }
-}
+    homeDir, err := homedir.Dir()
+    if err != nil {
+        return fmt.Errorf("failed to get user home directory: %w", err)
+    }
 
-// Create ~/.aws/saml2aws/ as a real directory.
-// saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
-  saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
-  if err := os.MkdirAll(saml2awsDir, 0o700); err != nil {
-      return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
-  }
+    // Create ~/.aws/saml2aws/ as a real directory.
+    // saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
+    saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+    if err := os.MkdirAll(saml2awsDir, 0o700); err != nil {
+        return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
+    }
 
-  return nil
+    return nil
 }
 ```
 

--- a/docs/fixes/2026-04-10-auth-windows-path-issues.md
+++ b/docs/fixes/2026-04-10-auth-windows-path-issues.md
@@ -24,9 +24,12 @@ expects.
 - [x] Rewrite `setupBrowserStorageDir` to use `os.MkdirAll`.
 - [x] Remove dead symlink code: `ensureStorageSymlink`,
   `isCorrectSymlink`, `stageExistingPath`, `restoreStagedPath`.
-- [x] Update tests — removed all symlink-dependent tests, added
+- [x] Update tests — removed symlink-strategy tests (ensureStorageSymlink,
+  isCorrectSymlink, stageExistingPath, restoreStagedPath). Added
   cross-platform directory-creation tests (idempotent, preserves
   existing state, handles `.aws` as file, verifies not-a-symlink).
+  Retained legacy-symlink migration tests (with and without existing
+  storageState.json) to cover the upgrade path.
   `setupBrowserStorageDir` at 88.9% (only `homedir.Dir()` error
   path uncovered). `setupBrowserAutomation` at 100%.
 - [ ] Full regression suite passes.
@@ -198,14 +201,17 @@ Rewrite `setupBrowserStorageDir` to:
 func (p *samlProvider) setupBrowserStorageDir() error {
     homeDir, err := homedir.Dir()
     if err != nil {
-        return fmt.Errorf("failed to get user home directory: %w", err)
+        return fmt.Errorf("%w: user home directory: %w", errUtils.ErrCreateDirectory, err)
     }
 
-    // Create ~/.aws/saml2aws/ as a real directory.
-    // saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
     saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+
+    // Migrate legacy symlink left by previous Atmos versions.
+    // os.MkdirAll would leave a stale symlink in place.
+    p.migrateLegacySymlink(saml2awsDir)
+
     if err := os.MkdirAll(saml2awsDir, 0o700); err != nil {
-        return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
+        return fmt.Errorf("%w: %s: %w", errUtils.ErrCreateDirectory, saml2awsDir, err)
     }
 
     return nil

--- a/pkg/auth/providers/aws/saml.go
+++ b/pkg/auth/providers/aws/saml.go
@@ -734,15 +734,10 @@ func (p *samlProvider) setupBrowserStorageDir() error {
 	// saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
 	saml2awsDir := filepath.Join(homeDir, awsDir, saml2awsSubdir)
 
-	// Remove legacy symlink left by previous Atmos versions. os.MkdirAll
+	// Migrate legacy symlink left by previous Atmos versions. os.MkdirAll
 	// would leave a stale symlink in place, so upgraded users would never
 	// receive the plain-directory migration.
-	if info, lstatErr := os.Lstat(saml2awsDir); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
-		log.Debug("Removing legacy saml2aws symlink", "path", saml2awsDir)
-		if removeErr := os.Remove(saml2awsDir); removeErr != nil {
-			return fmt.Errorf("%w: remove legacy saml2aws symlink: %w", errUtils.ErrCreateDirectory, removeErr)
-		}
-	}
+	p.migrateLegacySymlink(saml2awsDir)
 
 	if err := os.MkdirAll(saml2awsDir, samlStorageDirPerms); err != nil {
 		return fmt.Errorf("%w: %s: %w", errUtils.ErrCreateDirectory, saml2awsDir, err)
@@ -750,6 +745,59 @@ func (p *samlProvider) setupBrowserStorageDir() error {
 
 	log.Debug("Browser storage directory ready", "path", saml2awsDir)
 	return nil
+}
+
+// migrateLegacySymlink removes a legacy symlink at path and preserves any
+// existing storageState.json from the symlink target. This handles upgrades
+// from Atmos versions that used a symlink-based storage strategy.
+func (p *samlProvider) migrateLegacySymlink(path string) {
+	const (
+		storageStateFile   = "storageState.json"
+		migrationDirPerms  = 0o700
+		migrationFilePerms = 0o600
+	)
+
+	info, lstatErr := os.Lstat(path)
+	if lstatErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		return // Not a symlink — nothing to migrate.
+	}
+
+	// Read the symlink target to check for existing state before removing.
+	target, readErr := os.Readlink(path)
+	if readErr != nil {
+		log.Debug("Cannot read legacy symlink target, removing anyway", "path", path, "error", readErr)
+	}
+
+	// Check for existing storageState.json in the symlink target.
+	var stateData []byte
+	if target != "" {
+		statePath := filepath.Join(target, storageStateFile)
+		if data, readFileErr := os.ReadFile(statePath); readFileErr == nil {
+			stateData = data
+			log.Debug("Preserving browser state from legacy symlink target", "source", statePath)
+		}
+	}
+
+	// Remove the symlink.
+	log.Debug("Removing legacy saml2aws symlink", "path", path)
+	if removeErr := os.Remove(path); removeErr != nil {
+		log.Warn("Failed to remove legacy saml2aws symlink", "path", path, "error", removeErr)
+		return
+	}
+
+	// Restore storageState.json into the new real directory.
+	if len(stateData) > 0 {
+		if mkdirErr := os.MkdirAll(path, migrationDirPerms); mkdirErr != nil {
+			log.Warn("Failed to create directory for state migration", "path", path, "error", mkdirErr)
+			return
+		}
+		destPath := filepath.Join(path, storageStateFile)
+		if writeErr := os.WriteFile(destPath, stateData, migrationFilePerms); writeErr != nil {
+			log.Warn("Failed to migrate storageState.json", "dest", destPath, "error", writeErr)
+		} else {
+			log.Debug("Migrated storageState.json from legacy symlink", "dest", destPath)
+		}
+	}
 }
 
 // Logout removes provider-specific credential storage.

--- a/pkg/auth/providers/aws/saml.go
+++ b/pkg/auth/providers/aws/saml.go
@@ -705,118 +705,40 @@ func (p *samlProvider) validateBrowserExecutable() error {
 	return nil
 }
 
-// setupBrowserStorageDir creates an XDG-compliant directory for SAML browser storage state.
-// Saml2aws hardcodes ~/.aws/saml2aws/storageState.json, so we create ~/.aws/saml2aws
-// as a symlink to ~/.cache/atmos/aws-saml/<provider-name> to respect XDG conventions.
+// setupBrowserStorageDir ensures the directory that saml2aws uses for browser
+// storage state exists. The path is hardcoded upstream as
+// `~/.aws/saml2aws/storageState.json` (using fmt.Sprintf with forward slashes,
+// which produces mixed-separator paths on Windows). We cannot redirect this
+// path to an XDG location because saml2aws does not expose a configurable
+// storage path.
+//
+// The fix: create `~/.aws/saml2aws/` as a plain directory using filepath.Join
+// (correct separators on all platforms) and os.MkdirAll (no privilege
+// requirements). This replaces the previous symlink strategy which broke on
+// Windows due to symlink privilege requirements and mixed path separators.
+//
+// See docs/fixes/2026-04-10-auth-windows-path-issues.md for the full analysis.
 func (p *samlProvider) setupBrowserStorageDir() error {
 	const (
-		samlStorageSubdir   = "aws-saml"
 		samlStorageDirPerms = 0o700
 		awsDir              = ".aws"
 		saml2awsSubdir      = "saml2aws"
 	)
 
-	// Get XDG cache directory for SAML storage.
-	xdgCacheDir, err := xdg.GetXDGCacheDir(samlStorageSubdir, samlStorageDirPerms)
-	if err != nil {
-		return fmt.Errorf("failed to get XDG cache directory: %w", err)
-	}
-
-	// Create provider-specific subdirectory.
-	providerStorageDir := filepath.Join(xdgCacheDir, p.name)
-	if err := os.MkdirAll(providerStorageDir, samlStorageDirPerms); err != nil {
-		return fmt.Errorf("failed to create provider storage directory: %w", err)
-	}
-
-	// Get user home directory for ~/.aws symlink.
 	homeDir, err := homedir.Dir()
 	if err != nil {
 		return fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
-	// Create ~/.aws directory if it doesn't exist.
-	awsDirPath := filepath.Join(homeDir, awsDir)
-	if err := os.MkdirAll(awsDirPath, samlStorageDirPerms); err != nil {
-		return fmt.Errorf("failed to create .aws directory: %w", err)
+	// Create ~/.aws/saml2aws/ as a real directory (not a symlink).
+	// saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
+	saml2awsDir := filepath.Join(homeDir, awsDir, saml2awsSubdir)
+	if err := os.MkdirAll(saml2awsDir, samlStorageDirPerms); err != nil {
+		return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
 	}
 
-	// Create ~/.aws/saml2aws as symlink to provider-specific XDG cache directory.
-	saml2awsPath := filepath.Join(awsDirPath, saml2awsSubdir)
-	return p.ensureStorageSymlink(saml2awsPath, providerStorageDir)
-}
-
-// ensureStorageSymlink ensures ~/.aws/saml2aws symlink points to the correct target.
-func (p *samlProvider) ensureStorageSymlink(symlinkPath, targetPath string) error {
-	// Check if symlink already exists and points to correct target.
-	if p.isCorrectSymlink(symlinkPath, targetPath) {
-		log.Debug("Browser storage symlink already exists", "path", symlinkPath, "target", targetPath)
-		return nil
-	}
-
-	// Stage the existing path so we can restore it if symlink creation fails.
-	// This is critical on Windows where os.Symlink requires developer mode or
-	// elevated privileges — without staging, a failed symlink leaves the user
-	// with no ~/.aws/saml2aws at all, breaking subsequent browser runs.
-	if err := p.stageExistingPath(symlinkPath); err != nil {
-		return err
-	}
-
-	// Create symlink. If this fails (e.g. Windows without developer mode),
-	// restore the staged directory so the user is no worse off than before.
-	if err := os.Symlink(targetPath, symlinkPath); err != nil {
-		p.restoreStagedPath(symlinkPath)
-		return fmt.Errorf("failed to create symlink: %w", err)
-	}
-
-	// Clean up staged backup on success.
-	_ = os.RemoveAll(symlinkPath + ".bak")
-
-	log.Debug("Created browser storage symlink", "path", symlinkPath, "target", targetPath)
+	log.Debug("Browser storage directory ready", "path", saml2awsDir)
 	return nil
-}
-
-// isCorrectSymlink checks if path is a symlink pointing to expectedTarget.
-func (p *samlProvider) isCorrectSymlink(symlinkPath, expectedTarget string) bool {
-	info, err := os.Lstat(symlinkPath)
-	if err != nil {
-		return false
-	}
-
-	if info.Mode()&os.ModeSymlink == 0 {
-		return false
-	}
-
-	target, err := os.Readlink(symlinkPath)
-	return err == nil && target == expectedTarget
-}
-
-// stageExistingPath handles the existing path at symlinkPath before symlink
-// creation. If it's a stale symlink, removes it directly. If it's a directory
-// or file, renames it to .bak so it can be restored on failure.
-func (p *samlProvider) stageExistingPath(symlinkPath string) error {
-	info, lstatErr := os.Lstat(symlinkPath)
-	if lstatErr != nil {
-		return nil //nolint:nilerr // Path does not exist — nothing to stage; this is not an error condition.
-	}
-
-	if info.Mode()&os.ModeSymlink != 0 {
-		log.Debug("Removing stale symlink", "path", symlinkPath)
-		return os.Remove(symlinkPath)
-	}
-
-	backupPath := symlinkPath + ".bak"
-	log.Debug("Staging existing storage path", "path", symlinkPath, "backup", backupPath)
-	return os.Rename(symlinkPath, backupPath)
-}
-
-// restoreStagedPath restores a staged .bak path after a failed symlink
-// creation, so the user is no worse off than before.
-func (p *samlProvider) restoreStagedPath(symlinkPath string) {
-	backupPath := symlinkPath + ".bak"
-	if _, err := os.Stat(backupPath); err == nil {
-		_ = os.Rename(backupPath, symlinkPath)
-		log.Warn("Symlink creation failed, restored original storage path")
-	}
 }
 
 // Logout removes provider-specific credential storage.

--- a/pkg/auth/providers/aws/saml.go
+++ b/pkg/auth/providers/aws/saml.go
@@ -727,14 +727,25 @@ func (p *samlProvider) setupBrowserStorageDir() error {
 
 	homeDir, err := homedir.Dir()
 	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
+		return fmt.Errorf("%w: user home directory: %w", errUtils.ErrCreateDirectory, err)
 	}
 
 	// Create ~/.aws/saml2aws/ as a real directory (not a symlink).
 	// saml2aws hardcodes this path in pkg/provider/browser/browser.go:118.
 	saml2awsDir := filepath.Join(homeDir, awsDir, saml2awsSubdir)
+
+	// Remove legacy symlink left by previous Atmos versions. os.MkdirAll
+	// would leave a stale symlink in place, so upgraded users would never
+	// receive the plain-directory migration.
+	if info, lstatErr := os.Lstat(saml2awsDir); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		log.Debug("Removing legacy saml2aws symlink", "path", saml2awsDir)
+		if removeErr := os.Remove(saml2awsDir); removeErr != nil {
+			return fmt.Errorf("%w: remove legacy saml2aws symlink: %w", errUtils.ErrCreateDirectory, removeErr)
+		}
+	}
+
 	if err := os.MkdirAll(saml2awsDir, samlStorageDirPerms); err != nil {
-		return fmt.Errorf("failed to create saml2aws storage directory: %w", err)
+		return fmt.Errorf("%w: %s: %w", errUtils.ErrCreateDirectory, saml2awsDir, err)
 	}
 
 	log.Debug("Browser storage directory ready", "path", saml2awsDir)

--- a/pkg/auth/providers/aws/saml.go
+++ b/pkg/auth/providers/aws/saml.go
@@ -656,9 +656,8 @@ func (p *samlProvider) setupBrowserAutomation() error {
 		_ = os.Unsetenv("SAML2AWS_AUTO_BROWSER_DOWNLOAD")
 	}
 
-	// Set up XDG-compliant storage directory for browser state.
-	// saml2aws hardcodes ~/.aws/saml2aws/storageState.json, so we create this directory
-	// in an XDG-compliant location and symlink it.
+	// Ensure the storage directory that saml2aws expects exists.
+	// saml2aws hardcodes ~/.aws/saml2aws/storageState.json for browser state.
 	if err := p.setupBrowserStorageDir(); err != nil {
 		log.Warn("Failed to setup browser storage directory", "error", err)
 	}

--- a/pkg/auth/providers/aws/saml_storage_test.go
+++ b/pkg/auth/providers/aws/saml_storage_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,105 +14,58 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
-// skipIfSymlinksUnsupported skips the test on platforms where os.Symlink
-// requires elevated privileges (e.g. Windows without Developer Mode).
-func skipIfSymlinksUnsupported(t *testing.T) {
-	t.Helper()
-	tmpDir := t.TempDir()
-	target := filepath.Join(tmpDir, "target")
-	require.NoError(t, os.MkdirAll(target, 0o700))
-	link := filepath.Join(tmpDir, "link")
-	if err := os.Symlink(target, link); err != nil {
-		t.Skipf("Skipping: os.Symlink not available on this platform (%v)", err)
-	}
-}
-
 func TestSAMLProvider_setupBrowserStorageDir(t *testing.T) {
-	skipIfSymlinksUnsupported(t)
-
 	tests := []struct {
 		name          string
 		providerName  string
 		setup         func(t *testing.T) string // Returns home directory.
 		expectedError bool
-		verifySymlink bool
-		verifyXDGDir  bool
 	}{
 		{
-			name:          "creates directory and symlink successfully",
+			name:          "creates directory successfully",
 			providerName:  "test-saml",
 			expectedError: false,
 			setup: func(t *testing.T) string {
 				return t.TempDir()
 			},
-			verifySymlink: true,
-			verifyXDGDir:  true,
 		},
 		{
-			name:          "handles existing correct symlink",
+			name:          "idempotent when directory already exists",
 			providerName:  "existing-saml",
 			expectedError: false,
 			setup: func(t *testing.T) string {
 				homeDir := t.TempDir()
-
-				// Create XDG directory structure.
-				xdgCacheDir := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", "existing-saml")
-				require.NoError(t, os.MkdirAll(xdgCacheDir, 0o700))
-
-				// Create ~/.aws directory.
-				awsDir := filepath.Join(homeDir, ".aws")
-				require.NoError(t, os.MkdirAll(awsDir, 0o700))
-
-				// Create correct symlink.
-				saml2awsPath := filepath.Join(awsDir, "saml2aws")
-				require.NoError(t, os.Symlink(xdgCacheDir, saml2awsPath))
-
+				// Pre-create the directory.
+				saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+				require.NoError(t, os.MkdirAll(saml2awsDir, 0o700))
 				return homeDir
 			},
-			verifySymlink: true,
-			verifyXDGDir:  true,
 		},
 		{
-			name:          "replaces incorrect symlink",
-			providerName:  "replace-saml",
+			name:          "preserves existing storageState.json",
+			providerName:  "preserve-saml",
 			expectedError: false,
 			setup: func(t *testing.T) string {
 				homeDir := t.TempDir()
-
-				// Create ~/.aws directory with wrong symlink.
-				awsDir := filepath.Join(homeDir, ".aws")
-				require.NoError(t, os.MkdirAll(awsDir, 0o700))
-
-				saml2awsPath := filepath.Join(awsDir, "saml2aws")
-				wrongTarget := filepath.Join(homeDir, "wrong-target")
-				require.NoError(t, os.MkdirAll(wrongTarget, 0o700))
-				require.NoError(t, os.Symlink(wrongTarget, saml2awsPath))
-
+				saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+				require.NoError(t, os.MkdirAll(saml2awsDir, 0o700))
+				// Create a storage state file.
+				stateFile := filepath.Join(saml2awsDir, "storageState.json")
+				require.NoError(t, os.WriteFile(stateFile, []byte(`{"cookies":[]}`), 0o600))
 				return homeDir
 			},
-			verifySymlink: true,
-			verifyXDGDir:  true,
 		},
 		{
-			name:          "replaces existing directory with symlink",
-			providerName:  "dir-replace-saml",
-			expectedError: false,
+			name:          "fails when .aws is a file (not directory)",
+			providerName:  "fail-saml",
+			expectedError: true,
 			setup: func(t *testing.T) string {
 				homeDir := t.TempDir()
-
-				// Create ~/.aws/saml2aws as regular directory.
-				awsDir := filepath.Join(homeDir, ".aws")
-				saml2awsPath := filepath.Join(awsDir, "saml2aws")
-				require.NoError(t, os.MkdirAll(saml2awsPath, 0o700))
-
-				// Create a file inside to verify removal works.
-				testFile := filepath.Join(saml2awsPath, "test.txt")
-				require.NoError(t, os.WriteFile(testFile, []byte("test"), 0o600))
-
+				// Create .aws as a file so MkdirAll fails.
+				awsPath := filepath.Join(homeDir, ".aws")
+				require.NoError(t, os.WriteFile(awsPath, []byte("not a dir"), 0o600))
 				return homeDir
 			},
-			verifySymlink: true,
-			verifyXDGDir:  true,
 		},
 	}
 
@@ -120,239 +74,72 @@ func TestSAMLProvider_setupBrowserStorageDir(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			homeDir := tc.setup(t)
 
-			// Override environment variables for cross-platform compatibility.
 			t.Setenv("HOME", homeDir)
 			t.Setenv("USERPROFILE", homeDir)
-			t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
-
-			// Clear homedir cache so homedir.Dir() reads the fresh env vars.
 			homedir.Reset()
 
-			// Create provider.
 			p := &samlProvider{
 				name:   tc.providerName,
 				config: &schema.Provider{},
 			}
 
-			// Execute setup.
 			err := p.setupBrowserStorageDir()
 
-			// Verify error expectation.
 			if tc.expectedError {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			// Verify XDG directory was created.
-			if tc.verifyXDGDir {
-				xdgCacheDir := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", tc.providerName)
-				info, err := os.Stat(xdgCacheDir)
-				require.NoError(t, err, "XDG cache directory should exist")
-				assert.True(t, info.IsDir(), "XDG cache path should be a directory")
-				// Only check exact permissions on Unix — Windows does not
-				// support Unix-style permission bits, so os.MkdirAll(0700)
-				// may produce 0777 depending on the filesystem and umask.
-				if runtime.GOOS != "windows" {
-					assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "XDG directory should have 0700 permissions")
-				}
-			}
+			// Verify directory was created as a real directory (not symlink).
+			saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+			info, err := os.Stat(saml2awsDir)
+			require.NoError(t, err, "saml2aws directory should exist")
+			assert.True(t, info.IsDir(), "saml2aws path should be a directory")
 
-			// Verify symlink was created correctly.
-			if tc.verifySymlink {
-				awsDir := filepath.Join(homeDir, ".aws")
-				saml2awsPath := filepath.Join(awsDir, "saml2aws")
-
-				info, err := os.Lstat(saml2awsPath)
-				require.NoError(t, err, "Symlink should exist")
-				assert.True(t, info.Mode()&os.ModeSymlink != 0, "Path should be a symlink")
-
-				target, err := os.Readlink(saml2awsPath)
-				require.NoError(t, err, "Should be able to read symlink target")
-
-				expectedTarget := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", tc.providerName)
-				assert.Equal(t, expectedTarget, target, "Symlink should point to correct XDG directory")
-			}
-		})
-	}
-}
-
-func TestSAMLProvider_ensureStorageSymlink(t *testing.T) {
-	skipIfSymlinksUnsupported(t)
-
-	tests := []struct {
-		name          string
-		setup         func(t *testing.T, symlinkPath, targetPath string)
-		expectedError bool
-	}{
-		{
-			name: "creates new symlink",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				// Ensure parent directory exists.
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				// Target directory exists.
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-			},
-			expectedError: false,
-		},
-		{
-			name: "idempotent when correct symlink exists",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-				// Create correct symlink.
-				require.NoError(t, os.Symlink(targetPath, symlinkPath))
-			},
-			expectedError: false,
-		},
-		{
-			name: "replaces wrong symlink",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-				// Create wrong symlink.
-				wrongTarget := filepath.Join(filepath.Dir(targetPath), "wrong")
-				require.NoError(t, os.MkdirAll(wrongTarget, 0o700))
-				require.NoError(t, os.Symlink(wrongTarget, symlinkPath))
-			},
-			expectedError: false,
-		},
-		{
-			name: "replaces regular directory",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-				// Create regular directory at symlink path.
-				require.NoError(t, os.MkdirAll(symlinkPath, 0o700))
-				// Add file inside to verify removal.
-				testFile := filepath.Join(symlinkPath, "test.txt")
-				require.NoError(t, os.WriteFile(testFile, []byte("test"), 0o600))
-			},
-			expectedError: false,
-		},
-		{
-			name: "replaces regular file",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-				// Create regular file at symlink path.
-				require.NoError(t, os.WriteFile(symlinkPath, []byte("test"), 0o600))
-			},
-			expectedError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.name, func(t *testing.T) {
-			homeDir := t.TempDir()
-			symlinkPath := filepath.Join(homeDir, "aws", "saml2aws")
-			targetPath := filepath.Join(homeDir, "cache", "saml-target")
-
-			tc.setup(t, symlinkPath, targetPath)
-
-			p := &samlProvider{
-				name:   "test",
-				config: &schema.Provider{},
-			}
-
-			err := p.ensureStorageSymlink(symlinkPath, targetPath)
-
-			if tc.expectedError {
-				assert.Error(t, err)
-				return
-			}
+			// Verify it's NOT a symlink.
+			linfo, err := os.Lstat(saml2awsDir)
 			require.NoError(t, err)
+			assert.Zero(t, linfo.Mode()&os.ModeSymlink, "saml2aws path should NOT be a symlink")
 
-			// Verify symlink was created correctly.
-			info, err := os.Lstat(symlinkPath)
-			require.NoError(t, err, "Symlink should exist")
-			assert.True(t, info.Mode()&os.ModeSymlink != 0, "Path should be a symlink")
-
-			target, err := os.Readlink(symlinkPath)
-			require.NoError(t, err, "Should be able to read symlink")
-			assert.Equal(t, targetPath, target, "Symlink should point to correct target")
-		})
-	}
-}
-
-func TestSAMLProvider_isCorrectSymlink(t *testing.T) {
-	skipIfSymlinksUnsupported(t)
-
-	tests := []struct {
-		name           string
-		setup          func(t *testing.T, symlinkPath, targetPath string)
-		expectedResult bool
-	}{
-		{
-			name: "returns true for correct symlink",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				require.NoError(t, os.MkdirAll(targetPath, 0o700))
-				require.NoError(t, os.Symlink(targetPath, symlinkPath))
-			},
-			expectedResult: true,
-		},
-		{
-			name: "returns false for wrong symlink target",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				wrongTarget := filepath.Join(filepath.Dir(targetPath), "wrong")
-				require.NoError(t, os.MkdirAll(wrongTarget, 0o700))
-				require.NoError(t, os.Symlink(wrongTarget, symlinkPath))
-			},
-			expectedResult: false,
-		},
-		{
-			name: "returns false for regular directory",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(symlinkPath, 0o700))
-			},
-			expectedResult: false,
-		},
-		{
-			name: "returns false for regular file",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0o700))
-				require.NoError(t, os.WriteFile(symlinkPath, []byte("test"), 0o600))
-			},
-			expectedResult: false,
-		},
-		{
-			name: "returns false when path does not exist",
-			setup: func(t *testing.T, symlinkPath, targetPath string) {
-				// No setup - path doesn't exist.
-			},
-			expectedResult: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.name, func(t *testing.T) {
-			homeDir := t.TempDir()
-			symlinkPath := filepath.Join(homeDir, "aws", "saml2aws")
-			targetPath := filepath.Join(homeDir, "cache", "saml-target")
-
-			tc.setup(t, symlinkPath, targetPath)
-
-			p := &samlProvider{
-				name:   "test",
-				config: &schema.Provider{},
+			// Only check permissions on Unix.
+			if runtime.GOOS != "windows" {
+				assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+					"directory should have 0700 permissions")
 			}
-
-			result := p.isCorrectSymlink(symlinkPath, targetPath)
-			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
 
-func TestSAMLProvider_setupBrowserAutomation_CallsStorageSetup(t *testing.T) {
-	skipIfSymlinksUnsupported(t)
-
+func TestSAMLProvider_setupBrowserStorageDir_PreservesExistingState(t *testing.T) {
+	// Verify that an existing storageState.json file is preserved after
+	// setupBrowserStorageDir runs (os.MkdirAll is a no-op for existing dirs).
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
+	homedir.Reset()
+
+	// Create the directory and a state file.
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	require.NoError(t, os.MkdirAll(saml2awsDir, 0o700))
+	stateFile := filepath.Join(saml2awsDir, "storageState.json")
+	require.NoError(t, os.WriteFile(stateFile, []byte(`{"cookies":[{"name":"test"}]}`), 0o600))
+
+	p := &samlProvider{name: "test", config: &schema.Provider{}}
+	err := p.setupBrowserStorageDir()
+	require.NoError(t, err)
+
+	// State file must survive.
+	content, err := os.ReadFile(stateFile)
+	require.NoError(t, err)
+	assert.Equal(t, `{"cookies":[{"name":"test"}]}`, string(content),
+		"existing storageState.json must not be deleted or modified")
+}
+
+func TestSAMLProvider_setupBrowserAutomation_CallsStorageSetup(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	homedir.Reset()
 
 	p, err := NewSAMLProvider("test", &schema.Provider{
@@ -363,30 +150,20 @@ func TestSAMLProvider_setupBrowserAutomation_CallsStorageSetup(t *testing.T) {
 	require.NoError(t, err)
 
 	sp := p.(*samlProvider)
-	sp.setupBrowserAutomation()
+	err = sp.setupBrowserAutomation()
+	require.NoError(t, err)
 
-	// Verify that setupBrowserStorageDir was called by checking if directories exist.
-	xdgCacheDir := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", "test")
-	info, err := os.Stat(xdgCacheDir)
-	require.NoError(t, err, "XDG cache directory should be created")
+	// Verify that setupBrowserStorageDir was called: the directory should exist.
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	info, err := os.Stat(saml2awsDir)
+	require.NoError(t, err, "saml2aws directory should be created")
 	assert.True(t, info.IsDir())
-
-	// Verify symlink was created.
-	saml2awsPath := filepath.Join(homeDir, ".aws", "saml2aws")
-	info, err = os.Lstat(saml2awsPath)
-	require.NoError(t, err, "Symlink should be created")
-	assert.True(t, info.Mode()&os.ModeSymlink != 0)
 }
 
 func TestSAMLProvider_setupBrowserAutomation_HandlesStorageSetupFailureGracefully(t *testing.T) {
-	// Test that setupBrowserAutomation continues even if storage setup fails.
-	// This tests the error handling path in setupBrowserAutomation.
-
-	// Create an environment where setupBrowserStorageDir will fail.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
 	homedir.Reset()
 
 	// Create ~/.aws as a regular file (not directory) to cause mkdir failure.
@@ -403,8 +180,7 @@ func TestSAMLProvider_setupBrowserAutomation_HandlesStorageSetupFailureGracefull
 
 	sp := p.(*samlProvider)
 
-	// This should not error even though storage setup will fail internally.
-	// setupBrowserAutomation logs a warning for storage failures but returns nil.
+	// Storage dir failure is non-fatal — setupBrowserAutomation returns nil.
 	err = sp.setupBrowserAutomation()
 	assert.NoError(t, err, "storage dir failure is non-fatal — should return nil")
 
@@ -413,12 +189,9 @@ func TestSAMLProvider_setupBrowserAutomation_HandlesStorageSetupFailureGracefull
 }
 
 func TestSAMLProvider_setupBrowserAutomation_FailsOnInvalidExecutable(t *testing.T) {
-	// setupBrowserAutomation should return an error when a custom browser
-	// executable is configured but does not exist. This is the fail-fast path.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
 	homedir.Reset()
 
 	p := &samlProvider{
@@ -433,12 +206,9 @@ func TestSAMLProvider_setupBrowserAutomation_FailsOnInvalidExecutable(t *testing
 }
 
 func TestSAMLProvider_setupBrowserAutomation_UnsetsEnvWhenDownloadDisabled(t *testing.T) {
-	// Verify that SAML2AWS_AUTO_BROWSER_DOWNLOAD is explicitly unset when
-	// shouldDownloadBrowser() returns false, preventing env leak across calls.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
 	homedir.Reset()
 
 	// Pre-set the env var to simulate a previous auth flow.
@@ -447,7 +217,7 @@ func TestSAMLProvider_setupBrowserAutomation_UnsetsEnvWhenDownloadDisabled(t *te
 	p := &samlProvider{
 		name: "test",
 		config: &schema.Provider{
-			Driver: "GoogleApps", // Non-Browser driver → download disabled.
+			Driver: "GoogleApps",
 		},
 		url: "https://accounts.google.com/saml",
 	}
@@ -455,24 +225,21 @@ func TestSAMLProvider_setupBrowserAutomation_UnsetsEnvWhenDownloadDisabled(t *te
 	err := p.setupBrowserAutomation()
 	assert.NoError(t, err)
 
-	// The env var should be cleared.
 	assert.Empty(t, os.Getenv("SAML2AWS_AUTO_BROWSER_DOWNLOAD"),
 		"SAML2AWS_AUTO_BROWSER_DOWNLOAD should be unset for non-Browser drivers")
 }
 
 func TestSAMLProvider_setupBrowserAutomation_LogsBrowserType(t *testing.T) {
-	// Covers the BrowserType logging branch.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
 	homedir.Reset()
 
 	p := &samlProvider{
 		name: "test",
 		config: &schema.Provider{
 			BrowserType: "chromium",
-			Driver:      "GoogleApps", // Non-Browser to keep test fast.
+			Driver:      "GoogleApps",
 		},
 		url: "https://accounts.google.com/saml",
 	}
@@ -481,73 +248,115 @@ func TestSAMLProvider_setupBrowserAutomation_LogsBrowserType(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSAMLProvider_restoreStagedPath(t *testing.T) {
-	t.Run("restores backup when it exists", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		symlinkPath := filepath.Join(tmpDir, "saml2aws")
-		backupPath := symlinkPath + ".bak"
+func TestSAMLProvider_SetRealm(t *testing.T) {
+	p := &samlProvider{name: "test", config: &schema.Provider{}}
+	assert.Empty(t, p.realm)
 
-		// Create a .bak directory to simulate a staged path.
-		require.NoError(t, os.MkdirAll(backupPath, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(backupPath, "state.json"), []byte("{}"), 0o600))
+	p.SetRealm("my-realm")
+	assert.Equal(t, "my-realm", p.realm)
 
-		p := &samlProvider{config: &schema.Provider{}}
-		p.restoreStagedPath(symlinkPath)
-
-		// Backup should be moved back to the original path.
-		_, err := os.Stat(symlinkPath)
-		assert.NoError(t, err, "original path should be restored from backup")
-		_, err = os.Stat(backupPath)
-		assert.True(t, os.IsNotExist(err), ".bak should be gone after restore")
-		// Verify content survived.
-		content, err := os.ReadFile(filepath.Join(symlinkPath, "state.json"))
-		require.NoError(t, err)
-		assert.Equal(t, "{}", string(content))
-	})
-
-	t.Run("no-op when no backup exists", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		symlinkPath := filepath.Join(tmpDir, "saml2aws")
-
-		p := &samlProvider{config: &schema.Provider{}}
-		// Must not panic or error when no .bak exists.
-		p.restoreStagedPath(symlinkPath)
-
-		_, err := os.Stat(symlinkPath)
-		assert.True(t, os.IsNotExist(err), "nothing should be created when no backup exists")
-	})
+	// Overwrite.
+	p.SetRealm("other-realm")
+	assert.Equal(t, "other-realm", p.realm)
 }
 
-func TestSAMLProvider_ensureStorageSymlink_CleansUpBackupOnSuccess(t *testing.T) {
-	skipIfSymlinksUnsupported(t)
+func TestSAMLProvider_PrepareEnvironment(t *testing.T) {
+	p := &samlProvider{name: "test", config: &schema.Provider{}, region: "us-west-2"}
 
-	// When a directory at symlinkPath is staged to .bak and symlink creation
-	// succeeds, the .bak should be cleaned up.
-	tmpDir := t.TempDir()
-	symlinkPath := filepath.Join(tmpDir, "saml2aws")
-	targetPath := filepath.Join(tmpDir, "target")
+	// PrepareEnvironment should return the input environ unchanged.
+	input := map[string]string{"EXISTING": "value"}
+	result, err := p.PrepareEnvironment(context.TODO(), input)
+	require.NoError(t, err)
+	assert.Equal(t, input, result, "PrepareEnvironment should return environ unchanged")
+}
 
-	// Create both dirs.
-	require.NoError(t, os.MkdirAll(symlinkPath, 0o700))
-	require.NoError(t, os.MkdirAll(targetPath, 0o700))
+func TestSAMLProvider_Authenticate_GatesBrowserSetupOnDriver(t *testing.T) {
+	// When the driver is NOT "Browser", setupBrowserAutomation should be
+	// skipped entirely — no directory creation at ~/.aws/saml2aws/.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
 
-	p := &samlProvider{config: &schema.Provider{}}
-	err := p.ensureStorageSymlink(symlinkPath, targetPath)
+	p := &samlProvider{
+		name:   "test",
+		config: &schema.Provider{Driver: "GoogleApps"},
+		url:    "https://accounts.google.com/saml",
+		region: "us-east-1",
+		// No RoleToAssumeFromAssertion → Authenticate will fail early,
+		// but AFTER the browser setup gate check.
+	}
+
+	_, err := p.Authenticate(context.TODO())
+	require.Error(t, err, "should fail due to missing RoleToAssumeFromAssertion")
+
+	// The saml2aws directory should NOT have been created because the
+	// driver is GoogleApps (not Browser).
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	_, statErr := os.Stat(saml2awsDir)
+	assert.True(t, os.IsNotExist(statErr),
+		"saml2aws directory should not be created for non-Browser drivers")
+}
+
+func TestSAMLProvider_Authenticate_RunsBrowserSetupForBrowserDriver(t *testing.T) {
+	// When the driver IS "Browser", setupBrowserAutomation should run and
+	// create the storage directory. We set RoleToAssumeFromAssertion so the
+	// code passes the early guard and reaches the browser setup gate.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	p := &samlProvider{
+		name:                      "test",
+		config:                    &schema.Provider{Driver: "Browser"},
+		url:                       "https://idp.example.com/saml",
+		region:                    "us-east-1",
+		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
+	}
+
+	// Authenticate will fail downstream (no real SAML client), but browser
+	// setup runs before that point.
+	_, err := p.Authenticate(context.TODO())
+	require.Error(t, err)
+
+	// The saml2aws directory SHOULD have been created.
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	info, statErr := os.Stat(saml2awsDir)
+	require.NoError(t, statErr, "saml2aws directory should be created for Browser driver")
+	assert.True(t, info.IsDir())
+}
+
+func TestSAMLProvider_setupBrowserStorageDir_UsesFilepathJoin(t *testing.T) {
+	// Verify that the created directory path uses platform-correct separators
+	// (filepath.Join), not hardcoded forward slashes.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	p := &samlProvider{name: "test", config: &schema.Provider{}}
+	err := p.setupBrowserStorageDir()
 	require.NoError(t, err)
 
-	// Symlink should exist and point to target.
-	target, err := os.Readlink(symlinkPath)
+	// The directory should exist and be accessible via the platform path.
+	expectedDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	info, err := os.Stat(expectedDir)
 	require.NoError(t, err)
-	assert.Equal(t, targetPath, target)
+	assert.True(t, info.IsDir())
 
-	// .bak should NOT exist (cleaned up after success).
-	_, err = os.Stat(symlinkPath + ".bak")
-	assert.True(t, os.IsNotExist(err), ".bak should be cleaned up after successful symlink creation")
+	// Verify a file can be written inside (simulates what saml2aws does).
+	testFile := filepath.Join(expectedDir, "storageState.json")
+	err = os.WriteFile(testFile, []byte(`{"cookies":[]}`), 0o600)
+	assert.NoError(t, err, "should be able to write storageState.json inside the created directory")
+
+	// Verify the file can be read back.
+	content, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, `{"cookies":[]}`, string(content))
 }
 
 func TestSAMLProvider_GetFilesDisplayPath_ReturnsPlatformPath(t *testing.T) {
-	// GetFilesDisplayPath should always return a platform-aware path (no
-	// hardcoded ~ or forward-slash separators on Windows).
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
@@ -559,9 +368,7 @@ func TestSAMLProvider_GetFilesDisplayPath_ReturnsPlatformPath(t *testing.T) {
 	}
 
 	displayPath := p.GetFilesDisplayPath()
-	// The path must not contain literal "~/" — it should be a resolved path.
 	assert.NotContains(t, displayPath, "~/",
 		"display path must not contain literal ~/ — should be a resolved platform path")
-	// It must be a non-empty string.
 	assert.NotEmpty(t, displayPath, "display path must not be empty")
 }

--- a/pkg/auth/providers/aws/saml_storage_test.go
+++ b/pkg/auth/providers/aws/saml_storage_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
+// Compile-time sentinel: if any of these schema.Provider fields are renamed,
+// the build fails immediately instead of producing subtle test breakage.
+var _ = schema.Provider{
+	Kind:                  "",
+	URL:                   "",
+	Region:                "",
+	Driver:                "",
+	BrowserType:           "",
+	BrowserExecutablePath: "",
+	DownloadBrowserDriver: false,
+}
+
 func TestSAMLProvider_setupBrowserStorageDir(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -187,6 +199,54 @@ func TestSAMLProvider_setupBrowserStorageDir_MigratesEmptyLegacySymlink(t *testi
 	// No storageState.json should exist (nothing to migrate).
 	_, statErr := os.Stat(filepath.Join(saml2awsPath, "storageState.json"))
 	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestSAMLProvider_migrateLegacySymlink_NotASymlink(t *testing.T) {
+	// When the path is a regular directory (not a symlink), migration is a no-op.
+	tmpDir := t.TempDir()
+	dirPath := filepath.Join(tmpDir, "saml2aws")
+	require.NoError(t, os.MkdirAll(dirPath, 0o700))
+	// Write a file inside to verify nothing is deleted.
+	testFile := filepath.Join(dirPath, "keep.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("keep"), 0o600))
+
+	p := &samlProvider{config: &schema.Provider{}}
+	p.migrateLegacySymlink(dirPath)
+
+	// Directory and its contents must remain untouched.
+	content, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(content))
+}
+
+func TestSAMLProvider_migrateLegacySymlink_NonexistentPath(t *testing.T) {
+	// When the path does not exist at all, migration is a no-op.
+	p := &samlProvider{config: &schema.Provider{}}
+	// Must not panic.
+	p.migrateLegacySymlink(filepath.Join(t.TempDir(), "nonexistent"))
+}
+
+func TestSAMLProvider_migrateLegacySymlink_DanglingSymlink(t *testing.T) {
+	// A dangling symlink (target deleted) should still be removed and
+	// replaced with a directory. No state to migrate.
+	tmpDir := t.TempDir()
+	saml2awsPath := filepath.Join(tmpDir, "saml2aws")
+	deletedTarget := filepath.Join(tmpDir, "deleted-target")
+
+	// Create target, symlink, then delete target → dangling symlink.
+	require.NoError(t, os.MkdirAll(deletedTarget, 0o700))
+	if err := os.Symlink(deletedTarget, saml2awsPath); err != nil {
+		t.Skipf("Skipping: os.Symlink not available on this platform (%v)", err)
+	}
+	require.NoError(t, os.RemoveAll(deletedTarget))
+
+	p := &samlProvider{config: &schema.Provider{}}
+	p.migrateLegacySymlink(saml2awsPath)
+
+	// Symlink should be removed (path no longer exists — MkdirAll in
+	// setupBrowserStorageDir will create the directory).
+	_, err := os.Lstat(saml2awsPath)
+	assert.True(t, os.IsNotExist(err), "dangling symlink should be removed")
 }
 
 func TestSAMLProvider_setupBrowserStorageDir_PreservesExistingState(t *testing.T) {
@@ -397,6 +457,55 @@ func TestSAMLProvider_BrowserSetupGatedOnDriverType(t *testing.T) {
 				"getDriver() should return %q for driver=%q", tt.driver, tt.driver)
 		})
 	}
+}
+
+func TestSAMLProvider_Authenticate_BrowserGateCreatesDir(t *testing.T) {
+	// Verify the browser gate in Authenticate: when driver is "Browser",
+	// the storage directory is created. Uses a non-download config so
+	// saml2aws.NewSAMLClient is fast (no Playwright initialization).
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	p := &samlProvider{
+		name:                      "test",
+		config:                    &schema.Provider{Driver: "Browser"},
+		url:                       "https://idp.example.com/saml",
+		region:                    "us-east-1",
+		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
+	}
+
+	// Authenticate fails downstream (no real IDP), but the browser gate
+	// runs first and creates the storage directory.
+	_, _ = p.Authenticate(context.TODO())
+
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	info, err := os.Stat(saml2awsDir)
+	require.NoError(t, err, "browser gate should create storage directory")
+	assert.True(t, info.IsDir())
+}
+
+func TestSAMLProvider_Authenticate_NonBrowserSkipsDir(t *testing.T) {
+	// When driver is NOT "Browser", the storage directory should NOT be created.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	p := &samlProvider{
+		name:                      "test",
+		config:                    &schema.Provider{Driver: "GoogleApps"},
+		url:                       "https://accounts.google.com/saml",
+		region:                    "us-east-1",
+		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
+	}
+
+	_, _ = p.Authenticate(context.TODO())
+
+	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
+	_, err := os.Stat(saml2awsDir)
+	assert.True(t, os.IsNotExist(err), "non-Browser driver should not create storage directory")
 }
 
 func TestSAMLProvider_setupBrowserAutomation_CreatesStorageDir(t *testing.T) {

--- a/pkg/auth/providers/aws/saml_storage_test.go
+++ b/pkg/auth/providers/aws/saml_storage_test.go
@@ -111,6 +111,42 @@ func TestSAMLProvider_setupBrowserStorageDir(t *testing.T) {
 	}
 }
 
+func TestSAMLProvider_setupBrowserStorageDir_MigratesLegacySymlink(t *testing.T) {
+	// Previous Atmos versions created ~/.aws/saml2aws as a symlink to an
+	// XDG cache directory. On upgrade, setupBrowserStorageDir should remove
+	// the stale symlink and create a real directory in its place.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	// Create a legacy symlink (simulates pre-upgrade state).
+	awsDir := filepath.Join(homeDir, ".aws")
+	require.NoError(t, os.MkdirAll(awsDir, 0o700))
+	legacyTarget := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", "old-provider")
+	require.NoError(t, os.MkdirAll(legacyTarget, 0o700))
+
+	saml2awsPath := filepath.Join(awsDir, "saml2aws")
+	if err := os.Symlink(legacyTarget, saml2awsPath); err != nil {
+		t.Skipf("Skipping: os.Symlink not available on this platform (%v)", err)
+	}
+
+	// Verify it's a symlink before the fix.
+	info, err := os.Lstat(saml2awsPath)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSymlink, "precondition: should be a symlink")
+
+	p := &samlProvider{name: "test", config: &schema.Provider{}}
+	err = p.setupBrowserStorageDir()
+	require.NoError(t, err)
+
+	// After the fix: should be a real directory, not a symlink.
+	info, err = os.Lstat(saml2awsPath)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSymlink, "legacy symlink should be replaced with a real directory")
+	assert.True(t, info.IsDir())
+}
+
 func TestSAMLProvider_setupBrowserStorageDir_PreservesExistingState(t *testing.T) {
 	// Verify that an existing storageState.json file is preserved after
 	// setupBrowserStorageDir runs (os.MkdirAll is a no-op for existing dirs).
@@ -279,16 +315,17 @@ func TestSAMLProvider_Authenticate_GatesBrowserSetupOnDriver(t *testing.T) {
 	homedir.Reset()
 
 	p := &samlProvider{
-		name:   "test",
-		config: &schema.Provider{Driver: "GoogleApps"},
-		url:    "https://accounts.google.com/saml",
-		region: "us-east-1",
-		// No RoleToAssumeFromAssertion → Authenticate will fail early,
-		// but AFTER the browser setup gate check.
+		name:                      "test",
+		config:                    &schema.Provider{Driver: "GoogleApps"},
+		url:                       "https://accounts.google.com/saml",
+		region:                    "us-east-1",
+		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
 	}
 
+	// Authenticate will fail downstream (no real SAML client), but the
+	// browser setup gate at line 139 is evaluated before that point.
 	_, err := p.Authenticate(context.TODO())
-	require.Error(t, err, "should fail due to missing RoleToAssumeFromAssertion")
+	require.Error(t, err)
 
 	// The saml2aws directory should NOT have been created because the
 	// driver is GoogleApps (not Browser).
@@ -298,32 +335,30 @@ func TestSAMLProvider_Authenticate_GatesBrowserSetupOnDriver(t *testing.T) {
 		"saml2aws directory should not be created for non-Browser drivers")
 }
 
-func TestSAMLProvider_Authenticate_RunsBrowserSetupForBrowserDriver(t *testing.T) {
-	// When the driver IS "Browser", setupBrowserAutomation should run and
-	// create the storage directory. We set RoleToAssumeFromAssertion so the
-	// code passes the early guard and reaches the browser setup gate.
+func TestSAMLProvider_setupBrowserAutomation_CreatesStorageDir(t *testing.T) {
+	// Verify setupBrowserAutomation creates ~/.aws/saml2aws/ as a real
+	// directory. This tests the storage setup path directly without going
+	// through the full Authenticate flow (which would trigger saml2aws
+	// client creation and network calls).
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
 	homedir.Reset()
 
 	p := &samlProvider{
-		name:                      "test",
-		config:                    &schema.Provider{Driver: "Browser"},
-		url:                       "https://idp.example.com/saml",
-		region:                    "us-east-1",
-		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
+		name:   "test",
+		config: &schema.Provider{Driver: "Browser"},
+		url:    "https://idp.example.com/saml",
+		region: "us-east-1",
 	}
 
-	// Authenticate will fail downstream (no real SAML client), but browser
-	// setup runs before that point.
-	_, err := p.Authenticate(context.TODO())
-	require.Error(t, err)
+	err := p.setupBrowserAutomation()
+	require.NoError(t, err)
 
 	// The saml2aws directory SHOULD have been created.
 	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
 	info, statErr := os.Stat(saml2awsDir)
-	require.NoError(t, statErr, "saml2aws directory should be created for Browser driver")
+	require.NoError(t, statErr, "saml2aws directory should be created by setupBrowserAutomation")
 	assert.True(t, info.IsDir())
 }
 

--- a/pkg/auth/providers/aws/saml_storage_test.go
+++ b/pkg/auth/providers/aws/saml_storage_test.go
@@ -114,24 +114,27 @@ func TestSAMLProvider_setupBrowserStorageDir(t *testing.T) {
 func TestSAMLProvider_setupBrowserStorageDir_MigratesLegacySymlink(t *testing.T) {
 	// Previous Atmos versions created ~/.aws/saml2aws as a symlink to an
 	// XDG cache directory. On upgrade, setupBrowserStorageDir should remove
-	// the stale symlink and create a real directory in its place.
+	// the stale symlink, create a real directory, and preserve any existing
+	// storageState.json from the symlink target.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
 	homedir.Reset()
 
-	// Create a legacy symlink (simulates pre-upgrade state).
+	// Create a legacy symlink target with an existing storageState.json.
 	awsDir := filepath.Join(homeDir, ".aws")
 	require.NoError(t, os.MkdirAll(awsDir, 0o700))
 	legacyTarget := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", "old-provider")
 	require.NoError(t, os.MkdirAll(legacyTarget, 0o700))
+	legacyState := filepath.Join(legacyTarget, "storageState.json")
+	require.NoError(t, os.WriteFile(legacyState, []byte(`{"cookies":[{"name":"session"}]}`), 0o600))
 
 	saml2awsPath := filepath.Join(awsDir, "saml2aws")
 	if err := os.Symlink(legacyTarget, saml2awsPath); err != nil {
 		t.Skipf("Skipping: os.Symlink not available on this platform (%v)", err)
 	}
 
-	// Verify it's a symlink before the fix.
+	// Verify preconditions.
 	info, err := os.Lstat(saml2awsPath)
 	require.NoError(t, err)
 	require.NotZero(t, info.Mode()&os.ModeSymlink, "precondition: should be a symlink")
@@ -140,11 +143,50 @@ func TestSAMLProvider_setupBrowserStorageDir_MigratesLegacySymlink(t *testing.T)
 	err = p.setupBrowserStorageDir()
 	require.NoError(t, err)
 
-	// After the fix: should be a real directory, not a symlink.
+	// After migration: should be a real directory, not a symlink.
 	info, err = os.Lstat(saml2awsPath)
 	require.NoError(t, err)
 	assert.Zero(t, info.Mode()&os.ModeSymlink, "legacy symlink should be replaced with a real directory")
 	assert.True(t, info.IsDir())
+
+	// storageState.json should be preserved from the legacy target.
+	migratedState := filepath.Join(saml2awsPath, "storageState.json")
+	content, err := os.ReadFile(migratedState)
+	require.NoError(t, err, "storageState.json should be migrated from the legacy symlink target")
+	assert.Equal(t, `{"cookies":[{"name":"session"}]}`, string(content))
+}
+
+func TestSAMLProvider_setupBrowserStorageDir_MigratesEmptyLegacySymlink(t *testing.T) {
+	// Legacy symlink target with no storageState.json — should still
+	// replace the symlink with a real directory without errors.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	homedir.Reset()
+
+	awsDir := filepath.Join(homeDir, ".aws")
+	require.NoError(t, os.MkdirAll(awsDir, 0o700))
+	legacyTarget := filepath.Join(homeDir, ".cache", "atmos", "aws-saml", "empty-provider")
+	require.NoError(t, os.MkdirAll(legacyTarget, 0o700))
+
+	saml2awsPath := filepath.Join(awsDir, "saml2aws")
+	if err := os.Symlink(legacyTarget, saml2awsPath); err != nil {
+		t.Skipf("Skipping: os.Symlink not available on this platform (%v)", err)
+	}
+
+	p := &samlProvider{name: "test", config: &schema.Provider{}}
+	err := p.setupBrowserStorageDir()
+	require.NoError(t, err)
+
+	// Should be a real directory.
+	info, err := os.Lstat(saml2awsPath)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSymlink)
+	assert.True(t, info.IsDir())
+
+	// No storageState.json should exist (nothing to migrate).
+	_, statErr := os.Stat(filepath.Join(saml2awsPath, "storageState.json"))
+	assert.True(t, os.IsNotExist(statErr))
 }
 
 func TestSAMLProvider_setupBrowserStorageDir_PreservesExistingState(t *testing.T) {
@@ -306,33 +348,55 @@ func TestSAMLProvider_PrepareEnvironment(t *testing.T) {
 	assert.Equal(t, input, result, "PrepareEnvironment should return environ unchanged")
 }
 
-func TestSAMLProvider_Authenticate_GatesBrowserSetupOnDriver(t *testing.T) {
-	// When the driver is NOT "Browser", setupBrowserAutomation should be
-	// skipped entirely — no directory creation at ~/.aws/saml2aws/.
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-	t.Setenv("USERPROFILE", homeDir)
-	homedir.Reset()
-
-	p := &samlProvider{
-		name:                      "test",
-		config:                    &schema.Provider{Driver: "GoogleApps"},
-		url:                       "https://accounts.google.com/saml",
-		region:                    "us-east-1",
-		RoleToAssumeFromAssertion: "arn:aws:iam::123456789012:role/test",
+func TestSAMLProvider_BrowserSetupGatedOnDriverType(t *testing.T) {
+	// Verify the gate condition: setupBrowserAutomation only runs when
+	// getDriver() returns "Browser". We test the gate logic directly
+	// (via getDriver()) instead of going through Authenticate(), which
+	// would trigger saml2aws client creation and network calls.
+	tests := []struct {
+		name          string
+		driver        string
+		url           string
+		expectBrowser bool
+	}{
+		{
+			name:          "explicit GoogleApps driver is not Browser",
+			driver:        "GoogleApps",
+			url:           "https://accounts.google.com/saml",
+			expectBrowser: false,
+		},
+		{
+			name:          "explicit Okta driver is not Browser",
+			driver:        "Okta",
+			url:           "https://example.okta.com",
+			expectBrowser: false,
+		},
+		{
+			name:          "explicit Browser driver is Browser",
+			driver:        "Browser",
+			url:           "https://idp.example.com/saml",
+			expectBrowser: true,
+		},
 	}
 
-	// Authenticate will fail downstream (no real SAML client), but the
-	// browser setup gate at line 139 is evaluated before that point.
-	_, err := p.Authenticate(context.TODO())
-	require.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			t.Setenv("USERPROFILE", homeDir)
+			homedir.Reset()
 
-	// The saml2aws directory should NOT have been created because the
-	// driver is GoogleApps (not Browser).
-	saml2awsDir := filepath.Join(homeDir, ".aws", "saml2aws")
-	_, statErr := os.Stat(saml2awsDir)
-	assert.True(t, os.IsNotExist(statErr),
-		"saml2aws directory should not be created for non-Browser drivers")
+			p := &samlProvider{
+				name:   "test",
+				config: &schema.Provider{Driver: tt.driver},
+				url:    tt.url,
+			}
+
+			isBrowser := p.getDriver() == "Browser"
+			assert.Equal(t, tt.expectBrowser, isBrowser,
+				"getDriver() should return %q for driver=%q", tt.driver, tt.driver)
+		})
+	}
 }
 
 func TestSAMLProvider_setupBrowserAutomation_CreatesStorageDir(t *testing.T) {

--- a/pkg/auth/providers/aws/saml_test.go
+++ b/pkg/auth/providers/aws/saml_test.go
@@ -619,14 +619,14 @@ func TestSAMLProvider_createSAMLConfig_BrowserConfiguration(t *testing.T) {
 		Username:              "testuser",
 		Driver:                "Browser",
 		BrowserType:           "msedge",
-		BrowserExecutablePath: "/usr/bin/microsoft-edge",
+		BrowserExecutablePath: filepath.Join("opt", "browsers", "msedge"),
 	})
 	require.NoError(t, err)
 	sp := p.(*samlProvider)
 
 	cfg := sp.createSAMLConfig()
 	assert.Equal(t, "msedge", cfg.BrowserType)
-	assert.Equal(t, "/usr/bin/microsoft-edge", cfg.BrowserExecutablePath)
+	assert.Equal(t, filepath.Join("opt", "browsers", "msedge"), cfg.BrowserExecutablePath)
 	assert.Equal(t, "Browser", cfg.Provider)
 }
 
@@ -802,7 +802,7 @@ func TestSAMLProvider_shouldDownloadBrowser(t *testing.T) {
 		{
 			name: "custom browser_executable_path specified, skips auto-download",
 			config: &schema.Provider{
-				BrowserExecutablePath: "/usr/bin/google-chrome",
+				BrowserExecutablePath: filepath.Join("opt", "browsers", "chrome"),
 			},
 			driverValue:         "Browser",
 			playwrightInstalled: false,
@@ -812,7 +812,7 @@ func TestSAMLProvider_shouldDownloadBrowser(t *testing.T) {
 			name: "both custom browser fields specified, skips auto-download",
 			config: &schema.Provider{
 				BrowserType:           "chrome",
-				BrowserExecutablePath: "/usr/bin/google-chrome",
+				BrowserExecutablePath: filepath.Join("opt", "browsers", "chrome"),
 			},
 			driverValue:         "Browser",
 			playwrightInstalled: false,

--- a/pkg/auth/providers/aws/saml_test.go
+++ b/pkg/auth/providers/aws/saml_test.go
@@ -837,25 +837,36 @@ func TestSAMLProvider_shouldDownloadBrowser(t *testing.T) {
 				homeDir := tmpDir
 				t.Setenv("HOME", homeDir)
 				t.Setenv("USERPROFILE", homeDir)
+				t.Setenv("LOCALAPPDATA", homeDir) // Windows: playwright checks LOCALAPPDATA.
 
 				// Clear homedir cache to ensure environment variables take effect.
 				t.Cleanup(homedir.Reset)
 				homedir.Reset()
 
-				// Create a mock playwright driver directory with a file inside to pass validation.
-				playwrightPath := filepath.Join(homeDir, ".cache", "ms-playwright", "chromium-1084")
-				err := os.MkdirAll(playwrightPath, 0o755)
-				require.NoError(t, err)
+				// Create mock playwright drivers in the platform-appropriate cache path.
+				var playwrightPath string
+				switch runtime.GOOS {
+				case "darwin":
+					playwrightPath = filepath.Join(homeDir, "Library", "Caches", "ms-playwright", "chromium-1084")
+				case "windows":
+					playwrightPath = filepath.Join(homeDir, "ms-playwright", "chromium-1084")
+				default: // Linux.
+					playwrightPath = filepath.Join(homeDir, ".cache", "ms-playwright", "chromium-1084")
+				}
+				require.NoError(t, os.MkdirAll(playwrightPath, 0o755))
 
 				// hasValidPlaywrightDrivers checks for files inside version directory.
 				dummyBinary := filepath.Join(playwrightPath, "chrome")
-				err = os.WriteFile(dummyBinary, []byte("dummy"), 0o755)
-				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(dummyBinary, []byte("dummy"), 0o755))
 			} else {
 				// Use empty temp directory (no drivers).
 				tmpDir := t.TempDir()
 				t.Setenv("HOME", tmpDir)
 				t.Setenv("USERPROFILE", tmpDir)
+				// Windows: playwrightDriversInstalled checks LOCALAPPDATA via viper.
+				// Without overriding it, the real LOCALAPPDATA may contain actual
+				// Playwright drivers from the CI runner, causing false detection.
+				t.Setenv("LOCALAPPDATA", tmpDir)
 
 				// Clear homedir cache to ensure environment variables take effect.
 				t.Cleanup(homedir.Reset)


### PR DESCRIPTION
## what

- Fixes SAML browser storage state failing to save on Windows — the directory at `~/.aws/saml2aws/` was missing because the previous symlink-based strategy requires privileges most Windows users don't have
- Replaces the symlink-based storage directory strategy with plain directory creation on all platforms — no special privileges required
- Handles legacy symlink migration: detects and removes stale symlinks from previous Atmos versions, preserving any existing `storageState.json` from the symlink target
- Removes ~70 lines of dead symlink code (symlink creation, staging, restore, validation)
- Adds comprehensive cross-platform tests for the new directory-based storage strategy and legacy migration
- Adds fix doc with full end-to-end auth flow analysis explaining the two independent storage systems (AWS credentials vs Playwright browser session state)

## why

- **Root cause:** the previous symlink strategy created `~/.aws/saml2aws` as a symlink to an XDG cache directory. On Windows, `os.Symlink` requires Developer Mode or admin privileges — without these, the symlink creation failed silently and the directory was simply absent. The upstream saml2aws library then failed to write `storageState.json` because the parent directory did not exist ("The system cannot find the path specified")
- **Impact is browser session reuse only:** `storageState.json` contains Playwright browser session data (cookies for re-authentication). It is NOT part of the AWS credential pipeline — credentials are stored separately in INI files under `~/.config/atmos/aws/{provider}/credentials` using `filepath.Join` (correct on all platforms). Without the fix, users must re-authenticate in the browser every time instead of reusing a saved session
- **The fix creates a plain directory** at the path saml2aws expects using `os.MkdirAll` with `filepath.Join` — works on all platforms, no special privileges required. Legacy symlinks from previous versions are detected and migrated (preserving existing session state)
- **Upstream bug:** saml2aws also constructs the storage path using `fmt.Sprintf` with hardcoded forward slashes instead of `filepath.Join`, producing mixed separators on Windows. Go's `os` package normalizes these internally, so once the directory exists the path resolves correctly

## references

- Fix doc: `docs/fixes/2026-04-10-auth-windows-path-issues.md` (full root-cause analysis, auth flow trace, impact assessment)
- Upstream bug: `github.com/versent/saml2aws/v2/pkg/provider/browser/browser.go:118` — uses `fmt.Sprintf` with hardcoded forward slashes instead of `filepath.Join`
- Related: `saml-driver-install` branch / PR #1747 — the branch where the symlink strategy was originally implemented
- Related: `docs/prd/saml-browser-driver-integration.md` — SAML browser driver integration PRD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows failures saving browser session state during SAML authentication by ensuring a real, platform-correct storage directory and automatic migration of existing setups.
  * Improved cross-platform robustness and preserved existing session state where present.

* **Documentation**
  * Added a detailed guide describing the issue, root cause, and migration strategy.

* **Tests**
  * Added cross-platform tests verifying idempotent directory creation, state preservation, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->