### PR TITLE
fix: Custom command sharing name with experimental built-in no longer triggers warning

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -887,8 +887,11 @@ func isCompletionCommand(cmd *cobra.Command) bool {
 func findExperimentalParent(cmd *cobra.Command) string {
 	// First pass: Look for registry-based experimental commands.
 	// These are top-level commands like devcontainer, toolchain.
+	// Only match commands that are direct children of the root command,
+	// so custom commands that happen to share a name (e.g., "atmos utils ai")
+	// are not mistakenly flagged as experimental.
 	for c := cmd; c != nil; c = c.Parent() {
-		if internal.IsCommandExperimental(c.Name()) {
+		if internal.IsCommandExperimental(c.Name()) && isTopLevelCommand(c) {
 			return c.Name()
 		}
 	}
@@ -902,6 +905,15 @@ func findExperimentalParent(cmd *cobra.Command) string {
 	}
 
 	return ""
+}
+
+// isTopLevelCommand returns true if cmd is a direct child of the root command.
+// This is used to distinguish built-in registered commands (e.g., "atmos ai")
+// from custom commands that share the same name (e.g., "atmos utils ai").
+func isTopLevelCommand(cmd *cobra.Command) bool {
+	parent := cmd.Parent()
+	// A top-level command's parent is root (whose own parent is nil).
+	return parent != nil && parent.Parent() == nil
 }
 
 // flagStyles holds the lipgloss styles for flag rendering.

--- a/cmd/root_helpers_test.go
+++ b/cmd/root_helpers_test.go
@@ -1008,9 +1008,14 @@ func (p *testExperimentalProvider) IsExperimental() bool                { return
 // detection only matches top-level built-in commands, not custom commands that
 // share the same name (issue #2315).
 func TestFindExperimentalParent_RegistryBased(t *testing.T) {
-	// Register a mock experimental provider named "ai".
+	// Save and restore only the provider this test overrides.
+	prevProvider, hadPrev := internal.GetProvider("ai")
 	internal.Register(&testExperimentalProvider{name: "ai"})
-	defer internal.Reset()
+	t.Cleanup(func() {
+		if hadPrev {
+			internal.Register(prevProvider)
+		}
+	})
 
 	t.Run("top-level ai command is experimental", func(t *testing.T) {
 		// Simulate: atmos ai (root -> ai).

--- a/cmd/root_helpers_test.go
+++ b/cmd/root_helpers_test.go
@@ -14,8 +14,11 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cloudposse/atmos/cmd/internal"
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/flags"
+	"github.com/cloudposse/atmos/pkg/flags/compat"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/profiler"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -976,6 +979,104 @@ func TestFindExperimentalParent(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// testExperimentalProvider is a minimal CommandProvider for testing registry-based
+// experimental command detection.
+type testExperimentalProvider struct {
+	name string
+}
+
+func (p *testExperimentalProvider) GetCommand() *cobra.Command {
+	return &cobra.Command{Use: p.name}
+}
+
+func (p *testExperimentalProvider) GetName() string                { return p.name }
+func (p *testExperimentalProvider) GetGroup() string               { return "" }
+func (p *testExperimentalProvider) GetFlagsBuilder() flags.Builder { return nil }
+func (p *testExperimentalProvider) GetPositionalArgsBuilder() *flags.PositionalArgsBuilder {
+	return nil
+}
+
+func (p *testExperimentalProvider) GetCompatibilityFlags() map[string]compat.CompatibilityFlag {
+	return nil
+}
+func (p *testExperimentalProvider) GetAliases() []internal.CommandAlias { return nil }
+func (p *testExperimentalProvider) IsExperimental() bool                { return true }
+
+// TestFindExperimentalParent_RegistryBased tests that registry-based experimental
+// detection only matches top-level built-in commands, not custom commands that
+// share the same name (issue #2315).
+func TestFindExperimentalParent_RegistryBased(t *testing.T) {
+	// Register a mock experimental provider named "ai".
+	internal.Register(&testExperimentalProvider{name: "ai"})
+	defer internal.Reset()
+
+	t.Run("top-level ai command is experimental", func(t *testing.T) {
+		// Simulate: atmos ai (root -> ai).
+		root := &cobra.Command{Use: "atmos"}
+		ai := &cobra.Command{Use: "ai"}
+		root.AddCommand(ai)
+
+		result := findExperimentalParent(ai)
+		assert.Equal(t, "ai", result)
+	})
+
+	t.Run("top-level ai subcommand inherits experimental", func(t *testing.T) {
+		// Simulate: atmos ai chat (root -> ai -> chat).
+		root := &cobra.Command{Use: "atmos"}
+		ai := &cobra.Command{Use: "ai"}
+		chat := &cobra.Command{Use: "chat"}
+		root.AddCommand(ai)
+		ai.AddCommand(chat)
+
+		result := findExperimentalParent(chat)
+		assert.Equal(t, "ai", result)
+	})
+
+	t.Run("custom command named ai under utils is NOT experimental", func(t *testing.T) {
+		// Simulate: atmos utils ai (root -> utils -> ai).
+		// This is the bug from issue #2315.
+		root := &cobra.Command{Use: "atmos"}
+		utils := &cobra.Command{Use: "utils"}
+		ai := &cobra.Command{Use: "ai"}
+		root.AddCommand(utils)
+		utils.AddCommand(ai)
+
+		result := findExperimentalParent(ai)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("custom command named ai fix under utils is NOT experimental", func(t *testing.T) {
+		// Simulate: atmos utils ai fix (root -> utils -> ai -> fix).
+		root := &cobra.Command{Use: "atmos"}
+		utils := &cobra.Command{Use: "utils"}
+		ai := &cobra.Command{Use: "ai"}
+		fix := &cobra.Command{Use: "fix"}
+		root.AddCommand(utils)
+		utils.AddCommand(ai)
+		ai.AddCommand(fix)
+
+		result := findExperimentalParent(fix)
+		assert.Equal(t, "", result)
+	})
+}
+
+// TestIsTopLevelCommand tests the isTopLevelCommand helper.
+func TestIsTopLevelCommand(t *testing.T) {
+	root := &cobra.Command{Use: "atmos"}
+	topLevel := &cobra.Command{Use: "ai"}
+	nested := &cobra.Command{Use: "chat"}
+	root.AddCommand(topLevel)
+	topLevel.AddCommand(nested)
+
+	assert.True(t, isTopLevelCommand(topLevel), "direct child of root should be top-level")
+	assert.False(t, isTopLevelCommand(nested), "grandchild of root should not be top-level")
+	assert.False(t, isTopLevelCommand(root), "root itself should not be top-level")
+
+	// Command with no parent.
+	orphan := &cobra.Command{Use: "orphan"}
+	assert.False(t, isTopLevelCommand(orphan), "command with no parent should not be top-level")
 }
 
 // TestParseUseVersionFromArgsInternal tests --use-version flag parsing.


### PR DESCRIPTION
## what

- Fixed experimental command detection to only match top-level built-in commands, not custom commands that share the same name
- Added `isTopLevelCommand()` helper to verify a command is a direct child of the root command
- Updated `findExperimentalParent()` to require both a registry match **and** top-level position

## why

- A user-defined custom command `atmos utils ai` was incorrectly triggering the experimental warning for the built-in `atmos ai` command
- The detection logic in `findExperimentalParent()` walked the command tree and checked `IsCommandExperimental(c.Name())`, which matches on bare name only — so any nested command node named `ai` matched the registered built-in `ai` provider
- The fix ensures registry-based experimental detection only fires when the command is a direct child of root (parent's parent is nil), distinguishing `atmos ai` from `atmos utils ai`

## references

- Closes #2315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experimental command detection so only top-level experimental commands are treated as experimental. This prevents custom or nested commands with the same name from being misclassified, ensuring experimental labels and related behavior appear only for the intended root-level commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->