### PR TITLE
chore: Update Atmos Pro workflow to use v1.215.0 container image

### DIFF
--- a/.github/workflows/atmos-pro.yaml
+++ b/.github/workflows/atmos-pro.yaml
@@ -14,7 +14,7 @@ jobs:
       - extras=s3-cache
       - private=false
     container:
-      image: ghcr.io/cloudposse/atmos:1.214.0
+      image: ghcr.io/cloudposse/atmos:1.215.0
     permissions:
       contents: read
       id-token: write
@@ -67,12 +67,6 @@ jobs:
       - name: Generate NOTICE file
         run: ./scripts/generate-notice.sh
 
-      - name: Build atmos from source
-        env:
-          CGO_ENABLED: "0"
-          GOFLAGS: -buildvcs=false
-        run: go build -o /tmp/atmos-dev .
-
       # Format HCL files in test fixtures and examples
       - name: Format HCL
         run: |
@@ -81,11 +75,11 @@ jobs:
 
       # Regenerate README.md from README.yaml
       - name: Regenerate README
-        run: /tmp/atmos-dev docs generate readme
+        run: atmos docs generate readme
 
       - name: Commit fixes via Atmos Pro
         env:
           ATMOS_LOGS_LEVEL: debug
           ATMOS_PRO_WORKSPACE_ID: ${{ vars.ATMOS_PRO_WORKSPACE_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: /tmp/atmos-dev pro commit -m "[autocommit] formatting fixes" --all
+        run: atmos pro commit -m "[autocommit] formatting fixes" --all


### PR DESCRIPTION
## what

- Updated the Atmos Pro CI workflow container image from `1.214.0` to `1.215.0`
- Removed the "Build atmos from source" step that compiled a dev binary via `go build`
- Changed `atmos docs generate readme` and `atmos pro commit` to use the container's pre-installed `atmos` binary instead of `/tmp/atmos-dev`

## why

- Atmos v1.215.0 ships with the `pro commit` command built-in, so building from source is no longer necessary
- Simplifies the CI workflow and reduces build time by eliminating the Go compilation step

## references

- #2298 (`atmos pro commit` feature)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to use atmos container image version 1.215.0 (upgraded from 1.214.0).
  * Streamlined workflow execution by removing the local build step and invoking atmos directly from the container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->