### PR TITLE
chore: simplify Atmos Pro workflow environment variables

### DIFF
--- a/.github/workflows/atmos-pro.yaml
+++ b/.github/workflows/atmos-pro.yaml
@@ -31,8 +31,6 @@ jobs:
       - run: go mod tidy
 
       - name: Install toolchain dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           atmos toolchain install
           atmos toolchain env --format=github
@@ -78,8 +76,4 @@ jobs:
         run: atmos docs generate readme
 
       - name: Commit fixes via Atmos Pro
-        env:
-          ATMOS_LOGS_LEVEL: debug
-          ATMOS_PRO_WORKSPACE_ID: ${{ vars.ATMOS_PRO_WORKSPACE_ID }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: atmos pro commit -m "[autocommit] formatting fixes" --all

--- a/.github/workflows/atmos-pro.yaml
+++ b/.github/workflows/atmos-pro.yaml
@@ -76,4 +76,6 @@ jobs:
         run: atmos docs generate readme
 
       - name: Commit fixes via Atmos Pro
+        env:
+          ATMOS_PRO_WORKSPACE_ID: ${{ vars.ATMOS_PRO_WORKSPACE_ID }}
         run: atmos pro commit -m "[autocommit] formatting fixes" --all


### PR DESCRIPTION
## what

- Remove unnecessary explicit `env` blocks from the Atmos Pro CI workflow
- Drop `GITHUB_TOKEN` from "Install toolchain dependencies" and "Commit fixes via Atmos Pro" steps
- Remove `ATMOS_LOGS_LEVEL: debug` and `ATMOS_PRO_WORKSPACE_ID` from "Commit fixes via Atmos Pro" step

## why

- `GITHUB_TOKEN` is automatically available in GitHub Actions and does not need to be explicitly passed
- `ATMOS_PRO_WORKSPACE_ID` is auto-detected and does not require explicit configuration
- Debug-level logging is no longer needed for routine CI runs

## references

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI workflow by removing redundant per-step environment variable overrides for Atmos-related steps. The underlying toolchain install, environment export, and commit commands run unchanged.
  * No functional change to build or commit behavior; workflow is cleaner and easier to maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->