### PR TITLE
feat: auto-derive provider alias + e2e coverage (stacked on #2210)

### DIFF
--- a/internal/exec/terraform_providers_aliases_test.go
+++ b/internal/exec/terraform_providers_aliases_test.go
@@ -1,0 +1,112 @@
+package exec
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestGenerateProviderOverridesForAliases is an end-to-end integration test that
+// reproduces cloudposse/atmos#2208: provider keys using the `<base>.<alias>`
+// shorthand (e.g. `aws.use1`) must be grouped into a Terraform-JSON array under
+// the base key, not emitted as separate top-level keys.
+//
+// The test loads a real stack config via ProcessStacks, invokes the same
+// generateProviderOverrides() function that ExecuteTerraform calls in production
+// (terraform.go:394), reads the generated providers_override.tf.json from disk,
+// and asserts its JSON structure. This exercises the full path:
+//
+//	stack YAML -> stack processor -> ComponentProvidersSection ->
+//	  generateComponentProviderOverrides -> ProcessProviderAliases ->
+//	    WriteToFileAsJSON -> providers_override.tf.json
+//
+// Two components cover both forms of the shorthand:
+//   - `eip-explicit-alias`: the user writes `alias: use1` inside the block.
+//   - `eip-derived-alias`:  the user omits `alias:` and Atmos derives `use1`
+//     from the key suffix.
+func TestGenerateProviderOverridesForAliases(t *testing.T) {
+	// Unset env vars that would otherwise point Atmos at a different config.
+	require.NoError(t, os.Unsetenv("ATMOS_CLI_CONFIG_PATH"))
+	require.NoError(t, os.Unsetenv("ATMOS_BASE_PATH"))
+
+	fixture := "../../tests/fixtures/scenarios/atmos-providers-aliases"
+	t.Chdir(fixture)
+
+	tests := []struct {
+		name      string
+		component string
+	}{
+		{
+			name:      "explicit alias in block",
+			component: "eip-explicit-alias",
+		},
+		{
+			// Regression + enhancement: alias is derived from the key suffix
+			// when the block does not define it explicitly.
+			name:      "alias auto-derived from key",
+			component: "eip-derived-alias",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := schema.ConfigAndStacksInfo{
+				ComponentFromArg: tt.component,
+				Stack:            "nonprod",
+				ComponentType:    cfg.TerraformComponentType,
+			}
+			atmosConfig, err := cfg.InitCliConfig(info, true)
+			require.NoError(t, err)
+
+			result, err := ProcessStacks(&atmosConfig, info, true, false, false, nil, nil)
+			require.NoError(t, err, "ProcessStacks must load the fixture stack")
+			require.NotEmpty(t, result.ComponentProvidersSection, "ComponentProvidersSection should be populated from the stack")
+
+			// Write the provider override file to a test-scoped tempdir so the
+			// real filesystem is exercised but we leave no residue behind.
+			tempDir := t.TempDir()
+			require.NoError(t, generateProviderOverrides(&atmosConfig, &result, tempDir))
+
+			providersFile := filepath.Join(tempDir, "providers_override.tf.json")
+			raw, err := os.ReadFile(providersFile)
+			require.NoError(t, err, "providers_override.tf.json must be generated")
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(raw, &parsed), "generated file must be valid JSON")
+
+			// Top-level shape: {"provider": {...}}.
+			providerSection, ok := parsed["provider"].(map[string]any)
+			require.True(t, ok, "top-level `provider` must be an object, got %T", parsed["provider"])
+
+			// Regression signal: `aws.use1` MUST NOT appear as a top-level provider key.
+			_, hasDotKey := providerSection["aws.use1"]
+			assert.False(t, hasDotKey, "generated JSON must not contain `aws.use1` as a top-level provider key; got: %s", string(raw))
+
+			// The fix: `provider.aws` MUST be a JSON array of length 2.
+			awsEntries, ok := providerSection["aws"].([]any)
+			require.True(t, ok, "`provider.aws` must be a JSON array, got %T in: %s", providerSection["aws"], string(raw))
+			require.Len(t, awsEntries, 2, "`provider.aws` must contain 2 entries (base + 1 alias)")
+
+			// First entry is the bare base provider; must not carry an `alias`.
+			base, ok := awsEntries[0].(map[string]any)
+			require.True(t, ok, "first entry must be an object")
+			assert.Equal(t, "us-east-2", base["region"])
+			_, baseHasAlias := base["alias"]
+			assert.False(t, baseHasAlias, "base provider entry must not have an `alias` key")
+
+			// Second entry is the alias; must carry `alias: use1` regardless of
+			// whether it was explicit or auto-derived.
+			aliased, ok := awsEntries[1].(map[string]any)
+			require.True(t, ok, "second entry must be an object")
+			assert.Equal(t, "us-east-1", aliased["region"])
+			assert.Equal(t, "use1", aliased["alias"], "alias must be set (explicit or auto-derived)")
+		})
+	}
+}

--- a/internal/exec/utils_test.go
+++ b/internal/exec/utils_test.go
@@ -233,6 +233,45 @@ func TestGenerateComponentProviderOverrides(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for issue #2208: alias is auto-derived from the
+			// dot suffix when the provider block does not set it explicitly.
+			name: "alias-auto-derived",
+			providerOverrides: map[string]any{
+				"aws": map[string]any{
+					"region": "us-east-2",
+				},
+				"aws.use1": map[string]any{
+					"region": "us-east-1",
+				},
+			},
+			expected: map[string]any{
+				"provider": map[string]any{
+					"aws": []any{
+						map[string]any{"region": "us-east-2"},
+						map[string]any{"region": "us-east-1", "alias": "use1"},
+					},
+				},
+			},
+		},
+		{
+			// An explicit alias set inside the block must not be overwritten
+			// by the value derived from the dot suffix.
+			name: "explicit-alias-preserved",
+			providerOverrides: map[string]any{
+				"aws.use1": map[string]any{
+					"region": "us-east-1",
+					"alias":  "primary",
+				},
+			},
+			expected: map[string]any{
+				"provider": map[string]any{
+					"aws": []any{
+						map[string]any{"region": "us-east-1", "alias": "primary"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/terraform/output/backend.go
+++ b/pkg/terraform/output/backend.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"maps"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -146,19 +147,21 @@ func generateProviderOverrides(providerOverrides map[string]any, _ *schema.AuthC
 // ProcessProviderAliases groups providers that use dot notation (e.g., "aws.alias") into arrays.
 // This converts the Atmos shorthand notation into the Terraform JSON provider format.
 // For example, {"aws": {...}, "aws.use1": {...}} becomes {"aws": [{...}, {...}]}.
+//
+// When an aliased entry (e.g., "aws.use1") does not explicitly set the `alias` field
+// inside its configuration block, Atmos automatically derives it from the portion of
+// the key after the first dot. An explicit `alias` value always wins — Atmos will not
+// overwrite it. Non-map configuration values are passed through unchanged.
+//
+// The input map is not mutated; aliased blocks are cloned before being modified.
 func ProcessProviderAliases(providerOverrides map[string]any) map[string]any {
+	defer perf.Track(nil, "output.ProcessProviderAliases")()
+
 	if len(providerOverrides) == 0 {
 		return providerOverrides
 	}
 
-	// Find all base names that have aliased configurations (with dot notation).
-	baseNamesWithAliases := make(map[string]bool)
-	for key := range providerOverrides {
-		if idx := strings.Index(key, "."); idx > 0 {
-			baseName := key[:idx]
-			baseNamesWithAliases[baseName] = true
-		}
-	}
+	baseNamesWithAliases := collectAliasedBaseNames(providerOverrides)
 
 	// If no aliased providers, return as-is.
 	if len(baseNamesWithAliases) == 0 {
@@ -169,40 +172,87 @@ func ProcessProviderAliases(providerOverrides map[string]any) map[string]any {
 
 	// Build arrays for base providers that have aliases.
 	for baseName := range baseNamesWithAliases {
-		var configs []any
-
-		// Add the base config first (if it exists).
-		if config, exists := providerOverrides[baseName]; exists {
-			configs = append(configs, config)
-		}
-
-		// Add aliased configs in sorted order for determinism.
-		var aliasedKeys []string
-		for key := range providerOverrides {
-			if strings.HasPrefix(key, baseName+".") {
-				aliasedKeys = append(aliasedKeys, key)
-			}
-		}
-		sort.Strings(aliasedKeys)
-		for _, key := range aliasedKeys {
-			configs = append(configs, providerOverrides[key])
-		}
-
-		result[baseName] = configs
+		result[baseName] = buildAliasedProviderConfigs(baseName, providerOverrides)
 	}
 
-	// Copy over providers that don't have aliases.
-	for key, config := range providerOverrides {
-		// Skip dot-notation keys (already processed above).
+	// Copy over providers that are neither dot-notation keys nor bases with aliases.
+	copyNonAliasedProviders(result, providerOverrides, baseNamesWithAliases)
+
+	return result
+}
+
+// collectAliasedBaseNames returns the set of base provider names (prefix before
+// the first dot) that have at least one dot-notation aliased entry.
+func collectAliasedBaseNames(providerOverrides map[string]any) map[string]bool {
+	baseNames := make(map[string]bool)
+	for key := range providerOverrides {
+		if idx := strings.Index(key, "."); idx > 0 {
+			baseNames[key[:idx]] = true
+		}
+	}
+	return baseNames
+}
+
+// buildAliasedProviderConfigs returns the ordered slice of provider blocks for
+// a base provider that has aliases: the bare base block first (if present),
+// followed by alias blocks in sorted key order. Each alias block has its
+// `alias` field auto-derived from the key suffix when not set explicitly.
+func buildAliasedProviderConfigs(baseName string, providerOverrides map[string]any) []any {
+	var configs []any
+
+	// Add the base config first (if it exists).
+	if config, exists := providerOverrides[baseName]; exists {
+		configs = append(configs, config)
+	}
+
+	// Collect aliased keys for this base provider and sort for deterministic output.
+	var aliasedKeys []string
+	prefix := baseName + "."
+	for key := range providerOverrides {
+		if strings.HasPrefix(key, prefix) {
+			aliasedKeys = append(aliasedKeys, key)
+		}
+	}
+	sort.Strings(aliasedKeys)
+
+	for _, key := range aliasedKeys {
+		// Derive alias from the suffix after the first dot (e.g., "aws.use1" -> "use1").
+		aliasName := key[len(prefix):]
+		configs = append(configs, withDerivedAlias(providerOverrides[key], aliasName))
+	}
+
+	return configs
+}
+
+// copyNonAliasedProviders copies every provider from src into dst that is not
+// a dot-notation key and is not a base name of an aliased group (those are
+// handled separately by buildAliasedProviderConfigs).
+func copyNonAliasedProviders(dst, src map[string]any, baseNamesWithAliases map[string]bool) {
+	for key, config := range src {
 		if strings.Contains(key, ".") {
 			continue
 		}
-		// Skip base providers that have aliases (already processed above).
 		if baseNamesWithAliases[key] {
 			continue
 		}
-		result[key] = config
+		dst[key] = config
+	}
+}
+
+// withDerivedAlias returns the provider block with `alias` set to aliasName when
+// the block is a map and does not already define `alias`. An explicit alias value
+// (including an empty string) always wins. Non-map blocks are returned unchanged.
+// The input block is never mutated — a shallow copy is returned when a change is made.
+func withDerivedAlias(block any, aliasName string) any {
+	cfg, ok := block.(map[string]any)
+	if !ok {
+		return block
+	}
+	if _, hasAlias := cfg["alias"]; hasAlias {
+		return block
 	}
 
-	return result
+	cloned := maps.Clone(cfg)
+	cloned["alias"] = aliasName
+	return cloned
 }

--- a/pkg/terraform/output/backend_test.go
+++ b/pkg/terraform/output/backend_test.go
@@ -359,6 +359,69 @@ func TestGenerateProviderOverrides(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for issue #2208: alias should be derived from the dot
+			// suffix when the user omits it from the provider block.
+			name: "alias auto-derived from dot-suffix",
+			providers: map[string]any{
+				"aws": map[string]any{
+					"region": "us-east-2",
+				},
+				"aws.use1": map[string]any{
+					"region": "us-east-1",
+				},
+			},
+			authContext: nil,
+			expectedResult: map[string]any{
+				"provider": map[string]any{
+					"aws": []any{
+						map[string]any{"region": "us-east-2"},
+						map[string]any{"region": "us-east-1", "alias": "use1"},
+					},
+				},
+			},
+		},
+		{
+			// Explicit alias values must be preserved even when they differ from
+			// the dot suffix — user intent wins over Atmos auto-derivation.
+			name: "explicit alias preserved over auto-derive",
+			providers: map[string]any{
+				"aws.use1": map[string]any{
+					"region": "us-east-1",
+					"alias":  "primary",
+				},
+			},
+			authContext: nil,
+			expectedResult: map[string]any{
+				"provider": map[string]any{
+					"aws": []any{
+						map[string]any{"region": "us-east-1", "alias": "primary"},
+					},
+				},
+			},
+		},
+		{
+			// Aliased providers without a bare base provider must still produce
+			// an array; aliases are auto-derived when absent.
+			name: "aliased without base with auto-derive",
+			providers: map[string]any{
+				"aws.use1": map[string]any{
+					"region": "us-east-1",
+				},
+				"aws.use2": map[string]any{
+					"region": "us-east-2",
+				},
+			},
+			authContext: nil,
+			expectedResult: map[string]any{
+				"provider": map[string]any{
+					"aws": []any{
+						map[string]any{"region": "us-east-1", "alias": "use1"},
+						map[string]any{"region": "us-east-2", "alias": "use2"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -368,6 +431,40 @@ func TestGenerateProviderOverrides(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+// TestProcessProviderAliases_DoesNotMutateInput guards against accidental mutation
+// of the input map when auto-deriving the `alias` field — callers expect their
+// provider-overrides map to be unchanged after processing.
+func TestProcessProviderAliases_DoesNotMutateInput(t *testing.T) {
+	input := map[string]any{
+		"aws.use1": map[string]any{
+			"region": "us-east-1",
+		},
+	}
+
+	_ = ProcessProviderAliases(input)
+
+	// The inner block must not have been populated with an `alias` key by the
+	// auto-derive logic — the transformation operates on a clone.
+	innerBlock, ok := input["aws.use1"].(map[string]any)
+	assert.True(t, ok, "inner block should still be a map after processing")
+	_, hasAlias := innerBlock["alias"]
+	assert.False(t, hasAlias, "input block must not be mutated with a derived alias")
+}
+
+// TestProcessProviderAliases_NonMapAliasedBlock verifies that non-map values in
+// aliased keys pass through unchanged instead of panicking the auto-derive logic.
+func TestProcessProviderAliases_NonMapAliasedBlock(t *testing.T) {
+	input := map[string]any{
+		"aws.use1": "not-a-map",
+	}
+
+	result := ProcessProviderAliases(input)
+
+	assert.Equal(t, map[string]any{
+		"aws": []any{"not-a-map"},
+	}, result)
 }
 
 func TestDefaultBackendGenerator_GenerateBackendIfNeeded(t *testing.T) {

--- a/tests/fixtures/scenarios/atmos-providers-aliases/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-providers-aliases/atmos.yaml
@@ -1,0 +1,21 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "../../components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.stage }}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info

--- a/tests/fixtures/scenarios/atmos-providers-aliases/stacks/deploy/nonprod.yaml
+++ b/tests/fixtures/scenarios/atmos-providers-aliases/stacks/deploy/nonprod.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+
+# Reproduces cloudposse/atmos#2208. The two components below cover both forms
+# of the provider-aliases shorthand:
+#   - `eip-explicit-alias` matches the reporter's original config verbatim
+#     (with `alias: use1` set explicitly inside the block).
+#   - `eip-derived-alias` relies on Atmos to auto-derive `alias` from the key
+#     suffix (a user-ergonomics win added alongside the fix).
+#
+# Both components MUST produce a JSON array under `provider.aws` in the
+# generated `providers_override.tf.json`.
+
+vars:
+  stage: nonprod
+
+components:
+  terraform:
+    eip-explicit-alias:
+      metadata:
+        component: mock
+      providers:
+        aws:
+          region: us-east-2
+        aws.use1:
+          region: us-east-1
+          alias: use1
+
+    eip-derived-alias:
+      metadata:
+        component: mock
+      providers:
+        aws:
+          region: us-east-2
+        aws.use1:
+          region: us-east-1

--- a/website/docs/stacks/providers.mdx
+++ b/website/docs/stacks/providers.mdx
@@ -126,6 +126,14 @@ terraform:
 
 Configure multiple AWS regions using provider aliases:
 
+:::tip Dot-notation shorthand
+
+Atmos recognizes dot-notation provider keys (for example `aws.uswest2`) as aliased configurations of the same provider. When generating `providers_override.tf.json`, all keys that share a base provider name are grouped into a JSON array — the format Terraform requires for [multiple provider configurations](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations).
+
+Atmos also automatically derives the `alias` field from the portion of the key after the first dot, so `aws.uswest2` implies `alias: uswest2`. You can still set `alias:` explicitly inside the block — an explicit value always wins.
+
+:::
+
 <Tabs>
   <TabItem value="yaml" label="Stack Configuration" default>
     ```yaml title="stacks/orgs/acme/plat/prod/global.yaml"
@@ -135,9 +143,10 @@ Configure multiple AWS regions using provider aliases:
           providers:
             aws:
               region: us-east-1
+            # `alias: uswest2` is auto-derived from the key suffix.
             aws.uswest2:
               region: us-west-2
-              alias: uswest2
+            # You can also set `alias` explicitly to override the derived value.
             aws.euwest1:
               region: eu-west-1
               alias: euwest1


### PR DESCRIPTION
## what

Stacked on top of #2210 (`copilot/fix-multi-region-provider-aliases`). Retarget base to `main` once #2210 merges.

- Auto-derive `alias:` from the portion of a dot-notation key after the first dot (e.g. `aws.use1` implies `alias: use1`). An explicit `alias:` inside the block always wins; non-map blocks pass through unchanged; the input map is never mutated (aliased blocks are cloned via `maps.Clone` before assignment — avoids the CodeQL CWE-190 overflow alert that the manual `make(map, len+1)` pattern triggered).
- Refactor `ProcessProviderAliases` into three focused helpers (`collectAliasedBaseNames`, `buildAliasedProviderConfigs`, `copyNonAliasedProviders`) to stay under the cyclomatic-complexity cap and make the data flow easier to read.
- Add `defer perf.Track(nil, "output.ProcessProviderAliases")()` per repo convention for public transforms.
- Add unit coverage: auto-derive, explicit-alias-wins-over-derived, aliased-without-base with derive, no-mutation guard, non-map-block passthrough.
- Add end-to-end integration test `TestGenerateProviderOverridesForAliases` that loads a real stack via `ProcessStacks`, runs the same `generateProviderOverrides` path `ExecuteTerraform` uses, parses the generated `providers_override.tf.json` from disk, and asserts the JSON shape (no `aws.use1` top-level key; `provider.aws` is a 2-entry array; alias is set regardless of source).
- Add fixture `tests/fixtures/scenarios/atmos-providers-aliases/` with two components covering explicit-alias and auto-derived-alias flows.
- Update `website/docs/stacks/providers.mdx` to explain the dot-notation shorthand and the auto-derive behavior; demonstrate both styles in the YAML example.

## why

- #2210 fixes the core bug (aliased providers weren't grouped into arrays) but only covers it with an in-memory map transform test. This PR closes the gap with an end-to-end test that parses the generated file on disk — that's what actually matters for Terraform interoperability.
- Auto-deriving `alias:` from the key suffix removes a redundant field that duplicates information already present in the key, making the shorthand behave like users expect and matching what the documented "Multi-Region with Provider Aliases" example demonstrates.
- The refactor keeps the hot path within the repo's complexity and performance-tracking conventions.

## references

- closes #2208
- builds on #2210