### PR TITLE
perf(locals): memoize resolved locals per file to fix list stacks hang

### DIFF
--- a/internal/exec/stack_processor_cache.go
+++ b/internal/exec/stack_processor_cache.go
@@ -1,6 +1,8 @@
 package exec
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 	"sync"
 
@@ -27,6 +29,16 @@ var (
 	// No cache invalidation needed - schemas are immutable per command execution.
 	jsonSchemaCache   = make(map[string]*jsonschema.Schema)
 	jsonSchemaCacheMu sync.RWMutex
+
+	// localsExtractCache memoizes resolved locals per stack file for the lifetime of a
+	// single Atmos command. Locals resolution can trigger expensive YAML functions like
+	// `!terraform.state` and `!terraform.output` that hit remote backends (GCS/S3). During
+	// operations that visit every stack file (e.g. `atmos list stacks`), the same file's
+	// locals were previously re-resolved dozens or hundreds of times per command, causing
+	// multi-second hangs. Cache key is composed of the atmosConfig pointer, filePath, and
+	// a content hash so that the cache is safe across tests that reuse file paths with
+	// differing content or configuration. See GitHub issue #2344.
+	localsExtractCache sync.Map // map[string]*extractLocalsResult
 )
 
 // deepCopyBaseComponentConfigMaps deep copies all map fields from src to dst.
@@ -174,6 +186,54 @@ func ClearJsonSchemaCache() {
 	jsonSchemaCacheMu.Lock()
 	defer jsonSchemaCacheMu.Unlock()
 	jsonSchemaCache = make(map[string]*jsonschema.Schema)
+}
+
+// ClearLocalsExtractCache clears the locals extraction cache.
+// This should be called between independent operations (like tests) to ensure fresh processing.
+func ClearLocalsExtractCache() {
+	defer perf.Track(nil, "exec.ClearLocalsExtractCache")()
+
+	localsExtractCache.Range(func(key, value interface{}) bool {
+		localsExtractCache.Delete(key)
+		return true
+	})
+}
+
+// localsExtractCacheKey builds a cache key for locals extraction keyed on the
+// atmosConfig identity, absolute file path, and content hash.
+// Including the atmosConfig pointer prevents cross-test pollution when tests
+// reuse the same file path under different configurations; including the
+// content hash is a safety net in case the same path is ever reused with
+// different content in the same process.
+func localsExtractCacheKey(atmosConfig *schema.AtmosConfiguration, filePath, yamlContent string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(yamlContent))
+	return fmt.Sprintf("%p|%s|%x", atmosConfig, filePath, h.Sum64())
+}
+
+// deepCopyExtractLocalsResult returns a deep copy of an extractLocalsResult so that
+// callers who mutate the returned maps cannot corrupt the cached entry. Returns
+// (nil, err) if any deep copy fails; the caller should treat this as a cache miss
+// and fall through to full recomputation.
+func deepCopyExtractLocalsResult(src *extractLocalsResult) (*extractLocalsResult, error) {
+	if src == nil {
+		return nil, nil
+	}
+	dst := &extractLocalsResult{hasLocals: src.hasLocals}
+	var err error
+	if dst.locals, err = m.DeepCopyMap(src.locals); err != nil {
+		return nil, err
+	}
+	if dst.settings, err = m.DeepCopyMap(src.settings); err != nil {
+		return nil, err
+	}
+	if dst.vars, err = m.DeepCopyMap(src.vars); err != nil {
+		return nil, err
+	}
+	if dst.env, err = m.DeepCopyMap(src.env); err != nil {
+		return nil, err
+	}
+	return dst, nil
 }
 
 // ClearFileContentCache clears the file content cache.

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -52,6 +52,21 @@ type extractLocalsResult struct {
 func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlContent string, filePath string) (*extractLocalsResult, error) {
 	defer perf.Track(atmosConfig, "exec.extractLocalsFromRawYAML")()
 
+	// Memoize by (atmosConfig, filePath, contentHash). Locals resolution is deterministic
+	// for a given input and may trigger expensive YAML functions like !terraform.state that
+	// hit remote backends — without this cache, `atmos list stacks` re-resolves the same
+	// file hundreds of times. Return a deep copy so that callers that treat the result
+	// maps as mutable cannot corrupt future cache hits. See GitHub issue #2344.
+	cacheKey := localsExtractCacheKey(atmosConfig, filePath, yamlContent)
+	if cached, ok := localsExtractCache.Load(cacheKey); ok {
+		if cachedResult, ok := cached.(*extractLocalsResult); ok {
+			if copied, err := deepCopyExtractLocalsResult(cachedResult); err == nil {
+				return copied, nil
+			}
+			// Deep copy failed — fall through and recompute rather than return a shared reference.
+		}
+	}
+
 	// Parse raw YAML to extract the structure.
 	// YAML treats template expressions like {{ .locals.X }} as plain strings,
 	// so parsing succeeds even with unresolved templates.
@@ -75,7 +90,9 @@ func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlConten
 	}
 
 	if rawConfig == nil {
-		return &extractLocalsResult{}, nil
+		emptyResult := &extractLocalsResult{}
+		localsExtractCache.Store(cacheKey, emptyResult)
+		return emptyResult, nil
 	}
 
 	// Derive the stack name from the file path so that YAML functions like
@@ -89,7 +106,18 @@ func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlConten
 		return nil, fmt.Errorf("%w: failed to process stack locals: %w", errUtils.ErrInvalidStackManifest, err)
 	}
 
-	return buildLocalsResult(rawConfig, localsCtx), nil
+	result := buildLocalsResult(rawConfig, localsCtx)
+
+	// Store a deep copy in the cache so that callers' mutations cannot poison subsequent
+	// cache hits. Then return a second deep copy to the caller (also isolated from the
+	// cached entry). On copy failure, return the freshly built result directly and skip
+	// the cache store for this call — correctness is preserved at the cost of missing
+	// the memoization benefit for this file.
+	if cachedCopy, copyErr := deepCopyExtractLocalsResult(result); copyErr == nil {
+		localsExtractCache.Store(cacheKey, cachedCopy)
+	}
+
+	return result, nil
 }
 
 // deriveStackNameForLocals derives the stack name from the file path and raw config

--- a/internal/exec/stack_processor_utils_test.go
+++ b/internal/exec/stack_processor_utils_test.go
@@ -3711,3 +3711,98 @@ locals:
 	require.NotNil(t, result)
 	assert.Equal(t, "vpc-shared-01", result.locals["vpc_id"])
 }
+
+// TestExtractLocalsFromRawYAML_CachesTerraformStateCalls verifies that repeated calls
+// to extractLocalsFromRawYAML for the same (atmosConfig, filePath, content) trigger
+// `!terraform.state` exactly once. This is the regression test for GitHub issue #2344,
+// where `atmos list stacks` re-evaluated locals hundreds of times per file.
+func TestExtractLocalsFromRawYAML_CachesTerraformStateCalls(t *testing.T) {
+	ClearLocalsExtractCache()
+	defer ClearLocalsExtractCache()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStateGetterObj := NewMockTerraformStateGetter(ctrl)
+	originalGetter := stateGetter
+	stateGetter = mockStateGetterObj
+	defer func() { stateGetter = originalGetter }()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	// The mock expects exactly one GetState call — subsequent extractLocalsFromRawYAML
+	// invocations for the same file must be served from the cache. gomock's default
+	// .Times(1) enforces this: a second call would fail the test with an unexpected-call error.
+	mockStateGetterObj.EXPECT().
+		GetState(atmosConfig, gomock.Any(), "shared", "vpc", ".vpc_id", false, gomock.Any(), gomock.Any()).
+		Return("vpc-shared-01", nil).
+		Times(1)
+
+	yamlContent := `
+locals:
+  vpc_id: !terraform.state vpc shared .vpc_id
+`
+	for i := 0; i < 10; i++ {
+		result, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "test.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "vpc-shared-01", result.locals["vpc_id"], "call %d returned unexpected value", i)
+	}
+}
+
+// TestExtractLocalsFromRawYAML_CacheReturnsDeepCopy verifies that mutating the result
+// of one call does not affect subsequent cached calls. The cache must return deep copies
+// so that callers cannot poison each other through shared map references.
+func TestExtractLocalsFromRawYAML_CacheReturnsDeepCopy(t *testing.T) {
+	ClearLocalsExtractCache()
+	defer ClearLocalsExtractCache()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	yamlContent := `
+locals:
+  namespace: "acme"
+  environment: "dev"
+vars:
+  stage: "prod"
+`
+	first, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "cache-isolation-test.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	// Mutate the first result's maps. A leaky cache would propagate these mutations.
+	first.locals["namespace"] = "mutated"
+	first.vars["stage"] = "mutated"
+
+	second, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "cache-isolation-test.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	assert.Equal(t, "acme", second.locals["namespace"], "cache returned a reference to a mutated map")
+	assert.Equal(t, "prod", second.vars["stage"], "cache returned a reference to a mutated map")
+}
+
+// TestExtractLocalsFromRawYAML_CacheIsolatedByContent verifies that different yamlContent
+// at the same filePath produces distinct cached entries. The cache key must include a
+// content component so that test fixtures reusing the same filePath don't collide.
+func TestExtractLocalsFromRawYAML_CacheIsolatedByContent(t *testing.T) {
+	ClearLocalsExtractCache()
+	defer ClearLocalsExtractCache()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	contentA := `
+locals:
+  namespace: "acme"
+`
+	contentB := `
+locals:
+  namespace: "beta"
+`
+	resultA, err := extractLocalsFromRawYAML(atmosConfig, contentA, "shared.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", resultA.locals["namespace"])
+
+	resultB, err := extractLocalsFromRawYAML(atmosConfig, contentB, "shared.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "beta", resultB.locals["namespace"])
+}


### PR DESCRIPTION
A single locals block with `!terraform.state` refs caused each ref to be evaluated hundreds of times during `atmos list stacks`, because every stack file visit (direct and transitive) re-ran the full resolver. Without cloud auth each GCS/S3 call fails fast and the command still hangs for ~20s; with auth it is N× slower than necessary.

Cache `extractLocalsFromRawYAML` results in a sync.Map keyed on `(atmosConfig, filePath, content-hash)` for the lifetime of a single Atmos command. Deep-copy the cached entry on both store and load so caller mutations cannot poison subsequent cache hits, matching the pattern used by `baseComponentConfigCache`. Expose `ClearLocalsExtractCache` so tests can reset cache state between runs.

Fixes #2344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced cache management for stack configuration processing

* **Performance**
  * Configuration locals extraction results are now cached during command execution to prevent redundant reevaluation, improving performance on repeated operations

* **Tests**
  * Added comprehensive unit tests validating cache effectiveness, ensuring isolation between cached entries, and verifying proper content-based cache keying

<!-- end of auto-generated comment: release notes by coderabbit.ai -->