### PR TITLE
fix(locals): stop leaking leaf file context into imported stacks (#2343)

### DIFF
--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -236,8 +236,23 @@ func processTemplatesInSection(atmosConfig *schema.AtmosConfiguration, section m
 	return result, nil
 }
 
+// currentFileSections carries the sections (locals, vars, settings, env) that were
+// actually extracted and resolved from the CURRENT file's raw YAML in
+// extractAndAddLocalsToContext. It is distinct from the inherited template context,
+// which may contain values propagated from parent files during import processing.
+// Callers use this to safely update the current file's stackConfigMap without
+// polluting it with parent-file values.
+type currentFileSections struct {
+	hasLocals bool
+	locals    map[string]any
+	vars      map[string]any
+	settings  map[string]any
+	env       map[string]any
+}
+
 // extractAndAddLocalsToContext extracts locals from YAML and adds them to the template context.
-// Returns the updated context and any error encountered during locals extraction.
+// Returns the updated context, the sections resolved from the CURRENT file (for safe
+// stackConfigMap updates), and any error encountered during locals extraction.
 // Note: The "locals" key in context is reserved for file-scoped locals and will override
 // any user-provided "locals" key in the import context.
 // Settings, vars, and env sections are also added to the context so templates can reference them.
@@ -250,14 +265,24 @@ func extractAndAddLocalsToContext(
 	filePath string,
 	relativeFilePath string,
 	context map[string]any,
-) (map[string]any, error) {
+) (map[string]any, *currentFileSections, error) {
 	defer perf.Track(atmosConfig, "exec.extractAndAddLocalsToContext")()
 
-	// Enforce file-scoped locals: clear any inherited locals from parent context.
-	// Locals are file-scoped and should NOT inherit across file boundaries.
-	// This ensures that each file only has access to its own locals.
-	if context != nil {
-		delete(context, cfg.LocalsSectionName)
+	// Do not mutate the caller's map.
+	//
+	// The same `context` map is handed to multiple import goroutines in
+	// processYAMLConfigFileWithContextInternal (see the `mergedContext` shared
+	// across the per-import goroutines). Writing through the input map would
+	// race with sibling goroutines reading or mutating it. Work on a shallow
+	// copy, enforce file-scoped locals on that copy, and return it as the new
+	// context — the caller reassigns its local variable from the return value.
+	localCtx := make(map[string]any, len(context))
+	for k, v := range context {
+		if k == cfg.LocalsSectionName {
+			// Locals are file-scoped and must not inherit across file boundaries.
+			continue
+		}
+		localCtx[k] = v
 	}
 
 	extractResult, localsErr := extractLocalsFromRawYAML(atmosConfig, yamlContent, filePath)
@@ -267,12 +292,12 @@ func extractAndAddLocalsToContext(
 		// Log the error and continue without locals - template processing will happen next.
 		if strings.HasSuffix(filePath, u.TemplateExtension) {
 			log.Trace("Skipping locals extraction for template file with invalid YAML", "file", relativeFilePath, "error", localsErr)
-			return context, nil
+			return localCtx, nil, nil
 		}
 		// Circular dependencies in locals are a stack misconfiguration error.
 		// Return a helpful error with hints on how to fix it.
 		if stderrors.Is(localsErr, errUtils.ErrLocalsCircularDep) {
-			return context, errUtils.Build(errUtils.ErrLocalsCircularDep).
+			return localCtx, nil, errUtils.Build(errUtils.ErrLocalsCircularDep).
 				WithCause(localsErr).
 				WithContext("file", relativeFilePath).
 				WithHintf("Fix the circular dependency in '%s'", relativeFilePath).
@@ -281,7 +306,7 @@ func extractAndAddLocalsToContext(
 				WithExitCode(1).
 				Err()
 		}
-		return context, localsErr
+		return localCtx, nil, localsErr
 	}
 
 	// Only modify context if a locals section exists in the file.
@@ -290,13 +315,15 @@ func extractAndAddLocalsToContext(
 	// We check hasLocals instead of len(locals) to support empty locals: {} sections,
 	// which should still enable template context.
 	if !extractResult.hasLocals {
-		return context, nil
+		return localCtx, nil, nil
 	}
 
-	// Initialize context if nil.
-	if context == nil {
-		context = make(map[string]any)
-	}
+	// Track which sections came from the CURRENT file so the caller can update
+	// stackConfigMap without overwriting it with inherited parent values.
+	sections := &currentFileSections{hasLocals: true, locals: extractResult.locals}
+
+	// From here on, work exclusively on the local copy.
+	context = localCtx
 
 	// Add resolved locals to the template context first.
 	// This allows settings/vars/env templates to reference locals.
@@ -331,8 +358,10 @@ func extractAndAddLocalsToContext(
 			log.Debug("Failed to process templates in settings section", "file", relativeFilePath, "error", err)
 			// Fall back to raw settings on error.
 			context[cfg.SettingsSectionName] = extractResult.settings
+			sections.settings = extractResult.settings
 		} else {
 			context[cfg.SettingsSectionName] = processedSettings
+			sections.settings = processedSettings
 		}
 	}
 	if extractResult.vars != nil {
@@ -349,8 +378,10 @@ func extractAndAddLocalsToContext(
 			log.Debug("Failed to process templates in vars section", "file", relativeFilePath, "error", err)
 			// Fall back to raw vars on error.
 			context[cfg.VarsSectionName] = extractResult.vars
+			sections.vars = extractResult.vars
 		} else {
 			context[cfg.VarsSectionName] = processedVars
+			sections.vars = processedVars
 		}
 	}
 	if extractResult.env != nil {
@@ -370,12 +401,14 @@ func extractAndAddLocalsToContext(
 			log.Debug("Failed to process templates in env section", "file", relativeFilePath, "error", err)
 			// Fall back to raw env on error.
 			context[cfg.EnvSectionName] = extractResult.env
+			sections.env = extractResult.env
 		} else {
 			context[cfg.EnvSectionName] = processedEnv
+			sections.env = processedEnv
 		}
 	}
 
-	return context, nil
+	return context, sections, nil
 }
 
 // stackProcessResult holds the result of processing a single stack in parallel.
@@ -791,9 +824,10 @@ func processYAMLConfigFileWithContextInternal(
 	//       myapp:
 	//         vars:
 	//           name: "{{ .locals.name_prefix }}"
+	var currentFileResolved *currentFileSections
 	if !skipTemplatesProcessingInImports {
 		var localsErr error
-		context, localsErr = extractAndAddLocalsToContext(atmosConfig, stackYamlConfig, filePath, relativeFilePath, context)
+		context, currentFileResolved, localsErr = extractAndAddLocalsToContext(atmosConfig, stackYamlConfig, filePath, relativeFilePath, context)
 		if localsErr != nil {
 			if mergeContext != nil {
 				return nil, nil, nil, nil, nil, nil, nil, nil, mergeContext.FormatError(localsErr, fmt.Sprintf("stack manifest '%s'", relativeFilePath))
@@ -854,21 +888,24 @@ func processYAMLConfigFileWithContextInternal(
 	}
 
 	// Store resolved file-level sections in stackConfigMap so they're available during describe_stacks.
-	// The context contains resolved values from extractAndAddLocalsToContext, but the YAML content
-	// (and thus stackConfigMap) may still have unresolved template expressions.
-	// By updating stackConfigMap with resolved values, we ensure templates like {{ .locals.X }}
-	// and {{ .vars.X }} can be resolved correctly.
-	if resolvedLocals, ok := context[cfg.LocalsSectionName].(map[string]any); ok && len(resolvedLocals) > 0 {
-		stackConfigMap[cfg.LocalsSectionName] = resolvedLocals
-	}
-	if resolvedVars, ok := context[cfg.VarsSectionName].(map[string]any); ok && len(resolvedVars) > 0 {
-		stackConfigMap[cfg.VarsSectionName] = resolvedVars
-	}
-	if resolvedSettings, ok := context[cfg.SettingsSectionName].(map[string]any); ok && len(resolvedSettings) > 0 {
-		stackConfigMap[cfg.SettingsSectionName] = resolvedSettings
-	}
-	if resolvedEnv, ok := context[cfg.EnvSectionName].(map[string]any); ok && len(resolvedEnv) > 0 {
-		stackConfigMap[cfg.EnvSectionName] = resolvedEnv
+	// Only write back sections that were actually extracted from THIS file's raw YAML
+	// (tracked in currentFileResolved). Using the shared template context here would leak
+	// parent-file values into the current file and clobber its own sections when imports
+	// inherit a context populated by a downstream leaf file — e.g., ancestor `_defaults.yaml`
+	// losing its `namespace` because the importing leaf's vars were propagated into `context`.
+	if currentFileResolved != nil {
+		if currentFileResolved.hasLocals && len(currentFileResolved.locals) > 0 {
+			stackConfigMap[cfg.LocalsSectionName] = currentFileResolved.locals
+		}
+		if len(currentFileResolved.vars) > 0 {
+			stackConfigMap[cfg.VarsSectionName] = currentFileResolved.vars
+		}
+		if len(currentFileResolved.settings) > 0 {
+			stackConfigMap[cfg.SettingsSectionName] = currentFileResolved.settings
+		}
+		if len(currentFileResolved.env) > 0 {
+			stackConfigMap[cfg.EnvSectionName] = currentFileResolved.env
+		}
 	}
 
 	// Enable provenance tracking in merge context if tracking is enabled

--- a/internal/exec/stack_processor_utils_test.go
+++ b/internal/exec/stack_processor_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2855,7 +2856,7 @@ locals:
 settings:
   label: '{{ .locals.stage }}-config'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		settings, ok := ctx["settings"].(map[string]any)
 		require.True(t, ok, "settings should exist in context")
@@ -2871,7 +2872,7 @@ settings:
 vars:
   deploy_env: '{{ .locals.env }}'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		vars, ok := ctx["vars"].(map[string]any)
 		require.True(t, ok, "vars should exist in context")
@@ -2885,7 +2886,7 @@ locals:
 env:
   APP_NAME: '{{ .locals.app }}'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		env, ok := ctx["env"].(map[string]any)
 		require.True(t, ok, "env should exist in context")
@@ -2902,7 +2903,7 @@ settings:
   component: '{{ .atmos_component }}'
   static: plain-value
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		settings, ok := ctx["settings"].(map[string]any)
 		require.True(t, ok, "settings should exist in context (raw fallback)")
@@ -2918,7 +2919,7 @@ locals:
 vars:
   stack: '{{ .atmos_stack }}'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		vars, ok := ctx["vars"].(map[string]any)
 		require.True(t, ok, "vars should exist in context (raw fallback)")
@@ -2932,7 +2933,7 @@ locals:
 env:
   COMPONENT: '{{ .atmos_component }}'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 		env, ok := ctx["env"].(map[string]any)
 		require.True(t, ok, "env should exist in context (raw fallback)")
@@ -2947,7 +2948,7 @@ locals:
 		parentContext := map[string]any{
 			"locals": map[string]any{"inherited": "should-be-cleared"},
 		}
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", parentContext)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", parentContext)
 		require.NoError(t, err)
 		locals, ok := ctx["locals"].(map[string]any)
 		require.True(t, ok)
@@ -2969,7 +2970,7 @@ vars:
 env:
   NAMESPACE: '{{ .locals.ns }}'
 `
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 		require.NoError(t, err)
 
 		settings, ok := ctx["settings"].(map[string]any)
@@ -3008,7 +3009,7 @@ settings:
   label: '{{ .locals.stage }}-{{ .tenant }}'
 `
 		externalCtx := map[string]any{"tenant": "acme"}
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
 		require.NoError(t, err)
 		settings, ok := ctx["settings"].(map[string]any)
 		require.True(t, ok, "settings should exist in context")
@@ -3026,7 +3027,7 @@ vars:
   full_label: '{{ .settings.env_label }}'
 `
 		externalCtx := map[string]any{"region": "us-east-1"}
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
 		require.NoError(t, err)
 		settings, ok := ctx["settings"].(map[string]any)
 		require.True(t, ok)
@@ -3046,7 +3047,7 @@ settings:
   label: '{{ .locals.stage }}-{{ .missing_var }}'
 `
 		externalCtx := map[string]any{"tenant": "acme"}
-		ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
+		ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", externalCtx)
 		require.NoError(t, err)
 		settings, ok := ctx["settings"].(map[string]any)
 		require.True(t, ok, "settings should exist (raw fallback)")
@@ -3265,7 +3266,7 @@ settings:
 vars:
   from_settings: '{{ .settings.resolved_stage }}'
 `
-	ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+	ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 	require.NoError(t, err)
 
 	// Settings should have resolved {{ .locals.stage }} → "dev".
@@ -3301,7 +3302,7 @@ env:
   APP: '{{ .locals.ns }}'
   REGION: '{{ .settings.region }}'
 `
-	ctx, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
+	ctx, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", nil)
 	require.NoError(t, err)
 
 	env, ok := ctx["env"].(map[string]any)
@@ -3710,4 +3711,125 @@ locals:
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "vpc-shared-01", result.locals["vpc_id"])
+}
+
+// TestExtractAndAddLocalsToContext_DoesNotMutateInput documents the invariant that
+// extractAndAddLocalsToContext must not mutate its input context map, because
+// processYAMLConfigFileWithContextInternal hands the same `mergedContext` to many
+// import goroutines in parallel. Before the fix, the function mutated the caller's
+// map (delete "locals", then assign "locals"/"settings"/"vars"/"env") — which races
+// with sibling goroutines. This test catches that regression under `go test -race`.
+func TestExtractAndAddLocalsToContext_DoesNotMutateInput(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Templates: schema.Templates{
+			Settings: schema.TemplatesSettings{Enabled: true},
+		},
+	}
+
+	t.Run("file with locals: input map stays untouched", func(t *testing.T) {
+		yamlContent := `
+locals:
+  stage: dev
+vars:
+  name: '{{ .locals.stage }}-app'
+`
+		input := map[string]any{
+			"locals":   map[string]any{"inherited": "from-parent"},
+			"vars":     map[string]any{"region": "us-east-1"},
+			"settings": map[string]any{"foo": "bar"},
+		}
+
+		// Snapshot the input before the call so we can compare after.
+		snapshot := map[string]any{
+			"locals":   map[string]any{"inherited": "from-parent"},
+			"vars":     map[string]any{"region": "us-east-1"},
+			"settings": map[string]any{"foo": "bar"},
+		}
+
+		ctx, sections, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", input)
+		require.NoError(t, err)
+		require.NotNil(t, sections)
+		require.NotNil(t, ctx)
+
+		// Input contents must be unchanged after the call — no added/removed keys,
+		// no overwrites of nested values.
+		assert.Equal(t, snapshot, input, "input map contents must not be mutated")
+		// In particular, the caller's "locals" key must still be present
+		// (the file-scoping delete happens on the returned copy only).
+		assert.Contains(t, input, "locals", "caller's 'locals' key must not be removed")
+
+		// Returned context reflects file-scoped processing.
+		returnedLocals, _ := ctx["locals"].(map[string]any)
+		assert.Equal(t, "dev", returnedLocals["stage"], "returned context should contain file-scoped locals")
+		_, inheritedPresent := returnedLocals["inherited"]
+		assert.False(t, inheritedPresent, "parent locals must not be inherited into returned context")
+	})
+
+	t.Run("file without locals: input map stays untouched, returned context mirrors input minus locals", func(t *testing.T) {
+		yamlContent := `
+vars:
+  stage: prod
+`
+		input := map[string]any{
+			"locals": map[string]any{"inherited": "from-parent"},
+			"vars":   map[string]any{"namespace": "acme"},
+		}
+
+		ctx, sections, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", input)
+		require.NoError(t, err)
+		assert.Nil(t, sections, "no locals in file → no currentFileSections")
+
+		// Caller's map is untouched, including its "locals" key.
+		assert.Contains(t, input, "locals", "caller's 'locals' key must not be removed")
+
+		// Returned context enforces file-scoping (no "locals" key from parent) but
+		// preserves other inherited values like vars/namespace so downstream template
+		// processing can still reference them.
+		_, ctxHasLocals := ctx["locals"]
+		assert.False(t, ctxHasLocals, "returned context must drop inherited 'locals' key")
+		assert.Equal(t, input["vars"], ctx["vars"], "non-locals keys should still be available in returned context")
+	})
+}
+
+// TestExtractAndAddLocalsToContext_ConcurrentSafe exercises parallel invocations of
+// extractAndAddLocalsToContext against the same input map, mirroring the access
+// pattern in processYAMLConfigFileWithContextInternal's per-import goroutines.
+// Under `go test -race`, a regression that reintroduces input mutation would fire here.
+func TestExtractAndAddLocalsToContext_ConcurrentSafe(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Templates: schema.Templates{
+			Settings: schema.TemplatesSettings{Enabled: true},
+		},
+	}
+
+	sharedCtx := map[string]any{
+		"vars":     map[string]any{"namespace": "acme"},
+		"settings": map[string]any{"team": "platform"},
+	}
+
+	yamlContent := `
+locals:
+  stage: dev
+vars:
+  label: '{{ .locals.stage }}-{{ .vars.namespace }}'
+`
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := extractAndAddLocalsToContext(atmosConfig, yamlContent, "test.yaml", "test.yaml", sharedCtx)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// sharedCtx must still be intact after all goroutines finish.
+	assert.NotContains(t, sharedCtx, "locals", "shared input must not gain a 'locals' key")
+	assert.Equal(t, map[string]any{"namespace": "acme"}, sharedCtx["vars"],
+		"shared input 'vars' must not be overwritten")
+	assert.Equal(t, map[string]any{"team": "platform"}, sharedCtx["settings"],
+		"shared input 'settings' must not be overwritten")
 }

--- a/tests/cli_locals_test.go
+++ b/tests/cli_locals_test.go
@@ -1403,3 +1403,68 @@ func TestLocalsGoTemplateConditionalWithEnvEmpty(t *testing.T) {
 	assert.Equal(t, "", vars["pr_number"],
 		"pr_number should be empty when env var is not set")
 }
+
+// TestLocalsHierarchicalVarsStackListing is a regression test for GitHub issue #2343:
+// locals in a leaf stack file must not corrupt vars merged from parent `_defaults` imports.
+//
+// Before the fix, extractAndAddLocalsToContext propagated the leaf file's own `vars` through
+// the template context, which was then written back onto every imported file's stackConfigMap —
+// overwriting the parent's `vars` (e.g. the `_defaults.yaml` `namespace: acme`).
+// As a result, `name_template` rendered as `-prod` instead of `acme-prod`, and the real stack
+// disappeared from `atmos list stacks` / `atmos describe component`.
+func TestLocalsHierarchicalVarsStackListing(t *testing.T) {
+	t.Chdir("./fixtures/scenarios/locals-hierarchical-vars")
+
+	atmosConfig, err := config.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
+	require.NoError(t, err)
+
+	result, err := exec.ExecuteDescribeStacks(
+		&atmosConfig,
+		"",    // filterByStack
+		nil,   // components
+		nil,   // componentTypes
+		nil,   // sections
+		true,  // ignoreMissingFiles
+		true,  // processTemplates
+		true,  // processYamlFunctions
+		false, // includeEmptyStacks
+		nil,   // skip
+		nil,   // authManager
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The derived stack name must come from the merged (import + leaf) vars —
+	// "acme-prod", not "-prod" or "acme-" from a single-file view.
+	stack, ok := result["acme-prod"].(map[string]any)
+	require.True(t, ok, "expected stack 'acme-prod' in describe stacks output, got keys: %v", stackKeys(result))
+
+	components, ok := stack["components"].(map[string]any)
+	require.True(t, ok, "components section should exist")
+	terraform, ok := components["terraform"].(map[string]any)
+	require.True(t, ok, "terraform section should exist")
+	vpc, ok := terraform["vpc"].(map[string]any)
+	require.True(t, ok, "vpc component should exist")
+
+	vars, ok := vpc["vars"].(map[string]any)
+	require.True(t, ok, "vpc vars should be a map")
+
+	// Both import-provided and leaf-provided vars must be present after deep-merge.
+	assert.Equal(t, "acme", vars["namespace"],
+		"namespace from _defaults.yaml must survive locals processing")
+	assert.Equal(t, "prod", vars["stage"],
+		"stage from leaf stack must be present")
+
+	// Component var referencing a file-scoped local must still resolve correctly
+	// alongside the imported vars.
+	assert.Equal(t, "bucket-state", vars["name"],
+		"component var referencing a local should resolve to 'bucket-state'")
+}
+
+func stackKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/tests/fixtures/scenarios/locals-hierarchical-vars/atmos.yaml
+++ b/tests/fixtures/scenarios/locals-hierarchical-vars/atmos.yaml
@@ -1,0 +1,21 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "orgs/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.namespace }}-{{ .vars.stage }}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info
+
+templates:
+  settings:
+    enabled: true

--- a/tests/fixtures/scenarios/locals-hierarchical-vars/stacks/orgs/_defaults.yaml
+++ b/tests/fixtures/scenarios/locals-hierarchical-vars/stacks/orgs/_defaults.yaml
@@ -1,0 +1,2 @@
+vars:
+  namespace: acme

--- a/tests/fixtures/scenarios/locals-hierarchical-vars/stacks/orgs/prod.yaml
+++ b/tests/fixtures/scenarios/locals-hierarchical-vars/stacks/orgs/prod.yaml
@@ -1,0 +1,16 @@
+import:
+  - ./_defaults
+
+vars:
+  stage: prod
+
+locals:
+  suffix: state
+
+components:
+  terraform:
+    vpc:
+      metadata:
+        component: mock
+      vars:
+        name: "bucket-{{ .locals.suffix }}"


### PR DESCRIPTION
`extractAndAddLocalsToContext` mutated its caller's `context` map and stored the current file's own `vars`/`settings`/`env` in it. The caller then wrote that back into `stackConfigMap`, and the same map was handed to every per-import goroutine as `mergedContext`. Two consequences:

1. When a leaf stack file contained `locals:`, its `vars` were written onto every imported `_defaults.yaml`'s `stackConfigMap`, overwriting identity vars (e.g. `namespace: acme`). The deep-merge then produced malformed stack names like `-prod` and the real `acme-prod` stack disappeared from `atmos list stacks` / `atmos describe component`.
2. Concurrent import goroutines mutated the shared `mergedContext` (`delete`, plus section writes), a data race caught by Go's built-in `concurrent map iteration and map write` guard.

Fix:
- `extractAndAddLocalsToContext` now works on a shallow copy of the input context and returns it, so the caller's map is never mutated and goroutines cannot race on shared state.
- It also returns a `*currentFileSections` struct holding only the sections extracted from the current file's raw YAML. `processYAMLConfigFileWithContextInternal` uses that (not the shared context) to update `stackConfigMap`, so inherited parent values no longer leak into imports.

Tests:
- `tests/cli_locals_test.go`: `TestLocalsHierarchicalVarsStackListing` + new `locals-hierarchical-vars` fixture reproduces the issue #2343 repro (leaf `stage: prod` + `_defaults.yaml` `namespace: acme` + `name_template: "{{ .vars.namespace }}-{{ .vars.stage }}"` + `locals:`).
- `TestExtractAndAddLocalsToContext_DoesNotMutateInput` encodes the no-mutation invariant.
- `TestExtractAndAddLocalsToContext_ConcurrentSafe` exercises the shared-map-across-goroutines pattern; trips the Go runtime's map-race guard if the mutation is reintroduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed configuration inheritance to prevent parent-imported variables and settings from overwriting values defined in the current file, ensuring proper file-scoped configuration isolation.

* **Tests**
  * Added concurrency and immutability tests for context handling.
  * Added integration test with fixture demonstrating hierarchical variable inheritance with file-scoped locals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->