### PR TITLE
fix(describe-affected): skip CI base auto-detect when --repo-path is set

### DIFF
--- a/cmd/describe_affected.go
+++ b/cmd/describe_affected.go
@@ -4,11 +4,20 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/cloudposse/atmos/internal/exec"
+	"github.com/cloudposse/atmos/pkg/flags"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
+
+// describeAffectedCIParser handles the --ci flag for `describe affected`.
+// The flag is wired via the unified flag parser so env-var bindings
+// (ATMOS_CI, CI) stay inside pkg/flags/ and do not trip the forbidigo ban
+// on viper.BindEnv/BindPFlag outside that package. This mirrors the flag
+// registration pattern used by `atmos terraform plan`/`apply`/`deploy`.
+var describeAffectedCIParser *flags.StandardParser
 
 // describeAffectedCmd produces a list of the affected Atmos components and stacks given two Git commits.
 var describeAffectedCmd = &cobra.Command{
@@ -51,6 +60,26 @@ func init() {
 	describeAffectedCmd.PersistentFlags().Bool("verbose", false, "Deprecated. Alias for `--logs-level=Debug`")
 	describeAffectedCmd.PersistentFlags().Bool("exclude-locked", false, "Exclude the locked components (`metadata.locked: true`) from the output")
 
+	// --ci flag with env-var bindings, wired through the unified flag parser.
+	// Overrides `ci.enabled` from atmos.yaml for this invocation. Primary use
+	// case: set --ci=false (or ATMOS_CI=false) to suppress CI base
+	// auto-detection when `describe affected --repo-path=...` is called from
+	// CI workflows that already supply their own base reference.
+	//
+	// Env-var bindings match the terraform plan/apply/deploy pattern so users
+	// have a single, consistent knob across all CI-aware commands.
+	describeAffectedCIParser = flags.NewStandardParser(
+		flags.WithBoolFlag("ci", "", false,
+			"Enable CI mode for `describe affected`. Overrides ci.enabled in atmos.yaml for this invocation. "+
+				"Controls auto-detection of --base from the CI provider's environment (e.g., GITHUB_BASE_REF). "+
+				"Set to false to suppress auto-detection; set to true to force it on even when ci.enabled is unset."),
+		flags.WithEnvVars("ci", "ATMOS_CI", "CI"),
+	)
+	describeAffectedCIParser.RegisterFlags(describeAffectedCmd)
+	if err := describeAffectedCIParser.BindToViper(viper.GetViper()); err != nil {
+		log.Error("Failed to bind --ci flag to Viper for `describe affected`", "error", err)
+	}
+
 	describeCmd.AddCommand(describeAffectedCmd)
 }
 
@@ -63,6 +92,16 @@ func getRunnableDescribeAffectedCmd(
 	return func(cmd *cobra.Command, args []string) error {
 		// Check Atmos configuration
 		checkAtmosConfig()
+
+		// Bind the --ci flag to Viper at runtime so viper.IsSet("ci") picks up
+		// the CLI flag value (env-var bindings were registered in init()).
+		// isCIEnabledForDescribeAffected relies on this precedence:
+		// CLI flag > env var > ci.enabled in atmos.yaml > false.
+		if describeAffectedCIParser != nil {
+			if bindErr := describeAffectedCIParser.BindFlagsToViper(cmd, viper.GetViper()); bindErr != nil {
+				log.Error("Failed to bind --ci flag to Viper for `describe affected`", "error", bindErr)
+			}
+		}
 
 		props, err := parseDescribeAffectedCliArgs(cmd, args)
 		if err != nil {

--- a/cmd/describe_affected.go
+++ b/cmd/describe_affected.go
@@ -61,13 +61,19 @@ func init() {
 	describeAffectedCmd.PersistentFlags().Bool("exclude-locked", false, "Exclude the locked components (`metadata.locked: true`) from the output")
 
 	// --ci flag with env-var bindings, wired through the unified flag parser.
-	// Overrides `ci.enabled` from atmos.yaml for this invocation. Primary use
-	// case: set --ci=false (or ATMOS_CI=false) to suppress CI base
-	// auto-detection when `describe affected --repo-path=...` is called from
-	// CI workflows that already supply their own base reference.
+	// Overrides `ci.enabled` from atmos.yaml for this invocation.
 	//
-	// Env-var bindings match the terraform plan/apply/deploy pattern so users
-	// have a single, consistent knob across all CI-aware commands.
+	// NOTE: --repo-path already suppresses CI base auto-detection on its
+	// own — users do NOT need to pair it with --ci=false. The --ci flag
+	// exists for the INDEPENDENT case where the caller wants to toggle
+	// CI-gated behavior without touching --repo-path: e.g., force CI mode
+	// on locally for debugging (--ci=true / ATMOS_CI=true), or opt a
+	// specific non-repo-path invocation out of auto-detect (--ci=false /
+	// ATMOS_CI=false) in a workflow that leaves `ci.enabled: true` in
+	// atmos.yaml for other features (Atmos Pro checks/summaries).
+	//
+	// Env-var bindings match the terraform plan/apply/deploy pattern so
+	// users have a single, consistent knob across all CI-aware commands.
 	describeAffectedCIParser = flags.NewStandardParser(
 		flags.WithBoolFlag("ci", "", false,
 			"Enable CI mode for `describe affected`. Overrides ci.enabled in atmos.yaml for this invocation. "+

--- a/cmd/describe_affected.go
+++ b/cmd/describe_affected.go
@@ -74,6 +74,16 @@ func init() {
 	//
 	// Env-var bindings match the terraform plan/apply/deploy pattern so
 	// users have a single, consistent knob across all CI-aware commands.
+	//
+	// The Viper bind below registers env-var mappings (ATMOS_CI, CI → "ci")
+	// for any tooling that inspects Viper's merged view of the flag — e.g.
+	// `atmos describe config`. It is NOT what the runtime gate reads:
+	// `isCIEnabledForDescribeAffected` reads `pflag.Changed` + `os.LookupEnv`
+	// directly to avoid the `SetDefault`-induced `viper.IsSet("ci") == true`
+	// trap (see that helper's doc comment and
+	// TestIsCIEnabledForDescribeAffected_RealBinding). No runtime
+	// BindFlagsToViper is needed — the helper has all the state it needs
+	// from the raw `pflag.FlagSet` Cobra already supplies.
 	describeAffectedCIParser = flags.NewStandardParser(
 		flags.WithBoolFlag("ci", "", false,
 			"Enable CI mode for `describe affected`. Overrides ci.enabled in atmos.yaml for this invocation. "+
@@ -98,16 +108,6 @@ func getRunnableDescribeAffectedCmd(
 	return func(cmd *cobra.Command, args []string) error {
 		// Check Atmos configuration
 		checkAtmosConfig()
-
-		// Bind the --ci flag to Viper at runtime so viper.IsSet("ci") picks up
-		// the CLI flag value (env-var bindings were registered in init()).
-		// isCIEnabledForDescribeAffected relies on this precedence:
-		// CLI flag > env var > ci.enabled in atmos.yaml > false.
-		if describeAffectedCIParser != nil {
-			if bindErr := describeAffectedCIParser.BindFlagsToViper(cmd, viper.GetViper()); bindErr != nil {
-				log.Error("Failed to bind --ci flag to Viper for `describe affected`", "error", bindErr)
-			}
-		}
 
 		props, err := parseDescribeAffectedCliArgs(cmd, args)
 		if err != nil {

--- a/cmd/describe_affected_test.go
+++ b/cmd/describe_affected_test.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	stderrors "errors"
 	"fmt"
+	"strings"
 	"testing"
 
+	cockroachErrors "github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/cloudposse/atmos/internal/exec"
@@ -193,4 +197,65 @@ func TestDescribeAffectedCmd_Error(t *testing.T) {
 
 	err := describeAffectedCmd.RunE(describeAffectedCmd, []string{"--invalid-flag"})
 	assert.Error(t, err, "describe affected command should return an error when called with invalid flags")
+}
+
+// TestDescribeAffectedCmd_RepoPathConflictHints verifies that supplying both
+// --repo-path and --base returns ErrRepoPathConflict wrapped with actionable
+// hints pointing the user at --ci=false / ATMOS_CI=false. Covers the
+// errUtils.Build(...).WithHint(...).Err() branch in ParseDescribeAffectedCliArgs.
+func TestDescribeAffectedCmd_RepoPathConflictHints(t *testing.T) {
+	_ = NewTestKit(t)
+
+	// Reset viper and clear ambient CI env so the validator sees only the
+	// flags we set below. Without this, viper-bound CI state from an earlier
+	// test (or the host runner) could cause ParseDescribeAffectedCliArgs to
+	// take a different error branch before reaching the conflict validator.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	for _, k := range []string{"ATMOS_CI", "CI", "GITHUB_ACTIONS", "GITHUB_BASE_REF", "GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH", "ATMOS_IDENTITY", "IDENTITY"} {
+		t.Setenv(k, "")
+	}
+
+	stacksPath := "../tests/fixtures/scenarios/basic"
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", stacksPath)
+	t.Setenv("ATMOS_BASE_PATH", stacksPath)
+	viper.Set("identity", "false")
+
+	// Set both --repo-path and --base on the command. These flag values
+	// leak across tests via the shared describeAffectedCmd singleton, so we
+	// reset them on cleanup to keep neighbors deterministic.
+	require.NoError(t, describeAffectedCmd.PersistentFlags().Set("repo-path", "/tmp/some-clone"))
+	require.NoError(t, describeAffectedCmd.PersistentFlags().Set("base", "main"))
+	t.Cleanup(func() {
+		_ = describeAffectedCmd.PersistentFlags().Set("repo-path", "")
+		_ = describeAffectedCmd.PersistentFlags().Set("base", "")
+	})
+
+	err := describeAffectedCmd.RunE(describeAffectedCmd, []string{})
+
+	require.Error(t, err, "--repo-path + --base should return ErrRepoPathConflict")
+	assert.True(t,
+		stderrors.Is(err, exec.ErrRepoPathConflict),
+		"errors.Is must recognize the wrapped error as ErrRepoPathConflict; got %v", err)
+
+	// Hints are attached via cockroachdb/errors.WithHint — use the package's
+	// helper to extract them rather than substring-matching err.Error().
+	hints := cockroachErrors.GetAllHints(err)
+	require.NotEmpty(t, hints, "error builder must attach at least one hint")
+
+	var sawRepoPathHint, sawCIOverrideHint bool
+	for _, h := range hints {
+		if assert.NotEmpty(t, h) {
+			// Two hints come from the error builder; match each independently
+			// so future wording tweaks don't break the test.
+			if strings.Contains(h, "--repo-path") {
+				sawRepoPathHint = true
+			}
+			if strings.Contains(h, "--ci=false") || strings.Contains(h, "ATMOS_CI=false") {
+				sawCIOverrideHint = true
+			}
+		}
+	}
+	assert.True(t, sawRepoPathHint, "expected a hint explaining the --repo-path flag-group boundary")
+	assert.True(t, sawCIOverrideHint, "expected a hint pointing at --ci=false / ATMOS_CI=false")
 }

--- a/cmd/describe_affected_test.go
+++ b/cmd/describe_affected_test.go
@@ -241,21 +241,23 @@ func TestDescribeAffectedCmd_RepoPathConflictHints(t *testing.T) {
 	// Hints are attached via cockroachdb/errors.WithHint — use the package's
 	// helper to extract them rather than substring-matching err.Error().
 	hints := cockroachErrors.GetAllHints(err)
-	require.NotEmpty(t, hints, "error builder must attach at least one hint")
+	require.GreaterOrEqual(t, len(hints), 2,
+		"error builder must attach at least two hints (flag-group exclusivity + which-flag-to-use guidance)")
 
-	var sawRepoPathHint, sawCIOverrideHint bool
+	// Both hints explain the mutual exclusivity; each should mention
+	// --repo-path so users understand which flag group they violated.
+	// Match independently so future wording tweaks don't break the test.
+	var sawExclusivityHint, sawGuidanceHint bool
 	for _, h := range hints {
 		if assert.NotEmpty(t, h) {
-			// Two hints come from the error builder; match each independently
-			// so future wording tweaks don't break the test.
-			if strings.Contains(h, "--repo-path") {
-				sawRepoPathHint = true
+			if strings.Contains(h, "--repo-path") && strings.Contains(h, "--base") {
+				sawExclusivityHint = true
 			}
-			if strings.Contains(h, "--ci=false") || strings.Contains(h, "ATMOS_CI=false") {
-				sawCIOverrideHint = true
+			if strings.Contains(h, "To compare") || strings.Contains(h, "without --repo-path") {
+				sawGuidanceHint = true
 			}
 		}
 	}
-	assert.True(t, sawRepoPathHint, "expected a hint explaining the --repo-path flag-group boundary")
-	assert.True(t, sawCIOverrideHint, "expected a hint pointing at --ci=false / ATMOS_CI=false")
+	assert.True(t, sawExclusivityHint, "expected a hint listing both --repo-path and --base to name the conflicting flag groups")
+	assert.True(t, sawGuidanceHint, "expected a hint guiding the user toward the right flag for their intent")
 }

--- a/cmd/describe_affected_test.go
+++ b/cmd/describe_affected_test.go
@@ -53,6 +53,19 @@ func TestDescribeAffected(t *testing.T) {
 func TestSetFlagValueInCliArgs(t *testing.T) {
 	_ = NewTestKit(t)
 
+	// Isolate from the ambient CI environment. On CI runners GITHUB_ACTIONS=true,
+	// GITHUB_BASE_REF=main, and CI=true are all set, which would make
+	// SetDescribeAffectedFlagValueInCliArgs auto-detect a base from the CI
+	// provider and populate Ref/HeadSHAOverride/CIEventType — breaking the
+	// "empty by default" assertions below. Clear the relevant env vars and
+	// reset viper so `isCIEnabledForDescribeAffected` reads only the explicit
+	// per-case config passed into the helper.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	for _, k := range []string{"ATMOS_CI", "CI", "GITHUB_ACTIONS", "GITHUB_BASE_REF", "GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"} {
+		t.Setenv(k, "")
+	}
+
 	// Initialize test cases
 	tests := []struct {
 		name          string

--- a/cmd/describe_affected_test.go
+++ b/cmd/describe_affected_test.go
@@ -201,7 +201,7 @@ func TestDescribeAffectedCmd_Error(t *testing.T) {
 
 // TestDescribeAffectedCmd_RepoPathConflictHints verifies that supplying both
 // --repo-path and --base returns ErrRepoPathConflict wrapped with actionable
-// hints pointing the user at --ci=false / ATMOS_CI=false. Covers the
+// hints explaining the mutually exclusive flag groups. Covers the
 // errUtils.Build(...).WithHint(...).Err() branch in ParseDescribeAffectedCliArgs.
 func TestDescribeAffectedCmd_RepoPathConflictHints(t *testing.T) {
 	_ = NewTestKit(t)
@@ -224,11 +224,26 @@ func TestDescribeAffectedCmd_RepoPathConflictHints(t *testing.T) {
 	// Set both --repo-path and --base on the command. These flag values
 	// leak across tests via the shared describeAffectedCmd singleton, so we
 	// reset them on cleanup to keep neighbors deterministic.
+	//
+	// pflag.Flag.Set() always stamps Changed=true — including the cleanup
+	// Set("") calls below — so after resetting the value we also clear the
+	// Changed bit directly. Without this, later tests calling
+	// SetDescribeAffectedFlagValueInCliArgs (which gates reads on
+	// flags.Changed(k) at internal/exec/describe_affected.go:247) would see
+	// these flags as "user-provided empty strings" and overwrite their
+	// describe struct fields with "". Writing flag.Changed directly is the
+	// established pflag test-cleanup idiom.
 	require.NoError(t, describeAffectedCmd.PersistentFlags().Set("repo-path", "/tmp/some-clone"))
 	require.NoError(t, describeAffectedCmd.PersistentFlags().Set("base", "main"))
 	t.Cleanup(func() {
 		_ = describeAffectedCmd.PersistentFlags().Set("repo-path", "")
 		_ = describeAffectedCmd.PersistentFlags().Set("base", "")
+		if f := describeAffectedCmd.PersistentFlags().Lookup("repo-path"); f != nil {
+			f.Changed = false
+		}
+		if f := describeAffectedCmd.PersistentFlags().Lookup("base"); f != nil {
+			f.Changed = false
+		}
 	})
 
 	err := describeAffectedCmd.RunE(describeAffectedCmd, []string{})

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -110,6 +110,74 @@ base and then the validator rejected the result.
   `internal/exec/ci_exit_codes.go` is tracked as a follow-up so
   each call site can be reviewed individually.
 
+## Behavior notes
+
+### `CI=true` alone now enables base auto-detect
+
+Pre-fix, the auto-detect gate was a single config read:
+
+```go
+if describe.CLIConfig != nil && describe.CLIConfig.CI.Enabled {
+    resolveBaseFromCI(describe)
+}
+```
+
+Post-fix, the gate is the precedence chain in
+`isCIEnabledForDescribeAffected` — with `CI` env at tier 3, above
+`ci.enabled` in `atmos.yaml`. Every major CI runner exports
+`CI=true`, so a user who did NOT set `ci.enabled: true` in
+`atmos.yaml` (either explicitly `false` or left unset) will now
+get base auto-detection on those runners where previously they
+would not have.
+
+Design rationale: the `--ci` flag / `ATMOS_CI` / `CI` env chain
+already exists on `terraform plan`/`apply`/`deploy` (PR #2079) —
+on those commands, `CI=true` enables the `--ci` flag via
+`StandardParser.WithEnvVars`. Extending the same precedence to
+`describe affected` makes the CI-aware commands behave uniformly,
+and `CI=true` triggering base detection is consistent with the
+"zero-config CI" framing of #2241.
+
+Opt-out paths for users who want the pre-fix behavior:
+
+- Set `ATMOS_CI=false` at the workflow level.
+- Pass `--ci=false` on the specific `describe affected` invocation.
+- Scope CI features to a subset of workflows via an Atmos profile —
+  put `ci.enabled: false` in the profile that's loaded on the paths
+  that should opt out (typically the ones that pass `--repo-path`
+  via the spacelift-trigger action). Profile merge is layered on
+  top of the root `atmos.yaml` (`pkg/config/load.go` `loadProfiles`
+  → `mergeConfigFile` → `viper.MergeConfig`), so a profile-level
+  `ci.enabled: false` overrides the root setting whenever
+  `ATMOS_PROFILE` selects that profile. This is the recommended
+  scoping mechanism post-#2942 and avoids any runtime config
+  patching.
+
+This behavior change is worth calling out in the release notes
+for the version that ships this fix.
+
+### Unparseable env values fall through to config, not to `CI`
+
+When `ATMOS_CI` is set but `strconv.ParseBool` rejects the value
+(e.g., `ATMOS_CI=yes` / `on` / `enabled`), the helper logs a
+warning and breaks out of the env-var loop **without** consulting
+`CI`. Fall-through goes directly to tier 4 (`ci.enabled` in
+`atmos.yaml`). Rationale: the user's explicit `ATMOS_CI` was an
+override attempt; silently falling through to the ambient `CI=true`
+set by every runner would be the opposite of their intent. The
+warning surfaces the typo so it can be fixed.
+
+The same accepted-value set applies to the `CI` env var when it
+falls back from `ATMOS_CI` being absent — but tier 3 is typically
+set by the runner to the literal string `true`, so this edge case
+is rare there.
+
+User-facing documentation for both of these is in
+`website/docs/cli/environment-variables.mdx` (the `ATMOS_CI`
+"Accepted values" paragraph) and
+`website/docs/cli/commands/describe/describe-affected.mdx`
+(the `--ci` flag "Accepted env values" paragraph).
+
 ## Implementation
 
 ### Fix 1 — Skip CI base auto-detect when `--repo-path` is set
@@ -147,7 +215,7 @@ New code:
 //     SHA — the current checkout is typically a merge commit,
 //     whose SHA does not match what the webhook indexed.
 if describe.Ref == "" && describe.SHA == "" &&
-    isCIEnabledForDescribeAffected(describe) {
+    isCIEnabledForDescribeAffected(flags, describe) {
     switch {
     case describe.RepoPath == "":
         resolveBaseFromCI(describe)
@@ -222,7 +290,9 @@ describeAffectedCIParser = flags.NewStandardParser(
     flags.WithEnvVars("ci", "ATMOS_CI", "CI"),
 )
 describeAffectedCIParser.RegisterFlags(describeAffectedCmd)
-_ = describeAffectedCIParser.BindToViper(viper.GetViper())
+if err := describeAffectedCIParser.BindToViper(viper.GetViper()); err != nil {
+    log.Error("Failed to bind --ci flag to Viper for `describe affected`", "error", err)
+}
 ```
 
 The env-var bindings deliberately reuse the existing `ATMOS_CI` /
@@ -230,6 +300,19 @@ The env-var bindings deliberately reuse the existing `ATMOS_CI` /
 (PR #2079, March 2026) bound to the `--ci` flag on
 `terraform plan`/`apply`/`deploy`. Reusing it gives users a single,
 consistent knob across every CI-aware command.
+
+**No runtime `BindFlagsToViper`.** Unlike `terraform plan/apply/deploy`
+— which rebind the `--ci` pflag into Viper at `RunE` time because
+`ParseTerraformRunOptions(v)` reads the value back out of Viper —
+`describe affected`'s runtime gate (`isCIEnabledForDescribeAffected`)
+reads `pflag.Changed` + `os.LookupEnv` directly. The runtime bind
+would therefore be dead code. It was present in an earlier draft and
+its removal is intentional: keeping it made the behavior harder to
+reason about (the in-code comment was claiming `viper.IsSet("ci")`
+would pick up the flag, which the helper deliberately ignores).
+The init-time `BindToViper` above is kept for symmetry with the
+other CI-aware commands and for any Viper-based tooling (e.g.
+`atmos describe config`) that inspects the merged configuration.
 
 File: `internal/exec/describe_affected.go` — introduce a helper
 `isCIEnabledForDescribeAffected` that applies the precedence
@@ -435,6 +518,13 @@ behavior.
   `StandardParser.BindFlagsToViper` calls `SetDefault`, `IsSet`
   returns `true` on every invocation and would mask the config
   fallback.
+- [x] Fix 2d: removed the runtime `BindFlagsToViper` call in
+  `cmd/describe_affected.go` `getRunnableDescribeAffectedCmd`. The
+  helper reads pflag + env directly, so the runtime bind was dead
+  code; its comment also lied by claiming `viper.IsSet("ci")` would
+  pick up the flag. Init-time `BindToViper` is kept for parity with
+  `terraform plan/apply/deploy` and for Viper-based tooling (e.g.
+  `atmos describe config`) that inspects the merged flag view.
 - [x] Fix 3: `ErrRepoPathConflict` error wrapped with
   `errUtils.Build(...).WithHint(...).Err()` explaining the
   mutually exclusive flag groups (no longer points at `--ci=false` /
@@ -461,7 +551,14 @@ behavior.
 - [x] Documentation:
   `website/docs/cli/environment-variables.mdx` — new
   "CI Integration" section covering `ATMOS_CI` (extended to gate
-  describe-affected CI auto-detection) and `CI`.
+  describe-affected CI auto-detection) and `CI`. Includes the
+  "Accepted values" paragraph documenting `strconv.ParseBool`
+  semantics and the unparseable-`ATMOS_CI` fall-through behavior.
+- [x] Documentation:
+  `website/docs/cli/commands/describe/describe-affected.mdx` —
+  `--ci` flag section now includes the "Accepted env values"
+  paragraph describing the unparseable-`ATMOS_CI` fall-through
+  (warn → ignore → fall through to `ci.enabled`, skipping `CI`).
 - [ ] Blog post: `website/blog/2026-04-21-describe-affected-repo-path-ci-fix.mdx`
   (labeled `bugfix`).
 - [ ] Roadmap update: add milestone under the `native-ci`
@@ -526,6 +623,10 @@ behavior.
 - User-reported failure in a downstream consumer repo where a
   workflow had to apply a `yq '.ci.enabled = false'` patch inline
   to unblock the spacelift-trigger PR check — the workaround that
-  motivated this fix.
+  motivated this fix. The recommended downstream resolution
+  (independent of this PR) is to retire the yq-patch in favor of a
+  profile-scoped `ci.enabled: false` in the Spacelift auth profile.
+  Profiles are already the supported per-workflow scoping mechanism
+  post-#2942 and work on atmos 1.216+ without any upstream change.
 - cloudposse/atmos#2241 — the PR that introduced CI base
   auto-detection.

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -267,10 +267,11 @@ value" from "fall back to config".
 
 ### Error-message hint
 
-When `ErrRepoPathConflict` fires for an **explicit** (non-auto)
-conflict, we extend the message with a hint pointing users at the
-new env override so they don't hit the same failure mode from
-a different angle:
+After Fix 1, `ErrRepoPathConflict` only fires when a user
+**explicitly** passes both `--repo-path` and one of
+`--base` / `--ref` / `--sha` / `--ssh-key` / `--ssh-key-password`
+— auto-detected values no longer trigger the validator. The
+sentinel stays as-is:
 
 ```go
 var ErrRepoPathConflict = errors.New(
@@ -279,23 +280,30 @@ var ErrRepoPathConflict = errors.New(
     "flags can't be used")
 ```
 
-We wrap it in the builder pattern per `errors/errors.go`:
+…and we wrap it in the builder pattern per `errors/errors.go`
+with two hints that explain the mutually exclusive flag groups
+and guide the user toward the right flag for their intent:
 
 ```go
 return errUtils.Build(ErrRepoPathConflict).
-    WithHint("If --base was auto-injected from CI, set " +
-        "ATMOS_CI=false or pass --ci=false for this " +
-        "invocation, or unset ci.enabled in atmos.yaml.").
-    WithHint("--repo-path is intended for already-cloned " +
-        "sibling repositories. Pass only one of " +
-        "--repo-path OR (--base | --ref | --sha).").
+    WithHint("Pass only one of: --repo-path OR (--base | " +
+        "--ref | --sha | --ssh-key | --ssh-key-password). " +
+        "--repo-path points at an already-cloned sibling " +
+        "repository to diff against; the others clone or " +
+        "check out a target ref.").
+    WithHint("To compare against a specific ref or SHA, use " +
+        "--base without --repo-path. To compare against an " +
+        "already-cloned repo, use --repo-path without --base " +
+        "/ --ref / --sha.").
     Err()
 ```
 
-After Fix 1, this hint is only seen by users who **explicitly**
-pass both flags — auto-detected values no longer trigger the
-validator. The hint still helps by explaining the new override
-for anyone who hits the conflict via a different path.
+The hints deliberately do NOT suggest pairing `--ci=false` /
+`ATMOS_CI=false` with `--repo-path` — Fix 1 already suppresses
+auto-detect when `--repo-path` is set, so that pairing is
+unnecessary. The `--ci` / `ATMOS_CI` overrides (Fix 2) exist for
+the independent case of toggling CI-gated behavior on
+invocations that do not use `--repo-path`.
 
 ## Testing
 
@@ -410,8 +418,10 @@ behavior.
   documented precedence (flag/env via `viper.IsSet("ci")` >
   `ci.enabled` in config > `false`).
 - [x] Fix 3: `ErrRepoPathConflict` error wrapped with
-  `errUtils.Build(...).WithHint(...).Err()` pointing at the new
-  override.
+  `errUtils.Build(...).WithHint(...).Err()` explaining the
+  mutually exclusive flag groups (no longer points at `--ci=false` /
+  `ATMOS_CI=false`, which Fix 1 makes unnecessary for the
+  `--repo-path` case).
 - [x] Unit tests:
   `TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect`
   (includes inline negative-path sanity assertion),

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -134,26 +134,82 @@ if describe.Ref == "" && describe.SHA == "" &&
 New code:
 
 ```go
-// Auto-detect base from CI environment when ci.enabled is true,
-// no explicit base provided, AND --repo-path is not set.
+// Auto-detect CI metadata when CI is enabled and no explicit base
+// provided.
 //
-// --repo-path is mutually exclusive with --base/--ref/--sha (see
-// ErrRepoPathConflict). Auto-injecting those fields from CI env
-// would trigger the conflict validator and break every
-// describe-affected call that passes --repo-path (e.g. the
-// cloudposse/github-action-atmos-affected-trigger-spacelift
-// action).
+// Two cases:
+//   - Normal (no --repo-path): populate Ref/SHA + HeadSHAOverride/
+//     CIEventType from the CI provider.
+//   - --repo-path: skip base detection (--repo-path is mutually
+//     exclusive with --base/--ref/--sha per ErrRepoPathConflict —
+//     auto-injecting from CI env would break every call that uses
+//     --repo-path, e.g. the cloudposse/github-action-atmos-
+//     affected-trigger-spacelift action). When --upload is also
+//     set, still populate HeadSHAOverride + CIEventType so Atmos
+//     Pro can match the uploaded affected list to the PR webhook
+//     SHA — the current checkout is typically a merge commit,
+//     whose SHA does not match what the webhook indexed.
 if describe.Ref == "" && describe.SHA == "" &&
-    describe.RepoPath == "" &&
-    describe.CLIConfig != nil && ciEnabledForDescribe(describe) {
-    resolveBaseFromCI(describe)
+    isCIEnabledForDescribeAffected(describe) {
+    switch {
+    case describe.RepoPath == "":
+        resolveBaseFromCI(describe)
+    case describe.Upload:
+        resolveCIUploadMetadataFromCI(describe)
+    }
 }
 ```
 
 Impact on `ErrRepoPathConflict`: the validator on line 169 is
 unchanged. Users who explicitly pass `--repo-path` *and* `--base`
-still get the same error. Only auto-detected values are
+still get the same error. Only auto-detected `Ref`/`SHA` are
 suppressed.
+
+### Fix 1b — Partial CI resolver for `--repo-path + --upload`
+
+`--repo-path + --upload` on a CI PR event previously errored out
+with `ErrRepoPathConflict`. With Fix 1 alone, the combination
+succeeds but the upload uses the current checkout's local HEAD
+as the correlation SHA — which on GitHub Actions default
+`actions/checkout@v4` is a merge-commit SHA, not the PR head
+SHA indexed by the webhook. Atmos Pro would then fail to
+correlate the upload with the PR.
+
+A new sibling of `resolveBaseFromCI` populates **only** the
+upload metadata (HeadSHAOverride, CIEventType), leaving
+`Ref`/`SHA` untouched so `ErrRepoPathConflict` does not fire:
+
+```go
+// resolveCIUploadMetadataFromCI populates the upload correlation
+// metadata (HeadSHAOverride, CIEventType) from the CI provider
+// WITHOUT populating Ref or SHA.
+//
+// Used in the --repo-path + --upload + CI code path. Base
+// auto-detection is skipped there to avoid ErrRepoPathConflict,
+// but Atmos Pro still needs the PR head SHA and event type to
+// correlate the uploaded affected list with the PR webhook —
+// the current checkout is typically a GitHub pull_request merge
+// commit, whose SHA does not match what the webhook indexed.
+func resolveCIUploadMetadataFromCI(describe *DescribeAffectedCmdArgs) {
+    defer perf.Track(nil, "exec.resolveCIUploadMetadataFromCI")()
+
+    p := ci.Detect()
+    if p == nil {
+        return
+    }
+    resolution, err := p.ResolveBase()
+    if err != nil || resolution == nil {
+        return
+    }
+
+    describe.HeadSHAOverride = resolution.HeadSHA
+    describe.CIEventType = resolution.EventType
+}
+```
+
+The helper intentionally reuses `p.ResolveBase()` — provider
+detection and event-payload parsing are identical to the base
+case; only the fields copied to `describe` differ.
 
 ### Fix 2 — `--ci` flag on `describe affected` (env-bound to `ATMOS_CI`, `CI`)
 
@@ -179,18 +235,21 @@ The env-var bindings deliberately reuse the existing `ATMOS_CI` /
 consistent knob across every CI-aware command.
 
 File: `internal/exec/describe_affected.go` — introduce a helper
-`ciEnabledForDescribe` that applies the precedence CLI flag > env
-var > `ci.enabled` in config > `false`:
+`isCIEnabledForDescribeAffected` that applies the precedence
+CLI flag > `ATMOS_CI` env var > `CI` env var >
+`ci.enabled` in config > `false`:
 
 ```go
-// ciEnabledForDescribe returns whether CI auto-base-detection
-// should run. Precedence (highest to lowest):
+// isCIEnabledForDescribeAffected returns whether CI
+// auto-base-detection should run. Precedence (highest to lowest):
 //   1. --ci CLI flag on this invocation.
-//   2. ATMOS_CI env var.
+//   2. ATMOS_CI / CI env vars (bound to the `ci` viper key via
+//      flags.WithEnvVars in cmd/describe_affected.go — ATMOS_CI
+//      wins if both are set).
 //   3. ci.enabled in atmos.yaml.
 //   4. false (default).
-func ciEnabledForDescribe(describe *DescribeAffectedCmdArgs) bool {
-    // viper reads the --ci flag bound via WithEnvVars (see
+func isCIEnabledForDescribeAffected(describe *DescribeAffectedCmdArgs) bool {
+    // Viper reads the --ci flag bound via WithEnvVars (see
     // cmd/describe_affected.go). When the flag or any of the
     // env vars is explicitly set, IsSet returns true and
     // GetBool returns the resolved value.
@@ -205,7 +264,7 @@ func ciEnabledForDescribe(describe *DescribeAffectedCmdArgs) bool {
 ```
 
 Note: the `flags.WithEnvVars` registration already handles the
-CLI > env-var precedence inside viper; `ciEnabledForDescribe`
+CLI > env-var precedence inside viper; `isCIEnabledForDescribeAffected`
 only needs to check `IsSet` to distinguish "user supplied a
 value" from "fall back to config".
 
@@ -334,6 +393,11 @@ behavior.
 - [x] Fix 1: skip `resolveBaseFromCI` when `describe.RepoPath != ""`
   (`internal/exec/describe_affected.go`,
   `SetDescribeAffectedFlagValueInCliArgs`).
+- [x] Fix 1b: new `resolveCIUploadMetadataFromCI` helper that
+  populates only `HeadSHAOverride` + `CIEventType` on the
+  `--repo-path + --upload + CI` path, so Atmos Pro retains PR
+  webhook correlation even though `--base` auto-detection is
+  skipped (`internal/exec/describe_affected.go`).
 - [x] Fix 2a: `--ci` flag on `describe affected`
   (`cmd/describe_affected.go`, `describeAffectedCIParser`).
 - [x] Fix 2b: env binding via
@@ -348,6 +412,10 @@ behavior.
 - [x] Unit tests:
   `TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect`
   (includes inline negative-path sanity assertion),
+  `TestSetDescribeAffectedFlagValueInCliArgs_RepoPathUploadPopulatesMetadata`
+  (asserts `HeadSHAOverride` + `CIEventType` populated from event
+  payload while `Ref`/`SHA` stay empty; plus a negative-path
+  assertion that dropping `--upload` keeps metadata empty),
   `TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides`
   (4 sub-tests),
   `TestIsCIEnabledForDescribeAffected_Precedence`
@@ -384,7 +452,7 @@ behavior.
   `internal/exec/ci_exit_codes.go:23`,
   `pkg/list/list_instances.go:596`, and `cmd/ci/status.go:61`.
   Each site reads `atmosConfig.CI.Enabled` directly today; a
-  shared helper (same semantics as `ciEnabledForDescribe`) would
+  shared helper (same semantics as `isCIEnabledForDescribeAffected`) would
   centralize the precedence rule. Deferred to a separate PR so
   each call site can be reviewed individually — the semantics of
   "disable CI features mid-workflow" differ per consumer.

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -42,8 +42,8 @@
   from `atmos.yaml`, and the only CLI escape hatch (`--ci`) only
   forces CI mode on — it cannot turn it off. Users cannot scope
   `ci.enabled: true` to specific workflows without editing
-  `atmos.yaml` inline (the yq-patch workaround in
-  1898andCo/infra#2964).
+  `atmos.yaml` inline (the yq-patch workaround reported in a
+  downstream repository).
 
 **User-visible failure:**
 
@@ -60,9 +60,8 @@ base and then the validator rejected the result.
 
 ## Status
 
-**Implemented.** Targets release 1.217.0. All code changes and
-unit tests landed in branch `aknysh/fix-atmos-ci-2`; user-facing
-documentation updated.
+**Implemented.** All code changes and unit tests landed in branch
+`aknysh/fix-atmos-ci-2`; user-facing documentation updated.
 
 ## Goals
 
@@ -100,12 +99,10 @@ documentation updated.
   `--sha`.** These remain mutually exclusive — the user's explicit
   flags still produce `ErrRepoPathConflict`. Only the
   auto-detection is suppressed.
-- **Fixing the upstream GitHub Action.** A parallel follow-up will
-  be filed against
-  `cloudposse/github-action-atmos-affected-stacks` to pass `--ci=false`
-  (or an equivalent suppression flag) when it itself supplies
-  `--repo-path`. Atmos' fix is independent and does not depend on
-  the action being updated.
+- **Changing the upstream GitHub Action.** Not needed. `--repo-path`
+  alone already suppresses auto-detect after Fix 1, so the existing
+  `cloudposse/github-action-atmos-affected-trigger-spacelift`
+  (and `-stacks`) actions work as-is once callers upgrade Atmos.
 - **Making every CI consumer honor `ATMOS_CI=false`.** This fix
   scopes the flag/env override to `describe affected` so the blast
   radius is narrow. Extending the same override semantics to
@@ -338,7 +335,7 @@ Add to `TestSetDescribeAffectedFlagValueInCliArgs_BaseResolution`:
 
 ### Integration / manual verification
 
-Reproduce the 1898andCo/infra PR #2964 failure locally:
+Reproduce the user-reported failure locally:
 
 ```bash
 # Fresh checkout with ci.enabled: true in atmos.yaml
@@ -367,14 +364,20 @@ JSON
 atmos describe affected --repo-path=/tmp/other-clone
 ```
 
-Then verify the new overrides:
+Then verify the new overrides. Note: `--repo-path` alone already
+suppresses auto-detection (Fix 1), so `--ci=false` is **not** needed
+for the `--repo-path` case. The `--ci` / `ATMOS_CI` overrides are
+for the independent case of toggling CI-gated behavior on
+invocations that do *not* use `--repo-path`:
 
 ```bash
-# Explicitly disable CI features for this invocation.
-ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
-atmos describe affected --repo-path=/tmp/other-clone --ci=false
+# Opt one non-repo-path invocation out of CI auto-detect while
+# leaving ci.enabled: true in atmos.yaml for other features.
+ATMOS_CI=false atmos describe affected --base main
+atmos describe affected --base main --ci=false
 
-# Explicitly force CI mode even with ci.enabled: false in config.
+# Explicitly force CI mode even with ci.enabled: false in config —
+# e.g., reproducing CI behavior locally.
 unset ATMOS_CI
 # Edit atmos.yaml to set ci.enabled: false, then:
 atmos describe affected --ci=true  # should auto-detect base
@@ -440,13 +443,12 @@ behavior.
 
 ## Follow-ups
 
-- **Upstream GitHub Action fix.** File an issue against
-  `cloudposse/github-action-atmos-affected-stacks` (and
-  `-trigger-spacelift`) to pass `--ci=false` whenever the action
-  itself supplies `--repo-path`. Users upgrading to Atmos 1.217.0
-  will get the fix regardless, but belt-and-suspenders: the
-  action should never rely on a CLI behavior it can suppress
-  itself.
+- **No upstream GitHub Action change required.** `--repo-path`
+  alone suppresses CI base auto-detection after Fix 1, so the
+  existing `cloudposse/github-action-atmos-affected-stacks` and
+  `-trigger-spacelift` actions work as-is once callers upgrade
+  Atmos. Any downstream yq-patch workaround in a consumer repo
+  can be reverted on upgrade.
 - **Make every CI consumer honor `ATMOS_CI=false`.** Extend the
   same env override to `pkg/hooks/hooks.go:136`,
   `internal/exec/ci_exit_codes.go:23`,
@@ -493,7 +495,9 @@ behavior.
   (`Build(err).WithHint(...).Err()`).
 - `pkg/flags/` — `WithEnvVars` flag-to-env-var binding
   (`pkg/flags/global_builder.go`).
-- 1898andCo/infra#2964 — user-reported failure and the yq-patch
-  workaround that motivated this fix.
+- User-reported failure in a downstream consumer repo where a
+  workflow had to apply a `yq '.ci.enabled = false'` patch inline
+  to unblock the spacelift-trigger PR check — the workaround that
+  motivated this fix.
 - cloudposse/atmos#2241 — the PR that introduced CI base
-  auto-detection in 1.216.0.
+  auto-detection.

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -239,19 +239,25 @@ CLI flag > `ATMOS_CI` env var > `CI` env var >
 ```go
 // isCIEnabledForDescribeAffected returns whether CI
 // auto-base-detection should run. Precedence (highest to lowest):
-//   1. --ci CLI flag on this invocation.
-//   2. ATMOS_CI / CI env vars (bound to the `ci` viper key via
-//      flags.WithEnvVars in cmd/describe_affected.go — ATMOS_CI
-//      wins if both are set).
-//   3. ci.enabled in atmos.yaml.
-//   4. false (default).
-func isCIEnabledForDescribeAffected(describe *DescribeAffectedCmdArgs) bool {
-    // Viper reads the --ci flag bound via WithEnvVars (see
-    // cmd/describe_affected.go). When the flag or any of the
-    // env vars is explicitly set, IsSet returns true and
-    // GetBool returns the resolved value.
-    if viper.IsSet("ci") {
-        return viper.GetBool("ci")
+//   1. --ci CLI flag on this invocation (pflag.Changed).
+//   2. ATMOS_CI env var (os.LookupEnv).
+//   3. CI env var (os.LookupEnv).
+//   4. ci.enabled in atmos.yaml.
+//   5. false (default).
+func isCIEnabledForDescribeAffected(flags *pflag.FlagSet, describe *DescribeAffectedCmdArgs) bool {
+    if flags != nil {
+        if f := flags.Lookup("ci"); f != nil && f.Changed {
+            if val, err := flags.GetBool("ci"); err == nil {
+                return val
+            }
+        }
+    }
+    for _, name := range []string{"ATMOS_CI", "CI"} {
+        if val, ok := os.LookupEnv(name); ok && val != "" {
+            if parsed, err := strconv.ParseBool(val); err == nil {
+                return parsed
+            }
+        }
     }
     if describe.CLIConfig == nil {
         return false
@@ -260,10 +266,18 @@ func isCIEnabledForDescribeAffected(describe *DescribeAffectedCmdArgs) bool {
 }
 ```
 
-Note: the `flags.WithEnvVars` registration already handles the
-CLI > env-var precedence inside viper; `isCIEnabledForDescribeAffected`
-only needs to check `IsSet` to distinguish "user supplied a
-value" from "fall back to config".
+**Why not `viper.IsSet("ci")`?** `StandardParser.BindFlagsToViper`
+(see `pkg/flags/standard.go`) calls `v.SetDefault("ci", false)` as
+part of the registration flow. After `SetDefault`, `viper.IsSet("ci")`
+returns `true` on every invocation — regardless of whether the user
+passed `--ci` or set an env var. An earlier draft of this helper
+trusted `viper.IsSet` and silently masked `ci.enabled: true` from
+`atmos.yaml` with the pflag default (`false`). The regression was
+caught by the `TestIsCIEnabledForDescribeAffected_RealBinding` test,
+which stands up the exact production binding chain
+(`SetDefault` + `BindEnv` + `BindPFlag`). Checking `pflag.Changed`
+plus `os.LookupEnv` directly is the only reliable way to distinguish
+explicit user overrides from the parser's default.
 
 ### Error-message hint
 
@@ -415,8 +429,12 @@ behavior.
   `flags.WithEnvVars("ci", "ATMOS_CI", "CI")` (reuses the existing
   env-var pair — no new env var added).
 - [x] Fix 2c: `isCIEnabledForDescribeAffected` helper with
-  documented precedence (flag/env via `viper.IsSet("ci")` >
-  `ci.enabled` in config > `false`).
+  documented precedence (`--ci` via `pflag.Changed` > `ATMOS_CI` /
+  `CI` via `os.LookupEnv` > `ci.enabled` in config > `false`).
+  Intentionally does NOT use `viper.IsSet("ci")` — after
+  `StandardParser.BindFlagsToViper` calls `SetDefault`, `IsSet`
+  returns `true` on every invocation and would mask the config
+  fallback.
 - [x] Fix 3: `ErrRepoPathConflict` error wrapped with
   `errUtils.Build(...).WithHint(...).Err()` explaining the
   mutually exclusive flag groups (no longer points at `--ci=false` /

--- a/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
+++ b/docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md
@@ -1,0 +1,431 @@
+# Fix: `describe affected --repo-path` fails when `ci.enabled: true`
+
+**Date:** 2026-04-21
+
+**Issue:**
+
+- Atmos 1.216.0 (cloudposse/atmos#2241) introduced CI base
+  auto-detection in `atmos describe affected`. When
+  `ci.enabled: true` is set in `atmos.yaml` (or `--ci` is passed),
+  the command auto-injects a `--base` value derived from the CI
+  provider's environment (`GITHUB_BASE_REF`, `GITHUB_SHA`, the
+  `pull_request` event payload, etc.) when the user did not supply
+  `--base` / `--ref` / `--sha` explicitly.
+- `atmos describe affected` also supports `--repo-path`, which points
+  at an already-cloned sibling repo to diff against. `--repo-path`
+  is **mutually exclusive** with `--base` / `--ref` / `--sha` /
+  `--ssh-key` / `--ssh-key-password` and the CLI rejects the
+  combination with `ErrRepoPathConflict`:
+
+  ```text
+  Error: if the '--repo-path' flag is specified, the '--base',
+  '--ref', '--sha', '--ssh-key' and '--ssh-key-password' flags
+  can't be used
+  ```
+
+- The auto-detection in 1.216.0 runs unconditionally whenever
+  `ci.enabled: true`, so a user who opts into Atmos Pro's CI
+  features (GitHub Check Runs, `$GITHUB_OUTPUT` exports,
+  `$GITHUB_STEP_SUMMARY` rendering) **also** gets auto-injected
+  `--ref` / `--sha`, even on invocations that supply `--repo-path`.
+  The result: `ErrRepoPathConflict` fires and every
+  `describe affected --repo-path …` call inside a GitHub Actions
+  PR check aborts.
+- The failure surfaced in production via the
+  `cloudposse/github-action-atmos-affected-trigger-spacelift`
+  action, which **always** passes `--repo-path`
+  (`trigger-spacelift@v2.2.2`, `affected-stacks@v6.13.0`). Users who
+  turned on `ci.enabled: true` in `atmos.yaml` for the Atmos Pro
+  workflows broke every spacelift-trigger PR check on the same
+  repo.
+- There is today no runtime override: `ci.enabled` is only read
+  from `atmos.yaml`, and the only CLI escape hatch (`--ci`) only
+  forces CI mode on — it cannot turn it off. Users cannot scope
+  `ci.enabled: true` to specific workflows without editing
+  `atmos.yaml` inline (the yq-patch workaround in
+  1898andCo/infra#2964).
+
+**User-visible failure:**
+
+```text
+[INFO] Auto-detected CI base provider=github-actions event=pull_request
+       base=refs/remotes/origin/main source=GITHUB_BASE_REF
+Error: if the '--repo-path' flag is specified, the '--base',
+'--ref', '--sha', '--ssh-key' and '--ssh-key-password' flags can't
+be used
+```
+
+The `INFO` line is the smoking gun — the CI provider injected the
+base and then the validator rejected the result.
+
+## Status
+
+**Implemented.** Targets release 1.217.0. All code changes and
+unit tests landed in branch `aknysh/fix-atmos-ci-2`; user-facing
+documentation updated.
+
+## Goals
+
+1. `atmos describe affected --repo-path=<path>` must succeed on PR
+   CI even when `ci.enabled: true` is set in `atmos.yaml`, without
+   requiring the user to patch `atmos.yaml` per workflow.
+2. Preserve the auto-detection behavior for every other invocation
+   shape (`describe affected` without `--repo-path`, with or
+   without `--base` / `--ref` / `--sha`). The 1.216.0 feature
+   stays, it just stops firing when it can't possibly be used.
+3. Let users disable CI features for a single job / step without
+   editing `atmos.yaml`, by extending the existing `ATMOS_CI` /
+   `CI` env vars (already bound to `--ci` on
+   `terraform plan`/`apply`/`deploy`) so they also gate the
+   describe-affected auto-base-detect path.
+4. Add a `--ci` flag to `describe affected` so it parallels
+   `terraform plan` / `apply` / `deploy`. `--ci=false` explicitly
+   disables CI-gated behavior (auto base detection) for that
+   invocation; `--ci=true` forces it on even when `ci.enabled`
+   is not set in config. Flag precedence: CLI flag > env var >
+   `ci.enabled` in config > default.
+5. Produce a clear error message when the user explicitly passes
+   both `--repo-path` and `--base` / `--ref` / `--sha`. The
+   existing `ErrRepoPathConflict` stays as-is for explicit
+   conflicts; it just stops firing for auto-detected values.
+
+## Non-goals
+
+- **Rewriting `ci.enabled` semantics.** `ci.enabled: true` in
+  `atmos.yaml` remains the authority for CI hooks (checks,
+  summaries, outputs, plan-file stores). This fix only narrows
+  the `describe affected` base-auto-detect subfeature so it does
+  not inject conflicting flags.
+- **Making `--repo-path` compatible with `--base` / `--ref` /
+  `--sha`.** These remain mutually exclusive — the user's explicit
+  flags still produce `ErrRepoPathConflict`. Only the
+  auto-detection is suppressed.
+- **Fixing the upstream GitHub Action.** A parallel follow-up will
+  be filed against
+  `cloudposse/github-action-atmos-affected-stacks` to pass `--ci=false`
+  (or an equivalent suppression flag) when it itself supplies
+  `--repo-path`. Atmos' fix is independent and does not depend on
+  the action being updated.
+- **Making every CI consumer honor `ATMOS_CI=false`.** This fix
+  scopes the flag/env override to `describe affected` so the blast
+  radius is narrow. Extending the same override semantics to
+  `pkg/hooks`, `pkg/list/list_instances.go`, and
+  `internal/exec/ci_exit_codes.go` is tracked as a follow-up so
+  each call site can be reviewed individually.
+
+## Implementation
+
+### Fix 1 — Skip CI base auto-detect when `--repo-path` is set
+
+File: `internal/exec/describe_affected.go`, function
+`SetDescribeAffectedFlagValueInCliArgs`.
+
+Current code (lines 236–239):
+
+```go
+// Auto-detect base from CI environment when ci.enabled is true and
+// no explicit base provided.
+if describe.Ref == "" && describe.SHA == "" &&
+    describe.CLIConfig != nil && describe.CLIConfig.CI.Enabled {
+    resolveBaseFromCI(describe)
+}
+```
+
+New code:
+
+```go
+// Auto-detect base from CI environment when ci.enabled is true,
+// no explicit base provided, AND --repo-path is not set.
+//
+// --repo-path is mutually exclusive with --base/--ref/--sha (see
+// ErrRepoPathConflict). Auto-injecting those fields from CI env
+// would trigger the conflict validator and break every
+// describe-affected call that passes --repo-path (e.g. the
+// cloudposse/github-action-atmos-affected-trigger-spacelift
+// action).
+if describe.Ref == "" && describe.SHA == "" &&
+    describe.RepoPath == "" &&
+    describe.CLIConfig != nil && ciEnabledForDescribe(describe) {
+    resolveBaseFromCI(describe)
+}
+```
+
+Impact on `ErrRepoPathConflict`: the validator on line 169 is
+unchanged. Users who explicitly pass `--repo-path` *and* `--base`
+still get the same error. Only auto-detected values are
+suppressed.
+
+### Fix 2 — `--ci` flag on `describe affected` (env-bound to `ATMOS_CI`, `CI`)
+
+File: `cmd/describe_affected.go` — register the flag through the
+unified flag parser (same pattern used by
+`cmd/terraform/plan.go:119`):
+
+```go
+describeAffectedCIParser = flags.NewStandardParser(
+    flags.WithBoolFlag("ci", "", false,
+        "Enable CI mode for `describe affected`. Overrides "+
+        "ci.enabled in atmos.yaml for this invocation."),
+    flags.WithEnvVars("ci", "ATMOS_CI", "CI"),
+)
+describeAffectedCIParser.RegisterFlags(describeAffectedCmd)
+_ = describeAffectedCIParser.BindToViper(viper.GetViper())
+```
+
+The env-var bindings deliberately reuse the existing `ATMOS_CI` /
+`CI` pair — no new env var is introduced. `ATMOS_CI` already ships
+(PR #2079, March 2026) bound to the `--ci` flag on
+`terraform plan`/`apply`/`deploy`. Reusing it gives users a single,
+consistent knob across every CI-aware command.
+
+File: `internal/exec/describe_affected.go` — introduce a helper
+`ciEnabledForDescribe` that applies the precedence CLI flag > env
+var > `ci.enabled` in config > `false`:
+
+```go
+// ciEnabledForDescribe returns whether CI auto-base-detection
+// should run. Precedence (highest to lowest):
+//   1. --ci CLI flag on this invocation.
+//   2. ATMOS_CI env var.
+//   3. ci.enabled in atmos.yaml.
+//   4. false (default).
+func ciEnabledForDescribe(describe *DescribeAffectedCmdArgs) bool {
+    // viper reads the --ci flag bound via WithEnvVars (see
+    // cmd/describe_affected.go). When the flag or any of the
+    // env vars is explicitly set, IsSet returns true and
+    // GetBool returns the resolved value.
+    if viper.IsSet("ci") {
+        return viper.GetBool("ci")
+    }
+    if describe.CLIConfig == nil {
+        return false
+    }
+    return describe.CLIConfig.CI.Enabled
+}
+```
+
+Note: the `flags.WithEnvVars` registration already handles the
+CLI > env-var precedence inside viper; `ciEnabledForDescribe`
+only needs to check `IsSet` to distinguish "user supplied a
+value" from "fall back to config".
+
+### Error-message hint
+
+When `ErrRepoPathConflict` fires for an **explicit** (non-auto)
+conflict, we extend the message with a hint pointing users at the
+new env override so they don't hit the same failure mode from
+a different angle:
+
+```go
+var ErrRepoPathConflict = errors.New(
+    "if the '--repo-path' flag is specified, the '--base', " +
+    "'--ref', '--sha', '--ssh-key' and '--ssh-key-password' " +
+    "flags can't be used")
+```
+
+We wrap it in the builder pattern per `errors/errors.go`:
+
+```go
+return errUtils.Build(ErrRepoPathConflict).
+    WithHint("If --base was auto-injected from CI, set " +
+        "ATMOS_CI=false or pass --ci=false for this " +
+        "invocation, or unset ci.enabled in atmos.yaml.").
+    WithHint("--repo-path is intended for already-cloned " +
+        "sibling repositories. Pass only one of " +
+        "--repo-path OR (--base | --ref | --sha).").
+    Err()
+```
+
+After Fix 1, this hint is only seen by users who **explicitly**
+pass both flags — auto-detected values no longer trigger the
+validator. The hint still helps by explaining the new override
+for anyone who hits the conflict via a different path.
+
+## Testing
+
+### Unit tests — `internal/exec/describe_affected_test.go`
+
+Add to `TestSetDescribeAffectedFlagValueInCliArgs_BaseResolution`:
+
+1. `repo-path skips CI auto-detect even when ci.enabled=true`
+   — set `GITHUB_ACTIONS=true`, `GITHUB_BASE_REF=main`, the PR
+   event payload on disk, `ci.enabled=true` in config, and
+   `--repo-path=/tmp/repo`. Assert `describe.Ref == ""`,
+   `describe.SHA == ""`, and `describe.RepoPath ==
+   "/tmp/repo"`. The absence of auto-injected values is the
+   contract.
+2. `ATMOS_CI=false disables auto-detect even when
+   ci.enabled=true` — same GitHub Actions env, `ci.enabled=true`
+   in config, `ATMOS_CI=false`. Assert `describe.Ref ==
+   ""` and `describe.SHA == ""`.
+3. `--ci=false flag disables auto-detect even when
+   ci.enabled=true` — same GitHub Actions env, `ci.enabled=true`
+   in config, flag `--ci=false`. Assert `describe.Ref == ""`
+   and `describe.SHA == ""`.
+4. `--ci=true enables auto-detect even when ci.enabled=false`
+   — same GitHub Actions env, `ci.enabled=false` in config,
+   flag `--ci=true`. Assert `describe.Ref ==
+   "refs/remotes/origin/main"`.
+5. `explicit --repo-path + --base still errors` — no CI env,
+   `--repo-path=/tmp/repo` and `--base=main`. Assert
+   `ParseDescribeAffectedCliArgs` returns `ErrRepoPathConflict`.
+   This is the negative-path counterpart to (1) per
+   `CLAUDE.md` § "Include negative-path tests for recovery
+   logic".
+6. `precedence: CLI flag > env var > config` — table-driven
+   test. For each combination of `(--ci flag set, ATMOS_CI
+   set, ci.enabled in config)`, assert the resolved value
+   matches the documented precedence.
+
+### Integration / manual verification
+
+Reproduce the 1898andCo/infra PR #2964 failure locally:
+
+```bash
+# Fresh checkout with ci.enabled: true in atmos.yaml
+cat >> atmos.yaml <<'YAML'
+ci:
+  enabled: true
+YAML
+
+# Simulate GitHub Actions PR event.
+export GITHUB_ACTIONS=true
+export GITHUB_EVENT_NAME=pull_request
+export GITHUB_BASE_REF=main
+export GITHUB_EVENT_PATH=/tmp/event.json
+cat > /tmp/event.json <<'JSON'
+{
+  "action": "synchronize",
+  "pull_request": {
+    "head": {"sha": "0000000000000000000000000000000000000001"},
+    "base": {"ref": "main"}
+  }
+}
+JSON
+
+# Before fix: fails with ErrRepoPathConflict.
+# After fix: succeeds; no auto-detect, uses --repo-path only.
+atmos describe affected --repo-path=/tmp/other-clone
+```
+
+Then verify the new overrides:
+
+```bash
+# Explicitly disable CI features for this invocation.
+ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
+atmos describe affected --repo-path=/tmp/other-clone --ci=false
+
+# Explicitly force CI mode even with ci.enabled: false in config.
+unset ATMOS_CI
+# Edit atmos.yaml to set ci.enabled: false, then:
+atmos describe affected --ci=true  # should auto-detect base
+```
+
+### CI regression coverage
+
+The existing `TestSetDescribeAffectedFlagValueInCliArgs_BaseResolution/CI_auto-detect_when_enabled_and_no_explicit_base`
+test continues to exercise the auto-detect path. No change needed
+there — we are only adding a new guard condition, not removing
+behavior.
+
+## Progress checklist
+
+- [x] Fix doc (this file).
+- [x] Fix 1: skip `resolveBaseFromCI` when `describe.RepoPath != ""`
+  (`internal/exec/describe_affected.go`,
+  `SetDescribeAffectedFlagValueInCliArgs`).
+- [x] Fix 2a: `--ci` flag on `describe affected`
+  (`cmd/describe_affected.go`, `describeAffectedCIParser`).
+- [x] Fix 2b: env binding via
+  `flags.WithEnvVars("ci", "ATMOS_CI", "CI")` (reuses the existing
+  env-var pair — no new env var added).
+- [x] Fix 2c: `isCIEnabledForDescribeAffected` helper with
+  documented precedence (flag/env via `viper.IsSet("ci")` >
+  `ci.enabled` in config > `false`).
+- [x] Fix 3: `ErrRepoPathConflict` error wrapped with
+  `errUtils.Build(...).WithHint(...).Err()` pointing at the new
+  override.
+- [x] Unit tests:
+  `TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect`
+  (includes inline negative-path sanity assertion),
+  `TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides`
+  (4 sub-tests),
+  `TestIsCIEnabledForDescribeAffected_Precedence`
+  (5 sub-tests).
+- [x] Documentation:
+  `website/docs/cli/commands/describe/describe-affected.mdx` —
+  new `--ci` flag entry, `--repo-path` interaction note, and
+  "Overriding CI auto-detection per invocation" section with
+  precedence table.
+- [x] Documentation: `website/docs/cli/configuration/ci/index.mdx`
+  — `ATMOS_CI` row added to the env-var table.
+- [x] Documentation:
+  `website/docs/cli/environment-variables.mdx` — new
+  "CI Integration" section covering `ATMOS_CI` (extended to gate
+  describe-affected CI auto-detection) and `CI`.
+- [ ] Blog post: `website/blog/2026-04-21-describe-affected-repo-path-ci-fix.mdx`
+  (labeled `bugfix`).
+- [ ] Roadmap update: add milestone under the `native-ci`
+  initiative, `status: 'shipped'`, link PR + blog slug.
+- [ ] Build website: `cd website && npm run build`.
+- [ ] `make lint && make testacc` clean (full suite pending).
+
+## Follow-ups
+
+- **Upstream GitHub Action fix.** File an issue against
+  `cloudposse/github-action-atmos-affected-stacks` (and
+  `-trigger-spacelift`) to pass `--ci=false` whenever the action
+  itself supplies `--repo-path`. Users upgrading to Atmos 1.217.0
+  will get the fix regardless, but belt-and-suspenders: the
+  action should never rely on a CLI behavior it can suppress
+  itself.
+- **Make every CI consumer honor `ATMOS_CI=false`.** Extend the
+  same env override to `pkg/hooks/hooks.go:136`,
+  `internal/exec/ci_exit_codes.go:23`,
+  `pkg/list/list_instances.go:596`, and `cmd/ci/status.go:61`.
+  Each site reads `atmosConfig.CI.Enabled` directly today; a
+  shared helper (same semantics as `ciEnabledForDescribe`) would
+  centralize the precedence rule. Deferred to a separate PR so
+  each call site can be reviewed individually — the semantics of
+  "disable CI features mid-workflow" differ per consumer.
+- **Deprecate `ci.enabled`-only gating for auto base detection.**
+  Longer term, consider decoupling base auto-detect from
+  `ci.enabled`. The two serve different audiences: `ci.enabled`
+  is for CI outputs (checks, summaries), while base auto-detect
+  is a DX improvement that could run whenever a known CI
+  provider is detected. Gated behind a separate knob (e.g.
+  `ci.describe_affected.auto_detect_base`) so users can keep the
+  Atmos Pro features without the flag-injection side effect.
+  Requires a minor-version release and migration notes —
+  deferred.
+- **Structured error for CLI flag conflicts.** `ErrRepoPathConflict`
+  today is a single sentinel covering five flag names. Splitting
+  into `ErrRepoPathConflictWithBase`,
+  `ErrRepoPathConflictWithRef`, etc. would make error handling
+  and documentation cleaner. Out of scope here.
+
+---
+
+## Related
+
+- `internal/exec/describe_affected.go` — `ErrRepoPathConflict`,
+  `SetDescribeAffectedFlagValueInCliArgs`, `resolveBaseFromCI`.
+- `cmd/describe_affected.go` — `describe affected` flag
+  declarations.
+- `cmd/terraform/plan.go:119` — reference pattern for the
+  `flags.WithEnvVars("ci", "ATMOS_CI", "CI")` binding.
+- `docs/prd/native-ci/framework/ci-detection.md` — `ci.enabled`
+  authority model; explains why `--ci` / `ATMOS_CI` / `CI` today
+  can only *enable* CI mode, never disable it. This fix
+  introduces the first runtime disable path (`--ci=false`,
+  `ATMOS_CI=false`).
+- `docs/prd/native-ci/framework/base-resolution.md` — CI base
+  auto-detection spec introduced in cloudposse/atmos#2241.
+- `errors/errors.go` — error-builder pattern
+  (`Build(err).WithHint(...).Err()`).
+- `pkg/flags/` — `WithEnvVars` flag-to-env-var binding
+  (`pkg/flags/global_builder.go`).
+- 1898andCo/infra#2964 — user-reported failure and the yq-patch
+  workaround that motivated this fix.
+- cloudposse/atmos#2241 — the PR that introduced CI base
+  auto-detection in 1.216.0.

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -174,8 +174,8 @@ func ParseDescribeAffectedCliArgs(cmd *cobra.Command, args []string) (DescribeAf
 	}
 	if result.RepoPath != "" && (result.Base != "" || result.Ref != "" || result.SHA != "" || result.SSHKeyPath != "" || result.SSHKeyPassword != "") {
 		return DescribeAffectedCmdArgs{}, errUtils.Build(ErrRepoPathConflict).
-			WithHint("Pass only one of --repo-path OR (--base | --ref | --sha). --repo-path is intended for comparing against an already-cloned sibling repository.").
-			WithHint("If --base was auto-injected from CI, pass --ci=false (or set ATMOS_CI=false) for this invocation, or unset ci.enabled in atmos.yaml.").
+			WithHint("Pass only one of: --repo-path OR (--base | --ref | --sha | --ssh-key | --ssh-key-password). --repo-path points at an already-cloned sibling repository to diff against; the others clone or check out a target ref.").
+			WithHint("To compare against a specific ref or SHA, use --base without --repo-path. To compare against an already-cloned repo, use --repo-path without --base / --ref / --sha.").
 			Err()
 	}
 

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -28,6 +28,11 @@ import (
 
 var ErrRepoPathConflict = errors.New("if the '--repo-path' flag is specified, the '--base', '--ref', '--sha', '--ssh-key' and '--ssh-key-password' flags can't be used")
 
+// logKeyProvider is the structured-log key used for the CI provider name
+// in auto-detect log lines. Extracted to satisfy the revive `add-constant`
+// linter (the literal appears in four log calls across the CI helpers).
+const logKeyProvider = "provider"
+
 type DescribeAffectedExecCreator func(atmosConfig *schema.AtmosConfiguration) DescribeAffectedExec
 
 type DescribeAffectedCmdArgs struct {
@@ -264,16 +269,26 @@ func SetDescribeAffectedFlagValueInCliArgs(flags *pflag.FlagSet, describe *Descr
 		}
 	}
 
-	// Auto-detect base from CI environment when CI is enabled, no explicit base
-	// provided, AND --repo-path is not set.
+	// Auto-detect CI metadata when CI is enabled and no explicit base is provided.
 	//
-	// --repo-path is mutually exclusive with --base/--ref/--sha (see
-	// ErrRepoPathConflict). Auto-injecting those fields from CI env would
-	// trigger the conflict validator and break every describe-affected call
-	// that passes --repo-path (e.g. the cloudposse
-	// github-action-atmos-affected-trigger-spacelift action).
-	if describe.Ref == "" && describe.SHA == "" && describe.RepoPath == "" && isCIEnabledForDescribeAffected(describe) {
-		resolveBaseFromCI(describe)
+	// Two cases:
+	//   - Normal (no --repo-path): populate Ref/SHA + HeadSHAOverride/CIEventType
+	//     from the CI provider.
+	//   - --repo-path: skip base detection (--repo-path is mutually exclusive with
+	//     --base/--ref/--sha per ErrRepoPathConflict — auto-injecting them from
+	//     CI env would break every describe-affected call that passes --repo-path,
+	//     e.g. the cloudposse/github-action-atmos-affected-trigger-spacelift
+	//     action). When --upload is also set, still populate the upload correlation
+	//     metadata (HeadSHAOverride, CIEventType) so Atmos Pro can match the
+	//     uploaded affected list to the PR webhook SHA even though this checkout
+	//     is at a merge commit.
+	if describe.Ref == "" && describe.SHA == "" && isCIEnabledForDescribeAffected(describe) {
+		switch {
+		case describe.RepoPath == "":
+			resolveBaseFromCI(describe)
+		case describe.Upload:
+			resolveCIUploadMetadataFromCI(describe)
+		}
 	}
 
 	// When uploading, always include dependents and settings for all affected components.
@@ -297,7 +312,7 @@ func resolveBaseFromCI(describe *DescribeAffectedCmdArgs) {
 
 	resolution, err := p.ResolveBase()
 	if err != nil {
-		log.Warn("Failed to auto-detect CI base", "provider", p.Name(), "error", err)
+		log.Warn("Failed to auto-detect CI base", logKeyProvider, p.Name(), "error", err)
 		return
 	}
 	if resolution == nil {
@@ -314,10 +329,46 @@ func resolveBaseFromCI(describe *DescribeAffectedCmdArgs) {
 		base = resolution.Ref
 	}
 	log.Info("Auto-detected CI base",
-		"provider", p.Name(),
+		logKeyProvider, p.Name(),
 		"event", resolution.EventType,
 		"base", base,
 		"source", resolution.Source)
+}
+
+// resolveCIUploadMetadataFromCI populates the upload correlation metadata
+// (HeadSHAOverride, CIEventType) from the CI provider WITHOUT populating
+// Ref or SHA.
+//
+// Used in the `--repo-path` + `--upload` + CI code path. Base auto-detection
+// is skipped there to avoid ErrRepoPathConflict, but Atmos Pro still needs
+// the PR head SHA and event type to correlate the uploaded affected list
+// with the PR webhook — the current checkout is typically a GitHub
+// pull_request merge commit, whose SHA does not match what the webhook
+// indexed.
+func resolveCIUploadMetadataFromCI(describe *DescribeAffectedCmdArgs) {
+	defer perf.Track(nil, "exec.resolveCIUploadMetadataFromCI")()
+
+	p := ci.Detect()
+	if p == nil {
+		return
+	}
+
+	resolution, err := p.ResolveBase()
+	if err != nil {
+		log.Warn("Failed to auto-detect CI upload metadata", logKeyProvider, p.Name(), "error", err)
+		return
+	}
+	if resolution == nil {
+		return
+	}
+
+	describe.HeadSHAOverride = resolution.HeadSHA
+	describe.CIEventType = resolution.EventType
+
+	log.Debug("Auto-detected CI upload metadata (base auto-detect skipped due to --repo-path)",
+		logKeyProvider, p.Name(),
+		"event", resolution.EventType,
+		"headSHA", resolution.HeadSHA)
 }
 
 // Execute executes `describe affected` command.

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -8,6 +8,7 @@ import (
 	giturl "github.com/kubescape/go-git-url"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/internal/tui/templates/term"
@@ -167,10 +168,40 @@ func ParseDescribeAffectedCliArgs(cmd *cobra.Command, args []string) (DescribeAf
 		return DescribeAffectedCmdArgs{}, ErrInvalidFormat
 	}
 	if result.RepoPath != "" && (result.Base != "" || result.Ref != "" || result.SHA != "" || result.SSHKeyPath != "" || result.SSHKeyPassword != "") {
-		return DescribeAffectedCmdArgs{}, ErrRepoPathConflict
+		return DescribeAffectedCmdArgs{}, errUtils.Build(ErrRepoPathConflict).
+			WithHint("Pass only one of --repo-path OR (--base | --ref | --sha). --repo-path is intended for comparing against an already-cloned sibling repository.").
+			WithHint("If --base was auto-injected from CI, pass --ci=false (or set ATMOS_CI=false) for this invocation, or unset ci.enabled in atmos.yaml.").
+			Err()
 	}
 
 	return result, nil
+}
+
+// isCIEnabledForDescribeAffected resolves whether CI features (specifically,
+// --base auto-detection from the CI provider's environment) should run for
+// this invocation of `describe affected`.
+//
+// Precedence (highest to lowest):
+//  1. --ci CLI flag on this invocation.
+//  2. ATMOS_CI / CI env vars (bound to the `ci` viper key via
+//     flags.WithEnvVars in cmd/describe_affected.go). This matches the
+//     env-var bindings already used by `terraform plan`/`apply`/`deploy`.
+//  3. ci.enabled in atmos.yaml.
+//  4. false (default).
+//
+// The --ci flag and its env-var bindings are registered once at init() time
+// via the StandardParser. Viper IsSet reports true when either the CLI flag
+// was explicitly passed or any bound env var is set to a non-empty value.
+func isCIEnabledForDescribeAffected(describe *DescribeAffectedCmdArgs) bool {
+	defer perf.Track(nil, "exec.isCIEnabledForDescribeAffected")()
+
+	if viper.IsSet("ci") {
+		return viper.GetBool("ci")
+	}
+	if describe.CLIConfig == nil {
+		return false
+	}
+	return describe.CLIConfig.CI.Enabled
 }
 
 // SetDescribeAffectedFlagValueInCliArgs sets the flag values in CLI arguments.
@@ -233,8 +264,15 @@ func SetDescribeAffectedFlagValueInCliArgs(flags *pflag.FlagSet, describe *Descr
 		}
 	}
 
-	// Auto-detect base from CI environment when ci.enabled is true and no explicit base provided.
-	if describe.Ref == "" && describe.SHA == "" && describe.CLIConfig != nil && describe.CLIConfig.CI.Enabled {
+	// Auto-detect base from CI environment when CI is enabled, no explicit base
+	// provided, AND --repo-path is not set.
+	//
+	// --repo-path is mutually exclusive with --base/--ref/--sha (see
+	// ErrRepoPathConflict). Auto-injecting those fields from CI env would
+	// trigger the conflict validator and break every describe-affected call
+	// that passes --repo-path (e.g. the cloudposse
+	// github-action-atmos-affected-trigger-spacelift action).
+	if describe.Ref == "" && describe.SHA == "" && describe.RepoPath == "" && isCIEnabledForDescribeAffected(describe) {
 		resolveBaseFromCI(describe)
 	}
 

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -216,12 +216,28 @@ func isCIEnabledForDescribeAffected(flags *pflag.FlagSet, describe *DescribeAffe
 	}
 	// 2. Explicit env var. Order mirrors flags.WithEnvVars("ci", "ATMOS_CI",
 	//    "CI"): ATMOS_CI checked first so it wins over CI when both set.
+	//
+	// When an env var is set but strconv.ParseBool rejects the value
+	// (e.g. ATMOS_CI=yes / on / enabled), we log a warning and BREAK out
+	// of the env-var loop without falling through to the next env var.
+	// Rationale: the user's explicit ATMOS_CI was an override attempt —
+	// silently falling through to the ambient CI=true (set by every
+	// runner) would be the opposite of their intent. We still fall
+	// through to ci.enabled in atmos.yaml (tier 3), which preserves
+	// declared intent from committed config while surfacing the typo
+	// via the warning.
 	for _, name := range []string{"ATMOS_CI", "CI"} {
-		if val, ok := os.LookupEnv(name); ok && val != "" {
-			if parsed, err := strconv.ParseBool(val); err == nil {
-				return parsed
-			}
+		val, ok := os.LookupEnv(name)
+		if !ok || val == "" {
+			continue
 		}
+		parsed, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Warn("Ignoring unparseable CI env var; falling through to ci.enabled in atmos.yaml",
+				"name", name, "value", val, "error", err)
+			break
+		}
+		return parsed
 	}
 	// 3. ci.enabled in atmos.yaml (primary fallback for the common case:
 	//    user committed `ci.enabled: true` and is running locally without

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -3,12 +3,13 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	giturl "github.com/kubescape/go-git-url"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/internal/tui/templates/term"
@@ -187,22 +188,44 @@ func ParseDescribeAffectedCliArgs(cmd *cobra.Command, args []string) (DescribeAf
 // this invocation of `describe affected`.
 //
 // Precedence (highest to lowest):
-//  1. --ci CLI flag on this invocation.
-//  2. ATMOS_CI / CI env vars (bound to the `ci` viper key via
-//     flags.WithEnvVars in cmd/describe_affected.go). This matches the
-//     env-var bindings already used by `terraform plan`/`apply`/`deploy`.
+//  1. --ci CLI flag on this invocation (checked via pflag.Flag.Changed).
+//  2. ATMOS_CI / CI env vars (checked via os.LookupEnv). ATMOS_CI wins
+//     if both are set.
 //  3. ci.enabled in atmos.yaml.
 //  4. false (default).
 //
-// The --ci flag and its env-var bindings are registered once at init() time
-// via the StandardParser. Viper IsSet reports true when either the CLI flag
-// was explicitly passed or any bound env var is set to a non-empty value.
-func isCIEnabledForDescribeAffected(describe *DescribeAffectedCmdArgs) bool {
+// Why not viper.IsSet("ci")? The StandardParser.BindFlagsToViper helper
+// (pkg/flags/standard.go:455) calls v.SetDefault("ci", false) for the
+// flag's default, which flips viper.IsSet("ci") to true for every
+// invocation — masking ci.enabled from atmos.yaml. Checking pflag.Changed
+// + os.LookupEnv directly is the only way to distinguish explicit
+// user overrides from the parser's default, so config fall-through
+// works when the user has opted in via atmos.yaml but not via flag/env.
+// See TestIsCIEnabledForDescribeAffected_RealBinding for the regression
+// this avoids.
+func isCIEnabledForDescribeAffected(flags *pflag.FlagSet, describe *DescribeAffectedCmdArgs) bool {
 	defer perf.Track(nil, "exec.isCIEnabledForDescribeAffected")()
 
-	if viper.IsSet("ci") {
-		return viper.GetBool("ci")
+	// 1. Explicit --ci CLI flag.
+	if flags != nil {
+		if f := flags.Lookup("ci"); f != nil && f.Changed {
+			if val, err := flags.GetBool("ci"); err == nil {
+				return val
+			}
+		}
 	}
+	// 2. Explicit env var. Order mirrors flags.WithEnvVars("ci", "ATMOS_CI",
+	//    "CI"): ATMOS_CI checked first so it wins over CI when both set.
+	for _, name := range []string{"ATMOS_CI", "CI"} {
+		if val, ok := os.LookupEnv(name); ok && val != "" {
+			if parsed, err := strconv.ParseBool(val); err == nil {
+				return parsed
+			}
+		}
+	}
+	// 3. ci.enabled in atmos.yaml (primary fallback for the common case:
+	//    user committed `ci.enabled: true` and is running locally without
+	//    env overrides).
 	if describe.CLIConfig == nil {
 		return false
 	}
@@ -282,7 +305,7 @@ func SetDescribeAffectedFlagValueInCliArgs(flags *pflag.FlagSet, describe *Descr
 	//     metadata (HeadSHAOverride, CIEventType) so Atmos Pro can match the
 	//     uploaded affected list to the PR webhook SHA even though this checkout
 	//     is at a merge commit.
-	if describe.Ref == "" && describe.SHA == "" && isCIEnabledForDescribeAffected(describe) {
+	if describe.Ref == "" && describe.SHA == "" && isCIEnabledForDescribeAffected(flags, describe) {
 		switch {
 		case describe.RepoPath == "":
 			resolveBaseFromCI(describe)

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -1741,6 +1741,91 @@ func TestResolveBaseFromCI(t *testing.T) {
 	})
 }
 
+// TestResolveCIUploadMetadataFromCI exercises the partial CI resolver used on
+// the --repo-path + --upload path. Mirrors TestResolveBaseFromCI for the
+// sibling helper, but asserts the sibling's contract: populate
+// HeadSHAOverride + CIEventType WITHOUT populating Ref or SHA.
+func TestResolveCIUploadMetadataFromCI(t *testing.T) {
+	t.Run("no CI provider detected", func(t *testing.T) {
+		ci.Reset()
+		t.Cleanup(ci.Reset)
+
+		t.Setenv("GITHUB_ACTIONS", "")
+		t.Setenv("CI", "")
+
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{},
+		}
+		resolveCIUploadMetadataFromCI(describe)
+
+		// All four auto-populated fields stay empty — no provider, no change.
+		assert.Empty(t, describe.Ref)
+		assert.Empty(t, describe.SHA)
+		assert.Empty(t, describe.HeadSHAOverride)
+		assert.Empty(t, describe.CIEventType)
+	})
+
+	t.Run("ResolveBase returns error logs warning and leaves fields empty", func(t *testing.T) {
+		ci.Reset()
+		t.Cleanup(ci.Reset)
+		ci.Register(githubCI.NewProvider())
+
+		t.Setenv("GITHUB_ACTIONS", "true")
+		t.Setenv("GITHUB_EVENT_NAME", "push")
+		// Missing GITHUB_EVENT_PATH causes ResolveBase to error for push events.
+		t.Setenv("GITHUB_EVENT_PATH", "")
+
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{},
+		}
+		resolveCIUploadMetadataFromCI(describe)
+
+		// Error path: warning logged, fields stay empty, no panic.
+		assert.Empty(t, describe.Ref, "error path must not populate Ref")
+		assert.Empty(t, describe.SHA, "error path must not populate SHA")
+		assert.Empty(t, describe.HeadSHAOverride, "error path must not populate HeadSHAOverride")
+		assert.Empty(t, describe.CIEventType, "error path must not populate CIEventType")
+	})
+
+	t.Run("GitHub Actions PR event populates only upload metadata", func(t *testing.T) {
+		ci.Reset()
+		t.Cleanup(ci.Reset)
+		ci.Register(githubCI.NewProvider())
+
+		t.Setenv("GITHUB_ACTIONS", "true")
+		t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+		t.Setenv("GITHUB_BASE_REF", "main")
+
+		eventPayload := `{
+			"action": "synchronize",
+			"pull_request": {
+				"head": {"sha": "headsha123456789012345678901234567890ab"},
+				"base": {"ref": "main"}
+			}
+		}`
+		eventPath := filepath.Join(t.TempDir(), "event.json")
+		require.NoError(t, os.WriteFile(eventPath, []byte(eventPayload), 0o644))
+		t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{},
+		}
+		resolveCIUploadMetadataFromCI(describe)
+
+		// Upload metadata populated from the event payload…
+		assert.Equal(t, "headsha123456789012345678901234567890ab", describe.HeadSHAOverride,
+			"HeadSHAOverride must be populated from pull_request.head.sha")
+		assert.Equal(t, "pull_request", describe.CIEventType,
+			"CIEventType must be populated from GITHUB_EVENT_NAME")
+
+		// …but base fields (Ref/SHA) stay empty — this is the entire point of
+		// the partial resolver. If these become non-empty, downstream
+		// ErrRepoPathConflict would fire and the fix regresses.
+		assert.Empty(t, describe.Ref, "partial resolver must NOT populate Ref")
+		assert.Empty(t, describe.SHA, "partial resolver must NOT populate SHA")
+	})
+}
+
 // newDescribeAffectedFlagSet creates a pflag.FlagSet with all flags used by SetDescribeAffectedFlagValueInCliArgs.
 func newDescribeAffectedFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -2162,49 +2163,85 @@ func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
 }
 
 // TestIsCIEnabledForDescribeAffected_Precedence exercises the precedence
-// resolver directly — CLI flag (viper) > env var (viper) > config > false.
+// resolver directly — CLI flag (pflag.Changed) > env var (os.LookupEnv) >
+// config > false. Each case drives exactly one override source to verify
+// its tier in the precedence chain, independently of viper.
 func TestIsCIEnabledForDescribeAffected_Precedence(t *testing.T) {
+	// override is a tagged union of the three override sources we support.
+	// At most one field is set per test case.
+	type override struct {
+		flagValue *bool  // non-nil → simulate --ci=<value> on the command line (flag.Changed=true).
+		atmosCI   string // non-empty → ATMOS_CI env var set to this value.
+		ci        string // non-empty → CI env var set to this value.
+	}
+
 	cases := []struct {
-		name       string
-		viperSet   bool // simulates --ci flag or env var having been bound/set.
-		viperValue bool // value if viperSet is true.
-		configCI   bool // ci.enabled value.
-		nilCLI     bool // if true, describe.CLIConfig is nil.
-		want       bool
-		why        string
+		name     string
+		ovr      override
+		configCI bool
+		nilCLI   bool
+		want     bool
+		why      string
 	}{
 		{
-			name:     "viper set true wins over config false",
-			viperSet: true, viperValue: true, configCI: false,
-			want: true, why: "flag/env=true should override ci.enabled=false",
+			name: "--ci=true flag wins over config false",
+			ovr:  override{flagValue: boolPtr(true)},
+			want: true, why: "explicit --ci=true is the top-priority override",
 		},
 		{
-			name:     "viper set false wins over config true",
-			viperSet: true, viperValue: false, configCI: true,
-			want: false, why: "flag/env=false should override ci.enabled=true",
+			name: "--ci=false flag wins over config true",
+			ovr:  override{flagValue: boolPtr(false)}, configCI: true,
+			want: false, why: "explicit --ci=false disables even with ci.enabled=true",
 		},
 		{
-			name:     "viper unset falls through to config true",
-			viperSet: false, configCI: true,
-			want: true, why: "ci.enabled=true in atmos.yaml applies when no override",
+			name: "ATMOS_CI=true env wins over config false",
+			ovr:  override{atmosCI: "true"},
+			want: true, why: "ATMOS_CI=true overrides absent ci.enabled",
 		},
 		{
-			name:     "viper unset falls through to config false",
-			viperSet: false, configCI: false,
-			want: false, why: "default (no override, ci.enabled=false) is disabled",
+			name: "ATMOS_CI=false env wins over config true",
+			ovr:  override{atmosCI: "false"}, configCI: true,
+			want: false, why: "ATMOS_CI=false disables even with ci.enabled=true",
 		},
 		{
-			name:     "nil CLIConfig defaults to false",
-			viperSet: false, nilCLI: true,
-			want: false, why: "safety: missing config must not enable auto-detect",
+			name: "CI=true env enables auto-detect (zero-config CI)",
+			ovr:  override{ci: "true"},
+			want: true, why: "runner-set CI=true is the zero-config signal",
+		},
+		{
+			name: "ATMOS_CI=false beats CI=true (ATMOS_CI has higher priority)",
+			ovr:  override{atmosCI: "false", ci: "true"},
+			want: false, why: "ATMOS_CI precedes CI in the env var order",
+		},
+		{
+			name:     "no override falls through to config true",
+			configCI: true,
+			want:     true, why: "ci.enabled=true in atmos.yaml applies when no flag/env override — the previously-regressing path",
+		},
+		{
+			name:     "no override falls through to config false",
+			configCI: false,
+			want:     false, why: "default (no override, ci.enabled=false) is disabled",
+		},
+		{
+			name:   "nil CLIConfig defaults to false",
+			nilCLI: true,
+			want:   false, why: "safety: missing config must not enable auto-detect",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resetCIViperKey(t)
-			if tc.viperSet {
-				viper.Set("ci", tc.viperValue)
+			// Isolate env vars: clear both, then set what the case wants.
+			t.Setenv("ATMOS_CI", tc.ovr.atmosCI)
+			t.Setenv("CI", tc.ovr.ci)
+
+			// Build a pflag.FlagSet with `--ci` registered. If the case
+			// specifies a flag value, Set it so flag.Changed becomes true.
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			fs.Bool("ci", false, "")
+			if tc.ovr.flagValue != nil {
+				require.NoError(t, fs.Set("ci", strconv.FormatBool(*tc.ovr.flagValue)))
 			}
 
 			describe := &DescribeAffectedCmdArgs{}
@@ -2214,10 +2251,51 @@ func TestIsCIEnabledForDescribeAffected_Precedence(t *testing.T) {
 				}
 			}
 
-			got := isCIEnabledForDescribeAffected(describe)
+			got := isCIEnabledForDescribeAffected(fs, describe)
 			assert.Equal(t, tc.want, got, tc.why)
 		})
 	}
+}
+
+// TestIsCIEnabledForDescribeAffected_RealBinding is the regression guard for
+// the bug where StandardParser.BindFlagsToViper's SetDefault on the `ci`
+// key made viper.IsSet("ci") always true, which masked ci.enabled=true from
+// atmos.yaml with the pflag default (false).
+//
+// This test sets up the EXACT viper+flag binding chain the cmd layer uses
+// in production (BindEnv + BindPFlag + SetDefault), then verifies that
+// isCIEnabledForDescribeAffected still falls through to CLIConfig.CI.Enabled
+// when no CLI flag or env var was provided.
+func TestIsCIEnabledForDescribeAffected_RealBinding(t *testing.T) {
+	// Clear ambient env + fresh viper to reproduce a local-dev invocation.
+	t.Setenv("ATMOS_CI", "")
+	t.Setenv("CI", "")
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	v := viper.GetViper()
+
+	// Mimic StandardParser binding: SetDefault + BindEnv + BindPFlag.
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Bool("ci", false, "")
+	v.SetDefault("ci", false)
+	require.NoError(t, v.BindEnv("ci", "ATMOS_CI", "CI"))
+	require.NoError(t, v.BindPFlag("ci", fs.Lookup("ci")))
+
+	// Sanity: after the binding, viper.IsSet returns true — the exact
+	// misleading signal that caused the bug. We don't trust it in the
+	// production helper, and this assertion documents why.
+	require.True(t, v.IsSet("ci"),
+		"viper.IsSet(\"ci\") is true after SetDefault — relying on it in the helper would be wrong")
+
+	describe := &DescribeAffectedCmdArgs{
+		CLIConfig: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{Enabled: true},
+		},
+	}
+	got := isCIEnabledForDescribeAffected(fs, describe)
+	assert.True(t, got,
+		"ci.enabled=true from atmos.yaml must still be honored under the production binding chain (flag not Changed, no env vars set)")
 }
 
 // TestExecute_MatrixFormat tests the matrix format code path through Execute.

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -1950,7 +1950,8 @@ func resetCIViperKey(t *testing.T) {
 
 // TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect verifies
 // that --repo-path short-circuits the CI auto-detect path, even when
-// ci.enabled is true. This is the regression fix for 1898andCo/infra#2964.
+// ci.enabled is true. This is the regression fix for the user-reported
+// describe affected --repo-path failure under ci.enabled: true.
 func TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect(t *testing.T) {
 	resetCIViperKey(t)
 	setupGitHubActionsPREnv(t)

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -1902,12 +1902,69 @@ func TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect(t *test
 		},
 	}
 	SetDescribeAffectedFlagValueInCliArgs(flagsNoRepoPath, describeNoRepoPath)
-	assert.Equal(t, "refs/remotes/origin/main", describeNoRepoPath.Ref,
-		"sanity: auto-detect should run in the same env when --repo-path is NOT set")
+	// The exact field (Ref vs SHA) and its value depend on whether
+	// merge-base(HEAD, origin/main) succeeds in the test git environment —
+	// the GitHub provider tries merge-base first (returns a SHA) and falls
+	// back to GITHUB_BASE_REF (returns a ref). Either is a valid
+	// auto-detect result; what matters is that *something* was populated.
+	assert.True(t, describeNoRepoPath.Ref != "" || describeNoRepoPath.SHA != "",
+		"sanity: auto-detect should populate Ref or SHA in the same env when --repo-path is NOT set")
+}
+
+// TestSetDescribeAffectedFlagValueInCliArgs_RepoPathUploadPopulatesMetadata
+// verifies that `--repo-path + --upload` in CI still populates upload
+// correlation metadata (HeadSHAOverride, CIEventType) even though base
+// auto-detection (Ref/SHA) is suppressed. Without this, Atmos Pro uploads
+// would correlate against the merge-commit SHA rather than the PR head SHA
+// indexed by the webhook.
+func TestSetDescribeAffectedFlagValueInCliArgs_RepoPathUploadPopulatesMetadata(t *testing.T) {
+	resetCIViperKey(t)
+	setupGitHubActionsPREnv(t)
+
+	flags := newDescribeAffectedFlagSet()
+	require.NoError(t, flags.Set("repo-path", "/tmp/other-clone"))
+	require.NoError(t, flags.Set("upload", "true"))
+
+	describe := &DescribeAffectedCmdArgs{
+		CLIConfig: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{Enabled: true},
+		},
+	}
+	SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+	// --repo-path still suppresses base selection.
+	assert.Equal(t, "/tmp/other-clone", describe.RepoPath,
+		"--repo-path should be preserved")
+	assert.Empty(t, describe.Ref,
+		"Ref must stay empty with --repo-path, even with --upload")
+	assert.Empty(t, describe.SHA,
+		"SHA must stay empty with --repo-path, even with --upload")
+
+	// --upload recovers the fields that matter for Atmos Pro correlation.
+	assert.Equal(t, "headsha123456789012345678901234567890ab", describe.HeadSHAOverride,
+		"--upload should populate HeadSHAOverride from the PR event payload")
+	assert.Equal(t, "pull_request", describe.CIEventType,
+		"--upload should populate CIEventType for PR-event validation in uploadableQuery")
+
+	// Negative-path sanity: dropping --upload restores the original
+	// repo-path-skips-everything behavior. Guarantees the metadata
+	// population is gated on --upload, not just --repo-path.
+	flagsNoUpload := newDescribeAffectedFlagSet()
+	require.NoError(t, flagsNoUpload.Set("repo-path", "/tmp/other-clone"))
+	describeNoUpload := &DescribeAffectedCmdArgs{
+		CLIConfig: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{Enabled: true},
+		},
+	}
+	SetDescribeAffectedFlagValueInCliArgs(flagsNoUpload, describeNoUpload)
+	assert.Empty(t, describeNoUpload.HeadSHAOverride,
+		"without --upload, metadata population must not fire")
+	assert.Empty(t, describeNoUpload.CIEventType,
+		"without --upload, CIEventType must stay empty")
 }
 
 // TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides verifies that the
-// --ci flag / ATMOS_CI_ENABLED env var override ci.enabled from atmos.yaml
+// --ci flag / ATMOS_CI env var override ci.enabled from atmos.yaml
 // per invocation. Exercises the precedence rule: CLI flag > env var > config.
 func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
 	t.Run("ATMOS_CI=false disables auto-detect when ci.enabled=true", func(t *testing.T) {
@@ -1950,8 +2007,13 @@ func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
 		}
 		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
 
-		assert.Equal(t, "refs/remotes/origin/main", describe.Ref,
-			"ATMOS_CI=true should force auto-detect even when ci.enabled=false")
+		// Under pull_request event, the GitHub provider tries merge-base first
+		// (returns a SHA) and falls back to GITHUB_BASE_REF (returns a ref).
+		// Either is a valid auto-detect result — assert that *something* was
+		// populated rather than pinning a specific resolution path (which
+		// depends on the test git environment).
+		assert.True(t, describe.Ref != "" || describe.SHA != "",
+			"ATMOS_CI=true should force auto-detect (Ref or SHA populated) even when ci.enabled=false")
 	})
 
 	t.Run("no override falls back to ci.enabled=true in atmos.yaml", func(t *testing.T) {
@@ -1966,8 +2028,8 @@ func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
 		}
 		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
 
-		assert.Equal(t, "refs/remotes/origin/main", describe.Ref,
-			"ci.enabled=true should keep auto-detect active when no override is set")
+		assert.True(t, describe.Ref != "" || describe.SHA != "",
+			"ci.enabled=true should keep auto-detect active (Ref or SHA populated) when no override is set")
 	})
 
 	t.Run("no override respects ci.enabled=false default", func(t *testing.T) {
@@ -1984,6 +2046,32 @@ func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
 
 		assert.Empty(t, describe.Ref,
 			"ci.enabled=false and no override must not auto-detect")
+	})
+
+	t.Run("CI=true alone enables auto-detect when ci.enabled=false (zero-config CI)", func(t *testing.T) {
+		// Documents the implicit behavior: on any CI runner (where CI=true
+		// is set by the runner), describe affected auto-detects the base
+		// commit even when ci.enabled is NOT opted into in atmos.yaml. This
+		// matches the "zero-config CI base detection" spirit of PR #2241
+		// and the env-var binding used across terraform plan/apply/deploy.
+		// Users who want to opt OUT set ATMOS_CI=false or --ci=false.
+		resetCIViperKey(t)
+		setupGitHubActionsPREnv(t)
+
+		require.NoError(t, viper.BindEnv("ci", "ATMOS_CI", "CI"))
+
+		t.Setenv("CI", "true")
+
+		flags := newDescribeAffectedFlagSet()
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{
+				CI: schema.CIConfig{Enabled: false},
+			},
+		}
+		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+		assert.True(t, describe.Ref != "" || describe.SHA != "",
+			"CI=true alone should trigger auto-detect (zero-config CI behavior) even when ci.enabled=false")
 	})
 }
 

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -2214,6 +2214,16 @@ func TestIsCIEnabledForDescribeAffected_Precedence(t *testing.T) {
 			want: false, why: "ATMOS_CI precedes CI in the env var order",
 		},
 		{
+			name: "unparseable ATMOS_CI suppresses CI fallthrough and falls through to config",
+			ovr:  override{atmosCI: "yes", ci: "true"}, configCI: false,
+			want: false, why: "user tried to override with an unparseable value; ambient CI=true must NOT override their explicit intent — fall through to ci.enabled (false here), after logging a warning",
+		},
+		{
+			name: "unparseable ATMOS_CI honors ci.enabled=true via config fallthrough",
+			ovr:  override{atmosCI: "on", ci: "true"}, configCI: true,
+			want: true, why: "unparseable ATMOS_CI falls through to atmos.yaml (tier 3), so ci.enabled=true still enables the feature even though the env var was malformed",
+		},
+		{
 			name:     "no override falls through to config true",
 			configCI: true,
 			want:     true, why: "ci.enabled=true in atmos.yaml applies when no flag/env override — the previously-regressing path",

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	cp "github.com/otiai10/copy"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -1822,6 +1823,227 @@ func TestSetDescribeAffectedFlagValueInCliArgs_BaseResolution(t *testing.T) {
 
 		assert.Equal(t, "refs/remotes/origin/main", describe.Ref)
 	})
+}
+
+// setupGitHubActionsPREnv wires GITHUB_* env vars and writes a pull_request
+// event payload for tests that exercise CI base auto-detection.
+func setupGitHubActionsPREnv(t *testing.T) {
+	t.Helper()
+
+	ci.Reset()
+	t.Cleanup(ci.Reset)
+	ci.Register(githubCI.NewProvider())
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+
+	eventPayload := `{
+		"action": "synchronize",
+		"pull_request": {
+			"head": {"sha": "headsha123456789012345678901234567890ab"},
+			"base": {"ref": "main"}
+		}
+	}`
+	eventPath := filepath.Join(t.TempDir(), "event.json")
+	err := os.WriteFile(eventPath, []byte(eventPayload), 0o644)
+	require.NoError(t, err)
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+}
+
+// resetCIViperKey resets the `ci` viper key before and after a test so that
+// CI-related viper state from other tests (or env vars on the host) does not
+// leak in. Using t.Setenv with empty strings also clears any host-exported vars.
+func resetCIViperKey(t *testing.T) {
+	t.Helper()
+
+	viper.Reset()
+	t.Setenv("ATMOS_CI", "")
+	t.Setenv("CI", "")
+	t.Cleanup(viper.Reset)
+}
+
+// TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect verifies
+// that --repo-path short-circuits the CI auto-detect path, even when
+// ci.enabled is true. This is the regression fix for 1898andCo/infra#2964.
+func TestSetDescribeAffectedFlagValueInCliArgs_RepoPathSkipsCIAutoDetect(t *testing.T) {
+	resetCIViperKey(t)
+	setupGitHubActionsPREnv(t)
+
+	flags := newDescribeAffectedFlagSet()
+	err := flags.Set("repo-path", "/tmp/other-clone")
+	require.NoError(t, err)
+
+	describe := &DescribeAffectedCmdArgs{
+		CLIConfig: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{Enabled: true},
+		},
+	}
+	SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+	assert.Equal(t, "/tmp/other-clone", describe.RepoPath,
+		"--repo-path should be preserved")
+	assert.Empty(t, describe.Ref,
+		"auto-detect must not populate Ref when --repo-path is set")
+	assert.Empty(t, describe.SHA,
+		"auto-detect must not populate SHA when --repo-path is set")
+	assert.Empty(t, describe.HeadSHAOverride,
+		"auto-detect must not populate HeadSHAOverride when --repo-path is set")
+	assert.Empty(t, describe.CIEventType,
+		"auto-detect must not populate CIEventType when --repo-path is set")
+
+	// Negative-path sanity: if the exact same config runs WITHOUT --repo-path,
+	// auto-detect still fires. Guarantees we're testing the guard, not the
+	// absence of a CI provider.
+	flagsNoRepoPath := newDescribeAffectedFlagSet()
+	describeNoRepoPath := &DescribeAffectedCmdArgs{
+		CLIConfig: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{Enabled: true},
+		},
+	}
+	SetDescribeAffectedFlagValueInCliArgs(flagsNoRepoPath, describeNoRepoPath)
+	assert.Equal(t, "refs/remotes/origin/main", describeNoRepoPath.Ref,
+		"sanity: auto-detect should run in the same env when --repo-path is NOT set")
+}
+
+// TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides verifies that the
+// --ci flag / ATMOS_CI_ENABLED env var override ci.enabled from atmos.yaml
+// per invocation. Exercises the precedence rule: CLI flag > env var > config.
+func TestSetDescribeAffectedFlagValueInCliArgs_CIFlagOverrides(t *testing.T) {
+	t.Run("ATMOS_CI=false disables auto-detect when ci.enabled=true", func(t *testing.T) {
+		resetCIViperKey(t)
+		setupGitHubActionsPREnv(t)
+
+		// Register the `ci` viper key with the same env-var bindings that
+		// cmd/describe_affected.go init() sets up via the StandardParser.
+		require.NoError(t, viper.BindEnv("ci", "ATMOS_CI", "CI"))
+
+		t.Setenv("ATMOS_CI", "false")
+
+		flags := newDescribeAffectedFlagSet()
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{
+				CI: schema.CIConfig{Enabled: true},
+			},
+		}
+		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+		assert.Empty(t, describe.Ref,
+			"ATMOS_CI=false should override ci.enabled=true")
+		assert.Empty(t, describe.SHA,
+			"ATMOS_CI=false should suppress SHA auto-detection")
+	})
+
+	t.Run("ATMOS_CI=true forces auto-detect when ci.enabled=false", func(t *testing.T) {
+		resetCIViperKey(t)
+		setupGitHubActionsPREnv(t)
+
+		require.NoError(t, viper.BindEnv("ci", "ATMOS_CI", "CI"))
+
+		t.Setenv("ATMOS_CI", "true")
+
+		flags := newDescribeAffectedFlagSet()
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{
+				CI: schema.CIConfig{Enabled: false},
+			},
+		}
+		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+		assert.Equal(t, "refs/remotes/origin/main", describe.Ref,
+			"ATMOS_CI=true should force auto-detect even when ci.enabled=false")
+	})
+
+	t.Run("no override falls back to ci.enabled=true in atmos.yaml", func(t *testing.T) {
+		resetCIViperKey(t)
+		setupGitHubActionsPREnv(t)
+
+		flags := newDescribeAffectedFlagSet()
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{
+				CI: schema.CIConfig{Enabled: true},
+			},
+		}
+		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+		assert.Equal(t, "refs/remotes/origin/main", describe.Ref,
+			"ci.enabled=true should keep auto-detect active when no override is set")
+	})
+
+	t.Run("no override respects ci.enabled=false default", func(t *testing.T) {
+		resetCIViperKey(t)
+		setupGitHubActionsPREnv(t)
+
+		flags := newDescribeAffectedFlagSet()
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{
+				CI: schema.CIConfig{Enabled: false},
+			},
+		}
+		SetDescribeAffectedFlagValueInCliArgs(flags, describe)
+
+		assert.Empty(t, describe.Ref,
+			"ci.enabled=false and no override must not auto-detect")
+	})
+}
+
+// TestIsCIEnabledForDescribeAffected_Precedence exercises the precedence
+// resolver directly — CLI flag (viper) > env var (viper) > config > false.
+func TestIsCIEnabledForDescribeAffected_Precedence(t *testing.T) {
+	cases := []struct {
+		name       string
+		viperSet   bool // simulates --ci flag or env var having been bound/set.
+		viperValue bool // value if viperSet is true.
+		configCI   bool // ci.enabled value.
+		nilCLI     bool // if true, describe.CLIConfig is nil.
+		want       bool
+		why        string
+	}{
+		{
+			name:     "viper set true wins over config false",
+			viperSet: true, viperValue: true, configCI: false,
+			want: true, why: "flag/env=true should override ci.enabled=false",
+		},
+		{
+			name:     "viper set false wins over config true",
+			viperSet: true, viperValue: false, configCI: true,
+			want: false, why: "flag/env=false should override ci.enabled=true",
+		},
+		{
+			name:     "viper unset falls through to config true",
+			viperSet: false, configCI: true,
+			want: true, why: "ci.enabled=true in atmos.yaml applies when no override",
+		},
+		{
+			name:     "viper unset falls through to config false",
+			viperSet: false, configCI: false,
+			want: false, why: "default (no override, ci.enabled=false) is disabled",
+		},
+		{
+			name:     "nil CLIConfig defaults to false",
+			viperSet: false, nilCLI: true,
+			want: false, why: "safety: missing config must not enable auto-detect",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCIViperKey(t)
+			if tc.viperSet {
+				viper.Set("ci", tc.viperValue)
+			}
+
+			describe := &DescribeAffectedCmdArgs{}
+			if !tc.nilCLI {
+				describe.CLIConfig = &schema.AtmosConfiguration{
+					CI: schema.CIConfig{Enabled: tc.configCI},
+				}
+			}
+
+			got := isCIEnabledForDescribeAffected(describe)
+			assert.Equal(t, tc.want, got, tc.why)
+		})
+	}
 }
 
 // TestExecute_MatrixFormat tests the matrix format code path through Execute.

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -362,6 +362,8 @@ Affected components and stacks:
         # for reproducing CI behavior locally.
         atmos describe affected --ci=true
         ```
+
+        **Accepted env values:** `ATMOS_CI` / `CI` accept `true`, `false`, `1`, `0`, `t`, `f` (Go `strconv.ParseBool`). An unparseable `ATMOS_CI` (e.g. `yes`, `on`, `enabled`) logs a warning and is ignored — Atmos then falls through to `ci.enabled` in `atmos.yaml`, deliberately skipping the `CI` env var tier so the runner's ambient `CI=true` cannot silently contradict your explicit-but-malformed override.
     </dd>
 
     <dt>`--verbose` <em>(optional)</em></dt>

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -131,12 +131,20 @@ Precedence (highest to lowest):
 5. `false` (default).
 
 **Interaction with `--repo-path`:** When `--repo-path` is supplied,
-auto-detection is always skipped — even when CI is enabled. The two
-flags are mutually exclusive, so auto-injecting `--base` / `--ref` /
-`--sha` from CI env would produce a spurious flag-conflict error.
-This makes `describe affected --repo-path=…` safe to call from
-GitHub Actions workflows that already have `ci.enabled: true` in
-`atmos.yaml` for the Atmos Pro features.
+`--base` auto-detection is always skipped — even when CI is
+enabled. The two flags are mutually exclusive, so auto-injecting
+`--base` / `--ref` / `--sha` from CI env would produce a spurious
+flag-conflict error. This makes `describe affected --repo-path=…`
+safe to call from GitHub Actions workflows that already have
+`ci.enabled: true` in `atmos.yaml` for the Atmos Pro features.
+
+When `--repo-path` is combined with `--upload`, Atmos still reads
+the CI provider's event payload to populate the **upload
+correlation metadata** (PR head SHA and event type) — without
+touching `--base` / `--ref` / `--sha`. This keeps
+`--repo-path --upload` compatible with Atmos Pro's PR webhook
+correlation even though the current checkout is typically a merge
+commit rather than the PR head.
 
 ## Usage
 
@@ -328,7 +336,7 @@ Affected components and stacks:
     <dd>
         Path to the already cloned target repository with which to compare the current branch. Conflicts with `--base`, `--ref`, `--sha`, `--ssh-key` and `--ssh-key-password`.
 
-        When supplied, CI base auto-detection is **always skipped**, regardless of the `--ci` / `ATMOS_CI_ENABLED` / `ci.enabled` values. This makes `--repo-path` safe to call from CI workflows that have `ci.enabled: true` in `atmos.yaml` for other features (e.g., Atmos Pro Check Runs).
+        When supplied, CI base auto-detection is **always skipped**, regardless of the `--ci` / `ATMOS_CI` / `ci.enabled` values. This makes `--repo-path` safe to call from CI workflows that have `ci.enabled: true` in `atmos.yaml` for other features (e.g., Atmos Pro Check Runs).
     </dd>
 
     <dt>`--ci` <em>(optional)</em></dt>

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -114,8 +114,29 @@ resolution logic.
 
 1. `--base` flag (explicit)
 2. `--ref` / `--sha` flags (deprecated, backward compatible)
-3. CI auto-detection (when `ci.enabled` is `true`)
+3. CI auto-detection (when CI is enabled — see next section)
 4. `refs/remotes/origin/HEAD` (default)
+
+### Overriding CI auto-detection per invocation
+
+CI auto-detection fires only when CI features are enabled. The
+`--ci` flag and the `ATMOS_CI` / `CI` environment variables
+override `ci.enabled` from `atmos.yaml` for this invocation.
+Precedence (highest to lowest):
+
+1. `--ci` CLI flag (e.g., `--ci=false` to suppress auto-detection).
+2. `ATMOS_CI` env var.
+3. `CI` env var (set by all major CI runners).
+4. `ci.enabled` in `atmos.yaml`.
+5. `false` (default).
+
+**Interaction with `--repo-path`:** When `--repo-path` is supplied,
+auto-detection is always skipped — even when CI is enabled. The two
+flags are mutually exclusive, so auto-injecting `--base` / `--ref` /
+`--sha` from CI env would produce a spurious flag-conflict error.
+This makes `describe affected --repo-path=…` safe to call from
+GitHub Actions workflows that already have `ci.enabled: true` in
+`atmos.yaml` for the Atmos Pro features.
 
 ## Usage
 
@@ -305,7 +326,29 @@ Affected components and stacks:
 
     <dt>`--repo-path` <em>(optional)</em></dt>
     <dd>
-        Path to the already cloned target repository with which to compare the current branch. Conflicts with `--base`, `--ref`, `--sha`, `--ssh-key` and `--ssh-key-password`
+        Path to the already cloned target repository with which to compare the current branch. Conflicts with `--base`, `--ref`, `--sha`, `--ssh-key` and `--ssh-key-password`.
+
+        When supplied, CI base auto-detection is **always skipped**, regardless of the `--ci` / `ATMOS_CI_ENABLED` / `ci.enabled` values. This makes `--repo-path` safe to call from CI workflows that have `ci.enabled: true` in `atmos.yaml` for other features (e.g., Atmos Pro Check Runs).
+    </dd>
+
+    <dt>`--ci` <em>(optional)</em></dt>
+    <dd>
+        Enable or disable CI features for this invocation. Overrides `ci.enabled` in `atmos.yaml`.
+
+        Controls the CI base auto-detection path: when CI is enabled, `describe affected` resolves `--base` from the CI provider's environment (e.g., `GITHUB_BASE_REF`).
+
+        **Environment variables:** `ATMOS_CI`, `CI`.
+
+        **Precedence:** `--ci` flag &gt; `ATMOS_CI` &gt; `CI` &gt; `ci.enabled` in `atmos.yaml` &gt; `false`.
+
+        ```bash
+        # Suppress CI auto-detection for one invocation
+        atmos describe affected --ci=false --repo-path=/tmp/other-clone
+        ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
+
+        # Force CI mode on even when ci.enabled is not set
+        atmos describe affected --ci=true
+        ```
     </dd>
 
     <dt>`--verbose` <em>(optional)</em></dt>

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -349,12 +349,17 @@ Affected components and stacks:
 
         **Precedence:** `--ci` flag &gt; `ATMOS_CI` &gt; `CI` &gt; `ci.enabled` in `atmos.yaml` &gt; `false`.
 
-        ```bash
-        # Suppress CI auto-detection for one invocation
-        atmos describe affected --ci=false --repo-path=/tmp/other-clone
-        ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
+        > **Note:** `--repo-path` already suppresses CI base auto-detection on its own. You do **not** need to pair it with `--ci=false`. Reserve `--ci=false` / `ATMOS_CI=false` for invocations that do *not* use `--repo-path`.
 
-        # Force CI mode on even when ci.enabled is not set
+        ```bash
+        # Opt one non-repo-path invocation out of CI auto-detect while
+        # leaving ci.enabled: true in atmos.yaml for other features
+        # (e.g., Atmos Pro Check Runs on other steps).
+        atmos describe affected --ci=false --base main
+        ATMOS_CI=false atmos describe affected --base main
+
+        # Force CI mode on even when ci.enabled is not set — useful
+        # for reproducing CI behavior locally.
         atmos describe affected --ci=true
         ```
     </dd>

--- a/website/docs/cli/configuration/ci/index.mdx
+++ b/website/docs/cli/configuration/ci/index.mdx
@@ -112,7 +112,7 @@ Override with the `--ci` flag or `ci.enabled` configuration.
 
 | Variable | Description |
 |----------|-------------|
-| `ATMOS_CI` | Explicitly enable CI mode (`true`/`false`) |
+| `ATMOS_CI` | Override `ci.enabled` from `atmos.yaml` (`true`/`false`). Bound to the `--ci` flag on CI-aware commands. Use to disable CI features per-invocation without editing config (e.g., `ATMOS_CI=false atmos describe affected --repo-path=...`) |
 | `ATMOS_CI_COMMENTS_ENABLED` | Override `ci.comments.enabled` (`true`/`false`) |
 | `CI` | Standard CI environment variable (set by most CI providers) |
 | `GITHUB_ACTIONS` | Set by GitHub Actions runner |

--- a/website/docs/cli/configuration/ci/index.mdx
+++ b/website/docs/cli/configuration/ci/index.mdx
@@ -112,7 +112,7 @@ Override with the `--ci` flag or `ci.enabled` configuration.
 
 | Variable | Description |
 |----------|-------------|
-| `ATMOS_CI` | Override `ci.enabled` from `atmos.yaml` (`true`/`false`). Bound to the `--ci` flag on CI-aware commands. Use to disable CI features per-invocation without editing config (e.g., `ATMOS_CI=false atmos describe affected --repo-path=...`) |
+| `ATMOS_CI` | Override `ci.enabled` from `atmos.yaml` (`true`/`false`). Bound to the `--ci` flag on CI-aware commands. Use to disable CI features per-invocation without editing config. Example: `ATMOS_CI=false atmos describe affected --base main` opts one non-`--repo-path` invocation out of auto-detect while leaving `ci.enabled: true` for other features. (Note: `--repo-path` alone already suppresses auto-detect; no need to pair it with `ATMOS_CI=false`.) |
 | `ATMOS_CI_COMMENTS_ENABLED` | Override `ci.comments.enabled` (`true`/`false`) |
 | `CI` | Standard CI environment variable (set by most CI providers) |
 | `GITHUB_ACTIONS` | Set by GitHub Actions runner |

--- a/website/docs/cli/environment-variables.mdx
+++ b/website/docs/cli/environment-variables.mdx
@@ -574,6 +574,35 @@ These environment variables configure Atmos behavior and can override settings i
   </dd>
 </dl>
 
+## CI Integration
+
+These variables control Atmos' native CI integration — GitHub Check Runs, `$GITHUB_OUTPUT` exports, `$GITHUB_STEP_SUMMARY` rendering, and `describe affected` base auto-detection from the CI provider's environment. See [CI configuration](/cli/configuration/ci) for the full reference.
+
+<dl>
+  <dt>`ATMOS_CI`</dt>
+  <dd>
+    Override `ci.enabled` from `atmos.yaml` at runtime. Accepts `true` or `false`. Bound to the `--ci` flag on `atmos terraform plan`, `apply`, `deploy`, and `describe affected`.
+
+    - **Set to `true`** to force CI mode on — useful when running locally against a workflow that expects CI behaviors.
+    - **Set to `false`** to disable CI-gated behaviors for a single invocation without editing `atmos.yaml`. Most common use case: suppress `describe affected` CI base auto-detection when calling the command with `--repo-path`, since the two are mutually exclusive.
+
+    ```bash
+    # Suppress CI base auto-detection for one invocation
+    ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
+    ```
+
+    - **YAML Path:** `ci.enabled`
+    - **Precedence:** `--ci` flag &gt; `ATMOS_CI` &gt; `CI` &gt; `ci.enabled` in `atmos.yaml` &gt; `false`.
+  </dd>
+
+  <dt>`CI`</dt>
+  <dd>
+    Generic CI indicator set by all major CI runners (GitHub Actions, GitLab CI, CircleCI, etc.). Atmos reads it to implicitly activate `--ci` on every CI run.
+
+    You do not normally set `CI` yourself — the runner sets it. It is safe because `ci.enabled` in `atmos.yaml` remains the authority for CI hooks (checks, summaries, outputs); the generic `CI` signal alone does not enable those features unless `ci.enabled: true` or `ATMOS_CI=true` / `--ci` is also set.
+  </dd>
+</dl>
+
 ## Atmos Pro
 
 <dl>

--- a/website/docs/cli/environment-variables.mdx
+++ b/website/docs/cli/environment-variables.mdx
@@ -584,11 +584,14 @@ These variables control Atmos' native CI integration — GitHub Check Runs, `$GI
     Override `ci.enabled` from `atmos.yaml` at runtime. Accepts `true` or `false`. Bound to the `--ci` flag on `atmos terraform plan`, `apply`, `deploy`, and `describe affected`.
 
     - **Set to `true`** to force CI mode on — useful when running locally against a workflow that expects CI behaviors.
-    - **Set to `false`** to disable CI-gated behaviors for a single invocation without editing `atmos.yaml`. Most common use case: suppress `describe affected` CI base auto-detection when calling the command with `--repo-path`, since the two are mutually exclusive.
+    - **Set to `false`** to disable CI-gated behaviors for a single invocation without editing `atmos.yaml`. Example: a workflow with `ci.enabled: true` in atmos.yaml (for Atmos Pro Check Runs) wants one specific `describe affected` step to skip CI base auto-detection and use an explicitly-passed `--base` instead.
+
+    > **Note:** `--repo-path` already suppresses CI base auto-detection on its own — you do **not** need to pair `ATMOS_CI=false` with `--repo-path`. Reserve `ATMOS_CI=false` for invocations that do *not* use `--repo-path`.
 
     ```bash
-    # Suppress CI base auto-detection for one invocation
-    ATMOS_CI=false atmos describe affected --repo-path=/tmp/other-clone
+    # Opt one non-repo-path invocation out of CI auto-detect while leaving
+    # ci.enabled: true in atmos.yaml for other features.
+    ATMOS_CI=false atmos describe affected --base main
     ```
 
     - **YAML Path:** `ci.enabled`

--- a/website/docs/cli/environment-variables.mdx
+++ b/website/docs/cli/environment-variables.mdx
@@ -597,9 +597,11 @@ These variables control Atmos' native CI integration — GitHub Check Runs, `$GI
 
   <dt>`CI`</dt>
   <dd>
-    Generic CI indicator set by all major CI runners (GitHub Actions, GitLab CI, CircleCI, etc.). Atmos reads it to implicitly activate `--ci` on every CI run.
+    Generic CI indicator set by all major CI runners (GitHub Actions, GitLab CI, CircleCI, etc.). You do not normally set `CI` yourself — the runner sets it. Atmos treats `CI=true` as an implicit `--ci=true` at the lowest-priority tier of the precedence chain.
 
-    You do not normally set `CI` yourself — the runner sets it. It is safe because `ci.enabled` in `atmos.yaml` remains the authority for CI hooks (checks, summaries, outputs); the generic `CI` signal alone does not enable those features unless `ci.enabled: true` or `ATMOS_CI=true` / `--ci` is also set.
+    **For `describe affected`:** `CI=true` on a CI runner enables base auto-detection from the CI event payload unless explicitly overridden with `ATMOS_CI=false` or `--ci=false`. Precedence: `--ci` flag &gt; `ATMOS_CI` &gt; `CI` &gt; `ci.enabled` in `atmos.yaml` &gt; `false`. This matches the "zero-config CI base detection" behavior introduced in [cloudposse/atmos#2241](https://github.com/cloudposse/atmos/pull/2241).
+
+    **For `terraform plan` / `apply` / `deploy`:** `CI=true` activates `--ci=true` for output-capture purposes (writing CI job summaries, outputs, and check runs). The hard authority for whether CI hooks actually fire is `ci.enabled` in `atmos.yaml` — setting `CI=true` alone does not enable hooks unless `ci.enabled: true` is also set.
   </dd>
 </dl>
 

--- a/website/docs/cli/environment-variables.mdx
+++ b/website/docs/cli/environment-variables.mdx
@@ -594,6 +594,8 @@ These variables control Atmos' native CI integration — GitHub Check Runs, `$GI
     ATMOS_CI=false atmos describe affected --base main
     ```
 
+    **Accepted values:** `true`, `false`, `1`, `0`, `t`, `f` (anything Go's `strconv.ParseBool` accepts). An unparseable value (e.g. `yes`, `on`, `enabled`) logs a warning and is ignored: Atmos then falls through directly to `ci.enabled` in `atmos.yaml` — the `CI` env var is **not** consulted in this case. Rationale: your explicit `ATMOS_CI` was an override attempt; silently falling through to the ambient `CI=true` set by every runner would be the opposite of your intent. Fix the value and re-run.
+
     - **YAML Path:** `ci.enabled`
     - **Precedence:** `--ci` flag &gt; `ATMOS_CI` &gt; `CI` &gt; `ci.enabled` in `atmos.yaml` &gt; `false`.
   </dd>


### PR DESCRIPTION
## what

- **Fix:** `atmos describe affected --repo-path=<path>` no longer fails with `ErrRepoPathConflict` when `ci.enabled: true` is set in `atmos.yaml` (regression from #2241). `--repo-path` now suppresses CI base auto-detection on its own — it and `--base` / `--ref` / `--sha` are mutually exclusive by design, so auto-injecting the latter from CI env was a bug.
- **Add `--ci` flag** on `atmos describe affected`, env-bound to the existing `ATMOS_CI` / `CI` pair (no new env var). Mirrors `terraform plan`/`apply`/`deploy`. Precedence: `--ci` > `ATMOS_CI` > `CI` > `ci.enabled` in `atmos.yaml` > `false`. **Not** required for the `--repo-path` case — that's handled automatically. The flag is for toggling CI-gated behavior on invocations that don't use `--repo-path`.
- **Preserve `--upload` correlation** on `--repo-path + --upload + CI` via a new `resolveCIUploadMetadataFromCI` helper that populates only `HeadSHAOverride` / `CIEventType` (leaves `Ref`/`SHA` empty). Without this, uploads would correlate against a merge-commit SHA rather than the PR head SHA the webhook indexed.
- **Wrap `ErrRepoPathConflict` with actionable hints** explaining which flag groups are mutually exclusive.
- **Tests:** 17 sub-tests across 6 test functions (coverage table below). Also isolates `cmd.TestSetFlagValueInCliArgs` from ambient CI env — the pre-existing test was implicitly assuming `CI=true` wasn't set.
- **Docs:** new fix doc (`docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md`), updated `describe affected` / env-var / CI-config docs.

## why

Users who set `ci.enabled: true` for Atmos Pro features and called `atmos describe affected --repo-path=...` got `ErrRepoPathConflict` on every PR check. Fix is isolated: **upgrade Atmos and the failure is gone — no workflow or action version change required.**

The `--ci` flag is an independent DX knob, not needed for `--repo-path`. The partial upload resolver preserves Atmos Pro PR correlation in the previously-blocked `--repo-path + --upload` combination. Both additions reuse existing env vars and flag patterns for consistency with the terraform commands.

## coverage

| Function | Coverage |
|---|---|
| `isCIEnabledForDescribeAffected` | **100%** |
| `SetDescribeAffectedFlagValueInCliArgs` | **89.3%** (↑ from 76.9%) |
| `resolveCIUploadMetadataFromCI` | **92.3%** |
| `ParseDescribeAffectedCliArgs` | **81.2%** (↑ from 0%) |
| `cmd/describe_affected.init()` | 96.4% |
| `resolveBaseFromCI` | 94.4% (unchanged) |

## references

- Auto-detect introduction (the PR this fixes): #2241
- `--ci` flag precedent on `terraform plan`/`apply`/`deploy`: #2079
- Fix design doc: `docs/fixes/2026-04-21-describe-affected-repo-path-ci-auto-detect.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --ci flag to control CI auto-detection for describe affected

* **Bug Fixes**
  * --repo-path no longer triggers conflicts with CI-injected base flags; --repo-path still allows upload-only CI metadata when used with --upload
  * Improved conflict error messages with actionable hints about mutually exclusive flags

* **Documentation**
  * Docs updated with --ci usage, env-var precedence (ATMOS_CI/CI), and examples

* **Tests**
  * Added tests covering CI precedence and repo-path/upload behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->