### PR TITLE
Document CI statuses configuration options

### DIFF
--- a/website/docs/cli/configuration/ci/checks.mdx
+++ b/website/docs/cli/configuration/ci/checks.mdx
@@ -24,6 +24,11 @@ ci:
   checks:
     enabled: true
     context_prefix: "atmos"
+    statuses:
+      component: true
+      add: true
+      change: true
+      destroy: true
 ```
 </File>
 
@@ -44,6 +49,43 @@ ci:
 
     **Default:** `atmos`
   </dd>
+
+  <dt>`ci.statuses.component`</dt>
+  <dd>
+    Post commit status check summary operation on a component.
+
+    **Requires:** `checks: write` permission (GitHub) or API token with commit status scope (GitLab)
+
+    **Default:** `true`
+  </dd>
+
+  <dt>`ci.statuses.add`</dt>
+  <dd>
+    Post commit status check if a resource creation is involved.
+
+    **Requires:** `checks: write` permission (GitHub) or API token with commit status scope (GitLab)
+
+    **Default:** `true`
+  </dd>
+
+  <dt>`ci.statuses.change`</dt>
+  <dd>
+    Post commit status check if a resource update is involved.
+
+    **Requires:** `checks: write` permission (GitHub) or API token with commit status scope (GitLab)
+
+    **Default:** `true`
+  </dd>
+
+  <dt>`ci.statuses.destroy`</dt>
+  <dd>
+    Post commit status check if a resource delete is involved.
+
+    **Requires:** `checks: write` permission (GitHub) or API token with commit status scope (GitLab)
+
+    **Default:** `true`
+  </dd>
+
 </dl>
 
 ## How It Works

--- a/website/docs/cli/configuration/ci/checks.mdx
+++ b/website/docs/cli/configuration/ci/checks.mdx
@@ -50,7 +50,7 @@ ci:
     **Default:** `atmos`
   </dd>
 
-  <dt>`ci.statuses.component`</dt>
+  <dt>`ci.checks.statuses.component`</dt>
   <dd>
     Post commit status check summary operation on a component.
 
@@ -59,7 +59,7 @@ ci:
     **Default:** `true`
   </dd>
 
-  <dt>`ci.statuses.add`</dt>
+  <dt>`ci.checks.statuses.add`</dt>
   <dd>
     Post commit status check if a resource creation is involved.
 
@@ -68,7 +68,7 @@ ci:
     **Default:** `true`
   </dd>
 
-  <dt>`ci.statuses.change`</dt>
+  <dt>`ci.checks.statuses.change`</dt>
   <dd>
     Post commit status check if a resource update is involved.
 
@@ -77,7 +77,7 @@ ci:
     **Default:** `true`
   </dd>
 
-  <dt>`ci.statuses.destroy`</dt>
+  <dt>`ci.checks.statuses.destroy`</dt>
   <dd>
     Post commit status check if a resource delete is involved.
 


### PR DESCRIPTION
## what
* Document CI statuses configuration options

## why
* Improve documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs and example configuration for new CI post-commit status summary options: component, add, change, and destroy (flags default to true in the example).
  * Clarified required permissions to enable these status checks (GitHub checks: write or a commit-status-scoped API token for GitLab).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->