### PR TITLE
fix(terraform): strip TF_CLI_ARGS from internal setup subprocesses

### DIFF
--- a/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
+++ b/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
@@ -9,7 +9,7 @@ Actions workflow level (so OpenTofu would wait on remote state
 locks instead of failing immediately) hit a hard failure on every
 `atmos terraform plan` run:
 
-```
+```text
 Error parsing command-line flags: flag provided but not defined: -lock-timeout
 ```
 

--- a/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
+++ b/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
@@ -27,21 +27,21 @@ runs three classes of `tofu` subprocesses for one `atmos terraform
 plan`:
 
 1. **Setup** the user did not write — `tofu workspace select`
-   (`runWorkspaceSetup` at
-   `internal/exec/terraform_execute_helpers_exec.go:181`), the
-   `tofu workspace new` fallback (`createWorkspaceFallback`,
-   line 226), and the auto-`tofu init` pre-step
-   (`executeTerraformInitPhase` at
-   `internal/exec/terraform_execute_helpers.go:528`, only fires
-   when SubCommand ≠ "init" and `--skip-init` is not set).
+   (`runWorkspaceSetup` in
+   `internal/exec/terraform_execute_helpers_exec.go`), the
+   `tofu workspace new` fallback (`createWorkspaceFallback` in the
+   same file), and the auto-`tofu init` pre-step
+   (`executeTerraformInitPhase` in
+   `internal/exec/terraform_execute_helpers.go`, only fires when
+   SubCommand ≠ "init" and `--skip-init` is not set).
 2. **The user's primary subcommand** —
    `executeMainTerraformCommand` (e.g. `tofu plan`).
 3. **Data fetches** for `!terraform.output` /
    `atmos.Component(...)` template calls — handled separately
    in `pkg/terraform/output/`.
 
-All three classes go through `ExecuteShellCommand` at
-`internal/exec/shell_utils.go:96`, which builds the subprocess
+All three classes go through `ExecuteShellCommand` in
+`internal/exec/shell_utils.go`, which builds the subprocess
 environment from `os.Environ()`. That inherits whatever
 `TF_CLI_ARGS` the parent process exported. OpenTofu's documented
 behavior is to **prepend `TF_CLI_ARGS` to every subcommand's
@@ -58,8 +58,9 @@ reason. The bug class covers every Atmos-internal setup
 subprocess, not just `workspace select`.
 
 The third class (data fetches) was already correct:
-`pkg/terraform/output/environment.go:23-42` strips `TF_CLI_ARGS`
-and `TF_CLI_ARGS_*` from the env before invoking terraform-exec.
+`prohibitedEnvVars` / `prohibitedEnvVarPrefixes` in
+`pkg/terraform/output/environment.go` strip `TF_CLI_ARGS` and
+`TF_CLI_ARGS_*` from the env before invoking terraform-exec.
 The regular plan/apply flow simply did not apply the same hygiene
 to its own setup subprocesses.
 
@@ -156,9 +157,9 @@ Sites intentionally **not** sanitized:
 
 Open items (separate PRs):
 
-- Update the `warnOnConflictingEnvVars` log message at
-  `internal/exec/terraform_execute_helpers.go:341` to acknowledge
-  the new setup-step hygiene.
+- Update the `warnOnConflictingEnvVars` log message in
+  `internal/exec/terraform_execute_helpers.go` to acknowledge the
+  new setup-step hygiene.
 - Add a `TF_CLI_ARGS` vs `TF_CLI_ARGS_<subcommand>` paragraph to
   `website/docs/cli/configuration/terraform.mdx`.
 - Blog post under `website/blog/` (PR is `bugfix`-labeled, so the

--- a/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
+++ b/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
@@ -1,0 +1,159 @@
+# Fix: `TF_CLI_ARGS` env var breaks `atmos terraform plan/apply` via internal setup subcommands
+
+**Date:** 2026-04-27
+
+## Issue
+
+A user setting `TF_CLI_ARGS: "-lock-timeout=10m"` at the GitHub
+Actions workflow level (so OpenTofu would wait on remote state
+locks instead of failing immediately) hit a hard failure on every
+`atmos terraform plan` run:
+
+```
+Error parsing command-line flags: flag provided but not defined: -lock-timeout
+```
+
+The error is emitted by `tofu`, not Atmos, and aborts the run
+before `tofu plan` ever executes. The user worked around it by
+switching to `TF_CLI_ARGS_plan` / `TF_CLI_ARGS_apply`, but the
+unscoped form is what most CI configurations reach for first and
+the failure message points at a flag the user set deliberately on
+a Terraform subcommand the user did not know Atmos was running.
+
+## Root cause
+
+`atmos terraform plan` is not a single Terraform invocation. Atmos
+runs three classes of `tofu` subprocesses for one `atmos terraform
+plan`:
+
+1. **Setup** the user did not write — `tofu workspace select`
+   (`runWorkspaceSetup` at
+   `internal/exec/terraform_execute_helpers_exec.go:181`), the
+   `tofu workspace new` fallback (`createWorkspaceFallback`,
+   line 226), and the auto-`tofu init` pre-step
+   (`executeTerraformInitPhase` at
+   `internal/exec/terraform_execute_helpers.go:528`, only fires
+   when SubCommand ≠ "init" and `--skip-init` is not set).
+2. **The user's primary subcommand** —
+   `executeMainTerraformCommand` (e.g. `tofu plan`).
+3. **Data fetches** for `!terraform.output` /
+   `atmos.Component(...)` template calls — handled separately
+   in `pkg/terraform/output/`.
+
+All three classes go through `ExecuteShellCommand` at
+`internal/exec/shell_utils.go:96`, which builds the subprocess
+environment from `os.Environ()`. That inherits whatever
+`TF_CLI_ARGS` the parent process exported. OpenTofu's documented
+behavior is to **prepend `TF_CLI_ARGS` to every subcommand's
+argv**, so `tofu workspace select` sees
+`tofu -lock-timeout=10m workspace select <ws>` and rejects the
+unknown flag.
+
+The user's reported flag (`-lock-timeout`) is one of the few that
+*also* happens to be valid for `tofu init`, so init didn't crash
+in their case — but `-parallelism`, `-refresh=false`,
+`-detailed-exitcode`, `-target`, `-replace`, `-out` (all common in
+plan/apply contexts) all crash `tofu init` for exactly the same
+reason. The bug class covers every Atmos-internal setup
+subprocess, not just `workspace select`.
+
+The third class (data fetches) was already correct:
+`pkg/terraform/output/environment.go:23-42` strips `TF_CLI_ARGS`
+and `TF_CLI_ARGS_*` from the env before invoking terraform-exec.
+The regular plan/apply flow simply did not apply the same hygiene
+to its own setup subprocesses.
+
+## How
+
+When Atmos invokes a terraform/tofu subprocess **the user did not
+write**, strip the env vars that OpenTofu would inject as flags
+into a subcommand that does not accept them.
+
+Four files:
+
+1. **`internal/exec/terraform_env_sanitize.go`** *(new)* — defines
+   `terraformWorkspaceEnvBlocklist` (`TF_CLI_ARGS` and
+   `TF_CLI_ARGS_workspace`) and the pure helper
+   `sanitizeTerraformWorkspaceEnv(env []string) []string` that
+   returns a copy of `env` with blocked entries removed.
+   Per-subcommand variants (`TF_CLI_ARGS_plan`,
+   `TF_CLI_ARGS_apply`, `TF_CLI_ARGS_init`, …) are intentionally
+   preserved — OpenTofu only applies them to their named
+   subcommand by design, so they cannot affect setup subprocesses.
+
+2. **`internal/exec/shell_utils.go`** — adds
+   `WithSanitizedTerraformSetupEnv()` `ShellCommandOption` and a
+   `sanitizeTerraformSetupEnv` flag on `shellCommandConfig`. When
+   set, `ExecuteShellCommand` filters its `baseEnv` through
+   `sanitizeTerraformWorkspaceEnv` after the existing `processEnv`
+   override (so it composes cleanly with auth-sanitized envs) and
+   before merging in the global env and command-specific env.
+
+3. **`internal/exec/terraform_execute_helpers_exec.go`** —
+   `runWorkspaceSetup` and `createWorkspaceFallback` each append
+   `WithSanitizedTerraformSetupEnv()` to their per-call options
+   slice before calling `ExecuteShellCommand`.
+
+4. **`internal/exec/terraform_execute_helpers.go`** —
+   `executeTerraformInitPhase` does the same. Its existing mutual-
+   exclusion contract guarantees this function only runs as the
+   auto-init pre-step (never when the user invokes `atmos
+   terraform init` directly), so the sanitization cannot affect a
+   user-invoked init — that path goes through
+   `executeMainTerraformCommand` and is unchanged.
+
+## Tests
+
+- **`internal/exec/terraform_env_sanitize_test.go`** *(new)* —
+  table-driven tests for `sanitizeTerraformWorkspaceEnv`: drops
+  `TF_CLI_ARGS` and `TF_CLI_ARGS_workspace` (including empty
+  values); preserves `TF_CLI_ARGS_plan`, `_apply`, `_init`,
+  `TF_VAR_*`, `TF_LOG`, malformed entries with no `=`, values
+  containing `=`, and exact-prefix-match edge cases; does not
+  mutate the caller's slice.
+
+- **`internal/exec/terraform_workspace_env_sanitize_test.go`**
+  *(new)* — three integration tests using the test-binary-as-
+  subprocess pattern. A new `_ATMOS_TEST_ENV_DUMP_FILE` sentinel
+  in `internal/exec/testmain_test.go` makes the test binary write
+  its full environment to a file and exit 0, so each test can
+  inspect what the subprocess actually saw:
+  - `TestRunWorkspaceSetup_StripsTfCliArgs` (`workspace select`).
+  - `TestCreateWorkspaceFallback_StripsTfCliArgs` (`workspace
+    new`).
+  - `TestExecuteTerraformInitPhase_StripsTfCliArgs` (auto-init);
+    uses `TF_CLI_ARGS=-parallelism=4` to guard against the
+    user's specific `-lock-timeout` value being one of the few
+    that also passes `init`'s flag validation.
+
+  Each test was verified to fail when its corresponding code
+  delta is reverted, then pass with the fix in place.
+
+## Status
+
+**Fixed.** Branch `aknysh/update-terraform-args`. All 18 sub-tests
+across the four new test functions pass; the full `internal/exec`
+package re-runs cleanly (115 s, exit 0).
+
+The user's workaround (switching to `TF_CLI_ARGS_plan` /
+`TF_CLI_ARGS_apply`) continues to work; the fix removes the need
+for it for the common `-lock-timeout` / `-parallelism` cases.
+
+Sites intentionally **not** sanitized:
+
+- `executeMainTerraformCommand` — the user's primary subcommand.
+- `handleVersionSubcommand` — `atmos terraform version` is
+  user-invoked.
+- `isTerraformCurrentWorkspace` — file read only, no subprocess.
+- `pkg/terraform/output/` — already strips `TF_CLI_ARGS` /
+  `TF_CLI_ARGS_*` via its own prohibited-vars list.
+
+Open items (separate PRs):
+
+- Update the `warnOnConflictingEnvVars` log message at
+  `internal/exec/terraform_execute_helpers.go:341` to acknowledge
+  the new setup-step hygiene.
+- Add a `TF_CLI_ARGS` vs `TF_CLI_ARGS_<subcommand>` paragraph to
+  `website/docs/cli/configuration/terraform.mdx`.
+- Blog post under `website/blog/` (PR is `bugfix`-labeled, so the
+  CI gate requires one).

--- a/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
+++ b/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
@@ -151,7 +151,7 @@ Sites intentionally **not** sanitized:
 - `executeMainTerraformCommand` — the user's primary subcommand.
 - `handleVersionSubcommand` — `atmos terraform version` is
   user-invoked.
-- `isTerraformCurrentWorkspace` — file read only, no subprocess.
+- `isTerraformCurrentWorkspace` — read-only file access, no subprocess.
 - `pkg/terraform/output/` — already strips `TF_CLI_ARGS` /
   `TF_CLI_ARGS_*` via its own prohibited-vars list.
 

--- a/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
+++ b/docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md
@@ -84,10 +84,16 @@ Four files:
 2. **`internal/exec/shell_utils.go`** — adds
    `WithSanitizedTerraformSetupEnv()` `ShellCommandOption` and a
    `sanitizeTerraformSetupEnv` flag on `shellCommandConfig`. When
-   set, `ExecuteShellCommand` filters its `baseEnv` through
-   `sanitizeTerraformWorkspaceEnv` after the existing `processEnv`
-   override (so it composes cleanly with auth-sanitized envs) and
-   before merging in the global env and command-specific env.
+   set, `ExecuteShellCommand` filters the **fully merged** subprocess
+   env (base process env + `atmosConfig.Env` + per-command `env`
+   slice) through `sanitizeTerraformWorkspaceEnv` *after* the merge,
+   so blocked vars cannot be reintroduced by `atmosConfig.Env`
+   (atmos.yaml top-level `env:`) or by the per-command env slice
+   (`info.ComponentEnvList` → stack `env:` + auth hooks). The filter
+   runs *before* the `ATMOS_SHLVL` append so atmos's own bookkeeping
+   isn't stripped, and it composes cleanly with auth-sanitized envs
+   passed via `WithEnvironment` because `processEnv` is applied
+   before the merge.
 
 3. **`internal/exec/terraform_execute_helpers_exec.go`** —
    `runWorkspaceSetup` and `createWorkspaceFallback` each append

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -45,6 +45,14 @@ type shellCommandConfig struct {
 	// When set, ExecuteShellCommand uses this instead of re-reading os.Environ().
 	// This is used when auth has already sanitized the environment (e.g., removed IRSA vars).
 	processEnv []string
+	// sanitizeTerraformSetupEnv, when true, filters the base process environment
+	// through sanitizeTerraformWorkspaceEnv before merging.  This strips env
+	// vars (TF_CLI_ARGS, TF_CLI_ARGS_workspace) that would cause OpenTofu to
+	// inject flags into atmos-internal terraform/tofu setup subprocesses
+	// (`workspace select`, `workspace new`, the auto-`init` pre-step) that
+	// those subcommands do not accept.
+	// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
+	sanitizeTerraformSetupEnv bool
 }
 
 // WithStdoutCapture returns a ShellCommandOption that tees stdout to the provided writer.
@@ -83,6 +91,41 @@ func WithEnvironment(env []string) ShellCommandOption {
 	}
 }
 
+// WithSanitizedTerraformSetupEnv returns a ShellCommandOption that strips env
+// vars known to break atmos-internal terraform/tofu setup subprocesses.
+// Specifically: `TF_CLI_ARGS` and `TF_CLI_ARGS_workspace`.
+//
+// Atmos invokes several terraform/tofu subcommands as setup steps that the
+// user did not write:
+//   - `tofu workspace select` / `tofu workspace new` (workspace setup before
+//     plan/apply).
+//   - `tofu init` as an auto-init pre-step before plan/apply (when
+//     SubCommand ≠ "init" and --skip-init is not set).
+//
+// OpenTofu prepends `TF_CLI_ARGS` to the argv of every subcommand. Users
+// commonly put plan/apply-only flags in `TF_CLI_ARGS` (e.g.
+// `-lock-timeout=10m` for CI lock retries, `-parallelism=4` for performance,
+// `-refresh=false` for plan workflows). When Atmos's setup subcommands
+// inherit those flags, they crash with "flag provided but not defined: …"
+// before the user's target subcommand can run.
+//
+// This option only affects atmos-invoked SETUP subprocesses; the user's
+// primary subcommand (`plan`, `apply`, `init` when invoked as the target,
+// `version`, …) continues to receive `TF_CLI_ARGS` unchanged so that
+// intentional configuration still reaches its target command. Per-subcommand
+// variants (`TF_CLI_ARGS_plan`, `TF_CLI_ARGS_apply`, `TF_CLI_ARGS_init`, …)
+// are always preserved — OpenTofu only applies them to their named
+// subcommand by design, so they cannot interfere with setup commands.
+//
+// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
+func WithSanitizedTerraformSetupEnv() ShellCommandOption {
+	defer perf.Track(nil, "exec.WithSanitizedTerraformSetupEnv")()
+
+	return func(c *shellCommandConfig) {
+		c.sanitizeTerraformSetupEnv = true
+	}
+}
+
 // ExecuteShellCommand prints and executes the provided command with args and flags.
 func ExecuteShellCommand(
 	atmosConfig schema.AtmosConfiguration,
@@ -114,6 +157,13 @@ func ExecuteShellCommand(
 	baseEnv := os.Environ()
 	if cfg.processEnv != nil {
 		baseEnv = cfg.processEnv
+	}
+	// When the caller requested terraform-setup-env sanitization (atmos-internal
+	// `tofu workspace select` / `tofu workspace new` / auto-`tofu init` pre-step),
+	// filter out env vars that would cause OpenTofu to inject flags those
+	// subcommands do not accept.
+	if cfg.sanitizeTerraformSetupEnv {
+		baseEnv = sanitizeTerraformWorkspaceEnv(baseEnv)
 	}
 	cmdEnv := envpkg.MergeGlobalEnv(baseEnv, atmosConfig.Env)
 	cmdEnv = append(cmdEnv, env...)

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -158,15 +158,18 @@ func ExecuteShellCommand(
 	if cfg.processEnv != nil {
 		baseEnv = cfg.processEnv
 	}
+	cmdEnv := envpkg.MergeGlobalEnv(baseEnv, atmosConfig.Env)
+	cmdEnv = append(cmdEnv, env...)
 	// When the caller requested terraform-setup-env sanitization (atmos-internal
 	// `tofu workspace select` / `tofu workspace new` / auto-`tofu init` pre-step),
 	// filter out env vars that would cause OpenTofu to inject flags those
-	// subcommands do not accept.
+	// subcommands do not accept.  Applied AFTER the merge so blocked vars cannot
+	// be reintroduced by atmosConfig.Env (atmos.yaml top-level env:) or by the
+	// per-command env slice (info.ComponentEnvList → stack env: + auth hooks).
+	// Applied BEFORE the ATMOS_SHLVL append so we don't strip our own bookkeeping.
 	if cfg.sanitizeTerraformSetupEnv {
-		baseEnv = sanitizeTerraformWorkspaceEnv(baseEnv)
+		cmdEnv = sanitizeTerraformWorkspaceEnv(cmdEnv)
 	}
-	cmdEnv := envpkg.MergeGlobalEnv(baseEnv, atmosConfig.Env)
-	cmdEnv = append(cmdEnv, env...)
 	cmdEnv = append(cmdEnv, fmt.Sprintf("ATMOS_SHLVL=%d", newShellLevel))
 
 	// Propagate TTY state to subprocess.

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -45,12 +45,14 @@ type shellCommandConfig struct {
 	// When set, ExecuteShellCommand uses this instead of re-reading os.Environ().
 	// This is used when auth has already sanitized the environment (e.g., removed IRSA vars).
 	processEnv []string
-	// sanitizeTerraformSetupEnv, when true, filters the base process environment
-	// through sanitizeTerraformWorkspaceEnv before merging.  This strips env
-	// vars (TF_CLI_ARGS, TF_CLI_ARGS_workspace) that would cause OpenTofu to
-	// inject flags into atmos-internal terraform/tofu setup subprocesses
+	// sanitizeTerraformSetupEnv, when true, filters the fully merged subprocess
+	// environment (base env + atmosConfig.Env + per-command env) through
+	// sanitizeTerraformWorkspaceEnv AFTER the merge.  This strips env vars
+	// (TF_CLI_ARGS, TF_CLI_ARGS_workspace) that would cause OpenTofu to inject
+	// flags into atmos-internal terraform/tofu setup subprocesses
 	// (`workspace select`, `workspace new`, the auto-`init` pre-step) that
-	// those subcommands do not accept.
+	// those subcommands do not accept.  Filtering after the merge prevents
+	// reintroduction from atmosConfig.Env or the per-command env slice.
 	// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
 	sanitizeTerraformSetupEnv bool
 }

--- a/internal/exec/terraform_env_sanitize.go
+++ b/internal/exec/terraform_env_sanitize.go
@@ -1,0 +1,52 @@
+package exec
+
+import "strings"
+
+// terraformWorkspaceEnvBlocklist names env vars that must NOT reach
+// `tofu workspace select` / `tofu workspace new` subprocesses.
+//
+// Why: OpenTofu prepends `TF_CLI_ARGS` to every subcommand's argv. When a CI
+// workflow sets `TF_CLI_ARGS=-lock-timeout=10m` (sensible for plan/apply lock
+// retries) and Atmos invokes `tofu workspace select` as a setup step, the
+// workspace subcommand rejects the unknown flag with
+// "flag provided but not defined: -lock-timeout" and the user's target
+// subcommand never runs. `TF_CLI_ARGS_workspace` is the same hazard with a
+// narrower scope and no per-sub-subcommand override.
+//
+// Per-subcommand variants (`TF_CLI_ARGS_plan`, `TF_CLI_ARGS_apply`,
+// `TF_CLI_ARGS_init`, etc.) are intentionally NOT blocked — OpenTofu only
+// applies them to their named subcommand, so they cannot affect
+// `workspace select` / `workspace new`, and stripping them would silently
+// drop user-intentional configuration before it reached its target command.
+//
+// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
+var terraformWorkspaceEnvBlocklist = map[string]struct{}{
+	"TF_CLI_ARGS":           {},
+	"TF_CLI_ARGS_workspace": {},
+}
+
+// sanitizeTerraformWorkspaceEnv returns a copy of env with the variables in
+// terraformWorkspaceEnvBlocklist removed. The env parameter is a slice of
+// "KEY=VALUE" entries, matching the format of os.Environ().
+//
+// Entries without an '=' separator are preserved unchanged; we cannot classify
+// them as belonging to a blocked key, and dropping them would diverge from
+// os.Environ() semantics.
+func sanitizeTerraformWorkspaceEnv(env []string) []string {
+	if len(env) == 0 {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, blocked := terraformWorkspaceEnvBlocklist[kv[:eq]]; blocked {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/internal/exec/terraform_env_sanitize_test.go
+++ b/internal/exec/terraform_env_sanitize_test.go
@@ -1,0 +1,140 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSanitizeTerraformWorkspaceEnv exercises the blocklist filter at every
+// edge it can hit: blocked keys, preserved per-subcommand variants, malformed
+// entries, and empty inputs. Each row names a representative concrete value
+// rather than just "x=y" so a regression that miscategorizes a real variable
+// fails with a recognizable message.
+func TestSanitizeTerraformWorkspaceEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil input returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty input returns empty",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "TF_CLI_ARGS dropped — the user-reported bug",
+			in:   []string{"TF_CLI_ARGS=-lock-timeout=10m"},
+			want: []string{},
+		},
+		{
+			name: "TF_CLI_ARGS with empty value still dropped",
+			in:   []string{"TF_CLI_ARGS="},
+			want: []string{},
+		},
+		{
+			name: "TF_CLI_ARGS_workspace dropped — same hazard, narrower scope",
+			in:   []string{"TF_CLI_ARGS_workspace=-no-color"},
+			want: []string{},
+		},
+		{
+			name: "TF_CLI_ARGS_plan preserved — only applies to `tofu plan`",
+			in:   []string{"TF_CLI_ARGS_plan=-lock-timeout=10m"},
+			want: []string{"TF_CLI_ARGS_plan=-lock-timeout=10m"},
+		},
+		{
+			name: "TF_CLI_ARGS_apply preserved — only applies to `tofu apply`",
+			in:   []string{"TF_CLI_ARGS_apply=-parallelism=4"},
+			want: []string{"TF_CLI_ARGS_apply=-parallelism=4"},
+		},
+		{
+			name: "TF_CLI_ARGS_init preserved — only applies to `tofu init`",
+			in:   []string{"TF_CLI_ARGS_init=-upgrade"},
+			want: []string{"TF_CLI_ARGS_init=-upgrade"},
+		},
+		{
+			name: "TF_VAR_* preserved — not a CLI args injector",
+			in:   []string{"TF_VAR_region=us-east-1"},
+			want: []string{"TF_VAR_region=us-east-1"},
+		},
+		{
+			name: "TF_LOG preserved — not a CLI args injector",
+			in:   []string{"TF_LOG=DEBUG"},
+			want: []string{"TF_LOG=DEBUG"},
+		},
+		{
+			name: "non-TF env preserved",
+			in:   []string{"PATH=/usr/bin", "HOME=/home/user"},
+			want: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name: "entries without '=' preserved (cannot classify)",
+			in:   []string{"NO_EQUALS_SIGN", "PATH=/usr/bin"},
+			want: []string{"NO_EQUALS_SIGN", "PATH=/usr/bin"},
+		},
+		{
+			name: "value containing '=' preserved correctly (only first '=' splits)",
+			in:   []string{"AWS_PROFILE=foo=bar"},
+			want: []string{"AWS_PROFILE=foo=bar"},
+		},
+		{
+			name: "mixed: blocked entries removed, others preserved, order kept",
+			in: []string{
+				"PATH=/usr/bin",
+				"TF_CLI_ARGS=-lock-timeout=10m",
+				"TF_CLI_ARGS_plan=-lock-timeout=10m",
+				"TF_VAR_region=us-east-1",
+				"TF_CLI_ARGS_workspace=-no-color",
+				"TF_LOG=DEBUG",
+			},
+			want: []string{
+				"PATH=/usr/bin",
+				"TF_CLI_ARGS_plan=-lock-timeout=10m",
+				"TF_VAR_region=us-east-1",
+				"TF_LOG=DEBUG",
+			},
+		},
+		{
+			name: "key prefix match must be exact (TF_CLI_ARGS_PLAN_X kept)",
+			// Defensive: TF_CLI_ARGS_PLAN_X is not a real env var, but if a user
+			// sets some custom TF_CLI_ARGS_<weird-suffix> it should pass through.
+			// Only the exact blocklist keys are removed.
+			in:   []string{"TF_CLI_ARGS_PLAN_X=value"},
+			want: []string{"TF_CLI_ARGS_PLAN_X=value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeTerraformWorkspaceEnv(tt.in)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSanitizeTerraformWorkspaceEnv_DoesNotMutateInput verifies the helper
+// does not mutate the caller's slice — important because callers typically
+// pass os.Environ() or a struct field they intend to use elsewhere.
+func TestSanitizeTerraformWorkspaceEnv_DoesNotMutateInput(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"TF_CLI_ARGS=-lock-timeout=10m",
+		"TF_CLI_ARGS_plan=-lock-timeout=10m",
+	}
+	original := make([]string, len(in))
+	copy(original, in)
+
+	_ = sanitizeTerraformWorkspaceEnv(in)
+
+	assert.Equal(t, original, in,
+		"sanitizeTerraformWorkspaceEnv must not mutate the caller's slice")
+}

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -525,6 +525,17 @@ func prepareInitExecution(atmosConfig *schema.AtmosConfiguration, info *schema.C
 // buildInitSubcommandArgs in terraform_execute_helpers_args.go handles the provisioner
 // invocation via prepareInitExecution.  These two code paths must never both execute
 // in the same command invocation or provisioners will run twice.
+//
+// TF_CLI_ARGS sanitization: because this function only runs as a SETUP pre-step
+// (never as the user's target subcommand), it strips TF_CLI_ARGS /
+// TF_CLI_ARGS_workspace from the subprocess env via
+// WithSanitizedTerraformSetupEnv().  Otherwise a parent-process value like
+// `TF_CLI_ARGS=-parallelism=4` (commonly set in CI for plan/apply) would crash
+// the auto-init step with "flag provided but not defined: -parallelism" before
+// the user's plan/apply could run.  When the user invokes `atmos terraform init`
+// directly, this function is bypassed and the user's TF_CLI_ARGS reaches their
+// init invocation unchanged.
+// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
 func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, componentPath, varFile string, opts ...ShellCommandOption) (string, error) {
 	newPath, err := prepareInitExecution(atmosConfig, info, componentPath)
 	if err != nil {
@@ -532,6 +543,8 @@ func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *sch
 	}
 
 	initArgs := buildInitArgs(atmosConfig, info, varFile)
+	initOpts := append([]ShellCommandOption{}, opts...)
+	initOpts = append(initOpts, WithSanitizedTerraformSetupEnv())
 	if err = ExecuteShellCommand(
 		*atmosConfig,
 		info.Command,
@@ -540,7 +553,7 @@ func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *sch
 		info.ComponentEnvList,
 		info.DryRun,
 		info.RedirectStdErr,
-		opts...,
+		initOpts...,
 	); err != nil {
 		return newPath, err
 	}

--- a/internal/exec/terraform_execute_helpers_exec.go
+++ b/internal/exec/terraform_execute_helpers_exec.go
@@ -192,7 +192,12 @@ func runWorkspaceSetup(atmosConfig *schema.AtmosConfiguration, info *schema.Conf
 	// For data-producing subcommands redirect "Switched to workspace…" to stderr
 	// so it doesn't pollute captured stdout in $() substitutions.
 	// Merge caller-provided opts (e.g., WithEnvironment) with workspace-specific opts.
+	// WithSanitizedTerraformSetupEnv strips TF_CLI_ARGS / TF_CLI_ARGS_workspace from
+	// the subprocess env so a parent-process `TF_CLI_ARGS=-lock-timeout=10m` does
+	// not crash `tofu workspace select` (which does not accept `-lock-timeout`).
+	// See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
 	wsOpts := append([]ShellCommandOption{}, opts...)
+	wsOpts = append(wsOpts, WithSanitizedTerraformSetupEnv())
 	if info.SubCommand == "output" || info.SubCommand == "show" {
 		wsOpts = append(wsOpts, WithStdoutOverride(os.Stderr))
 	}
@@ -224,6 +229,13 @@ func runWorkspaceSetup(atmosConfig *schema.AtmosConfiguration, info *schema.Conf
 // If workspace creation also fails with exit code 1 and the workspace is already
 // active (stale .terraform/environment file), it proceeds with a warning.
 func createWorkspaceFallback(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, componentPath string, opts ...ShellCommandOption) error {
+	// WithSanitizedTerraformSetupEnv strips TF_CLI_ARGS / TF_CLI_ARGS_workspace —
+	// same rationale as in runWorkspaceSetup: `tofu workspace new` rejects
+	// unknown flags injected via TF_CLI_ARGS the same way `workspace select`
+	// does.  See docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md.
+	wsOpts := append([]ShellCommandOption{}, opts...)
+	wsOpts = append(wsOpts, WithSanitizedTerraformSetupEnv())
+
 	newErr := ExecuteShellCommand(
 		*atmosConfig,
 		info.Command,
@@ -232,7 +244,7 @@ func createWorkspaceFallback(atmosConfig *schema.AtmosConfiguration, info *schem
 		info.ComponentEnvList,
 		info.DryRun,
 		info.RedirectStdErr,
-		opts...,
+		wsOpts...,
 	)
 	if newErr == nil {
 		return nil

--- a/internal/exec/terraform_workspace_env_sanitize_test.go
+++ b/internal/exec/terraform_workspace_env_sanitize_test.go
@@ -67,8 +67,41 @@ func readSubprocessEnv(t *testing.T, path string) map[string]string {
 // reproduced).  After the fix: TF_CLI_ARGS is stripped; subcommand-scoped
 // variants like TF_CLI_ARGS_plan are preserved.
 func TestRunWorkspaceSetup_StripsTfCliArgs(t *testing.T) {
+	// Defensive: clear ambient TF_WORKSPACE so shouldSkipWorkspaceSetup
+	// (terraform_execute_helpers_exec.go:176) does not short-circuit
+	// runWorkspaceSetup before the subprocess can spawn.  Without this, a
+	// developer with TF_WORKSPACE exported in their shell would see a
+	// confusing "env dump file must exist" failure.
+	t.Setenv("TF_WORKSPACE", "")
+
 	exePath, err := os.Executable()
 	require.NoError(t, err, "os.Executable() must succeed")
+
+	// Prerequisite sub-test: confirm ComponentEnvList actually reaches the
+	// subprocess (per CLAUDE.md "Add prerequisite sub-tests for subprocess
+	// behavior").  Guards against a future refactor that drops the
+	// preserved-entries assertions below and turns the main test into a
+	// vacuous "TF_CLI_ARGS not in env → pass" — if env propagation breaks,
+	// this sub-test fails first with a clear cause.
+	t.Run("prerequisite: ComponentEnvList reaches the subprocess", func(t *testing.T) {
+		preDumpFile := filepath.Join(t.TempDir(), "pre.env.dump")
+		preInfo := schema.ConfigAndStacksInfo{
+			Command:              exePath,
+			SubCommand:           "plan",
+			TerraformWorkspace:   "precheck-ws",
+			ComponentBackendType: "",
+			ComponentEnvList: []string{
+				"_ATMOS_TEST_ENV_DUMP_FILE=" + preDumpFile,
+				"_ATMOS_TEST_PREREQ=ok",
+			},
+		}
+		require.NoError(t, runWorkspaceSetup(&schema.AtmosConfiguration{}, &preInfo, t.TempDir()),
+			"prerequisite: runWorkspaceSetup must succeed (subprocess exits 0)")
+		preEnv := readSubprocessEnv(t, preDumpFile)
+		assert.Equal(t, "ok", preEnv["_ATMOS_TEST_PREREQ"],
+			"prerequisite: ComponentEnvList must propagate to the subprocess; "+
+				"otherwise the main TF_CLI_ARGS assertions below are vacuous")
+	})
 
 	dumpFile := filepath.Join(t.TempDir(), "env.dump")
 
@@ -245,4 +278,85 @@ func TestExecuteTerraformInitPhase_StripsTfCliArgs(t *testing.T) {
 	// Unrelated env vars pass through.
 	assert.Equal(t, "us-east-1", subprocessEnv["TF_VAR_region"],
 		"TF_VAR_* must pass through; not a CLI args flag")
+}
+
+// TestExecuteShellCommand_SanitizeAfterMerge verifies that the sanitization
+// runs AFTER the env merge step in `ExecuteShellCommand`, so blocked vars
+// cannot be reintroduced by either of the two later sources:
+//
+//   - `atmosConfig.Env` — populated from `atmos.yaml`'s top-level `env:` section.
+//     A user who puts `TF_CLI_ARGS=-lock-timeout=10m` there to apply it
+//     globally to terraform calls would otherwise still hit the bug.
+//   - the `env` parameter — `info.ComponentEnvList`, which is built by
+//     `assembleComponentEnvVars` from `info.ComponentEnvSection` (auth hooks +
+//     stack-config `env:` section).  Same theoretical leak path.
+//
+// Without the merge-order fix, an earlier pre-merge sanitization could be
+// silently bypassed. This test pins the post-merge behavior.
+func TestExecuteShellCommand_SanitizeAfterMerge(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err, "os.Executable() must succeed")
+
+	dumpFile := filepath.Join(t.TempDir(), "env.dump")
+
+	// Parent-process env is clean — the leak is intentionally NOT from os.Environ()
+	// in this test.  We're testing that the OTHER two env sources are also sanitized.
+	// (t.Setenv to "" makes sure no ambient TF_CLI_ARGS interferes.)
+	t.Setenv("TF_CLI_ARGS", "")
+	t.Setenv("TF_CLI_ARGS_workspace", "")
+
+	// Source 1: atmosConfig.Env (atmos.yaml top-level env: section).
+	atmosConfig := schema.AtmosConfiguration{
+		Env: map[string]string{
+			"TF_CLI_ARGS":           "-lock-timeout=10m",
+			"TF_CLI_ARGS_workspace": "-no-color",
+			// Per-subcommand variants must still pass through.
+			"TF_CLI_ARGS_plan": "-lock-timeout=10m",
+		},
+	}
+
+	// Source 2: env param (= info.ComponentEnvList for the workspace call).
+	componentEnv := []string{
+		"_ATMOS_TEST_ENV_DUMP_FILE=" + dumpFile,
+		"TF_CLI_ARGS=-parallelism=4",          // would-be leak via the env param.
+		"TF_CLI_ARGS_workspace=-input=false",  // ditto.
+		"TF_CLI_ARGS_apply=-lock-timeout=10m", // per-subcommand variant — preserved.
+	}
+
+	// Call ExecuteShellCommand directly with WithSanitizedTerraformSetupEnv()
+	// so we exercise the full merge → sanitize → ATMOS_SHLVL pipeline.
+	shellErr := ExecuteShellCommand(
+		atmosConfig,
+		exePath,
+		[]string{"workspace", "select", "test-ws"},
+		t.TempDir(),
+		componentEnv,
+		false,
+		"",
+		WithSanitizedTerraformSetupEnv(),
+	)
+	require.NoError(t, shellErr, "subprocess (test binary) must exit 0 via _ATMOS_TEST_ENV_DUMP_FILE handler")
+
+	subprocessEnv := readSubprocessEnv(t, dumpFile)
+
+	// The whole point of this test: TF_CLI_ARGS / TF_CLI_ARGS_workspace must be
+	// stripped no matter which of the three sources contributed them.
+	_, hasUnscoped := subprocessEnv["TF_CLI_ARGS"]
+	assert.False(t, hasUnscoped,
+		"TF_CLI_ARGS must NOT survive merge from atmosConfig.Env or the env param. "+
+			"Got value: %q", subprocessEnv["TF_CLI_ARGS"])
+	_, hasWorkspaceVariant := subprocessEnv["TF_CLI_ARGS_workspace"]
+	assert.False(t, hasWorkspaceVariant,
+		"TF_CLI_ARGS_workspace must NOT survive merge from atmosConfig.Env or the env param. "+
+			"Got value: %q", subprocessEnv["TF_CLI_ARGS_workspace"])
+
+	// Per-subcommand variants from BOTH sources must pass through unchanged.
+	assert.Equal(t, "-lock-timeout=10m", subprocessEnv["TF_CLI_ARGS_plan"],
+		"TF_CLI_ARGS_plan from atmosConfig.Env must be preserved")
+	assert.Equal(t, "-lock-timeout=10m", subprocessEnv["TF_CLI_ARGS_apply"],
+		"TF_CLI_ARGS_apply from the env param must be preserved")
+
+	// ATMOS_SHLVL is appended AFTER sanitization, so the helper must not strip it.
+	assert.NotEmpty(t, subprocessEnv["ATMOS_SHLVL"],
+		"ATMOS_SHLVL must reach the subprocess; sanitization must not run after this append")
 }

--- a/internal/exec/terraform_workspace_env_sanitize_test.go
+++ b/internal/exec/terraform_workspace_env_sanitize_test.go
@@ -1,0 +1,248 @@
+package exec
+
+// terraform_workspace_env_sanitize_test.go verifies that Atmos does not leak
+// the user's `TF_CLI_ARGS` parent-process env var into atmos-internal
+// terraform/tofu setup subprocesses:
+//
+//   - `tofu workspace select` (runWorkspaceSetup)
+//   - `tofu workspace new`    (createWorkspaceFallback)
+//   - `tofu init` auto-init pre-step (executeTerraformInitPhase, when
+//     SubCommand ≠ "init")
+//
+// User-reported regression (see docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md):
+// when CI sets `TF_CLI_ARGS=-lock-timeout=10m` to wait on remote state locks,
+// `tofu workspace select` fails with "flag provided but not defined: -lock-timeout"
+// because OpenTofu prepends `TF_CLI_ARGS` to every subcommand. The user's
+// target subcommand (`plan`/`apply`) never runs.
+//
+// The same bug class applies to `tofu init` for plan/apply-only flags that
+// init does not accept (e.g. `-parallelism`, `-refresh`, `-detailed-exitcode`).
+// The user's specific report didn't trigger init because `init` accepts
+// `-lock-timeout`, but the next user with `-parallelism=4` would hit it.
+//
+// Strategy: use the test binary (os.Executable) as the "terraform" command.
+// TestMain in testmain_test.go honors `_ATMOS_TEST_ENV_DUMP_FILE` by writing
+// the subprocess env to that file and exiting 0. We then read the file and
+// assert which TF_CLI_ARGS_* keys reached the subprocess.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// readSubprocessEnv reads the env-dump file produced by the test-binary
+// subprocess and returns it as a map.
+func readSubprocessEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "env dump file must exist: subprocess was not invoked")
+	out := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		out[line[:eq]] = line[eq+1:]
+	}
+	return out
+}
+
+// TestRunWorkspaceSetup_StripsTfCliArgs is the regression test for
+// "TF_CLI_ARGS leaks into workspace select" — the user-reported issue where
+// `TF_CLI_ARGS=-lock-timeout=10m` set at the CI workflow level caused
+// `tofu workspace select` to abort with "flag provided but not defined:
+// -lock-timeout" before the user's target `tofu plan` could run.
+//
+// Before the fix: TF_CLI_ARGS reaches the workspace subprocess (regression
+// reproduced).  After the fix: TF_CLI_ARGS is stripped; subcommand-scoped
+// variants like TF_CLI_ARGS_plan are preserved.
+func TestRunWorkspaceSetup_StripsTfCliArgs(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err, "os.Executable() must succeed")
+
+	dumpFile := filepath.Join(t.TempDir(), "env.dump")
+
+	// Set the parent-process env exactly as a CI workflow would:
+	// the unscoped TF_CLI_ARGS targets every terraform subcommand
+	// (the leak), and the per-subcommand variants target only their named
+	// subcommand (must be preserved through the workspace-setup hop because
+	// the subprocess will go on to run plan/apply/init eventually).
+	t.Setenv("TF_CLI_ARGS", "-lock-timeout=10m")
+	t.Setenv("TF_CLI_ARGS_workspace", "-no-color")
+	t.Setenv("TF_CLI_ARGS_plan", "-lock-timeout=10m")
+	t.Setenv("TF_CLI_ARGS_apply", "-lock-timeout=10m")
+	t.Setenv("TF_CLI_ARGS_init", "-upgrade")
+	t.Setenv("TF_VAR_region", "us-east-1")
+	t.Setenv("TF_LOG", "DEBUG")
+
+	atmosConfig := schema.AtmosConfiguration{}
+	info := schema.ConfigAndStacksInfo{
+		Command:            exePath,
+		SubCommand:         "plan",
+		TerraformWorkspace: "test-ws",
+		// Empty backend type so workspace setup is not skipped by shouldSkipWorkspaceSetup.
+		ComponentBackendType: "",
+		// Tell the test-binary subprocess to dump its env and exit 0 — emulates
+		// `tofu workspace select` succeeding.
+		ComponentEnvList: []string{
+			"_ATMOS_TEST_ENV_DUMP_FILE=" + dumpFile,
+		},
+	}
+
+	componentPath := t.TempDir()
+	wsErr := runWorkspaceSetup(&atmosConfig, &info, componentPath)
+	require.NoError(t, wsErr, "workspace setup must succeed (test-binary subprocess exits 0)")
+
+	subprocessEnv := readSubprocessEnv(t, dumpFile)
+
+	// Core regression assertion: the unscoped TF_CLI_ARGS must NOT reach a
+	// workspace-setup subprocess. This is the actual bug fix.
+	_, hasUnscoped := subprocessEnv["TF_CLI_ARGS"]
+	assert.False(t, hasUnscoped,
+		"TF_CLI_ARGS must NOT leak into `tofu workspace select`; "+
+			"OpenTofu prepends it to every subcommand and `workspace select` rejects "+
+			"plan/apply-only flags like -lock-timeout. Got value: %q", subprocessEnv["TF_CLI_ARGS"])
+
+	// TF_CLI_ARGS_workspace explicitly targets workspace ops; it has the same
+	// failure mode if it carries an unsupported flag, so it is also stripped.
+	_, hasWorkspaceVariant := subprocessEnv["TF_CLI_ARGS_workspace"]
+	assert.False(t, hasWorkspaceVariant,
+		"TF_CLI_ARGS_workspace must NOT reach `tofu workspace select` either; "+
+			"its scope is the same and it has no fine-grained sub-subcommand override")
+
+	// Per-subcommand variants for OTHER subcommands must be preserved: they
+	// don't affect `workspace select` (OpenTofu only applies them to their
+	// named subcommand) and the user set them deliberately for plan/apply/init.
+	assert.Equal(t, "-lock-timeout=10m", subprocessEnv["TF_CLI_ARGS_plan"],
+		"TF_CLI_ARGS_plan must be preserved — only applies to `tofu plan`, not `workspace select`")
+	assert.Equal(t, "-lock-timeout=10m", subprocessEnv["TF_CLI_ARGS_apply"],
+		"TF_CLI_ARGS_apply must be preserved — only applies to `tofu apply`")
+	assert.Equal(t, "-upgrade", subprocessEnv["TF_CLI_ARGS_init"],
+		"TF_CLI_ARGS_init must be preserved — only applies to `tofu init`")
+
+	// Unrelated TF_* vars must pass through. They are not flag-injection vectors
+	// and are load-bearing for terraform's own behavior.
+	assert.Equal(t, "us-east-1", subprocessEnv["TF_VAR_region"],
+		"TF_VAR_* must pass through; not a CLI args flag")
+	assert.Equal(t, "DEBUG", subprocessEnv["TF_LOG"],
+		"TF_LOG must pass through; not a CLI args flag")
+}
+
+// TestCreateWorkspaceFallback_StripsTfCliArgs covers the workspace-new fallback
+// path. When `workspace select` fails with exit code 1 (workspace doesn't
+// exist), Atmos calls `workspace new`, which is just as vulnerable to the
+// TF_CLI_ARGS leak.
+//
+// Approach: drive createWorkspaceFallback directly with a test-binary
+// subprocess that dumps env and exits 0.
+func TestCreateWorkspaceFallback_StripsTfCliArgs(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err, "os.Executable() must succeed")
+
+	dumpFile := filepath.Join(t.TempDir(), "env.dump")
+
+	t.Setenv("TF_CLI_ARGS", "-lock-timeout=10m")
+	t.Setenv("TF_CLI_ARGS_apply", "-lock-timeout=10m")
+
+	atmosConfig := schema.AtmosConfiguration{}
+	info := schema.ConfigAndStacksInfo{
+		Command:            exePath,
+		SubCommand:         "apply",
+		TerraformWorkspace: "new-ws",
+		ComponentEnvList: []string{
+			"_ATMOS_TEST_ENV_DUMP_FILE=" + dumpFile,
+		},
+	}
+
+	componentPath := t.TempDir()
+	wsErr := createWorkspaceFallback(&atmosConfig, &info, componentPath)
+	require.NoError(t, wsErr, "workspace new fallback must succeed (subprocess exits 0)")
+
+	subprocessEnv := readSubprocessEnv(t, dumpFile)
+
+	_, hasUnscoped := subprocessEnv["TF_CLI_ARGS"]
+	assert.False(t, hasUnscoped,
+		"TF_CLI_ARGS must NOT leak into `tofu workspace new` either")
+
+	assert.Equal(t, "-lock-timeout=10m", subprocessEnv["TF_CLI_ARGS_apply"],
+		"per-subcommand variants must still be preserved on the fallback path")
+}
+
+// TestExecuteTerraformInitPhase_StripsTfCliArgs covers the auto-init pre-step.
+// Atmos invokes `tofu init` automatically before plan/apply (and other state
+// subcommands) when --skip-init is not set.  This is a setup subprocess the
+// user did not write, so it must not inherit unscoped `TF_CLI_ARGS` flags
+// that init does not accept.
+//
+// The user's original report used `-lock-timeout=10m` (which init accepts, so
+// init didn't crash for them) — but `-parallelism=4`, `-refresh=false`,
+// `-detailed-exitcode`, `-replace=…`, `-target=…`, `-out=…` etc. are all
+// plan/apply-only flags users commonly set in `TF_CLI_ARGS` that would crash
+// init. This test uses `-parallelism=4` as a representative non-`-lock-timeout`
+// case to guard against the next user hitting that variant.
+func TestExecuteTerraformInitPhase_StripsTfCliArgs(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err, "os.Executable() must succeed")
+
+	dumpFile := filepath.Join(t.TempDir(), "env.dump")
+
+	// `-parallelism=4` is a plan/apply-only flag; `tofu init` rejects it.
+	t.Setenv("TF_CLI_ARGS", "-parallelism=4")
+	// `TF_CLI_ARGS_init` is the user's deliberate per-subcommand override.
+	// It must be preserved through the auto-init pre-step.
+	t.Setenv("TF_CLI_ARGS_init", "-upgrade")
+	// Per-subcommand variants for OTHER subcommands must also be preserved.
+	t.Setenv("TF_CLI_ARGS_plan", "-parallelism=4")
+	t.Setenv("TF_VAR_region", "us-east-1")
+
+	atmosConfig := schema.AtmosConfiguration{}
+	info := schema.ConfigAndStacksInfo{
+		Command:    exePath,
+		SubCommand: "plan", // not "init" — this triggers the auto-init pre-step path
+		ComponentEnvList: []string{
+			"_ATMOS_TEST_ENV_DUMP_FILE=" + dumpFile,
+		},
+	}
+
+	componentPath := t.TempDir()
+	// executeTerraformInitPhase calls prepareInitExecution → cleanTerraformWorkspace
+	// → ExecuteShellCommand for `tofu init`. The test-binary subprocess dumps
+	// env and exits 0, so the init step "succeeds" and we can inspect what
+	// the subprocess actually saw.
+	_, initErr := executeTerraformInitPhase(&atmosConfig, &info, componentPath, "")
+	require.NoError(t, initErr, "init phase must succeed (test-binary subprocess exits 0)")
+
+	subprocessEnv := readSubprocessEnv(t, dumpFile)
+
+	// Core regression assertion: unscoped TF_CLI_ARGS must NOT reach the
+	// auto-init subprocess.  Same bug class as the workspace fix.
+	_, hasUnscoped := subprocessEnv["TF_CLI_ARGS"]
+	assert.False(t, hasUnscoped,
+		"TF_CLI_ARGS must NOT leak into the auto-`tofu init` pre-step; "+
+			"plan/apply-only flags like -parallelism crash init. "+
+			"Got value: %q", subprocessEnv["TF_CLI_ARGS"])
+
+	// Per-subcommand variants must be preserved.  `TF_CLI_ARGS_init` is
+	// especially important — that's how a user who actually wants `-upgrade`
+	// on every init expresses it.
+	assert.Equal(t, "-upgrade", subprocessEnv["TF_CLI_ARGS_init"],
+		"TF_CLI_ARGS_init must be preserved — it is the user-intentional "+
+			"per-subcommand variant that targets init specifically")
+	assert.Equal(t, "-parallelism=4", subprocessEnv["TF_CLI_ARGS_plan"],
+		"TF_CLI_ARGS_plan must be preserved — only applies to `tofu plan`, "+
+			"will not affect the init subprocess")
+
+	// Unrelated env vars pass through.
+	assert.Equal(t, "us-east-1", subprocessEnv["TF_VAR_region"],
+		"TF_VAR_* must pass through; not a CLI args flag")
+}

--- a/internal/exec/testmain_test.go
+++ b/internal/exec/testmain_test.go
@@ -14,6 +14,11 @@ import (
 //	_ATMOS_TEST_COUNTER_FILE=<path>  — if set, append one byte ("x") to <path>
 //	                                   on every invocation (for single-invocation
 //	                                   regression guard in terraform_execute_single_invocation_test.go).
+//	_ATMOS_TEST_ENV_DUMP_FILE=<path> — if set, write the subprocess env (one
+//	                                   KEY=VALUE per line) to <path> and exit 0.
+//	                                   Used to inspect the actual env passed to a
+//	                                   subprocess (e.g., to verify TF_CLI_ARGS
+//	                                   sanitization at the workspace-setup step).
 //	_ATMOS_TEST_EXIT_ONE=1           — if set, exit 1 immediately after the optional
 //	                                   counter-file write (for workspace recovery tests).
 func TestMain(m *testing.M) {
@@ -26,6 +31,20 @@ func TestMain(m *testing.M) {
 			_, _ = fd.WriteString("x")
 			_ = fd.Close()
 		}
+	}
+
+	// Subprocess helper: dump the entire process environment (one KEY=VALUE entry per line)
+	// to the given file and exit 0.  Used by tests that need to verify the exact env vars
+	// a subprocess receives — e.g., the TF_CLI_ARGS workspace-sanitization test.
+	if dumpFile := os.Getenv("_ATMOS_TEST_ENV_DUMP_FILE"); dumpFile != "" {
+		fd, err := os.OpenFile(dumpFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err == nil {
+			for _, kv := range os.Environ() {
+				_, _ = fd.WriteString(kv + "\n")
+			}
+			_ = fd.Close()
+		}
+		os.Exit(0)
 	}
 
 	// Subprocess helper: when the test binary is invoked as the "terraform" command,


### PR DESCRIPTION
## what

- Stops atmos from leaking the parent process's `TF_CLI_ARGS` env var into the terraform/tofu subcommands that atmos invokes as setup steps the user did not write: `tofu workspace select`, `tofu workspace new`, and the auto-`tofu init` pre-step that runs before `plan`/`apply`.
- Adds a new `WithSanitizedTerraformSetupEnv()` `ShellCommandOption` plus a pure helper `sanitizeTerraformWorkspaceEnv` that strips `TF_CLI_ARGS` and `TF_CLI_ARGS_workspace` from the subprocess env. Per-subcommand variants (`TF_CLI_ARGS_plan`, `TF_CLI_ARGS_apply`, `TF_CLI_ARGS_init`, …) are preserved.
- Wires the option into `runWorkspaceSetup`, `createWorkspaceFallback`, and `executeTerraformInitPhase`. Leaves the user's primary subcommand path (`executeMainTerraformCommand`, `handleVersionSubcommand`) untouched, so `TF_CLI_ARGS` still flows through to `plan`/`apply`/`init`-as-target as intended.
- Adds a pure-function test table for the helper plus three integration tests using a new `_ATMOS_TEST_ENV_DUMP_FILE` `TestMain` sentinel that lets the test binary act as a fake terraform/tofu and dump its actual subprocess env. Tests run cross-platform without needing `tofu` on `$PATH`. Each integration test was verified to fail when its corresponding code delta is reverted.
- Fix doc: `docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md`.

## why

- `atmos terraform plan` failed hard in CI when the workflow set `TF_CLI_ARGS: "-lock-timeout=10m"` (a sensible setting to wait on remote state locks): OpenTofu prepends `TF_CLI_ARGS` to **every** subcommand's argv, so atmos's pre-flight `tofu workspace select` aborted with `flag provided but not defined: -lock-timeout` before the user's `tofu plan` could run.
- The error message names a flag the user set deliberately, on a Terraform subcommand the user did not know atmos was running. The existing `warnOnConflictingEnvVars` log line already detected `TF_CLI_ARGS` but only warned; it still handed the var through to the workspace subprocess.
- Audit during the fix confirmed the same bug class affects the auto-init pre-step for any plan/apply-only flag users put in `TF_CLI_ARGS` that `tofu init` does not accept (`-parallelism`, `-refresh=false`, `-detailed-exitcode`, `-target`, `-replace`, `-out`). The reported flag (`-lock-timeout`) happens to be one of the few that `init` *does* accept, which is why init didn't crash for the original reporter — but the next user with `-parallelism=4` would hit it. The fix scope was widened to cover the auto-init pre-step too.
- The `!terraform.output` / `atmos.Component(...)` data-fetch path in `pkg/terraform/output/environment.go` already strips `TF_CLI_ARGS` and `TF_CLI_ARGS_*` before invoking terraform-exec; this PR brings the regular plan/apply flow in line for its own setup hops.
- The user-side workaround (`TF_CLI_ARGS_plan` / `TF_CLI_ARGS_apply` instead of the unscoped `TF_CLI_ARGS`) continues to work; the fix removes the *need* for it for the common `-lock-timeout` / `-parallelism` cases.

## references

- Fix doc with full diagnosis and verification: `docs/fixes/2026-04-27-tf-cli-args-breaks-workspace-select.md`.
- OpenTofu / Terraform docs on `TF_CLI_ARGS` and `TF_CLI_ARGS_<name>` semantics: the unscoped form is applied to **every** subcommand; per-subcommand variants only apply to their named subcommand.
- Prior art: `pkg/terraform/output/environment.go` (`prohibitedEnvVars` / `prohibitedEnvVarPrefixes`) — the existing strip-list applied to the terraform-exec data-fetch path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unscoped Terraform CLI-arg env vars (e.g., TF_CLI_ARGS, TF_CLI_ARGS_workspace) from reaching internal Terraform/OpenTofu setup subprocesses (workspace select/new and auto-run init), avoiding unintended flags while preserving subcommand-scoped variants and leaving user-invoked terraform init behavior unchanged.

* **Documentation**
  * Added a dated fix doc detailing the sanitization scope, ordering, and follow-up notes.

* **Tests**
  * Added unit and end-to-end tests validating sanitization, merge-ordering, and preservation of other Terraform env vars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->