### PR TITLE
fix(pro): friendlier 4xx error rendering and propagate hints to users

### DIFF
--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -78,9 +78,10 @@ func logAndReturnProAPIError(operation string, apiResponse dtos.AtmosApiResponse
 	}
 
 	// Always include trace_id when present — support uses it to correlate
-	// requests on the server side, regardless of 4xx vs 5xx.
+	// requests on the server side, regardless of 4xx vs 5xx. Put it on its
+	// own line so it doesn't get mistaken for the last validation bullet.
 	if traceID != "" {
-		errorMsg = fmt.Sprintf("%s (trace_id: %s)", errorMsg, traceID)
+		errorMsg = fmt.Sprintf("%s\ntrace_id: %s", errorMsg, traceID)
 	}
 
 	return errorMsg
@@ -91,20 +92,11 @@ func logAndReturnProAPIError(operation string, apiResponse dtos.AtmosApiResponse
 // errors after a trailing ": " separator, the trailing portion is stripped so
 // the bullets aren't shown twice.
 func renderValidationErrors(message string, validationErrors []string) string {
-	headline := message
-
-	// Best-effort dedupe: detect a trailing concatenation produced by the
-	// server (e.g. "Validation failed: A; B" or "Validation failed: A. B.")
-	// and strip it so we don't render the errors both inline and as bullets.
-	if idx := strings.Index(headline, ": "); idx != -1 {
-		tail := headline[idx+len(": "):]
-		if containsAllValidationErrors(tail, validationErrors) {
-			headline = headline[:idx]
-		}
-	}
-
-	var b strings.Builder
-	b.WriteString(headline)
+	// Normalize once: trim whitespace, drop empties, dedupe while preserving
+	// first-occurrence order. Both the tail-match below and the bullet
+	// rendering operate off the same cleaned set so behavior stays consistent
+	// for inputs like ["A", " A ", ""].
+	normalized := make([]string, 0, len(validationErrors))
 	seen := make(map[string]struct{}, len(validationErrors))
 	for _, ve := range validationErrors {
 		ve = strings.TrimSpace(ve)
@@ -115,6 +107,24 @@ func renderValidationErrors(message string, validationErrors []string) string {
 			continue
 		}
 		seen[ve] = struct{}{}
+		normalized = append(normalized, ve)
+	}
+
+	headline := message
+
+	// Best-effort dedupe: detect a trailing concatenation produced by the
+	// server (e.g. "Validation failed: A; B" or "Validation failed: A. B.")
+	// and strip it so we don't render the errors both inline and as bullets.
+	if idx := strings.Index(headline, ": "); idx != -1 {
+		tail := headline[idx+len(": "):]
+		if containsAllValidationErrors(tail, normalized) {
+			headline = headline[:idx]
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(headline)
+	for _, ve := range normalized {
 		b.WriteString("\n  - ")
 		b.WriteString(ve)
 	}

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -3,13 +3,13 @@ package pro
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"runtime"
+	"strings"
 	"time"
 
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -54,7 +54,7 @@ func logProAPIResponse(operation string, apiResponse dtos.AtmosApiResponse) {
 }
 
 func logAndReturnProAPIError(operation string, apiResponse dtos.AtmosApiResponse) string {
-	errorMsg := apiResponse.ErrorMessage
+	errorMsg := apiResponse.EffectiveErrorMessage()
 	traceID := apiResponse.TraceID
 
 	log.Error("Pro API Error",
@@ -71,11 +71,56 @@ func logAndReturnProAPIError(operation string, apiResponse dtos.AtmosApiResponse
 		errorMsg = fmt.Sprintf("API request failed with status %d", apiResponse.Status)
 	}
 
+	// Render data.validationErrors as a bullet list so the user can see each
+	// failure individually instead of one long concatenated sentence.
+	if apiResponse.Data != nil && len(apiResponse.Data.ValidationErrors) > 0 {
+		errorMsg = renderValidationErrors(errorMsg, apiResponse.Data.ValidationErrors)
+	}
+
+	// Always include trace_id when present — support uses it to correlate
+	// requests on the server side, regardless of 4xx vs 5xx.
 	if traceID != "" {
 		errorMsg = fmt.Sprintf("%s (trace_id: %s)", errorMsg, traceID)
 	}
 
 	return errorMsg
+}
+
+// renderValidationErrors formats a server-side message together with a list of
+// granular validation errors. When the message already concatenates the same
+// errors after a trailing ": " separator, the trailing portion is stripped so
+// the bullets aren't shown twice.
+func renderValidationErrors(message string, validationErrors []string) string {
+	headline := message
+
+	// Best-effort dedupe: detect a trailing concatenation produced by the
+	// server (e.g. "Validation failed: A; B" or "Validation failed: A. B.")
+	// and strip it so we don't render the errors both inline and as bullets.
+	if idx := strings.Index(headline, ": "); idx != -1 {
+		tail := headline[idx+len(": "):]
+		if containsAllValidationErrors(tail, validationErrors) {
+			headline = headline[:idx]
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(headline)
+	for _, ve := range validationErrors {
+		b.WriteString("\n  - ")
+		b.WriteString(ve)
+	}
+	return b.String()
+}
+
+// containsAllValidationErrors reports whether every validation error appears
+// somewhere in the given text. Used to detect a server-rendered concatenation.
+func containsAllValidationErrors(text string, validationErrors []string) bool {
+	for _, ve := range validationErrors {
+		if ve == "" || !strings.Contains(text, ve) {
+			return false
+		}
+	}
+	return true
 }
 
 // AtmosProAPIClientInterface defines the interface for the AtmosProAPIClient.
@@ -141,7 +186,7 @@ func NewAtmosProAPIClientFromEnv(atmosConfig *schema.AtmosConfiguration) (*Atmos
 	oidcToken, err := getGitHubOIDCToken(atmosConfig.Settings.Pro.GithubOIDC)
 	if err != nil {
 		log.Debug("Error while getting GitHub OIDC token.", "error", err)
-		return nil, errors.Join(errUtils.ErrFailedToGetGitHubOIDCToken, err)
+		return nil, wrapErr(errUtils.ErrFailedToGetGitHubOIDCToken, err)
 	}
 
 	// Get workspace ID from environment
@@ -153,7 +198,7 @@ func NewAtmosProAPIClientFromEnv(atmosConfig *schema.AtmosConfiguration) (*Atmos
 	// Exchange OIDC token for Atmos token.
 	apiToken, err = exchangeOIDCTokenForAtmosToken(baseURL, baseAPIEndpoint, oidcToken, workspaceID)
 	if err != nil {
-		return nil, errors.Join(errUtils.ErrOIDCTokenExchangeFailed, err)
+		return nil, wrapErr(errUtils.ErrOIDCTokenExchangeFailed, err)
 	}
 
 	client := NewAtmosProAPIClient(baseURL, baseAPIEndpoint, apiToken)
@@ -172,7 +217,7 @@ func userAgent() string {
 func getAuthenticatedRequest(c *AtmosProAPIClient, method, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return nil, errors.Join(errUtils.ErrFailedToCreateRequest, err)
+		return nil, wrapErr(errUtils.ErrFailedToCreateRequest, err)
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIToken))
@@ -194,13 +239,13 @@ func (c *AtmosProAPIClient) RefreshToken() error {
 
 	oidcToken, err := getGitHubOIDCToken(c.atmosConfig.Settings.Pro.GithubOIDC)
 	if err != nil {
-		return errors.Join(errUtils.ErrTokenRefreshFailed, err)
+		return wrapErr(errUtils.ErrTokenRefreshFailed, err)
 	}
 
 	workspaceID := c.atmosConfig.Settings.Pro.WorkspaceID
 	newToken, err := exchangeOIDCTokenForAtmosToken(c.BaseURL, c.BaseAPIEndpoint, oidcToken, workspaceID)
 	if err != nil {
-		return errors.Join(errUtils.ErrTokenRefreshFailed, err)
+		return wrapErr(errUtils.ErrTokenRefreshFailed, err)
 	}
 
 	c.APIToken = newToken
@@ -251,7 +296,7 @@ func (c *AtmosProAPIClient) UploadAffectedStacks(dto *dtos.UploadAffectedStacksR
 func (c *AtmosProAPIClient) sendAffectedStacksRequest(url string, dto *dtos.UploadAffectedStacksRequest) error {
 	data, err := json.Marshal(dto)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	log.Debug("Uploading affected components and stacks.", logKeyURL, url)
@@ -260,19 +305,19 @@ func (c *AtmosProAPIClient) sendAffectedStacksRequest(url string, dto *dtos.Uplo
 	err = doWithRetry("UploadAffectedStacks", func() error {
 		req, reqErr := getAuthenticatedRequest(c, "POST", url, bytes.NewBuffer(data))
 		if reqErr != nil {
-			return errors.Join(errUtils.ErrFailedToCreateAuthRequest, reqErr)
+			return wrapErr(errUtils.ErrFailedToCreateAuthRequest, reqErr)
 		}
 
 		resp, doErr := c.HTTPClient.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 		if doErr != nil {
-			return errors.Join(errUtils.ErrFailedToMakeRequest, doErr)
+			return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 		}
 		defer resp.Body.Close()
 
 		return handleAPIResponse(resp, "UploadAffectedStacks")
 	}, c, defaultRetryConfig())
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToUploadStacks, err)
+		return wrapErr(errUtils.ErrFailedToUploadStacks, err)
 	}
 
 	log.Debug("Uploaded affected components and stacks.", logKeyURL, url)
@@ -284,23 +329,23 @@ func (c *AtmosProAPIClient) sendAffectedStacksRequest(url string, dto *dtos.Uplo
 func (c *AtmosProAPIClient) doStackLockAction(params *schema.StackLockActionParams) error {
 	data, err := json.Marshal(params.Body)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	req, err := getAuthenticatedRequest(c, params.Method, params.URL, bytes.NewBuffer(data))
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToCreateAuthRequest, err)
+		return wrapErr(errUtils.ErrFailedToCreateAuthRequest, err)
 	}
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToMakeRequest, err)
+		return wrapErr(errUtils.ErrFailedToMakeRequest, err)
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToReadResponseBody, err)
+		return wrapErr(errUtils.ErrFailedToReadResponseBody, err)
 	}
 
 	if err := json.Unmarshal(b, params.Out); err != nil {
@@ -312,9 +357,9 @@ func (c *AtmosProAPIClient) doStackLockAction(params *schema.StackLockActionPara
 				WithContext("operation", params.Op).
 				WithHint("The API returned an unexpected response format. See troubleshooting: https://atmos-pro.com/docs/learn/troubleshooting").
 				Err()
-			return errors.Join(params.WrapErr, enrichedErr)
+			return wrapErr(params.WrapErr, enrichedErr)
 		}
-		return errors.Join(errUtils.ErrFailedToUnmarshalAPIResponse, err)
+		return wrapErr(errUtils.ErrFailedToUnmarshalAPIResponse, err)
 	}
 
 	// Log the structured response for debugging and check success.
@@ -323,13 +368,13 @@ func (c *AtmosProAPIClient) doStackLockAction(params *schema.StackLockActionPara
 	case *dtos.LockStackResponse:
 		logProAPIResponse(params.Op, responseData.AtmosApiResponse)
 		if !responseData.Success {
-			return errors.Join(params.WrapErr,
+			return wrapErr(params.WrapErr,
 				buildProAPIError(params.Op, resp.StatusCode, responseData.AtmosApiResponse))
 		}
 	case *dtos.UnlockStackResponse:
 		logProAPIResponse(params.Op, responseData.AtmosApiResponse)
 		if !responseData.Success {
-			return errors.Join(params.WrapErr,
+			return wrapErr(params.WrapErr,
 				buildProAPIError(params.Op, resp.StatusCode, responseData.AtmosApiResponse))
 		}
 	}
@@ -386,7 +431,7 @@ func handleAPIResponse(resp *http.Response, operation string) error {
 	// Read the response body.
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToReadResponseBody, err)
+		return wrapErr(errUtils.ErrFailedToReadResponseBody, err)
 	}
 
 	var apiResponse dtos.AtmosApiResponse
@@ -454,6 +499,13 @@ func buildProAPIError(operation string, statusCode int, apiResponse dtos.AtmosAp
 	// Add status-specific hints with targeted documentation links.
 	// Each hint is self-contained (each renders with its own lightbulb icon).
 	switch statusCode {
+	case http.StatusBadRequest:
+		builder = builder.
+			WithHint("This looks like a configuration error in your stack settings. Check the `settings.pro.*` block (drift_detection workflows, etc.). See: https://atmos-pro.com/docs/configure/atmos")
+		if isDriftDetectionError(&apiResponse) {
+			builder = builder.
+				WithHint("Drift detection requires `detect` and `remediate` workflows under `settings.pro.drift_detection`. See: https://atmos-pro.com/docs/configure/drift-detection")
+		}
 	case http.StatusForbidden:
 		builder = builder.
 			WithHint("Permissions are configured per-repository in Atmos Pro. Check that this repo has the required permissions: https://atmos-pro.com/docs/learn/permissions").
@@ -473,6 +525,22 @@ func buildProAPIError(operation string, statusCode int, apiResponse dtos.AtmosAp
 	}
 
 	return builder.Err()
+}
+
+// isDriftDetectionError reports whether the API response describes a
+// drift-detection configuration validation failure. Prefers the structured
+// errorTag when present; falls back to a substring match on the message.
+func isDriftDetectionError(apiResponse *dtos.AtmosApiResponse) bool {
+	if apiResponse.ErrorTag == "DriftDetectionValidationError" {
+		return true
+	}
+	msg := strings.ToLower(apiResponse.EffectiveErrorMessage())
+	if msg == "" {
+		return false
+	}
+	return strings.Contains(msg, "drift detection") ||
+		strings.Contains(msg, "remediate workflow") ||
+		strings.Contains(msg, "detect workflow")
 }
 
 // getGitHubOIDCToken retrieves an OIDC token from GitHub Actions.
@@ -508,7 +576,7 @@ func getGitHubOIDCToken(githubOIDCSettings schema.GithubOIDCSettings, clients ..
 
 	req, err := http.NewRequest("GET", requestOIDCTokenURL, nil)
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToCreateRequest, err)
+		return "", wrapErr(errUtils.ErrFailedToCreateRequest, err)
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", requestToken))
@@ -524,13 +592,13 @@ func getGitHubOIDCToken(githubOIDCSettings schema.GithubOIDCSettings, clients ..
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Debug("getGitHubOIDCToken", "error", err)
-		return "", errors.Join(errUtils.ErrFailedToGetOIDCToken, err)
+		return "", wrapErr(errUtils.ErrFailedToGetOIDCToken, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToReadResponseBody, err)
+		return "", wrapErr(errUtils.ErrFailedToReadResponseBody, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -540,7 +608,7 @@ func getGitHubOIDCToken(githubOIDCSettings schema.GithubOIDCSettings, clients ..
 
 	var tokenResp dtos.GetGitHubOIDCResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return "", errors.Join(errUtils.ErrFailedToDecodeOIDCResponse, err)
+		return "", wrapErr(errUtils.ErrFailedToDecodeOIDCResponse, err)
 	}
 
 	return tokenResp.Value, nil
@@ -572,12 +640,12 @@ func exchangeOIDCTokenForAtmosToken(baseURL, baseAPIEndpoint, oidcToken, workspa
 
 	data, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return "", wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToCreateRequest, err)
+		return "", wrapErr(errUtils.ErrFailedToCreateRequest, err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -586,13 +654,13 @@ func exchangeOIDCTokenForAtmosToken(baseURL, baseAPIEndpoint, oidcToken, workspa
 	client := getHTTPClientWithTimeout()
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToExchangeOIDCToken, err)
+		return "", wrapErr(errUtils.ErrFailedToExchangeOIDCToken, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Join(errUtils.ErrFailedToReadResponseBody, err)
+		return "", wrapErr(errUtils.ErrFailedToReadResponseBody, err)
 	}
 
 	// Try to parse the response to get trace ID from the response body
@@ -611,13 +679,13 @@ func exchangeOIDCTokenForAtmosToken(baseURL, baseAPIEndpoint, oidcToken, workspa
 				WithContext("operation", "ExchangeOIDCToken").
 				WithHint("The API returned an unexpected response format. See troubleshooting: https://atmos-pro.com/docs/learn/troubleshooting").
 				Err()
-			return "", errors.Join(errUtils.ErrFailedToExchangeOIDCToken, enrichedErr)
+			return "", wrapErr(errUtils.ErrFailedToExchangeOIDCToken, enrichedErr)
 		}
-		return "", errors.Join(errUtils.ErrFailedToDecodeTokenResponse, err)
+		return "", wrapErr(errUtils.ErrFailedToDecodeTokenResponse, err)
 	}
 
 	if !tokenResp.Success {
-		return "", errors.Join(errUtils.ErrFailedToExchangeOIDCToken,
+		return "", wrapErr(errUtils.ErrFailedToExchangeOIDCToken,
 			buildProAPIError("ExchangeOIDCToken", resp.StatusCode, tokenResp.AtmosApiResponse))
 	}
 

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -105,7 +105,16 @@ func renderValidationErrors(message string, validationErrors []string) string {
 
 	var b strings.Builder
 	b.WriteString(headline)
+	seen := make(map[string]struct{}, len(validationErrors))
 	for _, ve := range validationErrors {
+		ve = strings.TrimSpace(ve)
+		if ve == "" {
+			continue
+		}
+		if _, ok := seen[ve]; ok {
+			continue
+		}
+		seen[ve] = struct{}{}
 		b.WriteString("\n  - ")
 		b.WriteString(ve)
 	}

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -43,7 +43,8 @@ const (
 var oidcHTTPClientOverride *http.Client //nolint:gochecknoglobals
 
 func logProAPIResponse(operation string, apiResponse dtos.AtmosApiResponse) {
-	log.Debug("Pro API Response",
+	log.Debug(
+		"Pro API Response",
 		logKeyOperation, operation,
 		logKeyRequest, apiResponse.Request,
 		logKeyStatus, apiResponse.Status,
@@ -57,7 +58,8 @@ func logAndReturnProAPIError(operation string, apiResponse dtos.AtmosApiResponse
 	errorMsg := apiResponse.EffectiveErrorMessage()
 	traceID := apiResponse.TraceID
 
-	log.Error("Pro API Error",
+	log.Error(
+		"Pro API Error",
 		logKeyOperation, operation,
 		logKeyRequest, apiResponse.Request,
 		logKeyStatus, apiResponse.Status,

--- a/pkg/pro/api_client.go
+++ b/pkg/pro/api_client.go
@@ -117,10 +117,16 @@ func renderValidationErrors(message string, validationErrors []string) string {
 	// Best-effort dedupe: detect a trailing concatenation produced by the
 	// server (e.g. "Validation failed: A; B" or "Validation failed: A. B.")
 	// and strip it so we don't render the errors both inline and as bullets.
-	if idx := strings.Index(headline, ": "); idx != -1 {
-		tail := headline[idx+len(": "):]
-		if containsAllValidationErrors(tail, normalized) {
-			headline = headline[:idx]
+	// Skip when normalization produced no errors — otherwise containsAll would
+	// vacuously return true and we'd drop the headline tail despite rendering
+	// no bullets. Use LastIndex so colon-delimited context earlier in the
+	// headline (e.g. "Component vpc: validation failed: A; B") is preserved.
+	if len(normalized) > 0 {
+		if idx := strings.LastIndex(headline, ": "); idx != -1 {
+			tail := headline[idx+len(": "):]
+			if containsAllValidationErrors(tail, normalized) {
+				headline = headline[:idx]
+			}
 		}
 	}
 

--- a/pkg/pro/api_client_commit.go
+++ b/pkg/pro/api_client_commit.go
@@ -3,7 +3,6 @@ package pro
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +20,7 @@ const operationCreateCommit = "CreateCommit"
 // backoff, refreshing the OIDC token on 401 errors before each retry.
 func (c *AtmosProAPIClient) CreateCommit(dto *dtos.CommitRequest) (*dtos.CommitResponse, error) {
 	if dto == nil {
-		return nil, errors.Join(errUtils.ErrFailedToCreateCommit, errUtils.ErrNilRequestDTO)
+		return nil, wrapErr(errUtils.ErrFailedToCreateCommit, errUtils.ErrNilRequestDTO)
 	}
 
 	targetURL := fmt.Sprintf("%s/%s/git/commit", c.BaseURL, c.BaseAPIEndpoint)
@@ -29,7 +28,7 @@ func (c *AtmosProAPIClient) CreateCommit(dto *dtos.CommitRequest) (*dtos.CommitR
 
 	data, err := json.Marshal(dto)
 	if err != nil {
-		return nil, errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return nil, wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	var commitResp dtos.CommitResponse
@@ -38,7 +37,7 @@ func (c *AtmosProAPIClient) CreateCommit(dto *dtos.CommitRequest) (*dtos.CommitR
 		return c.sendCommitRequest(targetURL, data, &commitResp)
 	}, c, defaultRetryConfig())
 	if err != nil {
-		return nil, errors.Join(errUtils.ErrFailedToCreateCommit, err)
+		return nil, wrapErr(errUtils.ErrFailedToCreateCommit, err)
 	}
 
 	log.Debug("Created commit via Atmos Pro.", logKeyURL, targetURL, "sha", commitResp.Data.SHA)
@@ -50,7 +49,7 @@ func (c *AtmosProAPIClient) CreateCommit(dto *dtos.CommitRequest) (*dtos.CommitR
 func (c *AtmosProAPIClient) sendCommitRequest(targetURL string, data []byte, commitResp *dtos.CommitResponse) error {
 	req, reqErr := getAuthenticatedRequest(c, "POST", targetURL, bytes.NewBuffer(data))
 	if reqErr != nil {
-		return errors.Join(errUtils.ErrFailedToCreateAuthRequest, reqErr)
+		return wrapErr(errUtils.ErrFailedToCreateAuthRequest, reqErr)
 	}
 
 	// Guard against nil HTTPClient by ensuring a default client with a sane timeout.
@@ -61,13 +60,13 @@ func (c *AtmosProAPIClient) sendCommitRequest(targetURL string, data []byte, com
 
 	resp, doErr := client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 	if doErr != nil {
-		return errors.Join(errUtils.ErrFailedToMakeRequest, doErr)
+		return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
-		return errors.Join(errUtils.ErrFailedToReadResponseBody, readErr)
+		return wrapErr(errUtils.ErrFailedToReadResponseBody, readErr)
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
@@ -75,7 +74,7 @@ func (c *AtmosProAPIClient) sendCommitRequest(targetURL string, data []byte, com
 	}
 
 	if jsonErr := json.Unmarshal(body, commitResp); jsonErr != nil {
-		return errors.Join(errUtils.ErrFailedToUnmarshalAPIResponse, jsonErr)
+		return wrapErr(errUtils.ErrFailedToUnmarshalAPIResponse, jsonErr)
 	}
 
 	logProAPIResponse(operationCreateCommit, commitResp.AtmosApiResponse)

--- a/pkg/pro/api_client_commit.go
+++ b/pkg/pro/api_client_commit.go
@@ -60,6 +60,11 @@ func (c *AtmosProAPIClient) sendCommitRequest(targetURL string, data []byte, com
 
 	resp, doErr := client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 	if doErr != nil {
+		// http.Client.Do can return a non-nil response alongside an error
+		// (e.g., on redirect failures); close it to avoid leaking the connection.
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 	}
 	defer resp.Body.Close()

--- a/pkg/pro/api_client_commit_test.go
+++ b/pkg/pro/api_client_commit_test.go
@@ -156,6 +156,43 @@ func TestCreateCommit_NetworkError(t *testing.T) {
 	assert.ErrorIs(t, err, errUtils.ErrFailedToCreateCommit)
 }
 
+// TestSendCommitRequest_RedirectErrorClosesBody triggers the rare
+// "non-nil response with non-nil error" return path of http.Client.Do by
+// using a CheckRedirect that returns an error. This exercises the defensive
+// resp.Body.Close() guard added to avoid leaking connections.
+func TestSendCommitRequest_RedirectErrorClosesBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path+"/loop", http.StatusFound)
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirectBlocked
+		},
+	}
+
+	client := &AtmosProAPIClient{
+		BaseURL:         server.URL,
+		BaseAPIEndpoint: "api",
+		APIToken:        "test-token",
+		HTTPClient:      httpClient,
+	}
+
+	var resp dtos.CommitResponse
+	err := client.sendCommitRequest(server.URL+"/api/git/commit", []byte(`{}`), &resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrFailedToMakeRequest)
+}
+
+// errRedirectBlocked is used by tests that need CheckRedirect to fail so
+// http.Client.Do returns a non-nil response together with the error.
+var errRedirectBlocked = errSentinel("redirect blocked")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
+
 func TestSendCommitRequest_NilHTTPClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/pro/api_client_exchange_oidc_token_test.go
+++ b/pkg/pro/api_client_exchange_oidc_token_test.go
@@ -128,19 +128,11 @@ func TestExchangeOIDCTokenForAtmosToken_ErrorStatusNonJSON(t *testing.T) {
 	assert.Equal(t, "", token)
 	assert.ErrorIs(t, err, errUtils.ErrFailedToExchangeOIDCToken)
 	assert.ErrorIs(t, err, errUtils.ErrFailedToDecodeTokenResponse)
-	// The troubleshooting hint is attached to the enriched inner error.
-	// errors.Join doesn't propagate cockroach hints, so unwrap to find them.
-	var innerErrs interface{ Unwrap() []error }
-	if assert.ErrorAs(t, err, &innerErrs) {
-		for _, inner := range innerErrs.Unwrap() {
-			hints := cockroachErrors.GetAllHints(inner)
-			allHints := strings.Join(hints, "\n")
-			if strings.Contains(allHints, "troubleshooting") {
-				return // Found it.
-			}
-		}
-		t.Error("expected troubleshooting hint in inner errors")
-	}
+	// The troubleshooting hint is now visible at the top-level error because
+	// wrapErr re-attaches cockroach hints to the outer layer.
+	hints := cockroachErrors.GetAllHints(err)
+	allHints := strings.Join(hints, "\n")
+	assert.Contains(t, allHints, "troubleshooting")
 }
 
 func TestExchangeOIDCTokenForAtmosToken_MarshalError(t *testing.T) {

--- a/pkg/pro/api_client_instance_status.go
+++ b/pkg/pro/api_client_instance_status.go
@@ -3,7 +3,6 @@ package pro
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -19,7 +18,7 @@ import (
 // the OIDC token on 401 errors before each retry.
 func (c *AtmosProAPIClient) UploadInstanceStatus(dto *dtos.InstanceStatusUploadRequest) error {
 	if dto == nil {
-		return errors.Join(errUtils.ErrFailedToUploadInstanceStatus, errUtils.ErrNilRequestDTO)
+		return wrapErr(errUtils.ErrFailedToUploadInstanceStatus, errUtils.ErrNilRequestDTO)
 	}
 	// Use the correct endpoint format: /api/v1/repos/{owner}/{repo}/instances?stack={stack}&component={component}.
 	targetURL := fmt.Sprintf("%s/%s/repos/%s/%s/instances?stack=%s&component=%s",
@@ -43,26 +42,26 @@ func (c *AtmosProAPIClient) UploadInstanceStatus(dto *dtos.InstanceStatusUploadR
 
 	data, err := json.Marshal(payload)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	// Wrap the HTTP call in retry logic to handle transient 401/5xx failures.
 	err = doWithRetry("UploadInstanceStatus", func() error {
 		req, reqErr := getAuthenticatedRequest(c, "PATCH", targetURL, bytes.NewBuffer(data))
 		if reqErr != nil {
-			return errors.Join(errUtils.ErrFailedToCreateAuthRequest, reqErr)
+			return wrapErr(errUtils.ErrFailedToCreateAuthRequest, reqErr)
 		}
 
 		resp, doErr := c.HTTPClient.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 		if doErr != nil {
-			return errors.Join(errUtils.ErrFailedToMakeRequest, doErr)
+			return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 		}
 		defer resp.Body.Close()
 
 		return handleAPIResponse(resp, "UploadInstanceStatus")
 	}, c, defaultRetryConfig())
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToUploadInstanceStatus, err)
+		return wrapErr(errUtils.ErrFailedToUploadInstanceStatus, err)
 	}
 
 	log.Debug("Uploaded instance status.", "url", targetURL)

--- a/pkg/pro/api_client_instances.go
+++ b/pkg/pro/api_client_instances.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -27,10 +26,8 @@ const (
 // the OIDC token on 401 errors before each retry.
 func (c *AtmosProAPIClient) UploadInstances(dto *dtos.InstancesUploadRequest) error {
 	if dto == nil {
-		return errors.Join(
-			errUtils.ErrFailedToUploadInstances,
-			fmt.Errorf("UploadInstances: %w", errUtils.ErrNilRequestDTO),
-		)
+		return wrapErr(errUtils.ErrFailedToUploadInstances,
+			fmt.Errorf("UploadInstances: %w", errUtils.ErrNilRequestDTO))
 	}
 	endpoint := fmt.Sprintf("%s/%s/instances", c.BaseURL, c.BaseAPIEndpoint)
 
@@ -71,7 +68,7 @@ func (c *AtmosProAPIClient) sendInstancesRequest(endpoint string, dto *dtos.Inst
 
 	data, err := json.Marshal(dto)
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToMarshalPayload, err)
+		return wrapErr(errUtils.ErrFailedToMarshalPayload, err)
 	}
 
 	// Log safe metadata instead of full payload to prevent secret leakage.
@@ -90,19 +87,19 @@ func (c *AtmosProAPIClient) sendInstancesRequest(endpoint string, dto *dtos.Inst
 	err = doWithRetry("UploadInstances", func() error {
 		req, reqErr := getAuthenticatedRequest(c, "POST", endpoint, bytes.NewReader(data))
 		if reqErr != nil {
-			return errors.Join(errUtils.ErrFailedToCreateAuthRequest, reqErr)
+			return wrapErr(errUtils.ErrFailedToCreateAuthRequest, reqErr)
 		}
 
 		resp, doErr := client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 		if doErr != nil {
-			return errors.Join(errUtils.ErrFailedToMakeRequest, doErr)
+			return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 		}
 		defer resp.Body.Close()
 
 		return handleAPIResponse(resp, "UploadInstances")
 	}, c, defaultRetryConfig())
 	if err != nil {
-		return errors.Join(errUtils.ErrFailedToUploadInstances, err)
+		return wrapErr(errUtils.ErrFailedToUploadInstances, err)
 	}
 
 	log.Debug("Uploaded instances.", "endpoint", endpoint)

--- a/pkg/pro/api_client_instances.go
+++ b/pkg/pro/api_client_instances.go
@@ -73,7 +73,8 @@ func (c *AtmosProAPIClient) sendInstancesRequest(endpoint string, dto *dtos.Inst
 
 	// Log safe metadata instead of full payload to prevent secret leakage.
 	hash := sha256.Sum256(data)
-	log.Debug("Uploading instances DTO.",
+	log.Debug(
+		"Uploading instances DTO.",
 		"repo_owner", dto.RepoOwner,
 		"repo_name", dto.RepoName,
 		"instances_count", len(dto.Instances),

--- a/pkg/pro/api_client_instances.go
+++ b/pkg/pro/api_client_instances.go
@@ -92,6 +92,11 @@ func (c *AtmosProAPIClient) sendInstancesRequest(endpoint string, dto *dtos.Inst
 
 		resp, doErr := client.Do(req) //nolint:gosec // URL constructed from trusted config, not user input.
 		if doErr != nil {
+			// http.Client.Do can return a non-nil response alongside an error
+			// (e.g., on redirect failures); close it to avoid leaking the connection.
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
 			return wrapErr(errUtils.ErrFailedToMakeRequest, doErr)
 		}
 		defer resp.Body.Close()

--- a/pkg/pro/api_client_instances_test.go
+++ b/pkg/pro/api_client_instances_test.go
@@ -5,10 +5,15 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	cockroachErrors "github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/pro/dtos"
@@ -125,4 +130,67 @@ func TestUploadInstances_Error(t *testing.T) {
 	assert.True(t, errors.Is(err, errUtils.ErrFailedToUploadInstances))
 
 	mockRoundTripper.AssertExpectations(t)
+}
+
+// TestUploadInstances_400_NotRetried verifies that a 400 response from the
+// server is treated as non-retryable: exactly one HTTP request is made, the
+// returned error contains the server's user-facing message rendered as a
+// bullet list, the trace_id is preserved, and the drift-detection hint is
+// attached.
+func TestUploadInstances_400_NotRetried(t *testing.T) {
+	var requestCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+			"success": false,
+			"status": 400,
+			"errorTag": "DriftDetectionValidationError",
+			"errorMessage": "Drift detection validation failed: A; B",
+			"data": {"validationErrors": ["A", "B"]},
+			"traceId": "abc-trace"
+		}`))
+	}))
+	defer server.Close()
+
+	apiClient := &AtmosProAPIClient{
+		BaseURL:         server.URL,
+		BaseAPIEndpoint: "api",
+		APIToken:        "test-token",
+		HTTPClient:      &http.Client{},
+	}
+
+	dto := dtos.InstancesUploadRequest{
+		RepoURL:   "https://github.com/org/repo",
+		RepoName:  "repo",
+		RepoOwner: "org",
+		RepoHost:  "github.com",
+		Instances: []dtos.UploadInstance{
+			{Component: "vpc", Stack: "tenant1-ue2-dev", ComponentType: "terraform"},
+		},
+	}
+
+	err := apiClient.UploadInstances(&dto)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errUtils.ErrFailedToUploadInstances))
+
+	// 4xx must not trigger retries.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "400 must not be retried")
+
+	// User-facing rendering: bullets, trace_id, no "HTTP 400:" noise.
+	msg := err.Error()
+	assert.Contains(t, msg, "UploadInstances:")
+	assert.NotContains(t, msg, "HTTP 400:")
+	assert.Contains(t, msg, "- A")
+	assert.Contains(t, msg, "- B")
+	assert.Contains(t, msg, "trace_id: abc-trace")
+
+	// Status-specific hints surface at the top-level error: wrapErr re-attaches
+	// cockroach hints from the cause onto the outer wrap, so the CLI renderer
+	// (which calls cockroachErrors.GetAllHints on the final error) sees them.
+	hints := cockroachErrors.GetAllHints(err)
+	allHints := strings.Join(hints, "\n")
+	assert.Contains(t, allHints, "settings.pro")
+	assert.Contains(t, allHints, "atmos-pro.com/docs/configure/drift-detection")
 }

--- a/pkg/pro/api_client_instances_test.go
+++ b/pkg/pro/api_client_instances_test.go
@@ -194,3 +194,42 @@ func TestUploadInstances_400_NotRetried(t *testing.T) {
 	assert.Contains(t, allHints, "settings.pro")
 	assert.Contains(t, allHints, "atmos-pro.com/docs/configure/drift-detection")
 }
+
+// TestUploadInstances_RedirectErrorClosesBody triggers the rare
+// "non-nil response with non-nil error" return path of http.Client.Do via
+// CheckRedirect, exercising the defensive resp.Body.Close() guard inside
+// the doWithRetry closure.
+func TestUploadInstances_RedirectErrorClosesBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path+"/loop", http.StatusFound)
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirectBlocked
+		},
+	}
+
+	apiClient := &AtmosProAPIClient{
+		BaseURL:         server.URL,
+		BaseAPIEndpoint: "api",
+		APIToken:        "test-token",
+		HTTPClient:      httpClient,
+	}
+
+	dto := dtos.InstancesUploadRequest{
+		RepoURL:   "https://github.com/org/repo",
+		RepoName:  "repo",
+		RepoOwner: "org",
+		RepoHost:  "github.com",
+		Instances: []dtos.UploadInstance{
+			{Component: "vpc", Stack: "tenant1-ue2-dev", ComponentType: "terraform"},
+		},
+	}
+
+	err := apiClient.UploadInstances(&dto)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUtils.ErrFailedToUploadInstances))
+	assert.True(t, errors.Is(err, errUtils.ErrFailedToMakeRequest))
+}

--- a/pkg/pro/api_client_test.go
+++ b/pkg/pro/api_client_test.go
@@ -895,6 +895,20 @@ func TestRenderValidationErrors(t *testing.T) {
 			errors:   []string{"completely unrelated"},
 			contains: []string{"Some other message", "- completely unrelated"},
 		},
+		{
+			name:     "preserves headline when normalization removes every error",
+			message:  "Validation failed: details elided",
+			errors:   []string{"", "  ", "\t"},
+			contains: []string{"Validation failed: details elided"},
+			excludes: []string{"\n  - "},
+		},
+		{
+			name:     "preserves earlier colon-delimited context via LastIndex",
+			message:  "Component vpc: validation failed: A; B",
+			errors:   []string{"A", "B"},
+			contains: []string{"Component vpc: validation failed", "- A", "- B"},
+			excludes: []string{"failed: A; B"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pro/api_client_test.go
+++ b/pkg/pro/api_client_test.go
@@ -677,10 +677,13 @@ func TestBuildProAPIError_HintsPerStatusCode(t *testing.T) {
 			},
 		},
 		{
-			name:           "400 has no status-specific hints",
-			statusCode:     http.StatusBadRequest,
-			expectedHints:  []string{},
-			unexpectedHint: "atmos-pro.com/docs",
+			name:       "400 includes settings.pro hint",
+			statusCode: http.StatusBadRequest,
+			expectedHints: []string{
+				"settings.pro",
+				"atmos-pro.com/docs/configure/atmos",
+			},
+			unexpectedHint: "drift-detection",
 		},
 		{
 			name:       "401 with missing response status (status=0 in body)",
@@ -756,6 +759,179 @@ func TestHandleAPIResponse_NonJSON_IncludesTroubleshootingHint(t *testing.T) {
 	hints := cockroachErrors.GetAllHints(err)
 	allHints := strings.Join(hints, "\n")
 	assert.Contains(t, allHints, "atmos-pro.com/docs/learn/troubleshooting")
+}
+
+// TestBuildProAPIError_400DriftDetection covers the user-facing rendering
+// for the canonical drift-detection 400 case: bullet list, drift-detection
+// hint, and trace_id preserved for support.
+func TestBuildProAPIError_400DriftDetection(t *testing.T) {
+	apiResponse := dtos.AtmosApiResponse{
+		Status:       http.StatusBadRequest,
+		ErrorTag:     "DriftDetectionValidationError",
+		ErrorMessage: "Drift detection validation failed: A; B",
+		Data: &dtos.AtmosApiResponseData{
+			ValidationErrors: []string{"A", "B"},
+		},
+		TraceID: "abc-trace",
+	}
+
+	err := buildProAPIError("UploadInstances", http.StatusBadRequest, apiResponse)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errUtils.ErrAPIResponseError))
+
+	msg := err.Error()
+	assert.Contains(t, msg, "- A", "bullet for first validation error")
+	assert.Contains(t, msg, "- B", "bullet for second validation error")
+	assert.Contains(t, msg, "trace_id: abc-trace", "trace_id preserved on 4xx for support")
+
+	hints := cockroachErrors.GetAllHints(err)
+	allHints := strings.Join(hints, "\n")
+	assert.Contains(t, allHints, "settings.pro")
+	assert.Contains(t, allHints, "atmos-pro.com/docs/configure/drift-detection")
+}
+
+// TestBuildProAPIError_400LegacyErrorField verifies the DTO falls back to the
+// legacy `error` field when `errorMessage` isn't populated.
+func TestBuildProAPIError_400LegacyErrorField(t *testing.T) {
+	apiResponse := dtos.AtmosApiResponse{
+		Status: http.StatusBadRequest,
+		Error:  "Bad input",
+	}
+
+	err := buildProAPIError("UploadInstances", http.StatusBadRequest, apiResponse)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Bad input")
+}
+
+// TestHandleAPIResponse_400IsNotRetried verifies that a 400 is non-retryable
+// and that the user-facing error contains the server's message and bullets,
+// without the redundant "HTTP 400:" prefix.
+func TestHandleAPIResponse_400IsNotRetried(t *testing.T) {
+	body := `{
+		"success": false,
+		"status": 400,
+		"errorTag": "DriftDetectionValidationError",
+		"errorMessage": "Drift detection validation failed: A; B",
+		"data": {"validationErrors": ["A", "B"]},
+		"traceId": "abc-trace"
+	}`
+
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     "400 Bad Request",
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := handleAPIResponse(resp, "UploadInstances")
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	assert.False(t, apiErr.IsRetryable(), "4xx must not be retryable")
+
+	msg := apiErr.Error()
+	assert.Contains(t, msg, "UploadInstances:", "operation prefix")
+	assert.NotContains(t, msg, "HTTP 400:", "HTTP <code> prefix dropped on 4xx")
+	assert.Contains(t, msg, "- A")
+	assert.Contains(t, msg, "- B")
+	assert.Contains(t, msg, "trace_id: abc-trace")
+}
+
+// TestHandleAPIResponse_500KeepsHTTPPrefixAndTraceID verifies 5xx responses
+// retain the diagnostic "HTTP <code>:" prefix and the trace_id.
+func TestHandleAPIResponse_500KeepsHTTPPrefixAndTraceID(t *testing.T) {
+	body := `{"success":false,"status":500,"errorMessage":"boom","traceId":"srv-trace"}`
+
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := handleAPIResponse(resp, "UploadInstances")
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.True(t, apiErr.IsRetryable(), "5xx must be retryable")
+
+	msg := apiErr.Error()
+	assert.Contains(t, msg, "HTTP 500:", "diagnostic prefix preserved on 5xx")
+	assert.Contains(t, msg, "boom")
+	assert.Contains(t, msg, "trace_id: srv-trace")
+
+	hints := cockroachErrors.GetAllHints(err)
+	allHints := strings.Join(hints, "\n")
+	assert.Contains(t, allHints, "server-side error")
+}
+
+// TestRenderValidationErrors covers the dedupe/bullet helper directly so the
+// formatting is exercised without rebuilding a full API error.
+func TestRenderValidationErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		errors   []string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "strips trailing concatenation when message includes the errors",
+			message:  "Drift detection validation failed: A; B",
+			errors:   []string{"A", "B"},
+			contains: []string{"Drift detection validation failed", "- A", "- B"},
+			excludes: []string{"failed: A; B"},
+		},
+		{
+			name:     "appends bullets when message is just a headline",
+			message:  "Validation failed",
+			errors:   []string{"foo", "bar"},
+			contains: []string{"Validation failed", "- foo", "- bar"},
+		},
+		{
+			name:     "leaves message intact when errors not present in tail",
+			message:  "Some other message",
+			errors:   []string{"completely unrelated"},
+			contains: []string{"Some other message", "- completely unrelated"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderValidationErrors(tt.message, tt.errors)
+			for _, s := range tt.contains {
+				assert.Contains(t, got, s)
+			}
+			for _, s := range tt.excludes {
+				assert.NotContains(t, got, s)
+			}
+		})
+	}
+}
+
+// TestIsDriftDetectionError covers both the structured tag path and the
+// fallback substring matcher.
+func TestIsDriftDetectionError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *dtos.AtmosApiResponse
+		want bool
+	}{
+		{"matches by errorTag", &dtos.AtmosApiResponse{ErrorTag: "DriftDetectionValidationError"}, true},
+		{"matches by message: drift detection", &dtos.AtmosApiResponse{ErrorMessage: "Drift detection failed"}, true},
+		{"matches by message: remediate workflow", &dtos.AtmosApiResponse{ErrorMessage: "Missing remediate workflow"}, true},
+		{"matches by message: detect workflow", &dtos.AtmosApiResponse{ErrorMessage: "Missing detect workflow"}, true},
+		{"matches by legacy error field", &dtos.AtmosApiResponse{Error: "drift detection failed"}, true},
+		{"no match for unrelated 400", &dtos.AtmosApiResponse{ErrorMessage: "Bad input"}, false},
+		{"no match for empty response", &dtos.AtmosApiResponse{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDriftDetectionError(tt.in))
+		})
+	}
 }
 
 // failingReader is a reader that always fails.

--- a/pkg/pro/api_client_test.go
+++ b/pkg/pro/api_client_test.go
@@ -910,6 +910,17 @@ func TestRenderValidationErrors(t *testing.T) {
 	}
 }
 
+// TestRenderValidationErrors_Dedupe verifies that duplicate or whitespace-only
+// validation errors are collapsed into a single bullet so the user-facing
+// list isn't noisy.
+func TestRenderValidationErrors_Dedupe(t *testing.T) {
+	got := renderValidationErrors("Validation failed", []string{"A", "A", "  ", "", " A ", "B"})
+
+	assert.Equal(t, 2, strings.Count(got, "\n  - "), "duplicate bullets must be collapsed")
+	assert.Contains(t, got, "\n  - A")
+	assert.Contains(t, got, "\n  - B")
+}
+
 // TestIsDriftDetectionError covers both the structured tag path and the
 // fallback substring matcher.
 func TestIsDriftDetectionError(t *testing.T) {

--- a/pkg/pro/api_error.go
+++ b/pkg/pro/api_error.go
@@ -14,7 +14,18 @@ type APIError struct {
 }
 
 // Error returns a human-readable description of the API error.
+//
+// For 4xx responses the server's error message is already user-facing
+// ("Drift detection validation failed: ..."), so the redundant "HTTP <code>:"
+// prefix is dropped — the user sees "UploadInstances: <message>".
+//
+// For 5xx and other errors the prefix is kept because the inner cause is
+// usually a generic fallback like "API request failed with status N" and
+// the explicit status code helps both users and support.
 func (e *APIError) Error() string {
+	if e.StatusCode >= http.StatusBadRequest && e.StatusCode < http.StatusInternalServerError {
+		return fmt.Sprintf("%s: %v", e.Operation, e.Err)
+	}
 	return fmt.Sprintf("%s: HTTP %d: %v", e.Operation, e.StatusCode, e.Err)
 }
 

--- a/pkg/pro/api_error_test.go
+++ b/pkg/pro/api_error_test.go
@@ -10,12 +10,48 @@ import (
 )
 
 func TestAPIError_Error(t *testing.T) {
-	err := &APIError{
-		StatusCode: 500,
-		Operation:  "UploadInstanceStatus",
-		Err:        fmt.Errorf("internal server error"),
+	tests := []struct {
+		name       string
+		statusCode int
+		operation  string
+		inner      error
+		want       string
+	}{
+		{
+			name:       "5xx keeps HTTP <code> prefix",
+			statusCode: 500,
+			operation:  "UploadInstanceStatus",
+			inner:      fmt.Errorf("internal server error"),
+			want:       "UploadInstanceStatus: HTTP 500: internal server error",
+		},
+		{
+			name:       "4xx drops HTTP <code> prefix because server message is user-facing",
+			statusCode: 400,
+			operation:  "UploadInstances",
+			inner:      fmt.Errorf("Drift detection validation failed"),
+			want:       "UploadInstances: Drift detection validation failed",
+		},
+		{
+			name:       "404 also drops HTTP prefix",
+			statusCode: 404,
+			operation:  "LockStack",
+			inner:      fmt.Errorf("workspace not found"),
+			want:       "LockStack: workspace not found",
+		},
+		{
+			name:       "200 (unexpected, but defined) keeps HTTP prefix",
+			statusCode: 200,
+			operation:  "Op",
+			inner:      fmt.Errorf("something"),
+			want:       "Op: HTTP 200: something",
+		},
 	}
-	assert.Equal(t, "UploadInstanceStatus: HTTP 500: internal server error", err.Error())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &APIError{StatusCode: tt.statusCode, Operation: tt.operation, Err: tt.inner}
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
 }
 
 func TestAPIError_Unwrap(t *testing.T) {

--- a/pkg/pro/dtos/atmos_api_response.go
+++ b/pkg/pro/dtos/atmos_api_response.go
@@ -1,10 +1,39 @@
 package dtos
 
+// AtmosApiResponse is the canonical envelope for all Atmos Pro API responses.
+//
+// The server returns the user-facing failure description in `errorMessage`
+// (camelCase). Older deployments may instead populate `error`; both are
+// unmarshaled and EffectiveErrorMessage prefers `errorMessage` when present.
+//
+// `data.validationErrors` carries a list of granular failure reasons (e.g.
+// per-rule drift-detection violations) that are rendered as bullets to the
+// user instead of being smushed into a single sentence.
 type AtmosApiResponse struct {
 	Request      string                 `json:"request"`
 	Status       int                    `json:"status"`
 	Success      bool                   `json:"success"`
+	ErrorTag     string                 `json:"errorTag,omitempty"`
 	ErrorMessage string                 `json:"errorMessage,omitempty"`
+	Error        string                 `json:"error,omitempty"`
 	Context      map[string]interface{} `json:"context,omitempty"`
 	TraceID      string                 `json:"traceId,omitempty"`
+	Data         *AtmosApiResponseData  `json:"data,omitempty"`
+}
+
+// AtmosApiResponseData carries auxiliary structured data on error responses.
+// Typed responses that embed AtmosApiResponse and define their own `Data`
+// field shadow this one (Go field promotion + JSON unmarshaling rules).
+type AtmosApiResponseData struct {
+	ValidationErrors []string `json:"validationErrors,omitempty"`
+}
+
+// EffectiveErrorMessage returns ErrorMessage when populated, otherwise Error.
+// This tolerates both the current server format (errorMessage) and legacy or
+// future deployments that may use the simpler `error` field.
+func (r *AtmosApiResponse) EffectiveErrorMessage() string {
+	if r.ErrorMessage != "" {
+		return r.ErrorMessage
+	}
+	return r.Error
 }

--- a/pkg/pro/dtos/atmos_api_response_test.go
+++ b/pkg/pro/dtos/atmos_api_response_test.go
@@ -59,6 +59,58 @@ func TestAtmosApiResponse(t *testing.T) {
 		assert.Equal(t, "", response.TraceID)
 	})
 
+	t.Run("EffectiveErrorMessage prefers errorMessage over error", func(t *testing.T) {
+		r := AtmosApiResponse{ErrorMessage: "primary", Error: "legacy"}
+		assert.Equal(t, "primary", r.EffectiveErrorMessage())
+	})
+
+	t.Run("EffectiveErrorMessage falls back to error", func(t *testing.T) {
+		r := AtmosApiResponse{Error: "legacy only"}
+		assert.Equal(t, "legacy only", r.EffectiveErrorMessage())
+	})
+
+	t.Run("EffectiveErrorMessage returns empty when neither set", func(t *testing.T) {
+		r := AtmosApiResponse{}
+		assert.Equal(t, "", r.EffectiveErrorMessage())
+	})
+
+	t.Run("unmarshals legacy error field", func(t *testing.T) {
+		body := []byte(`{"success":false,"status":400,"error":"Bad input"}`)
+		var r AtmosApiResponse
+		require := assert.New(t)
+		require.NoError(json.Unmarshal(body, &r))
+		require.Equal("Bad input", r.Error)
+		require.Equal("", r.ErrorMessage)
+		require.Equal("Bad input", r.EffectiveErrorMessage())
+	})
+
+	t.Run("unmarshals errorTag and validationErrors", func(t *testing.T) {
+		body := []byte(`{
+			"success":false,
+			"status":400,
+			"errorTag":"DriftDetectionValidationError",
+			"errorMessage":"Drift detection validation failed",
+			"data":{"validationErrors":["A","B"]},
+			"traceId":"abc"
+		}`)
+		var r AtmosApiResponse
+		require := assert.New(t)
+		require.NoError(json.Unmarshal(body, &r))
+		require.Equal("DriftDetectionValidationError", r.ErrorTag)
+		require.Equal("Drift detection validation failed", r.EffectiveErrorMessage())
+		require.NotNil(r.Data)
+		require.Equal([]string{"A", "B"}, r.Data.ValidationErrors)
+		require.Equal("abc", r.TraceID)
+	})
+
+	t.Run("unmarshals without data leaves Data nil", func(t *testing.T) {
+		body := []byte(`{"success":false,"status":400,"errorMessage":"oops"}`)
+		var r AtmosApiResponse
+		require := assert.New(t)
+		require.NoError(json.Unmarshal(body, &r))
+		require.Nil(r.Data)
+	})
+
 	t.Run("JSON round-trip test", func(t *testing.T) {
 		// Test that JSON serialization/deserialization works correctly with camelCase traceId
 		original := AtmosApiResponse{

--- a/pkg/pro/retry.go
+++ b/pkg/pro/retry.go
@@ -88,7 +88,8 @@ func doWithRetry(operation string, fn func() error, refresher tokenRefresher, cf
 		// Wrap "max attempts exceeded" from the generic retry package with our
 		// domain-specific sentinel so callers can errors.Is for it.
 		if attempt > cfg.maxRetries {
-			log.Error("Upload failed after all retries.",
+			log.Error(
+				"Upload failed after all retries.",
 				logKeyOperation, operation,
 				logKeyMaxRetries, cfg.maxRetries,
 				"error", err,
@@ -111,7 +112,8 @@ func classifyError(operation string, lastErr error, attempt int, cfg retryConfig
 		}
 
 		// Remaining non-API errors are likely transient network issues — retry.
-		log.Warn("Upload failed with network error, retrying.",
+		log.Warn(
+			"Upload failed with network error, retrying.",
 			logKeyOperation, operation,
 			logKeyAttempt, attempt,
 			logKeyMaxRetries, cfg.maxRetries,
@@ -126,14 +128,16 @@ func classifyError(operation string, lastErr error, attempt int, cfg retryConfig
 	}
 
 	if apiErr.IsAuthError() {
-		log.Warn("Upload received 401, refreshing token before retry.",
+		log.Warn(
+			"Upload received 401, refreshing token before retry.",
 			logKeyOperation, operation,
 			logKeyAttempt, attempt,
 			logKeyMaxRetries, cfg.maxRetries,
 		)
 
 		if refreshErr := refresher.RefreshToken(); refreshErr != nil {
-			log.Error("Token refresh failed, aborting retries.",
+			log.Error(
+				"Token refresh failed, aborting retries.",
 				logKeyOperation, operation,
 				"error", refreshErr,
 			)
@@ -143,7 +147,8 @@ func classifyError(operation string, lastErr error, attempt int, cfg retryConfig
 	}
 
 	// 5xx — retry without token refresh.
-	log.Warn("Upload received server error, retrying.",
+	log.Warn(
+		"Upload received server error, retrying.",
 		logKeyOperation, operation,
 		logKeyAttempt, attempt,
 		logKeyMaxRetries, cfg.maxRetries,

--- a/pkg/pro/retry.go
+++ b/pkg/pro/retry.go
@@ -93,7 +93,7 @@ func doWithRetry(operation string, fn func() error, refresher tokenRefresher, cf
 				logKeyMaxRetries, cfg.maxRetries,
 				"error", err,
 			)
-			return errors.Join(errUtils.ErrUploadRetryExhausted, err)
+			return wrapErr(errUtils.ErrUploadRetryExhausted, err)
 		}
 	}
 

--- a/pkg/pro/wrap.go
+++ b/pkg/pro/wrap.go
@@ -1,0 +1,24 @@
+package pro
+
+import (
+	errUtils "github.com/cloudposse/atmos/errors"
+)
+
+// wrapErr returns an error that labels cause with the given sentinel.
+//
+// Both errors.Is(result, sentinel) and errors.Is(result, anyInnerSentinel)
+// match. Cockroach hints attached to cause are preserved at the top level
+// of the returned error. Note that stdlib errors.Join and fmt.Errorf with
+// multiple %w verbs both produce multi-errors that hide hints from
+// cockroachErrors.GetAllHints — using the project error builder's WithCause
+// re-attaches hints on the outer layer, so the CLI renderer surfaces them.
+func wrapErr(sentinel, cause error) error {
+	switch {
+	case cause == nil:
+		return sentinel
+	case sentinel == nil:
+		return cause
+	default:
+		return errUtils.Build(sentinel).WithCause(cause).Err()
+	}
+}

--- a/pkg/pro/wrap_test.go
+++ b/pkg/pro/wrap_test.go
@@ -1,0 +1,43 @@
+package pro
+
+import (
+	"errors"
+	"testing"
+
+	cockroachErrors "github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+)
+
+// TestWrapErr_NilCauseReturnsSentinel verifies that a nil cause short-circuits
+// to the sentinel itself, avoiding an unnecessary builder allocation.
+func TestWrapErr_NilCauseReturnsSentinel(t *testing.T) {
+	got := wrapErr(errUtils.ErrFailedToMakeRequest, nil)
+	require.Error(t, got)
+	assert.Same(t, errUtils.ErrFailedToMakeRequest, got)
+}
+
+// TestWrapErr_NilSentinelReturnsCause verifies that when no sentinel is
+// supplied the cause is returned untouched, so callers can pass through
+// errors without losing the chain.
+func TestWrapErr_NilSentinelReturnsCause(t *testing.T) {
+	cause := errors.New("boom")
+	got := wrapErr(nil, cause)
+	require.Error(t, got)
+	assert.Same(t, cause, got)
+}
+
+// TestWrapErr_BothNonNil verifies that errors.Is matches the sentinel and the
+// cause, and that any cockroach hints attached to the cause are surfaced on
+// the outer wrapper so the CLI renderer can show them.
+func TestWrapErr_BothNonNil(t *testing.T) {
+	cause := cockroachErrors.WithHint(errors.New("inner"), "try again later")
+	got := wrapErr(errUtils.ErrFailedToMakeRequest, cause)
+
+	require.Error(t, got)
+	assert.True(t, errors.Is(got, errUtils.ErrFailedToMakeRequest), "outer sentinel must match")
+	assert.True(t, errors.Is(got, cause), "inner cause must remain in chain")
+	assert.Contains(t, cockroachErrors.GetAllHints(got), "try again later")
+}


### PR DESCRIPTION
## what

- Surface the Atmos Pro server's user-facing 4xx fields (`errorMessage`, `errorTag`, `data.validationErrors[]`) directly to the CLI user instead of opaque `HTTP 500: API response error: API request failed with status N` noise.
- Render `data.validationErrors[]` as a bullet list under the headline (with dedupe of trailing server-side concatenations like `"failed: A; B"`).
- Add a 400 hint linking to `settings.pro.*` docs and a drift-detection-specific hint (selected by `errorTag == DriftDetectionValidationError` or substring match on the message).
- Drop the redundant `HTTP <code>:` prefix in `APIError.Error()` for 4xx so output reads `UploadInstances: <server message>` instead of `UploadInstances: HTTP 400: API response error: <server message>`.
- Preserve `trace_id` on all statuses (including 4xx) so support can correlate user-reported issues.
- Tolerate both `errorMessage` (current) and legacy `error` field on responses; new `EffectiveErrorMessage()` prefers the former.
- Replace `errors.Join(sentinel, cause)` with a small `wrapErr` helper using the existing `errUtils.Build(...).WithCause(...)` pattern. Stdlib `errors.Join` and `fmt.Errorf("%w: %w", ...)` both produce multi-errors that hide cockroach hint annotations from `GetAllHints`, which is why the existing 401/403/404/5xx hints never actually rendered to users.
- Retry behavior unchanged: 4xx remains non-retryable, 401 still refreshes the OIDC token, 5xx still backs off.

## why

- Real user pain: running `atmos list instances --upload` against a misconfigured stack produced `UploadInstances: HTTP 500: API response error: API request failed with status 500 (trace_id: ...)` four times in a row. The server actually returned a clean validation message describing the missing drift-detection workflows, but the CLI couldn't surface it (DTO field-name mismatch + lost hints).
- The atmos-pro server now correctly returns 4xx (not 500) with structured `errorMessage` and `data.validationErrors[]` for user-error conditions; this PR is the CLI side of that contract.
- Hints attached via `errUtils.Build(...).WithHint(...)` were silently dropped at the outermost wrap layer because `errors.Join` doesn't expose its children to `cockroachErrors.GetAllHints`. Users never saw the lightbulb hints the 401/403/404/5xx code paths were already emitting; this PR makes them visible.

## references

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer API error parsing that surfaces structured messages, validation bullets, and drift-detection guidance.
  * Unified error-wrapping semantics that preserve original error hints and improve retry exhaustion reporting.

* **Bug Fixes**
  * Cleaner 4xx error text (removed redundant HTTP prefix) while preserving trace IDs.
  * 400 responses are not retried and now surface clearer, deduplicated validation bullets.
  * More consistent error handling and ensured response bodies are closed on error.

* **Tests**
  * Expanded tests covering error rendering, drift-detection cases, retry behavior, and response-body/redirect edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->