### PR TITLE
test(describe-affected): accept all three valid Source values in TestResolveBase_PullRequest_Closed

### DIFF
--- a/pkg/ci/providers/github/base_test.go
+++ b/pkg/ci/providers/github/base_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,10 +177,34 @@ func TestResolveBase_PullRequest_Closed(t *testing.T) {
 	require.NotNil(t, res)
 	assert.Equal(t, "pull_request", res.EventType)
 	assert.Equal(t, "headsha123456789012345678901234567890ab", res.HeadSHA)
-	// In test env, merge-base and HEAD~1 may or may not work.
-	// Either way we get a valid resolution through the fallback chain.
+	// In test env, merge-base and HEAD~1 may or may not work; any of the
+	// three documented fallbacks produces a valid resolution. Whichever
+	// branch fires depends on the CI runner's checkout depth and whether
+	// origin/<base> has been fetched: PR runs typically reach merge-base
+	// or HEAD~1, but post-merge runs on main commonly hit the payload-SHA
+	// fallback, where Source = "event.pull_request.base.sha".
+	//
+	// Bug history: the original assertion was
+	//   assert.Contains(t, res.Source, "merge-base", "HEAD~1")
+	// which testify treats as a single Contains check with "HEAD~1" as
+	// the failure-message argument -- it never matched the payload-SHA
+	// path. Symptom: green on the PR (HEAD~1 reachable), red on main
+	// (only the payload SHA is available).
 	if res.SHA != "" {
-		assert.Contains(t, res.Source, "merge-base", "HEAD~1")
+		validSources := []string{
+			"merge-base",
+			"HEAD~1",
+			"event.pull_request.base.sha",
+		}
+		matched := false
+		for _, want := range validSources {
+			if strings.Contains(res.Source, want) {
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched,
+			"Source %q must contain one of %v", res.Source, validSources)
 	} else {
 		assert.Equal(t, "refs/remotes/origin/main", res.Ref)
 	}


### PR DESCRIPTION
## what

Fix a CI-blocking test bug in \`pkg/ci/providers/github/base_test.go\` introduced silently by PR #2380.

\`TestResolveBase_PullRequest_Closed\` passes on PR runs (where \`merge-base\` or \`HEAD~1\` is reachable) but fails on post-merge runs to \`main\` (where only the documented \`event.pull_request.base.sha\` fallback is available):

- https://github.com/cloudposse/atmos/actions/runs/25254046463/job/74053358101
- https://github.com/cloudposse/atmos/actions/runs/25254046463/job/74053358088

## why

The assertion

\`\`\`go
assert.Contains(t, res.Source, \"merge-base\", \"HEAD~1\")
\`\`\`

has a silent bug: testify treats the 4th positional argument to \`assert.Contains\` as the failure *message*, not an alternate value to match. So the test only ever checked for \`\"merge-base\"\`, and quietly passed on PR runs (where \`merge-base\` or \`HEAD~1\` was reachable) while failing on post-merge runs to \`main\` (where the GitHub Actions checkout depth and missing \`origin/<base>\` fetch leave only the third documented fallback, \`event.pull_request.base.sha\`).

\`ResolveBase()\`'s closed-PR fallback chain in \`pkg/ci/providers/github/base.go\` documents three valid Sources:

1. \`\"merge-base(HEAD, origin/<target>)\"\`
2. \`\"HEAD~1 (merged PR, merge-base unavailable)\"\`
3. \`\"event.pull_request.base.sha\"\`

Replace the broken \`Contains\`-with-msg call with an explicit OR over the three substrings. The fix matches the test's own existing comment (\"merge-base and HEAD~1 may or may not work; either way we get a valid resolution\") -- the bug was that the assertion didn't actually check for \"either way.\"

**No production code change** -- \`ResolveBase()\` already implements all three fallback paths correctly.

## references

- Failing CI runs on \`main\` (post-merge of #2380):
  - https://github.com/cloudposse/atmos/actions/runs/25254046463/job/74053358101
  - https://github.com/cloudposse/atmos/actions/runs/25254046463/job/74053358088
- Originating PR: #2380 (the resolver itself is correct; only the test's assertion was wrong).