### PR TITLE
fix(website): single H1 per page for valid Algolia search hierarchy

### DIFF
--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -174,7 +174,7 @@ atmos describe affected --query '[.[] | select(.deleted == true)]'
 atmos describe affected --query '[.[] | select(.deleted != true)]'
 ```
 
-# Example Output
+## Example Output
 
 <Terminal title="atmos describe affected --verbose=true">
 ```shell

--- a/website/docs/howto/inheritance.mdx
+++ b/website/docs/howto/inheritance.mdx
@@ -42,7 +42,7 @@ and `metadata` component's configuration section.
 <dd>is an Atmos component that derives the configuration properties from other Atmos components</dd>
 </dl>
 
-# Understanding Inheritance
+## Understanding Inheritance
 
 The concept of inheritance in Atmos is implemented through deep merging. Deep merging involves taking two maps or objects and combining them in a specific order, where the values in the latter map override those in the former. This approach allows us to achieve a template-free way of defining configurations in a logical, predictable, and consistent manner.
 

--- a/website/docs/howto/inheritance.mdx
+++ b/website/docs/howto/inheritance.mdx
@@ -48,7 +48,7 @@ The concept of inheritance in Atmos is implemented through deep merging. Deep me
 
 Base component vars (from `metadata.inherits`) sit between global-level vars and component-level vars — the current component's values always override inherited values.
 
-## What Gets Inherited
+### What Gets Inherited
 
 When a component inherits from a base component, the following sections are deep-merged:
 
@@ -79,7 +79,7 @@ stacks:
 ```
 :::
 
-## Single Inheritance
+### Single Inheritance
 
 <PillBox>Easy</PillBox>
 
@@ -118,7 +118,7 @@ classDiagram
       }
 ```
 
-### Single Inheritance Example
+#### Single Inheritance Example
 
 Let's say we want to provision two VPCs with different settings into the same AWS account.
 
@@ -248,7 +248,7 @@ As we can see, using the principles of **Component-Oriented Programming (COP)**,
 different settings, and provision them into the same (or different) environment (account/region) using the same Terraform code (which is
 environment-agnostic). And the configurations are extremely DRY and reusable.
 
-## Multiple Inheritance
+### Multiple Inheritance
 
 <PillBox>Advanced</PillBox>
 
@@ -322,7 +322,7 @@ All the base components/mixins referenced by `metadata.inherits` must be already
 statement or by explicitly defining them in the Stack configuration. The `metadata.inherits` statement does not imply that we are importing anything.
 :::
 
-### Multiple Inheritance Example
+#### Multiple Inheritance Example
 
 Here is a concrete example:
 
@@ -389,7 +389,7 @@ Inheritance: test/test-component-override-3 -> mixin/test-2 -> mixin/test-1 ->
 The `Inheritance` output shows the multiple inheritance steps that Atmos performed and deep-merged into the final configuration, including
 the variables which are sent to the Terraform component `test/test-component` that is being provisioned.
 
-### Multilevel Inheritance
+#### Multilevel Inheritance
 
 <PillBox>Advanced</PillBox>
 
@@ -433,7 +433,7 @@ classDiagram
       }
 ```
 
-### Hierarchical Inheritance
+#### Hierarchical Inheritance
 
 <PillBox>Advanced</PillBox>
 
@@ -555,7 +555,7 @@ For `ComponentG`:
 
 - And finally, `ComponentG` is processed, and it overrides `ComponentC`, `ComponentA` and `ComponentI`
 
-#### Hierarchical Inheritance Example
+##### Hierarchical Inheritance Example
 
 Let's consider the following configuration for Atmos components `base-component-1`, `base-component-2`, `derived-component-1`
 and `derived-component-2`:

--- a/website/docs/learn/mindset.mdx
+++ b/website/docs/learn/mindset.mdx
@@ -39,7 +39,7 @@ You're about to discover a new way to think about terraform...
 </Link>
 
 
-<h1> Your Architecture is Made up of Components</h1>
+## Your Architecture is Made up of Components
 
 Start by thinking about your architecture in terms of its logical components.
 

--- a/website/src/components/EmbedExample/index.tsx
+++ b/website/src/components/EmbedExample/index.tsx
@@ -68,8 +68,21 @@ function stripFrontmatter(content: string): string {
 
 /**
  * Markdown components for rendering README content.
+ *
+ * Heading levels are demoted by one (h1→h2, h2→h3, …) so that an embedded
+ * README's top-level `# Heading` does not produce a second `<h1>` on the host
+ * page. The host page's own H1 (frontmatter title or first `#` directive)
+ * stays the only H1, preserving valid HTML5 semantics and clean Algolia
+ * hierarchy extraction.
  */
 const markdownComponents = {
+  h1: ({ children, ...props }: { children?: React.ReactNode }) => (
+    <h2 {...props} className={styles.embeddedH1}>{children}</h2>
+  ),
+  h2: ({ children, ...props }: { children?: React.ReactNode }) => <h3 {...props}>{children}</h3>,
+  h3: ({ children, ...props }: { children?: React.ReactNode }) => <h4 {...props}>{children}</h4>,
+  h4: ({ children, ...props }: { children?: React.ReactNode }) => <h5 {...props}>{children}</h5>,
+  h5: ({ children, ...props }: { children?: React.ReactNode }) => <h6 {...props}>{children}</h6>,
   code({ className, children, ...props }: { className?: string; children?: React.ReactNode }) {
     const match = /language-(\w+)/.exec(className || '');
     const isInline = !match;

--- a/website/src/components/EmbedExample/index.tsx
+++ b/website/src/components/EmbedExample/index.tsx
@@ -76,13 +76,13 @@ function stripFrontmatter(content: string): string {
  * hierarchy extraction.
  */
 const markdownComponents = {
-  h1: ({ children, ...props }: { children?: React.ReactNode }) => (
+  h1: ({ children, node, ...props }: { children?: React.ReactNode; node?: unknown }) => (
     <h2 {...props} className={styles.embeddedH1}>{children}</h2>
   ),
-  h2: ({ children, ...props }: { children?: React.ReactNode }) => <h3 {...props}>{children}</h3>,
-  h3: ({ children, ...props }: { children?: React.ReactNode }) => <h4 {...props}>{children}</h4>,
-  h4: ({ children, ...props }: { children?: React.ReactNode }) => <h5 {...props}>{children}</h5>,
-  h5: ({ children, ...props }: { children?: React.ReactNode }) => <h6 {...props}>{children}</h6>,
+  h2: ({ children, node, ...props }: { children?: React.ReactNode; node?: unknown }) => <h3 {...props}>{children}</h3>,
+  h3: ({ children, node, ...props }: { children?: React.ReactNode; node?: unknown }) => <h4 {...props}>{children}</h4>,
+  h4: ({ children, node, ...props }: { children?: React.ReactNode; node?: unknown }) => <h5 {...props}>{children}</h5>,
+  h5: ({ children, node, ...props }: { children?: React.ReactNode; node?: unknown }) => <h6 {...props}>{children}</h6>,
   code({ className, children, ...props }: { className?: string; children?: React.ReactNode }) {
     const match = /language-(\w+)/.exec(className || '');
     const isInline = !match;

--- a/website/src/components/EmbedExample/styles.module.css
+++ b/website/src/components/EmbedExample/styles.module.css
@@ -136,6 +136,19 @@
   margin-top: 0;
 }
 
+/*
+ * The README's original `# Heading` is rendered as <h2 class="embeddedH1">
+ * (see EmbedExample's markdownComponents) so it doesn't create a second
+ * <h1> on the host page, but visually it should still read as a section
+ * title — match the typography of a real h1.
+ */
+.embeddedH1 {
+  font-size: var(--ifm-h1-font-size);
+  font-weight: var(--ifm-heading-font-weight);
+  line-height: var(--ifm-heading-line-height);
+  margin-bottom: calc(var(--ifm-heading-margin-bottom) * 1.25);
+}
+
 .readmeContent table {
   display: block;
   overflow-x: auto;

--- a/website/src/components/File/index.css
+++ b/website/src/components/File/index.css
@@ -41,7 +41,7 @@
     transform-origin: bottom;
 }
 
-.file div.tab > h1 {
+.file div.tab > .file-title {
     font-size: 0.98em;
     line-height: 1.2em;
     margin-top: 5px;
@@ -54,11 +54,11 @@
     transform-style: preserve-3d;
     transform: perspective(0.6em) rotateX(-1deg);
 }
-.file div.tab > h1 svg.svg-inline--fa {
+.file div.tab > .file-title svg.svg-inline--fa {
     margin-right: 0.5em;
 }
 
-html[data-theme='dark'] .file div.tab > h1 {
+html[data-theme='dark'] .file div.tab > .file-title {
     color: var(--ifm-heading-color);
 }
 

--- a/website/src/components/File/index.tsx
+++ b/website/src/components/File/index.tsx
@@ -65,7 +65,7 @@ export default function File({ title, className, type, icon, size = '1x', childr
         <div className={className}>
             <div className="file">
                 <div className="tab">
-                    <h1><FontAwesomeIcon icon={selectedIcon} size={size} /><span>{title}</span></h1>
+                    <div className="file-title"><FontAwesomeIcon icon={selectedIcon} size={size} /><span>{title}</span></div>
                 </div>
                 <div className="viewport">{children}</div>
             </div>

--- a/website/src/components/Screengrab/index.tsx
+++ b/website/src/components/Screengrab/index.tsx
@@ -20,7 +20,7 @@ export default function Screengrab({ title, command, className, slug, children }
                         <div className="control-dot minimize-dot"></div>
                         <div className="control-dot maximize-dot"></div>
                     </div>
-                    <h1>{title}</h1>
+                    <div className="window-title">{title}</div>
                 </div>
                 <div className="viewport">
                     {command && <Typewriter>{command}</Typewriter>}

--- a/website/src/components/Terminal/index.css
+++ b/website/src/components/Terminal/index.css
@@ -30,7 +30,7 @@ html[data-theme="dark"] .terminal {
     background-size: 9px 20px;
 }
 
-.terminal h1 {
+.terminal .window-title {
     text-align: center;
     font-size: 1em;
     font-family: monospace;
@@ -52,7 +52,7 @@ html[data-theme="dark"] .terminal {
     text-overflow: ellipsis;
 }
 
-html[data-theme="dark"] .terminal h1 {
+html[data-theme="dark"] .terminal .window-title {
     color: #fff;
 }
 

--- a/website/src/components/Terminal/index.tsx
+++ b/website/src/components/Terminal/index.tsx
@@ -12,7 +12,7 @@ export default function Terminal({ title, command, className, children }) {
                         <div className="control-dot minimize-dot"></div>
                         <div className="control-dot maximize-dot"></div>
                     </div>
-                    <h1>{title}</h1>
+                    <div className="window-title">{title}</div>
                 </div>
                 <div className="viewport">{command && <div className="command"><span className="prompt">&gt;</span><Typewriter>{command}</Typewriter></div>}<div>{children}</div></div>
             </div>


### PR DESCRIPTION
## what

- Stop rendering decorative `<h1>` in `Terminal`, `Screengrab`, and `File` chrome components — replaced with semantic `<div className="window-title|file-title">` and matching CSS selectors.
- Demote heading levels (h1→h2, h2→h3, …) in embedded README content rendered by `EmbedExample`, with an `embeddedH1` class so the visual size is preserved.
- Demote stray `# Heading` markdown to `##` in three docs pages: `describe-affected.mdx`, `inheritance.mdx`, `mindset.mdx`.


<img width="2068" height="1634" alt="image" src="https://github.com/user-attachments/assets/a317471d-ed63-48d8-be92-1c549f7198c9" />


## why

- Algolia DocSearch builds its sidebar/breadcrumbs from the page's H1 → H2 → H3 outline. Multiple H1s per page (one from the Docusaurus title, one from a Terminal window chrome, another from an embedded README) caused jumbled/duplicated search results.
- Valid HTML5 also expects a single H1 per page; this aligns the rendered DOM with that convention without changing any visible styling.

## references

- Algolia DocSearch indexing rules: https://docsearch.algolia.com/docs/record-extractor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Adjusted heading levels, reordered section headings, and converted several top-level headings to second-level for clearer structure and to avoid duplicate page-level headings in embedded content.

* **Style**
  * Switched component title markup from top-level headings to classed containers and added styling to preserve visual hierarchy.
  * Shifted embedded content heading levels in rendering and updated terminal/embedded title styles for consistent appearance across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->