### PR TITLE
fix(ci): classify output-only plan summaries

### DIFF
--- a/docs/fixes/2026-05-14-ci-output-only-plan-badge.md
+++ b/docs/fixes/2026-05-14-ci-output-only-plan-badge.md
@@ -1,0 +1,44 @@
+# Fix: CI summary shows no-change badge for output-only plans
+
+**Date:** 2026-05-14
+
+## Problem
+
+When an OpenTofu or Terraform plan reported only output value changes, the CI
+job summary could show a `No Changes` heading and gray `NO_CHANGE` badge even
+though the details correctly said:
+
+```text
+Output values will change. No infrastructure changes.
+```
+
+This happened on the stdout fallback path when the plan output contained
+`Changes to Outputs:` without a resource change summary.
+
+## Root Cause
+
+The stdout parser set the overall result to `HasChanges=true` and populated the
+changed-result text, but it did not preserve an explicit output-change signal in
+the Terraform-specific parsed data.
+
+The summary template context derived `HasOutputChanges` from parsed output
+values only. JSON plan parsing has structured output changes, but stdout parsing
+does not populate output values, so the template fell through to the no-change
+heading and badge.
+
+## Fix
+
+Terraform CI parsing now records output changes explicitly in
+`TerraformOutputData.HasOutputChanges`.
+
+- JSON plan parsing sets the flag when `output_changes` are present.
+- Stdout plan parsing sets the flag when `Changes to Outputs:` is present.
+- Summary rendering uses the explicit flag, so output-only plans render the
+  output-change heading and badge.
+
+## Test Coverage
+
+Added a regression test that renders the real `after.terraform.plan` CI summary
+path from anonymized OpenTofu stdout containing `Changes to Outputs:`. The test
+asserts that the summary uses `Output Changes Found` and `PLAN-OUTPUT_CHANGE`,
+and does not use the no-change heading or badge.

--- a/pkg/ci/internal/plugin/types.go
+++ b/pkg/ci/internal/plugin/types.go
@@ -145,6 +145,9 @@ type TerraformOutputData struct {
 	// Outputs contains terraform output values (after apply).
 	Outputs map[string]TerraformOutput
 
+	// HasOutputChanges indicates whether a plan includes output value changes.
+	HasOutputChanges bool
+
 	// ChangedResult contains the plan summary text.
 	ChangedResult string
 

--- a/pkg/ci/plugins/terraform/context.go
+++ b/pkg/ci/plugins/terraform/context.go
@@ -69,7 +69,7 @@ func NewTemplateContext(base *plugin.TemplateContext, data *plugin.TerraformOutp
 		ctx.Outputs = data.Outputs
 		ctx.ChangedResult = data.ChangedResult
 		ctx.HasDestroy = data.ResourceCounts.Destroy > 0
-		ctx.HasOutputChanges = len(data.Outputs) > 0
+		ctx.HasOutputChanges = data.HasOutputChanges || len(data.Outputs) > 0
 		ctx.Warnings = blockquoteWarnings(data.Warnings)
 	}
 

--- a/pkg/ci/plugins/terraform/handlers_test.go
+++ b/pkg/ci/plugins/terraform/handlers_test.go
@@ -615,6 +615,50 @@ func TestOnAfterPlan_OutputEnabled_WritesVariables(t *testing.T) {
 	assert.Equal(t, "0", mp.writer.outputs["resources_to_destroy"])
 }
 
+func TestOnAfterPlan_OutputOnlyStdout_RendersOutputChangeSummary(t *testing.T) {
+	p := &Plugin{}
+	mp := newMockProvider()
+
+	ctx := &plugin.HookContext{
+		Config: &schema.AtmosConfiguration{
+			CI: schema.CIConfig{
+				Summary: schema.CISummaryConfig{Enabled: boolPtr(true)},
+				Output:  schema.CIOutputConfig{Enabled: boolPtr(false)},
+				Checks:  schema.CIChecksConfig{Enabled: boolPtr(false)},
+			},
+		},
+		Provider:       mp,
+		TemplateLoader: templates.NewLoader(&schema.AtmosConfiguration{}),
+		Command:        "plan",
+		Info: &schema.ConfigAndStacksInfo{
+			Stack:            "test-stack",
+			ComponentFromArg: "test/component",
+		},
+		Output: `Note: Objects have changed outside of OpenTofu
+
+OpenTofu detected changes made outside of OpenTofu since the last apply.
+
+Changes to Outputs:
+  ~ image_id = "old-image" -> "new-image"
+
+You can apply this plan to save these new output values to the OpenTofu
+state, without changing any real infrastructure.
+`,
+	}
+
+	err := p.onAfterPlan(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, mp.writer.summaries, 1, "summary should have been rendered")
+	rendered := mp.writer.summaries[0]
+
+	assert.Contains(t, rendered, "## Output Changes Found for")
+	assert.Contains(t, rendered, "PLAN-OUTPUT_CHANGE-blue")
+	assert.Contains(t, rendered, "Output values will change. No infrastructure changes.")
+	assert.NotContains(t, rendered, "## No Changes for")
+	assert.NotContains(t, rendered, "NO_CHANGE-inactive")
+}
+
 func TestOnAfterPlan_CheckEnabled_UpdatesCheckRun(t *testing.T) {
 	p := &Plugin{}
 	mp := newMockProvider()

--- a/pkg/ci/plugins/terraform/parser.go
+++ b/pkg/ci/plugins/terraform/parser.go
@@ -79,10 +79,10 @@ func ParsePlanJSON(jsonData []byte) (*plugin.OutputResult, error) {
 	processResourceChanges(plan.ResourceChanges, data)
 	processOutputChanges(plan.OutputChanges, data)
 
-	result.HasChanges = hasResourceChanges(data.ResourceCounts) || len(data.Outputs) > 0
+	result.HasChanges = hasResourceChanges(data.ResourceCounts) || data.HasOutputChanges
 	if hasResourceChanges(data.ResourceCounts) {
 		data.ChangedResult = buildChangeSummary(data.ResourceCounts)
-	} else if len(data.Outputs) > 0 {
+	} else if data.HasOutputChanges {
 		data.ChangedResult = buildOutputChangeSummary(len(data.Outputs))
 	}
 
@@ -150,6 +150,7 @@ func processOutputChanges(changes map[string]*tfjson.Change, data *plugin.Terraf
 		if output == nil {
 			continue
 		}
+		data.HasOutputChanges = true
 		data.Outputs[name] = plugin.TerraformOutput{
 			Value:     output.After,
 			Sensitive: output.AfterSensitive != nil,
@@ -369,6 +370,7 @@ func ParsePlanOutput(output string) *plugin.OutputResult {
 	// Detect output-only changes (no resource changes but outputs changing).
 	if !result.HasChanges && outputChangesRe.MatchString(output) {
 		result.HasChanges = true
+		data.HasOutputChanges = true
 		data.ChangedResult = "Output values will change. No infrastructure changes."
 	}
 

--- a/pkg/ci/plugins/terraform/parser_test.go
+++ b/pkg/ci/plugins/terraform/parser_test.go
@@ -170,6 +170,7 @@ func TestParsePlanJSON_OutputOnlyChanges(t *testing.T) {
 
 	tfData, ok := result.Data.(*plugin.TerraformOutputData)
 	require.True(t, ok)
+	assert.True(t, tfData.HasOutputChanges, "HasOutputChanges should be true for output-only changes")
 
 	// No resource changes.
 	assert.Equal(t, 0, tfData.ResourceCounts.Create)
@@ -428,18 +429,19 @@ Second details
 // Legacy tests for stdout parsing (fallback behavior).
 func TestParsePlanOutput(t *testing.T) {
 	tests := []struct {
-		name            string
-		output          string
-		hasChanges      bool
-		hasErrors       bool
-		create          int
-		change          int
-		destroy         int
-		wantCreatedRes  []string
-		wantUpdatedRes  []string
-		wantDeletedRes  []string
-		wantWarnings    int
-		wantWarningText []string
+		name             string
+		output           string
+		hasChanges       bool
+		hasErrors        bool
+		hasOutputChanges bool
+		create           int
+		change           int
+		destroy          int
+		wantCreatedRes   []string
+		wantUpdatedRes   []string
+		wantDeletedRes   []string
+		wantWarnings     int
+		wantWarningText  []string
 	}{
 		{
 			name: "plan with changes",
@@ -558,8 +560,9 @@ Changes to Outputs:
 
 You can apply this plan to save these new output values to the Terraform state,
 without changing any real infrastructure.
-`,
-			hasChanges: true,
+			`,
+			hasChanges:       true,
+			hasOutputChanges: true,
 		},
 		{
 			name: "plan with errors",
@@ -584,6 +587,7 @@ Error: Reference to undeclared resource
 			assert.Equal(t, tt.hasErrors, result.HasErrors, "HasErrors mismatch")
 
 			if data, ok := result.Data.(*plugin.TerraformOutputData); ok {
+				assert.Equal(t, tt.hasOutputChanges, data.HasOutputChanges, "HasOutputChanges mismatch")
 				assert.Equal(t, tt.create, data.ResourceCounts.Create, "Create count mismatch")
 				assert.Equal(t, tt.change, data.ResourceCounts.Change, "Change count mismatch")
 				assert.Equal(t, tt.destroy, data.ResourceCounts.Destroy, "Destroy count mismatch")


### PR DESCRIPTION
## Summary

Fixes CI summary classification for output-only Terraform/OpenTofu plans on the stdout fallback path. These plans already had `HasChanges=true`, but the rendered summary could still use the no-change heading and badge because the template context only inferred output changes from parsed output values.

## Root Cause

JSON plan parsing has structured `output_changes`, but stdout parsing only sees `Changes to Outputs:`. The parser set the changed-result text but did not preserve an explicit output-change signal for the template context.

## Changes

- Add `TerraformOutputData.HasOutputChanges`.
- Set it from JSON plan output changes and stdout `Changes to Outputs:` detection.
- Use the explicit signal when building the Terraform summary template context.
- Add an anonymized end-to-end regression test for the `after.terraform.plan` summary path.
- Document the fix under `docs/fixes`.

## Validation

- `go test ./pkg/ci/plugins/terraform -run TestOnAfterPlan_OutputOnlyStdout_RendersOutputChangeSummary -count=1`
- `go test ./pkg/ci/plugins/terraform -run 'OutputOnly|OnAfterPlan|Template' -count=1`
- `go test ./pkg/ci/plugins/terraform -count=1`
- pre-commit hooks during commit, including Go build, gofumpt, tidy check, and golangci-lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI summary display for Terraform and OpenTofu plans containing output-only changes. Previously, plans that only modified output values incorrectly displayed "No Changes" heading and badge on CI summaries. They now correctly display "Output Changes" heading with appropriate messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2407)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->