### PR TITLE
Fail fast on missing component identity

### DIFF
--- a/docs/fixes/2026-05-15-list-instances-auth-fail-fast.md
+++ b/docs/fixes/2026-05-15-list-instances-auth-fail-fast.md
@@ -1,0 +1,33 @@
+# List Instances Auth Fail-Fast
+
+## Problem
+
+`atmos list instances --upload` could emit the same `Initialize Identities` error once per component and keep processing after a component declared a default identity that was not configured.
+
+For example, a missing profile for `example-root/terraform` produced repeated blocks like:
+
+```text
+Initialize Identities
+Error: invalid identity config
+Identity "example-root/terraform" is not configured. Did you forget to specify a profile?
+```
+
+## Root Cause
+
+Per-component auth resolution treated resolver failures as non-fatal. When a component had `auth.identities.<name>.default: true`, the resolver attempted to create a component-specific auth manager, printed the initialization error, returned an error, and the describe-stacks processor silently fell back to the parent auth manager.
+
+That made a fatal configuration problem look recoverable and repeated the same error for each matching component.
+
+## Fix
+
+Components that declare a default identity now fail fast when per-component auth resolution fails. The error is returned with component and stack context, and processing stops before template or YAML-function evaluation can continue with the wrong identity.
+
+Auth manager initialization no longer prints these errors eagerly from the construction path. The returned error is left for the top-level command handler to format once.
+
+## Expected Behavior
+
+When a declared default component identity is missing or invalid:
+
+- `atmos list instances --upload` stops on the first affected component.
+- The command exits non-zero.
+- The user sees a single formatted error instead of repeated `Initialize Identities` blocks.

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -142,7 +143,7 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	}
 	resolved, createErr := resolver(p.atmosConfig, componentSection, componentName, stackName, p.authManager)
 	if createErr != nil {
-		return componentAuthManager, fmt.Errorf("failed to resolve auth for component %q in stack %q: %w", componentName, stackName, createErr)
+		return componentAuthManager, fmt.Errorf("%w: failed to resolve auth for component %q in stack %q: %w", errUtils.ErrAuthManager, componentName, stackName, createErr)
 	}
 	if resolved != nil {
 		return resolved, nil

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -121,30 +121,33 @@ func shouldResolvePerComponentAuth(processTemplates, processYamlFunctions bool) 
 // resolveComponentAuthManager returns the AuthManager to use for this component.
 // It returns the parent AuthManager unchanged when per-component resolution is
 // disabled (see shouldResolvePerComponentAuth) or when the component does not
-// declare its own default identity in its auth section. Any error from the
-// resolver is swallowed and the parent AuthManager is used — this preserves the
-// original swallow-on-error behavior of the inline code that was refactored.
+// declare its own default identity in its auth section. When the component
+// declares a default identity, resolver errors are fatal: falling back to the
+// parent manager could read the wrong backend/account.
 func (p *describeStacksProcessor) resolveComponentAuthManager(
 	componentSection map[string]any,
 	componentName, stackName string,
-) auth.AuthManager {
+) (auth.AuthManager, error) {
 	componentAuthManager := p.authManager
 	if !shouldResolvePerComponentAuth(p.processTemplates, p.processYamlFunctions) {
-		return componentAuthManager
+		return componentAuthManager, nil
 	}
 	authSection, hasAuth := componentSection[cfg.AuthSectionName].(map[string]any)
 	if !hasAuth || !hasDefaultIdentity(authSection) {
-		return componentAuthManager
+		return componentAuthManager, nil
 	}
 	resolver := p.componentAuthResolver
 	if resolver == nil {
 		resolver = createComponentAuthManager
 	}
 	resolved, createErr := resolver(p.atmosConfig, componentSection, componentName, stackName, p.authManager)
-	if createErr == nil && resolved != nil {
-		componentAuthManager = resolved
+	if createErr != nil {
+		return componentAuthManager, fmt.Errorf("failed to resolve auth for component %q in stack %q: %w", componentName, stackName, createErr)
 	}
-	return componentAuthManager
+	if resolved != nil {
+		return resolved, nil
+	}
+	return componentAuthManager, nil
 }
 
 // processStackFile processes one stack file, iterating over all requested component types.
@@ -304,7 +307,10 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	info.Context = resolvedContext
 
 	// Resolve the per-component auth manager (may fall back to the parent).
-	componentAuthManager := p.resolveComponentAuthManager(componentSection, componentName, stackName)
+	componentAuthManager, err := p.resolveComponentAuthManager(componentSection, componentName, stackName)
+	if err != nil {
+		return err
+	}
 	propagateAuth(&info, componentAuthManager)
 
 	// Filter: skip this component if it does not belong to the requested stack.

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
@@ -293,6 +294,7 @@ func TestResolveComponentAuthManager_ResolverErrorIsFatal(t *testing.T) {
 	require.EqualValues(t, 1, spy.calls.Load(), "resolver should still be called on error path")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
+	assert.ErrorIs(t, err, errUtils.ErrAuthManager, "error must be wrapped with ErrAuthManager sentinel")
 	assert.Contains(t, err.Error(), "test-component")
 	assert.Contains(t, err.Error(), "test-stack")
 	assert.Nil(t, got, "error path should return the parent AuthManager value alongside the error")

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -234,7 +234,8 @@ func TestResolveComponentAuthManager(t *testing.T) {
 				finalStacksMap:        make(map[string]any),
 			}
 
-			got := p.resolveComponentAuthManager(tc.componentSection, "test-component", "test-stack")
+			got, err := p.resolveComponentAuthManager(tc.componentSection, "test-component", "test-stack")
+			require.NoError(t, err)
 
 			if tc.expectResolverCall {
 				assert.EqualValues(t, 1, spy.calls.Load(),
@@ -258,12 +259,10 @@ func TestResolveComponentAuthManager(t *testing.T) {
 	}
 }
 
-// TestResolveComponentAuthManager_ResolverErrorFallsBackToParent verifies that
-// when the per-component resolver returns an error, we silently fall back to
-// the parent AuthManager. This preserves the original swallow-on-error behavior
-// of the inline code that was refactored in
-// docs/fixes/2026-04-24-list-instances-per-component-auth.md.
-func TestResolveComponentAuthManager_ResolverErrorFallsBackToParent(t *testing.T) {
+// TestResolveComponentAuthManager_ResolverErrorIsFatal verifies that when a
+// component declares a default identity, per-component auth resolver failures
+// stop processing instead of falling back to the parent AuthManager.
+func TestResolveComponentAuthManager_ResolverErrorIsFatal(t *testing.T) {
 	t.Parallel()
 
 	parentMgr := auth.AuthManager(nil)
@@ -284,13 +283,54 @@ func TestResolveComponentAuthManager_ResolverErrorFallsBackToParent(t *testing.T
 		finalStacksMap:        make(map[string]any),
 	}
 
-	got := p.resolveComponentAuthManager(
+	got, err := p.resolveComponentAuthManager(
 		componentSectionWithAuth(authSectionWithDefault()),
 		"test-component",
 		"test-stack",
 	)
 
 	require.EqualValues(t, 1, spy.calls.Load(), "resolver should still be called on error path")
-	assert.Nil(t, got, "error path should fall back to the parent AuthManager (nil in this test)")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "test-component")
+	assert.Contains(t, err.Error(), "test-stack")
+	assert.Nil(t, got, "error path should return the parent AuthManager value alongside the error")
 	_ = parentMgr // documented intent: parentMgr is the untyped-nil fallback value.
+}
+
+func TestProcessComponentEntry_ComponentAuthResolverErrorIsFatal(t *testing.T) {
+	t.Parallel()
+
+	spy := &componentAuthResolverSpy{
+		returnMgr: nil,
+		returnErr: assert.AnError,
+	}
+
+	componentSection := componentSectionWithAuth(authSectionWithDefault())
+	allTypeComponents := map[string]any{
+		"test-component": componentSection,
+	}
+	p := &describeStacksProcessor{
+		atmosConfig:           &schema.AtmosConfiguration{},
+		processTemplates:      true,
+		processYamlFunctions:  false,
+		componentAuthResolver: spy.resolver(),
+		finalStacksMap:        make(map[string]any),
+	}
+
+	err := p.processComponentEntry(
+		"test-stack",
+		"",
+		"helmfile",
+		"test-component",
+		componentSection,
+		allTypeComponents,
+		processComponentTypeOpts{},
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "test-component")
+	assert.Contains(t, err.Error(), "test-stack")
+	assert.EqualValues(t, 1, spy.calls.Load(), "resolver should stop processing after the first auth failure")
 }

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -60,7 +60,8 @@ func TestShouldResolvePerComponentAuth(t *testing.T) {
 			t.Parallel()
 
 			got := shouldResolvePerComponentAuth(tc.processTemplates, tc.processYaml)
-			assert.Equal(t, tc.want, got,
+			assert.Equal(
+				t, tc.want, got,
 				"shouldResolvePerComponentAuth(processTemplates=%v, processYamlFunctions=%v)",
 				tc.processTemplates, tc.processYaml,
 			)

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -173,7 +173,6 @@ func NewAuthManager(
 	// Initialize providers.
 	if err := m.initializeProviders(); err != nil {
 		wrappedErr := fmt.Errorf("failed to initialize providers: %w", err)
-		errUtils.CheckErrorAndPrint(wrappedErr, "Initialize Providers", "")
 		return nil, wrappedErr
 	}
 
@@ -185,7 +184,6 @@ func NewAuthManager(
 	// Initialize identities.
 	if err := m.initializeIdentities(); err != nil {
 		wrappedErr := fmt.Errorf("failed to initialize identities: %w", err)
-		errUtils.CheckErrorAndPrint(wrappedErr, "Initialize Identities", "")
 		return nil, wrappedErr
 	}
 
@@ -594,7 +592,6 @@ func (m *manager) initializeProviders() error {
 	for name, providerConfig := range m.config.Providers {
 		provider, err := factory.NewProvider(name, &providerConfig)
 		if err != nil {
-			errUtils.CheckErrorAndPrint(err, "Initialize Providers", "")
 			return fmt.Errorf("%w: provider=%s: %w", errUtils.ErrInvalidProviderConfig, name, err)
 		}
 		m.providers[name] = provider
@@ -628,13 +625,11 @@ func (m *manager) initializeIdentities() error {
 			err := builder.
 				WithHint("Run `atmos profile list` to see available profiles").
 				WithExitCode(1).Err()
-			errUtils.CheckErrorAndPrint(err, "Initialize Identities", "")
 			return err
 		}
 
 		identity, err := factory.NewIdentity(name, &identityConfig)
 		if err != nil {
-			errUtils.CheckErrorAndPrint(err, "Initialize Identities", "")
 			return fmt.Errorf("%w: identity=%s: %w", errUtils.ErrInvalidIdentityConfig, name, err)
 		}
 		m.identities[name] = identity


### PR DESCRIPTION
## what

- Fail fast when per-component auth resolution fails for components that declare a default identity.
- Stop eager auth-manager error printing so the top-level command emits one formatted error.
- Add regression coverage and document the fix under docs/fixes.

## why

- Missing or invalid component identities are fatal because falling back to parent or ambient auth can use the wrong backend or account.
- This prevents `atmos list instances --upload` from repeating the same identity error per component and continuing after bad auth.

## references

- See `docs/fixes/2026-05-15-list-instances-auth-fail-fast.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `atmos list instances --upload` now fails fast when per-component auth resolution fails for components with a default identity; returns a clear error including component and stack context and stops further processing.
  * Eager error printing during auth initialization was removed and centralized to avoid repeated initialization messages.

* **Documentation**
  * Added docs describing the updated authentication failure behavior.

* **Tests**
  * Updated tests to verify resolver failures are treated as fatal and include component/stack context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2411)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->