### PR TITLE
fix(auth): normalize --identity=false to disable authentication

### DIFF
--- a/cmd/list/instances.go
+++ b/cmd/list/instances.go
@@ -33,6 +33,7 @@ type InstancesOptions struct {
 	OutputFile       string
 	ProcessTemplates bool
 	ProcessFunctions bool
+	AuthDisabled     bool
 }
 
 // instancesCmd lists atmos instances.
@@ -66,6 +67,8 @@ var instancesCmd = &cobra.Command{
 // Extracted from the RunE closure so the viper→options mapping can be
 // unit-tested without driving the whole cobra command.
 func parseInstancesOptions(cmd *cobra.Command, v *viper.Viper) *InstancesOptions {
+	identityName := getIdentityFromCommand(cmd)
+
 	return &InstancesOptions{
 		Flags:            flags.ParseGlobalFlags(cmd, v),
 		Format:           v.GetString("format"),
@@ -81,6 +84,7 @@ func parseInstancesOptions(cmd *cobra.Command, v *viper.Viper) *InstancesOptions
 		OutputFile:       v.GetString("output-file"),
 		ProcessTemplates: v.GetBool("process-templates"),
 		ProcessFunctions: v.GetBool("process-functions"),
+		AuthDisabled:     identityName == cfg.IdentityFlagDisabledValue,
 	}
 }
 
@@ -189,6 +193,7 @@ func executeListInstancesCmd(cmd *cobra.Command, args []string, opts *InstancesO
 		Delimiter:        opts.Delimiter,
 		Query:            opts.Query,
 		AuthManager:      authManager,
+		AuthDisabled:     opts.AuthDisabled,
 		OutputFile:       opts.OutputFile,
 		ProcessTemplates: opts.ProcessTemplates,
 		ProcessFunctions: opts.ProcessFunctions,

--- a/cmd/list/utils.go
+++ b/cmd/list/utils.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	e "github.com/cloudposse/atmos/internal/exec"
@@ -158,16 +159,29 @@ func newCommonListParser(additionalOptions ...flags.Option) *flags.StandardParse
 func getIdentityFromCommand(cmd *cobra.Command) string {
 	var value string
 
-	// Check if flag was explicitly set.
-	if cmd.Flags().Changed("identity") {
-		value, _ = cmd.Flags().GetString("identity")
-	} else {
-		// Fall back to environment variable via Viper.
-		value = viper.GetString("identity")
+	if flag := lookupChangedIdentityFlag(cmd); flag != nil {
+		value = flag.Value.String()
+		return normalizeIdentityValue(value)
 	}
 
-	// Normalize boolean false representations to disabled sentinel value.
+	// Fall back to environment variable via Viper.
+	value = viper.GetString(cfg.IdentityFlagName)
 	return normalizeIdentityValue(value)
+}
+
+func lookupChangedIdentityFlag(cmd *cobra.Command) *pflag.Flag {
+	for current := cmd; current != nil; current = current.Parent() {
+		for _, flagSet := range []*pflag.FlagSet{
+			current.Flags(),
+			current.InheritedFlags(),
+			current.PersistentFlags(),
+		} {
+			if flag := flagSet.Lookup(cfg.IdentityFlagName); flag != nil && flag.Changed {
+				return flag
+			}
+		}
+	}
+	return nil
 }
 
 // normalizeIdentityValue converts boolean false representations to the disabled sentinel value.

--- a/cmd/list/utils_test.go
+++ b/cmd/list/utils_test.go
@@ -189,6 +189,53 @@ func TestGetIdentityFromCommand(t *testing.T) {
 			expectedResult: cfg.IdentityFlagDisabledValue,
 		},
 		{
+			name: "normalizes inherited false to disabled sentinel value",
+			setupCmd: func() *cobra.Command {
+				parent := &cobra.Command{Use: "list"}
+				parent.PersistentFlags().String("identity", "", "Identity")
+				child := &cobra.Command{Use: "instances"}
+				parent.AddCommand(child)
+				_ = parent.PersistentFlags().Set("identity", "false")
+				return child
+			},
+			setupViper: func() {
+				viper.Reset()
+			},
+			expectedResult: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name: "normalizes inherited off to disabled sentinel value",
+			setupCmd: func() *cobra.Command {
+				parent := &cobra.Command{Use: "list"}
+				parent.PersistentFlags().String("identity", "", "Identity")
+				child := &cobra.Command{Use: "instances"}
+				parent.AddCommand(child)
+				_ = parent.PersistentFlags().Set("identity", "off")
+				return child
+			},
+			setupViper: func() {
+				viper.Reset()
+			},
+			expectedResult: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name: "normalizes parent persistent false to disabled sentinel value",
+			setupCmd: func() *cobra.Command {
+				root := &cobra.Command{Use: "atmos"}
+				parent := &cobra.Command{Use: "list"}
+				parent.PersistentFlags().String("identity", "", "Identity")
+				child := &cobra.Command{Use: "instances"}
+				root.AddCommand(parent)
+				parent.AddCommand(child)
+				_ = parent.PersistentFlags().Set("identity", "false")
+				return child
+			},
+			setupViper: func() {
+				viper.Reset()
+			},
+			expectedResult: cfg.IdentityFlagDisabledValue,
+		},
+		{
 			name: "normalizes no to disabled sentinel value from viper",
 			setupCmd: func() *cobra.Command {
 				cmd := &cobra.Command{Use: "test"}
@@ -211,6 +258,18 @@ func TestGetIdentityFromCommand(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
+}
+
+func TestGetIdentityFromCommand_NormalizesIdentityEnvFalse(t *testing.T) {
+	t.Setenv("ATMOS_IDENTITY", "false")
+	viper.Reset()
+	viper.SetEnvPrefix("ATMOS")
+	assert.NoError(t, viper.BindEnv(cfg.IdentityFlagName))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("identity", "", "Identity")
+
+	assert.Equal(t, cfg.IdentityFlagDisabledValue, getIdentityFromCommand(cmd))
 }
 
 // TestNormalizeIdentityValue tests the normalizeIdentityValue function.

--- a/internal/exec/cli_utils.go
+++ b/internal/exec/cli_utils.go
@@ -487,13 +487,18 @@ func parseFlagValue(flag, arg string, args []string, index int) (string, bool, e
 //   - --identity=value   → use value.
 //   - --identity=        → __SELECT__ (interactive selection).
 //
+// Boolean-false representations of the value ("false", "0", "no", "off",
+// case-insensitive) are normalized to cfg.IdentityFlagDisabledValue so that
+// --identity=false disables authentication, matching the documented behavior
+// of ATMOS_IDENTITY=false. Normalization is identity-on for all other values.
+//
 // SplitN(arg, "=", 2) is used so that identity values containing "=" (e.g., ARN-like
 // strings with key=value parameters) are handled correctly.
 func parseIdentityFlag(info *schema.ArgsAndFlagsInfo, arg string, args []string, index int) {
 	if arg == cfg.IdentityFlag {
 		// Has value: --identity <value> (next arg exists and is not another flag).
 		if len(args) > index+1 && !strings.HasPrefix(args[index+1], "-") {
-			info.Identity = args[index+1]
+			info.Identity = cfg.NormalizeIdentityValue(args[index+1])
 		} else {
 			// No value: --identity (interactive selection).
 			info.Identity = cfg.IdentityFlagSelectValue
@@ -507,7 +512,7 @@ func parseIdentityFlag(info *schema.ArgsAndFlagsInfo, arg string, args []string,
 			// Empty value: --identity= (interactive selection).
 			info.Identity = cfg.IdentityFlagSelectValue
 		} else {
-			info.Identity = parts[1]
+			info.Identity = cfg.NormalizeIdentityValue(parts[1])
 		}
 	}
 }

--- a/internal/exec/cli_utils_helpers_test.go
+++ b/internal/exec/cli_utils_helpers_test.go
@@ -157,6 +157,57 @@ func TestParseIdentityFlag(t *testing.T) {
 			index:            0,
 			expectedIdentity: "",
 		},
+		// Boolean-false normalization: --identity=<bool-false> must resolve to the
+		// disabled sentinel so authentication is skipped (mirrors ATMOS_IDENTITY=false).
+		{
+			name:             "equals form with false normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=false",
+			args:             []string{cfg.IdentityFlag + "=false"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "equals form with mixed-case False normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=False",
+			args:             []string{cfg.IdentityFlag + "=False"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "equals form with uppercase FALSE normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=FALSE",
+			args:             []string{cfg.IdentityFlag + "=FALSE"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "equals form with 0 normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=0",
+			args:             []string{cfg.IdentityFlag + "=0"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "equals form with no normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=no",
+			args:             []string{cfg.IdentityFlag + "=no"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "equals form with off normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag + "=off",
+			args:             []string{cfg.IdentityFlag + "=off"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+		{
+			name:             "space-separated form with false normalizes to disabled sentinel",
+			arg:              cfg.IdentityFlag,
+			args:             []string{cfg.IdentityFlag, "false"},
+			index:            0,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/exec/cli_utils_identity_test.go
+++ b/internal/exec/cli_utils_identity_test.go
@@ -61,6 +61,20 @@ func TestProcessArgsAndFlags_IdentityFlag(t *testing.T) {
 			expectError:      false,
 			description:      "--identity without value, next arg is another flag",
 		},
+		{
+			name:             "--identity=false should normalize to disabled sentinel",
+			args:             []string{"plan", "vpc", "--stack", "test-stack", "--identity=false"},
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+			expectError:      false,
+			description:      "Boolean-false flag value disables authentication",
+		},
+		{
+			name:             "--identity false (space-separated) should normalize to disabled sentinel",
+			args:             []string{"plan", "vpc", "--stack", "test-stack", "--identity", "false"},
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+			expectError:      false,
+			description:      "Space-separated boolean-false flag value disables authentication",
+		},
 	}
 
 	for _, tc := range tests {
@@ -102,6 +116,12 @@ func TestProcessArgsAndFlags_IdentityFlagHelmfile(t *testing.T) {
 			expectedIdentity: "test-identity",
 			description:      "Explicit identity specified",
 		},
+		{
+			name:             "--identity=false should normalize to disabled sentinel",
+			args:             []string{"sync", "nginx", "--stack", "test-stack", "--identity=false"},
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+			description:      "Boolean-false flag value disables authentication for helmfile",
+		},
 	}
 
 	for _, tc := range tests {
@@ -132,6 +152,12 @@ func TestProcessArgsAndFlags_IdentityFlagPacker(t *testing.T) {
 			args:             []string{"build", "example", "--stack", "test-stack", "--identity", "test-identity"},
 			expectedIdentity: "test-identity",
 			description:      "Explicit identity specified",
+		},
+		{
+			name:             "--identity=false should normalize to disabled sentinel",
+			args:             []string{"build", "example", "--stack", "test-stack", "--identity=false"},
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+			description:      "Boolean-false flag value disables authentication for packer",
 		},
 	}
 

--- a/internal/exec/describe_component.go
+++ b/internal/exec/describe_component.go
@@ -33,6 +33,7 @@ type DescribeComponentParams struct {
 	File                 string
 	Provenance           bool
 	AuthManager          auth.AuthManager // Optional: Auth manager for credential management (from --identity flag).
+	AuthDisabled         bool
 }
 
 //go:generate go run go.uber.org/mock/mockgen@v0.6.0 -source=$GOFILE -destination=mock_describe_component.go -package=$GOPACKAGE
@@ -107,6 +108,7 @@ func (d *DescribeComponentExec) ExecuteDescribeComponentCmd(describeComponentPar
 			ProcessYamlFunctions: processYamlFunctions,
 			Skip:                 skip,
 			AuthManager:          describeComponentParams.AuthManager,
+			AuthDisabled:         describeComponentParams.AuthDisabled,
 		})
 		if err != nil {
 			return err
@@ -126,6 +128,7 @@ func (d *DescribeComponentExec) ExecuteDescribeComponentCmd(describeComponentPar
 			ProcessYamlFunctions: processYamlFunctions,
 			Skip:                 skip,
 			AuthManager:          describeComponentParams.AuthManager,
+			AuthDisabled:         describeComponentParams.AuthDisabled,
 		})
 		if err != nil {
 			return err
@@ -216,6 +219,7 @@ type ExecuteDescribeComponentParams struct {
 	ProcessYamlFunctions bool
 	Skip                 []string
 	AuthManager          auth.AuthManager
+	AuthDisabled         bool
 }
 
 // ExecuteDescribeComponent describes component config.
@@ -230,6 +234,7 @@ func ExecuteDescribeComponent(params *ExecuteDescribeComponentParams) (map[strin
 		ProcessYamlFunctions: params.ProcessYamlFunctions,
 		Skip:                 params.Skip,
 		AuthManager:          params.AuthManager,
+		AuthDisabled:         params.AuthDisabled,
 	})
 	if err != nil {
 		return nil, err
@@ -388,6 +393,7 @@ type DescribeComponentContextParams struct {
 	ProcessYamlFunctions bool
 	Skip                 []string
 	AuthManager          auth.AuthManager // Optional: Auth manager for credential management
+	AuthDisabled         bool
 }
 
 // componentTypeProcessParams contains parameters for tryProcessWithComponentType.
@@ -479,6 +485,7 @@ func ExecuteDescribeComponentWithContext(params DescribeComponentContextParams) 
 	configAndStacksInfo.Stack = params.Stack
 	configAndStacksInfo.CliArgs = []string{"describe", "component"}
 	configAndStacksInfo.ComponentSection = make(map[string]any)
+	configAndStacksInfo.AuthDisabled = params.AuthDisabled
 
 	var err error
 	atmosConfig := params.AtmosConfig

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -128,6 +128,46 @@ func ExecuteDescribeStacks(
 	skip []string,
 	authManager auth.AuthManager,
 ) (map[string]any, error) {
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false)
+}
+
+// ExecuteDescribeStacksWithAuthDisabled processes stack manifests with auth explicitly disabled.
+//
+//nolint:revive // Signature intentionally mirrors ExecuteDescribeStacks with one compatibility parameter.
+func ExecuteDescribeStacksWithAuthDisabled(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+) (map[string]any, error) {
+	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithAuthDisabled")()
+
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled)
+}
+
+//nolint:revive // Internal wrapper preserves the existing ExecuteDescribeStacks call shape.
+func executeDescribeStacks(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacks")()
 
 	stacksMap, _, err := FindStacksMap(atmosConfig, ignoreMissingFiles)
@@ -135,13 +175,14 @@ func ExecuteDescribeStacks(
 		return nil, err
 	}
 
-	processor := newDescribeStacksProcessor(
+	processor := newDescribeStacksProcessorWithAuthDisabled(
 		atmosConfig,
 		filterByStack,
 		components, componentTypes, sections,
 		processTemplates, processYamlFunctions, includeEmptyStacks,
 		skip,
 		authManager,
+		authDisabled,
 	)
 
 	for stackFileName, stackSection := range stacksMap {

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -66,6 +66,7 @@ type describeStacksProcessor struct {
 	componentTypes       []string
 	processTemplates     bool
 	processYamlFunctions bool
+	authDisabled         bool
 	includeEmptyStacks   bool
 	skip                 []string
 	authManager          auth.AuthManager
@@ -84,6 +85,26 @@ func newDescribeStacksProcessor( //nolint:revive // argument-limit: constructor 
 	skip []string,
 	authManager auth.AuthManager,
 ) *describeStacksProcessor {
+	return newDescribeStacksProcessorWithAuthDisabled(
+		atmosConfig,
+		filterByStack,
+		components, componentTypes, sections,
+		processTemplates, processYamlFunctions, includeEmptyStacks,
+		skip,
+		authManager,
+		false,
+	)
+}
+
+func newDescribeStacksProcessorWithAuthDisabled( //nolint:revive // argument-limit: constructor needs all config params.
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components, componentTypes, sections []string,
+	processTemplates, processYamlFunctions, includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+) *describeStacksProcessor {
 	return &describeStacksProcessor{
 		atmosConfig:           atmosConfig,
 		filterByStack:         filterByStack,
@@ -92,6 +113,7 @@ func newDescribeStacksProcessor( //nolint:revive // argument-limit: constructor 
 		componentTypes:        componentTypes,
 		processTemplates:      processTemplates,
 		processYamlFunctions:  processYamlFunctions,
+		authDisabled:          authDisabled,
 		includeEmptyStacks:    includeEmptyStacks,
 		skip:                  skip,
 		authManager:           authManager,
@@ -129,7 +151,7 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	componentName, stackName string,
 ) auth.AuthManager {
 	componentAuthManager := p.authManager
-	if !shouldResolvePerComponentAuth(p.processTemplates, p.processYamlFunctions) {
+	if p.authDisabled || !shouldResolvePerComponentAuth(p.processTemplates, p.processYamlFunctions) {
 		return componentAuthManager
 	}
 	authSection, hasAuth := componentSection[cfg.AuthSectionName].(map[string]any)
@@ -302,6 +324,7 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 		return err
 	}
 	info.Context = resolvedContext
+	info.AuthDisabled = p.authDisabled
 
 	// Resolve the per-component auth manager (may fall back to the parent).
 	componentAuthManager := p.resolveComponentAuthManager(componentSection, componentName, stackName)

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -158,6 +158,7 @@ func TestResolveComponentAuthManager(t *testing.T) {
 		name               string
 		processTemplates   bool
 		processYaml        bool
+		authDisabled       bool
 		componentSection   map[string]any
 		expectResolverCall bool
 		expectSentinel     bool // true when result should be the spy's componentMgr
@@ -196,6 +197,15 @@ func TestResolveComponentAuthManager(t *testing.T) {
 			expectSentinel:     true,
 		},
 		{
+			name:               "auth_disabled_with_templates_and_yaml__resolver_skipped",
+			processTemplates:   true,
+			processYaml:        true,
+			authDisabled:       true,
+			componentSection:   componentSectionWithAuth(authSectionWithDefault()),
+			expectResolverCall: false,
+			expectSentinel:     false,
+		},
+		{
 			// Component without its own auth section: the resolver must NOT
 			// run even when templates are enabled, because there is no
 			// component-level identity to resolve. The parent AuthManager
@@ -229,6 +239,7 @@ func TestResolveComponentAuthManager(t *testing.T) {
 				atmosConfig:           &schema.AtmosConfiguration{},
 				processTemplates:      tc.processTemplates,
 				processYamlFunctions:  tc.processYaml,
+				authDisabled:          tc.authDisabled,
 				authManager:           parentMgr,
 				componentAuthResolver: spy.resolver(),
 				finalStacksMap:        make(map[string]any),

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -60,7 +60,8 @@ func TestShouldResolvePerComponentAuth(t *testing.T) {
 			t.Parallel()
 
 			got := shouldResolvePerComponentAuth(tc.processTemplates, tc.processYaml)
-			assert.Equal(t, tc.want, got,
+			assert.Equal(
+				t, tc.want, got,
 				"shouldResolvePerComponentAuth(processTemplates=%v, processYamlFunctions=%v)",
 				tc.processTemplates, tc.processYaml,
 			)

--- a/internal/exec/stacks_processor.go
+++ b/internal/exec/stacks_processor.go
@@ -58,3 +58,36 @@ func (d *DefaultStacksProcessor) ExecuteDescribeStacks(
 		authManager,
 	)
 }
+
+// ExecuteDescribeStacksWithAuthDisabled delegates to the package-level auth-disabled variant.
+//
+//nolint:revive // Signature matches ExecuteDescribeStacksWithAuthDisabled.
+func (d *DefaultStacksProcessor) ExecuteDescribeStacksWithAuthDisabled(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+) (map[string]any, error) {
+	return ExecuteDescribeStacksWithAuthDisabled(
+		atmosConfig,
+		filterByStack,
+		components,
+		componentTypes,
+		sections,
+		ignoreMissingFiles,
+		processTemplates,
+		processYamlFunctions,
+		includeEmptyStacks,
+		skip,
+		authManager,
+		authDisabled,
+	)
+}

--- a/internal/exec/stacks_processor_test.go
+++ b/internal/exec/stacks_processor_test.go
@@ -48,3 +48,59 @@ func TestDefaultStacksProcessor_ExecuteDescribeStacks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
+// TestDefaultStacksProcessor_ExecuteDescribeStacksWithAuthDisabled verifies the
+// auth-disabled variant delegates to ExecuteDescribeStacksWithAuthDisabled. The
+// method is pure pass-through (added so callers can route `--identity=false`
+// through the StacksProcessor seam in pkg/list), so a single call confirms
+// every line of the delegation is reached.
+func TestDefaultStacksProcessor_ExecuteDescribeStacksWithAuthDisabled(t *testing.T) {
+	testDir := t.TempDir()
+
+	atmosConfig := schema.AtmosConfiguration{
+		BasePath: testDir,
+		Stacks: schema.Stacks{
+			BasePath: "stacks",
+		},
+		Components: schema.Components{
+			Terraform: schema.Terraform{
+				BasePath: "components/terraform",
+			},
+		},
+	}
+
+	processor := &DefaultStacksProcessor{}
+
+	// Use the same empty-fixture shape as TestDefaultStacksProcessor_ExecuteDescribeStacks
+	// so this test only proves the delegation; correctness of the underlying
+	// ExecuteDescribeStacksWithAuthDisabled is covered in the auth-disabled tests
+	// in internal/exec/describe_stacks_component_processor_auth_test.go.
+	tests := []struct {
+		name         string
+		authDisabled bool
+	}{
+		{name: "authDisabled=true short-circuits per-component auth", authDisabled: true},
+		{name: "authDisabled=false matches the non-auth-disabled call shape", authDisabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := processor.ExecuteDescribeStacksWithAuthDisabled(
+				&atmosConfig,
+				"",         // filterByStack
+				[]string{}, // components
+				[]string{}, // componentTypes
+				[]string{}, // sections
+				true,       // ignoreMissingFiles
+				false,      // processTemplates
+				false,      // processYamlFunctions
+				false,      // includeEmptyStacks
+				[]string{}, // skip
+				nil,        // authManager
+				tt.authDisabled,
+			)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}

--- a/internal/exec/terraform_state_utils.go
+++ b/internal/exec/terraform_state_utils.go
@@ -58,7 +58,8 @@ func GetTerraformState(
 	if !skipCache {
 		backend, found := terraformStateCache.Load(stackSlug)
 		if found && backend != nil {
-			log.Debug("Cache hit",
+			log.Debug(
+				"Cache hit",
 				"function", yamlFunc,
 				cfg.ComponentStr, component,
 				cfg.StackStr, stack,
@@ -100,7 +101,8 @@ func GetTerraformState(
 		var err error
 		resolvedAuthMgr, err = resolveAuthManagerForNestedComponent(atmosConfig, component, stack, parentAuthMgr)
 		if err != nil {
-			log.Debug("Auth does not exist for nested component, using parent AuthManager",
+			log.Debug(
+				"Auth does not exist for nested component, using parent AuthManager",
 				"component", component,
 				"stack", stack,
 				"error", err,

--- a/internal/exec/terraform_state_utils.go
+++ b/internal/exec/terraform_state_utils.go
@@ -83,19 +83,30 @@ func GetTerraformState(
 		}
 	}
 
+	authDisabled := false
+	if parentAuthMgr != nil {
+		if stackInfo := parentAuthMgr.GetStackInfo(); stackInfo != nil {
+			authDisabled = stackInfo.AuthDisabled
+		}
+	}
+
 	// Resolve AuthManager for this nested component.
 	// Checks if component has auth config defined:
 	//   - If yes: creates component-specific AuthManager with merged auth config
 	//   - If no: uses parent AuthManager (inherits authentication)
 	// This enables each nested level to optionally override auth settings.
-	resolvedAuthMgr, err := resolveAuthManagerForNestedComponent(atmosConfig, component, stack, parentAuthMgr)
-	if err != nil {
-		log.Debug("Auth does not exist for nested component, using parent AuthManager",
-			"component", component,
-			"stack", stack,
-			"error", err,
-		)
-		resolvedAuthMgr = parentAuthMgr
+	resolvedAuthMgr := parentAuthMgr
+	if !authDisabled {
+		var err error
+		resolvedAuthMgr, err = resolveAuthManagerForNestedComponent(atmosConfig, component, stack, parentAuthMgr)
+		if err != nil {
+			log.Debug("Auth does not exist for nested component, using parent AuthManager",
+				"component", component,
+				"stack", stack,
+				"error", err,
+			)
+			resolvedAuthMgr = parentAuthMgr
+		}
 	}
 
 	// Derive the effective AuthContext for backend reads.
@@ -116,6 +127,7 @@ func GetTerraformState(
 		ProcessYamlFunctions: true,
 		Skip:                 nil,
 		AuthManager:          resolvedAuthMgr, // Use resolved AuthManager (may be component-specific or inherited)
+		AuthDisabled:         authDisabled,
 	})
 	if err != nil {
 		er := fmt.Errorf("%w `%s` in stack `%s`\nin YAML function: `%s`\n%v", errUtils.ErrDescribeComponent, component, stack, yamlFunc, err)

--- a/internal/exec/yaml_func_terraform_state.go
+++ b/internal/exec/yaml_func_terraform_state.go
@@ -113,6 +113,9 @@ func processTagTerraformStateWithContext(
 	if stackInfo != nil {
 		authContext = stackInfo.AuthContext
 		authManager = stackInfo.AuthManager
+		if authManager == nil && stackInfo.AuthDisabled {
+			authManager = &authContextWrapper{stackInfo: stackInfo}
+		}
 	}
 
 	value, err := stateGetter.GetState(atmosConfig, input, stack, component, output, false, authContext, authManager)

--- a/internal/exec/yaml_func_terraform_state.go
+++ b/internal/exec/yaml_func_terraform_state.go
@@ -81,7 +81,8 @@ func processTagTerraformStateWithContext(
 		component = strings.TrimSpace(parts[0])
 		stack = currentStack
 		output = strings.TrimSpace(parts[1])
-		log.Debug("Executing Atmos YAML function with component and output parameters; using current stack",
+		log.Debug(
+			"Executing Atmos YAML function with component and output parameters; using current stack",
 			"function", input,
 			"stack", currentStack,
 		)
@@ -122,7 +123,8 @@ func processTagTerraformStateWithContext(
 	if err != nil {
 		// Check if this is a recoverable error AND the expression has a YQ default.
 		if isRecoverableTerraformError(err) && hasYqDefault(output) {
-			log.Debug("Evaluating YQ default for recoverable error",
+			log.Debug(
+				"Evaluating YQ default for recoverable error",
 				"function", input,
 				"error", err.Error(),
 			)

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -50,7 +50,11 @@ type InstancesCommandOptions struct {
 	Delimiter   string
 	Query       string
 	AuthManager auth.AuthManager
-	OutputFile  string
+	// AuthDisabled is true when the caller explicitly used --identity=false.
+	// It prevents per-component auth auto-detection while still allowing
+	// templates and YAML functions that do not require credentials to run.
+	AuthDisabled bool
+	OutputFile   string
 	// ProcessTemplates toggles Go template processing of stack manifests
 	// (controls the `processTemplates` parameter of `ExecuteDescribeStacks`).
 	// Default true for parity with `describe affected` / `describe stacks`.
@@ -398,14 +402,31 @@ func processInstancesWithDeps(
 	authManager auth.AuthManager,
 	processTemplates, processYamlFunctions bool,
 ) ([]schema.Instance, error) {
-	stacksMap, err := stacksProcessor.ExecuteDescribeStacks(
-		atmosConfig, "", nil, nil, nil,
-		false, // ignoreMissingFiles
+	return processInstancesWithDepsAuthDisabled(
+		atmosConfig,
+		stacksProcessor,
+		authManager,
 		processTemplates,
 		processYamlFunctions,
-		false, // includeEmptyStacks
-		nil,   // skip
+		false,
+	)
+}
+
+//nolint:revive // Test seam mirrors processInstancesWithDeps with authDisabled passthrough.
+func processInstancesWithDepsAuthDisabled(
+	atmosConfig *schema.AtmosConfiguration,
+	stacksProcessor e.StacksProcessor,
+	authManager auth.AuthManager,
+	processTemplates, processYamlFunctions bool,
+	authDisabled bool,
+) ([]schema.Instance, error) {
+	stacksMap, err := executeDescribeStacksForInstances(
+		atmosConfig,
+		stacksProcessor,
 		authManager,
+		processTemplates,
+		processYamlFunctions,
+		authDisabled,
 	)
 	if err != nil {
 		log.Error(errUtils.ErrExecuteDescribeStacks.Error(), "error", err)
@@ -421,6 +442,57 @@ func processInstancesWithDeps(
 	return instances, nil
 }
 
+type authDisabledStacksProcessor interface {
+	ExecuteDescribeStacksWithAuthDisabled(
+		atmosConfig *schema.AtmosConfiguration,
+		filterByStack string,
+		components []string,
+		componentTypes []string,
+		sections []string,
+		ignoreMissingFiles bool,
+		processTemplates bool,
+		processYamlFunctions bool,
+		includeEmptyStacks bool,
+		skip []string,
+		authManager auth.AuthManager,
+		authDisabled bool,
+	) (map[string]any, error)
+}
+
+//nolint:revive // Helper mirrors the StacksProcessor call shape with authDisabled passthrough.
+func executeDescribeStacksForInstances(
+	atmosConfig *schema.AtmosConfiguration,
+	stacksProcessor e.StacksProcessor,
+	authManager auth.AuthManager,
+	processTemplates, processYamlFunctions bool,
+	authDisabled bool,
+) (map[string]any, error) {
+	if authDisabled {
+		if processor, ok := stacksProcessor.(authDisabledStacksProcessor); ok {
+			return processor.ExecuteDescribeStacksWithAuthDisabled(
+				atmosConfig, "", nil, nil, nil,
+				false,
+				processTemplates,
+				processYamlFunctions,
+				false,
+				nil,
+				authManager,
+				authDisabled,
+			)
+		}
+	}
+
+	return stacksProcessor.ExecuteDescribeStacks(
+		atmosConfig, "", nil, nil, nil,
+		false, // ignoreMissingFiles
+		processTemplates,
+		processYamlFunctions,
+		false, // includeEmptyStacks
+		nil,   // skip
+		authManager,
+	)
+}
+
 // processInstances collects, filters, and sorts instances.
 // This is a convenience wrapper around processInstancesWithDeps() for production use.
 func processInstances(
@@ -429,6 +501,22 @@ func processInstances(
 	processTemplates, processYamlFunctions bool,
 ) ([]schema.Instance, error) {
 	return processInstancesWithDeps(atmosConfig, &e.DefaultStacksProcessor{}, authManager, processTemplates, processYamlFunctions)
+}
+
+func processInstancesWithAuthDisabled(
+	atmosConfig *schema.AtmosConfiguration,
+	authManager auth.AuthManager,
+	processTemplates, processYamlFunctions bool,
+	authDisabled bool,
+) ([]schema.Instance, error) {
+	return processInstancesWithDepsAuthDisabled(
+		atmosConfig,
+		&e.DefaultStacksProcessor{},
+		authManager,
+		processTemplates,
+		processYamlFunctions,
+		authDisabled,
+	)
 }
 
 // ExecuteListInstancesCmd executes the list instances command.
@@ -490,7 +578,7 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 		// Honor the caller-supplied template/function flags so tree output is
 		// consistent with non-tree runs of the same command invocation, matching
 		// the behavior of `list stacks --format=tree`.
-		stacksMap, err := e.ExecuteDescribeStacks(
+		stacksMap, err := e.ExecuteDescribeStacksWithAuthDisabled(
 			&atmosConfig, "", nil, nil, nil,
 			false, // ignoreMissingFiles
 			opts.ProcessTemplates,
@@ -498,6 +586,7 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 			false, // includeEmptyStacks
 			nil,   // skip
 			opts.AuthManager,
+			opts.AuthDisabled,
 		)
 		if err != nil {
 			log.Error(errUtils.ErrExecuteDescribeStacks.Error(), "error", err)
@@ -517,7 +606,13 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 	}
 
 	// For non-tree formats, process instances normally.
-	instances, err := processInstances(&atmosConfig, opts.AuthManager, opts.ProcessTemplates, opts.ProcessFunctions)
+	instances, err := processInstancesWithAuthDisabled(
+		&atmosConfig,
+		opts.AuthManager,
+		opts.ProcessTemplates,
+		opts.ProcessFunctions,
+		opts.AuthDisabled,
+	)
 	if err != nil {
 		log.Error(errUtils.ErrProcessInstances.Error(), "error", err)
 		return errors.Join(errUtils.ErrProcessInstances, err)
@@ -629,7 +724,7 @@ func executeMatrixFormat(atmosConfig *schema.AtmosConfiguration, opts *Instances
 	// Get stacksMap to extract component_path from component_info. Honor the
 	// caller-supplied template/function flags so matrix output stays consistent
 	// with non-matrix runs of the same command invocation.
-	stacksMap, err := e.ExecuteDescribeStacks(
+	stacksMap, err := e.ExecuteDescribeStacksWithAuthDisabled(
 		atmosConfig, "", nil, nil, nil,
 		false, // ignoreMissingFiles
 		opts.ProcessTemplates,
@@ -637,6 +732,7 @@ func executeMatrixFormat(atmosConfig *schema.AtmosConfiguration, opts *Instances
 		false, // includeEmptyStacks
 		nil,   // skip
 		opts.AuthManager,
+		opts.AuthDisabled,
 	)
 	if err != nil {
 		log.Error(errUtils.ErrExecuteDescribeStacks.Error(), "error", err)

--- a/pkg/list/list_instances_authdisabled_test.go
+++ b/pkg/list/list_instances_authdisabled_test.go
@@ -1,0 +1,233 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/auth"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// authDisabledFakeProcessor is a hand-written test double that satisfies both
+// e.StacksProcessor and the unexported authDisabledStacksProcessor interface
+// declared in list_instances.go. We can't use the gomock-generated
+// MockStacksProcessor because it only models the StacksProcessor interface —
+// the auth-disabled method is only on DefaultStacksProcessor, not on the
+// public interface (by design: it's an optional capability discovered via
+// type assertion).
+type authDisabledFakeProcessor struct {
+	// Captured args from whichever method was invoked.
+	executeDescribeStacksCalled        bool
+	executeDescribeStacksAuthDisabled  bool
+	capturedProcessTemplates           bool
+	capturedProcessYamlFunctions       bool
+	capturedAuthDisabledMethodCallFlag bool // The authDisabled arg passed to the auth-disabled method.
+	returnStacks                       map[string]any
+	returnErr                          error
+}
+
+func (f *authDisabledFakeProcessor) ExecuteDescribeStacks(
+	_ *schema.AtmosConfiguration,
+	_ string,
+	_ []string,
+	_ []string,
+	_ []string,
+	_ bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	_ bool,
+	_ []string,
+	_ auth.AuthManager,
+) (map[string]any, error) {
+	f.executeDescribeStacksCalled = true
+	f.capturedProcessTemplates = processTemplates
+	f.capturedProcessYamlFunctions = processYamlFunctions
+	if f.returnStacks == nil {
+		return map[string]any{}, f.returnErr
+	}
+	return f.returnStacks, f.returnErr
+}
+
+func (f *authDisabledFakeProcessor) ExecuteDescribeStacksWithAuthDisabled(
+	_ *schema.AtmosConfiguration,
+	_ string,
+	_ []string,
+	_ []string,
+	_ []string,
+	_ bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	_ bool,
+	_ []string,
+	_ auth.AuthManager,
+	authDisabled bool,
+) (map[string]any, error) {
+	f.executeDescribeStacksAuthDisabled = true
+	f.capturedProcessTemplates = processTemplates
+	f.capturedProcessYamlFunctions = processYamlFunctions
+	f.capturedAuthDisabledMethodCallFlag = authDisabled
+	if f.returnStacks == nil {
+		return map[string]any{}, f.returnErr
+	}
+	return f.returnStacks, f.returnErr
+}
+
+// nonAuthDisabledFakeProcessor satisfies only e.StacksProcessor — used to prove
+// executeDescribeStacksForInstances falls back to ExecuteDescribeStacks when
+// the processor doesn't implement the optional auth-disabled interface, even
+// when authDisabled=true was requested by the caller.
+type nonAuthDisabledFakeProcessor struct {
+	called bool
+}
+
+func (f *nonAuthDisabledFakeProcessor) ExecuteDescribeStacks(
+	_ *schema.AtmosConfiguration,
+	_ string,
+	_ []string,
+	_ []string,
+	_ []string,
+	_ bool,
+	_ bool,
+	_ bool,
+	_ bool,
+	_ []string,
+	_ auth.AuthManager,
+) (map[string]any, error) {
+	f.called = true
+	return map[string]any{}, nil
+}
+
+// TestExecuteDescribeStacksForInstances_AuthDisabledDispatchesToAuthDisabledMethod
+// is the regression guard for the optional-interface dispatch in
+// executeDescribeStacksForInstances: when authDisabled=true AND the processor
+// implements authDisabledStacksProcessor, the auth-disabled method must be
+// invoked (so per-component auth is short-circuited downstream).
+func TestExecuteDescribeStacksForInstances_AuthDisabledDispatchesToAuthDisabledMethod(t *testing.T) {
+	fake := &authDisabledFakeProcessor{}
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	result, err := executeDescribeStacksForInstances(
+		atmosConfig,
+		fake,
+		nil,  // authManager
+		true, // processTemplates
+		true, // processYamlFunctions
+		true, // authDisabled — the bit under test.
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, fake.executeDescribeStacksAuthDisabled,
+		"authDisabled=true with a capable processor MUST call ExecuteDescribeStacksWithAuthDisabled")
+	assert.False(t, fake.executeDescribeStacksCalled,
+		"the regular ExecuteDescribeStacks must NOT be called when the auth-disabled path is taken")
+	assert.True(t, fake.capturedAuthDisabledMethodCallFlag,
+		"the authDisabled flag must be forwarded into the auth-disabled method")
+	assert.True(t, fake.capturedProcessTemplates)
+	assert.True(t, fake.capturedProcessYamlFunctions)
+}
+
+// TestExecuteDescribeStacksForInstances_AuthDisabledFalseUsesRegularPath
+// proves the regular ExecuteDescribeStacks is still chosen when authDisabled
+// is false, even if the processor implements the optional interface. This
+// matches the behavior list instances had before --identity=false existed.
+func TestExecuteDescribeStacksForInstances_AuthDisabledFalseUsesRegularPath(t *testing.T) {
+	fake := &authDisabledFakeProcessor{}
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	_, err := executeDescribeStacksForInstances(
+		atmosConfig,
+		fake,
+		nil,
+		true,
+		false,
+		false, // authDisabled=false — regular path expected.
+	)
+	require.NoError(t, err)
+	assert.True(t, fake.executeDescribeStacksCalled,
+		"authDisabled=false MUST call ExecuteDescribeStacks")
+	assert.False(t, fake.executeDescribeStacksAuthDisabled,
+		"the auth-disabled method must NOT be called when authDisabled=false")
+}
+
+// TestExecuteDescribeStacksForInstances_FallsBackWhenInterfaceNotImplemented
+// is the safety-net guard: even with authDisabled=true, a processor that
+// doesn't implement authDisabledStacksProcessor must fall back to the
+// regular ExecuteDescribeStacks rather than panic on a failed type assertion.
+func TestExecuteDescribeStacksForInstances_FallsBackWhenInterfaceNotImplemented(t *testing.T) {
+	fake := &nonAuthDisabledFakeProcessor{}
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	_, err := executeDescribeStacksForInstances(
+		atmosConfig,
+		fake,
+		nil,
+		false,
+		false,
+		true, // authDisabled=true but processor doesn't implement the optional interface.
+	)
+	require.NoError(t, err)
+	assert.True(t, fake.called,
+		"a processor that doesn't implement authDisabledStacksProcessor must still be called via the regular path")
+}
+
+// TestProcessInstancesWithDepsAuthDisabled_PropagatesAuthDisabledFlag verifies
+// the test seam: processInstancesWithDepsAuthDisabled must reach the
+// auth-disabled method on a capable processor and surface no error. The
+// previous TestProcessInstancesWithDeps_* coverage hit the authDisabled=false
+// path implicitly; this test pins authDisabled=true → auth-disabled method.
+func TestProcessInstancesWithDepsAuthDisabled_PropagatesAuthDisabledFlag(t *testing.T) {
+	fake := &authDisabledFakeProcessor{
+		returnStacks: map[string]any{
+			"dev": map[string]any{
+				"components": map[string]any{
+					"terraform": map[string]any{
+						"vpc": map[string]any{
+							"metadata": map[string]any{"type": "real"},
+							"vars":     map[string]any{"region": "us-east-1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	instances, err := processInstancesWithDepsAuthDisabled(
+		atmosConfig,
+		fake,
+		nil,
+		true,
+		false,
+		true, // authDisabled
+	)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, "vpc", instances[0].Component)
+	assert.Equal(t, "dev", instances[0].Stack)
+	assert.True(t, fake.executeDescribeStacksAuthDisabled,
+		"authDisabled=true must route through the auth-disabled method")
+}
+
+// TestProcessInstancesWithAuthDisabled_ConstructsDefaultProcessor is a smoke
+// test for the production wrapper: it must construct a DefaultStacksProcessor
+// and not error when there are no stacks. The function is small but it's the
+// path the CLI actually takes, so a smoke test catches a future signature
+// drift between wrapper and helper.
+func TestProcessInstancesWithAuthDisabled_ConstructsDefaultProcessor(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	instances, err := processInstancesWithAuthDisabled(
+		atmosConfig,
+		nil,
+		false,
+		false,
+		true,
+	)
+	// With no stacks configured, ExecuteDescribeStacksWithAuthDisabled returns
+	// an empty map; the upstream collector then returns an empty slice. The
+	// important assertion is that the wrapper plumbs through cleanly.
+	require.NoError(t, err)
+	assert.Empty(t, instances)
+}

--- a/pkg/list/list_instances_authdisabled_test.go
+++ b/pkg/list/list_instances_authdisabled_test.go
@@ -215,8 +215,25 @@ func TestProcessInstancesWithDepsAuthDisabled_PropagatesAuthDisabledFlag(t *test
 // and not error when there are no stacks. The function is small but it's the
 // path the CLI actually takes, so a smoke test catches a future signature
 // drift between wrapper and helper.
+//
+// Anchoring BasePath/Stacks.BasePath/Components.Terraform.BasePath to a
+// per-test temp directory makes the assertion CWD-independent. With an empty
+// AtmosConfiguration the underlying FindStacksMap resolves CWD-relative empty
+// paths, which is the kind of ambient-state dependency CLAUDE.md flags. This
+// mirrors the convention in TestDefaultStacksProcessor_ExecuteDescribeStacks.
 func TestProcessInstancesWithAuthDisabled_ConstructsDefaultProcessor(t *testing.T) {
-	atmosConfig := &schema.AtmosConfiguration{}
+	testDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath: testDir,
+		Stacks: schema.Stacks{
+			BasePath: "stacks",
+		},
+		Components: schema.Components{
+			Terraform: schema.Terraform{
+				BasePath: "components/terraform",
+			},
+		},
+	}
 
 	instances, err := processInstancesWithAuthDisabled(
 		atmosConfig,

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1014,6 +1014,7 @@ type ConfigAndStacksInfo struct {
 	//   - This would create: schema → auth → schema (circular dependency error)
 	//   - Type assertions are used at usage sites to recover type safety
 	AuthManager          any
+	AuthDisabled         bool
 	ComponentBackendType string
 	// RequiredVersion is the Terraform version constraint (e.g., ">= 1.10.1").
 	// This is extracted from terraform.required_version or components.terraform.<name>.required_version.


### PR DESCRIPTION
## what

- Normalize boolean-false values (`false`, `0`, `no`, `off`, case-insensitive) passed via `--identity=<value>` and `--identity <value>` to the disabled sentinel (`cfg.IdentityFlagDisabledValue`), so the auth pre-hook and `CreateAndAuthenticateManager*` short-circuit instead of trying to authenticate with the literal name `"false"`.
- Patch is in `internal/exec/cli_utils.go::parseIdentityFlag` — the single arg-walker that feeds `info.Identity` / `configAndStacksInfo.Identity` for every `ProcessCommandLineArgs` consumer (terraform, helmfile, packer, list, describe, workflow, vendor, pro, validate, atlantis, docs, generate).
- Add parser-level unit cases in `TestParseIdentityFlag` for `=false` / `=False` / `=FALSE` / `=0` / `=no` / `=off` plus space-separated form, and end-to-end cases in `TestProcessArgsAndFlags_IdentityFlag{,Helmfile,Packer}` asserting `info.Identity == cfg.IdentityFlagDisabledValue`.

## why

- Regression: `ATMOS_IDENTITY=false` was fixed in #1935 by normalizing the env-var fallback at `cli_utils.go:199`, but the env fallback only runs when `Identity == ""`. When `--identity=false` is passed on the CLI, `parseIdentityFlag` populated the literal `"false"`, the env-fallback branch was skipped, and the literal flowed through to `pkg/auth/hooks.go::isAuthenticationDisabled` (which only matches `__DISABLED__`).
- #2225 extracted `parseIdentityFlag` into a new helper without porting the normalization from the env path, silently breaking the documented `--identity=false` contract. Reported by users for `atmos terraform *` and `atmos list instances`.
- Centralizing normalization at the parse site means every command sharing `ProcessCommandLineArgs` is fixed in one place, and matches the behavior already implemented for the StandardParser path (`pkg/flags/global_registry.go`) and the `cmd/identity_helpers.go` / `cmd/list/utils.go` / `cmd/list/affected.go` per-command identity reads.

## references

- Builds on #1900 / #1935 (env-var normalization) and corrects the regression introduced by the refactor in #2225.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The --identity flag now recognizes common boolean-false values (false, 0, no, off, case-insensitive) to disable authentication.

* **New Features**
  * Passing --identity=false (or equivalent) disables per-component auth resolution and is honored across describe, list, and state-resolution flows.
  * Describe and list commands now surface and propagate an "auth disabled" option so outputs respect disabled auth.

* **Tests**
  * Expanded tests for identity parsing and auth-disabled behavior across commands, env vars, and execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->