### PR TITLE
fix(list): make `list components` output deterministic across runs

### DIFF
--- a/pkg/list/extract/components.go
+++ b/pkg/list/extract/components.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"sort"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	perf "github.com/cloudposse/atmos/pkg/perf"
@@ -203,7 +204,19 @@ func UniqueComponents(stacksMap map[string]any, stackPattern string) ([]map[stri
 	// Key: "componentName:componentType" (e.g., "vpc:terraform").
 	seen := make(map[string]map[string]any)
 
-	for stackName, stackData := range stacksMap {
+	// Iterate stacks in sorted order so the aggregated component state
+	// (especially metadata fields taken from the first occurrence) is
+	// deterministic. Go map iteration order is randomized; without this,
+	// `--enabled=false` would return inconsistent results across runs
+	// when a component is defined in multiple stacks (issue #2359).
+	stackNames := make([]string, 0, len(stacksMap))
+	for name := range stacksMap {
+		stackNames = append(stackNames, name)
+	}
+	sort.Strings(stackNames)
+
+	for _, stackName := range stackNames {
+		stackData := stacksMap[stackName]
 		// Apply stack filter if provided.
 		if stackPattern != "" {
 			// Stack names are slash-separated; normalize for cross-platform matching.
@@ -232,10 +245,16 @@ func UniqueComponents(stacksMap map[string]any, stackPattern string) ([]map[stri
 		extractUniqueComponentType("packer", componentsMap, seen)
 	}
 
-	// Convert map to slice.
-	var components []map[string]any
-	for _, comp := range seen {
-		components = append(components, comp)
+	// Convert map to slice in deterministic order, sorted by the
+	// "componentName:componentType" key.
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	components := make([]map[string]any, 0, len(seen))
+	for _, k := range keys {
+		components = append(components, seen[k])
 	}
 
 	return components, nil
@@ -248,10 +267,18 @@ func extractUniqueComponentType(componentType string, componentsMap map[string]a
 		return
 	}
 
-	for componentName, componentData := range typeComponents {
+	// Iterate component names in sorted order so the first-occurrence
+	// metadata (component_folder, vars, etc.) is deterministic.
+	names := make([]string, 0, len(typeComponents))
+	for name := range typeComponents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, componentName := range names {
+		componentData := typeComponents[componentName]
 		key := componentName + ":" + componentType
 
-		// If we haven't seen this component, add it.
 		if _, exists := seen[key]; !exists {
 			comp := map[string]any{
 				fieldComponent: componentName,
@@ -262,6 +289,10 @@ func extractUniqueComponentType(componentType string, componentsMap map[string]a
 			// Extract metadata from first occurrence.
 			enrichUniqueComponentMetadata(comp, componentData)
 			seen[key] = comp
+		} else {
+			// Merge enabled/locked across instances so the aggregate
+			// reflects every stack, not just the first one iterated.
+			updateAggregatedState(seen[key], componentData)
 		}
 
 		// Increment stack count.
@@ -269,6 +300,44 @@ func extractUniqueComponentType(componentType string, componentsMap map[string]a
 			seen[key]["stack_count"] = count + 1
 		}
 	}
+}
+
+// updateAggregatedState merges the enabled/locked state of an additional
+// component instance into the unique component aggregate.
+//
+// Policy:
+//   - enabled: any-disabled-wins. If any stack instance has enabled=false,
+//     the unique component is reported as disabled. This makes
+//     `atmos list components --enabled=false` surface every component that
+//     is disabled somewhere, matching user expectations from issue #2359.
+//   - locked: any-locked-wins. If any stack instance has locked=true, the
+//     unique component is reported as locked.
+//
+// status/status_text are recomputed from the resulting aggregated state.
+func updateAggregatedState(comp map[string]any, componentData any) {
+	compMap, ok := componentData.(map[string]any)
+	if !ok {
+		return
+	}
+
+	metadata, hasMetadata := compMap[fieldMetadata].(map[string]any)
+	// Without metadata, the instance is enabled=true, locked=false by
+	// default — neither weakens an existing aggregate, so nothing to do.
+	if !hasMetadata {
+		return
+	}
+
+	if instanceEnabled := getBoolWithDefault(metadata, metadataEnabled, true); !instanceEnabled {
+		comp[metadataEnabled] = false
+	}
+	if instanceLocked := getBoolWithDefault(metadata, metadataLocked, false); instanceLocked {
+		comp[metadataLocked] = true
+	}
+
+	aggEnabled, _ := comp[metadataEnabled].(bool)
+	aggLocked, _ := comp[metadataLocked].(bool)
+	comp["status"] = getStatusIndicator(aggEnabled, aggLocked)
+	comp["status_text"] = getStatusText(aggEnabled, aggLocked)
 }
 
 // enrichUniqueComponentMetadata adds metadata fields to a unique component.

--- a/pkg/list/extract/components_test.go
+++ b/pkg/list/extract/components_test.go
@@ -673,6 +673,172 @@ func TestBuildBaseComponent(t *testing.T) {
 	assert.Equal(t, "terraform", comp["type"])
 }
 
+// TestUniqueComponents_EnabledFieldDeterministic_Issue2359 reproduces
+// https://github.com/cloudposse/atmos/issues/2359. When the same component
+// has different `enabled` values across stacks, UniqueComponents must
+// return a deterministic `enabled` value. Currently it records metadata
+// only from the first stack iterated (in extractUniqueComponentType, see
+// components.go:251-271), and Go map iteration order is randomized — so
+// the result varies between runs. This causes `atmos list components
+// --enabled=false` to return different content on every invocation.
+func TestUniqueComponents_EnabledFieldDeterministic_Issue2359(t *testing.T) {
+	// vpc is disabled in two stacks and enabled in a third.
+	// Whichever stack iterates first determines the reported `enabled`.
+	stacksMap := map[string]any{
+		"stack-a-disabled": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"metadata": map[string]any{"enabled": false},
+					},
+				},
+			},
+		},
+		"stack-b-disabled": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"metadata": map[string]any{"enabled": false},
+					},
+				},
+			},
+		},
+		"stack-c-enabled": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"metadata": map[string]any{"enabled": true},
+					},
+				},
+			},
+		},
+	}
+
+	const iterations = 200
+	seenEnabled := make(map[bool]int)
+	for i := 0; i < iterations; i++ {
+		components, err := UniqueComponents(stacksMap, "")
+		require.NoError(t, err)
+		require.Len(t, components, 1)
+		enabled, ok := components[0]["enabled"].(bool)
+		require.True(t, ok, "enabled field missing or not bool")
+		seenEnabled[enabled]++
+	}
+
+	// With the pre-fix code, both true and false appeared across iterations
+	// because Go map iteration order is randomized. Post-fix, the value must
+	// be deterministic (only one key in the map).
+	assert.Lenf(t, seenEnabled, 1,
+		"issue #2359: enabled field is non-deterministic across runs — "+
+			"saw distribution %v over %d iterations",
+		seenEnabled, iterations)
+
+	// Fix policy: any-disabled-wins. vpc is disabled in at least one stack,
+	// so the aggregate must be disabled regardless of iteration order.
+	assert.Equal(t, 200, seenEnabled[false],
+		"issue #2359: when any instance is disabled, the unique component "+
+			"must be reported as disabled (any-disabled-wins)")
+}
+
+// TestUniqueComponents_AnyDisabledWins verifies the aggregation policy:
+// when a component is enabled in some stacks and disabled in others, the
+// unique component is reported as disabled so it appears under
+// `atmos list components --enabled=false`.
+func TestUniqueComponents_AnyDisabledWins(t *testing.T) {
+	stacksMap := map[string]any{
+		"stack-1": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"metadata": map[string]any{"enabled": true},
+					},
+					"eks": map[string]any{
+						"metadata": map[string]any{"enabled": true, "locked": true},
+					},
+				},
+			},
+		},
+		"stack-2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"vpc": map[string]any{
+						"metadata": map[string]any{"enabled": false},
+					},
+					"eks": map[string]any{
+						"metadata": map[string]any{"enabled": true, "locked": false},
+					},
+				},
+			},
+		},
+	}
+
+	components, err := UniqueComponents(stacksMap, "")
+	require.NoError(t, err)
+	require.Len(t, components, 2)
+
+	byName := make(map[string]map[string]any, len(components))
+	for _, c := range components {
+		byName[c["component"].(string)] = c
+	}
+
+	// vpc: enabled in stack-1, disabled in stack-2 → aggregate disabled.
+	require.Contains(t, byName, "vpc")
+	assert.Equal(t, false, byName["vpc"]["enabled"])
+	assert.Equal(t, "disabled", byName["vpc"]["status_text"])
+	assert.Equal(t, 2, byName["vpc"]["stack_count"])
+
+	// eks: enabled in both; locked in stack-1, unlocked in stack-2 → aggregate locked.
+	require.Contains(t, byName, "eks")
+	assert.Equal(t, true, byName["eks"]["enabled"])
+	assert.Equal(t, true, byName["eks"]["locked"])
+	assert.Equal(t, "locked", byName["eks"]["status_text"])
+	assert.Equal(t, 2, byName["eks"]["stack_count"])
+}
+
+// TestUniqueComponents_DeterministicOrder verifies that the output slice
+// itself is returned in a stable order across runs, not just that the
+// per-component metadata is stable.
+func TestUniqueComponents_DeterministicOrder(t *testing.T) {
+	stacksMap := map[string]any{
+		"stack-a": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"zebra": map[string]any{},
+					"alpha": map[string]any{},
+					"mango": map[string]any{},
+				},
+				"helmfile": map[string]any{
+					"alpha": map[string]any{},
+				},
+			},
+		},
+		"stack-b": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"alpha": map[string]any{},
+				},
+			},
+		},
+	}
+
+	var first []string
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		components, err := UniqueComponents(stacksMap, "")
+		require.NoError(t, err)
+		names := make([]string, len(components))
+		for j, c := range components {
+			names[j] = c["component"].(string) + ":" + c["type"].(string)
+		}
+		if i == 0 {
+			first = names
+			continue
+		}
+		require.Equal(t, first, names,
+			"issue #2359: UniqueComponents output order must be deterministic")
+	}
+}
+
 // Test extractUniqueComponentType function.
 func TestExtractUniqueComponentType(t *testing.T) {
 	seen := make(map[string]map[string]any)

--- a/website/docs/cli/commands/list/list-components.mdx
+++ b/website/docs/cli/commands/list/list-components.mdx
@@ -159,10 +159,10 @@ This means you can write simple `select()` expressions without worrying about th
   <dd>Include abstract components in output. Equivalent to `--type all`.<br/>Environment variable: `ATMOS_ABSTRACT`</dd>
 
   <dt>`--enabled`</dt>
-  <dd>Filter by enabled status (omit for all, `--enabled=true` for enabled only, `--enabled=false` for disabled only).<br/>Environment variable: `ATMOS_COMPONENT_ENABLED`</dd>
+  <dd>Filter by enabled status (omit for all, `--enabled=true` for enabled only, `--enabled=false` for disabled only). Because `list components` returns each component deduplicated across stacks, a component is reported as `enabled=false` if it is disabled in **any** of its stack instances. To see per-stack-instance state, use [`atmos list instances`](/cli/commands/list/list-instances).<br/>Environment variable: `ATMOS_COMPONENT_ENABLED`</dd>
 
   <dt>`--locked`</dt>
-  <dd>Filter by locked status (omit for all, `--locked=true` for locked only, `--locked=false` for unlocked only).<br/>Environment variable: `ATMOS_COMPONENT_LOCKED`</dd>
+  <dd>Filter by locked status (omit for all, `--locked=true` for locked only, `--locked=false` for unlocked only). A deduplicated component is reported as `locked=true` if it is locked in **any** of its stack instances. Use [`atmos list instances`](/cli/commands/list/list-instances) for per-stack-instance state.<br/>Environment variable: `ATMOS_COMPONENT_LOCKED`</dd>
 
   <dt>`--sort`</dt>
   <dd>Sort by column:order (e.g., `component:asc,stack:desc`). Multiple sort columns separated by comma.<br/>Environment variable: `ATMOS_LIST_SORT`</dd>


### PR DESCRIPTION
## what

- `atmos list components` (and especially `--enabled=false` / `--locked=true`) now returns deterministic, consistent results across invocations on the same workspace.
- Aggregate per-stack `enabled`/`locked` state into the deduplicated component view: **any-disabled-wins** for `enabled`, **any-locked-wins** for `locked`. `status` / `status_text` are recomputed from the aggregate.
- Sort stack names, component names, and the output slice so iteration order no longer depends on Go's randomized map iteration.
- Documentation for `--enabled` / `--locked` now describes the cross-stack aggregation semantics and points at `atmos list instances` for per-stack-instance state.
- Adds regression tests in `pkg/list/extract/`: a 200-iteration determinism test for `--enabled=false`, an aggregation-policy test for `enabled`/`locked`, and an output-order stability test.

## why

- Reported in #2359: running `atmos list components --enabled=false` repeatedly produced different output every time — sometimes empty, sometimes 1 component, sometimes 2 or 3 *different* components — with no changes to the workspace.
- Root cause: `extractUniqueComponentType` in `pkg/list/extract/components.go` extracted metadata only from the *first* stack iterated for each component, and `UniqueComponents` iterated `stacksMap` (a Go map) in randomized order. When the same component had `enabled: false` in some stacks and `enabled: true` in others, the recorded value depended on iteration order — so `BoolFilter.Apply` would include or exclude the component non-deterministically.
- Sorting alone would have made the output stable but not necessarily *correct* for users with mixed-state components; the aggregation policy ensures a component disabled anywhere shows up under `--enabled=false`, which matches the user's expected behavior in the issue.

## references

- closes #2359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved non-deterministic output in `list components` command; results now consistent across invocations.
  * Adjusted `--enabled` and `--locked` flags to aggregate state across stack instances: a component is shown as disabled/locked if any instance has that state.

* **Documentation**
  * Clarified `list components` flag behavior for cross-stack aggregation reporting.

* **Tests**
  * Added regression test coverage for deterministic component aggregation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->