### PR TITLE
feat(toolchain): default UseLockFile to true (reproducible builds by default)

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -500,6 +500,11 @@ func setDefaultConfiguration(v *viper.Viper) {
 	// Atmos Pro defaults
 	v.SetDefault("settings.pro.base_url", AtmosProDefaultBaseUrl)
 	v.SetDefault("settings.pro.endpoint", AtmosProDefaultEndpoint)
+
+	// Toolchain lockfile enabled by default — reproducible builds are the whole point.
+	// Users who want the old "re-resolve every time" behavior set use_lock_file: false
+	// or pass `--no-lockfile` on the CLI.
+	v.SetDefault("toolchain.use_lock_file", true)
 }
 
 // loadConfigSources loads configuration from multiple sources in priority order,

--- a/pkg/config/load_toolchain_defaults_test.go
+++ b/pkg/config/load_toolchain_defaults_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestToolchainUseLockFileDefault locks in the contract that toolchain.use_lock_file
+// defaults to true (reproducible builds are the default behavior). A regression that
+// flipped the default to false would silently degrade every install to "re-resolve
+// from the registry every run with no checksum verification" — exactly what the
+// lockfile feature exists to prevent.
+func TestToolchainUseLockFileDefault(t *testing.T) {
+	v := viper.New()
+	setDefaultConfiguration(v)
+	assert.True(t, v.GetBool("toolchain.use_lock_file"),
+		"toolchain.use_lock_file must default to true so reproducible builds are the default")
+}
+
+// TestToolchainUseLockFileExplicitFalse verifies that an explicit `false` from config
+// wins over the default — users can opt out via `toolchain.use_lock_file: false` in
+// atmos.yaml or `ATMOS_TOOLCHAIN_USE_LOCK_FILE=false` if they want the old behavior.
+func TestToolchainUseLockFileExplicitFalse(t *testing.T) {
+	v := viper.New()
+	setDefaultConfiguration(v)
+	v.Set("toolchain.use_lock_file", false)
+	assert.False(t, v.GetBool("toolchain.use_lock_file"),
+		"an explicit false from config must override the default true")
+}


### PR DESCRIPTION
## what

Adds a Viper default for `toolchain.use_lock_file: true`.

Before this change, the lockfile was opt-in via explicit config — every fresh `atmos toolchain install` re-resolved tools from the upstream registry, with no checksum verification, no cross-OS reproducibility, no lockfile generation. That silent fallback defeats the entire reason the lockfile feature exists.

With this default:
- `atmos toolchain install` uses the lockfile whenever one exists
- A lockfile gets written when one doesn't exist (upcoming PRs)
- Reproducible-by-default

Users who want the old re-resolve-every-time behavior opt out explicitly via:

```yaml
toolchain:
  use_lock_file: false
```

or `ATMOS_TOOLCHAIN_USE_LOCK_FILE=false`, or (when it lands) `--no-lockfile` on the CLI.

## tests

- `TestToolchainUseLockFileDefault` — locks in the polarity (a regression that flipped this to false would silently degrade every install).
- `TestToolchainUseLockFileExplicitFalse` — verifies the opt-out path still works (user-provided false beats the default true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
