### PR TITLE
fix(ci): fire CI hooks per-component in --all / --query plan mode (#2…

### DIFF
--- a/cmd/terraform/plan.go
+++ b/cmd/terraform/plan.go
@@ -36,13 +36,18 @@ For complete Terraform/OpenTofu documentation, see:
 		return runHooks(h.BeforeTerraformPlan, cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (runErr error) {
-		// Reset captured output for this run.
+		// Reset per-run globals. Both must be initialised before any early return
+		// so that the deferred hook and PostRunE read consistent state even when
+		// terraformRunWithOptions exits before reaching its routing block.
 		capturedPlanOutput = ""
+		wasMultiComponentExecution = false
 
 		// On failure, run after hooks with error context so CI check runs
 		// are updated to failure status. Cobra skips PostRunE on error.
+		// In multi-component mode the per-component hook already fired for each
+		// component, so the global error call is suppressed to avoid double-firing.
 		defer func() {
-			if runErr != nil {
+			if runErr != nil && !wasMultiComponentExecution {
 				runHooksOnErrorWithOutput(h.AfterTerraformPlan, cmd, args, runErr, capturedPlanOutput)
 			}
 		}()
@@ -101,6 +106,14 @@ For complete Terraform/OpenTofu documentation, see:
 		return err
 	},
 	PostRunE: func(cmd *cobra.Command, args []string) error {
+		// In multi-component mode, CI hooks already fired per-component inside
+		// ExecuteTerraformQuery. Calling them again here would either double-fire
+		// on the last component or fire with empty/misattributed output.
+		// User-defined hooks (hooks.RunAll) are not per-component-aware today, so
+		// suppress the entire PostRunE block to avoid confusion until that is fixed.
+		if wasMultiComponentExecution {
+			return nil
+		}
 		return runHooksWithOutput(h.AfterTerraformPlan, cmd, args, capturedPlanOutput)
 	},
 }

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudposse/atmos/cmd/terraform/shared"
 	errUtils "github.com/cloudposse/atmos/errors"
 	e "github.com/cloudposse/atmos/internal/exec"
+	"github.com/cloudposse/atmos/pkg/ansi"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/ci/plugins/terraform/planfile"
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -26,6 +27,11 @@ import (
 
 // errWrapFormat is the format string for wrapping errors with a cause.
 const errWrapFormat = "%w: %w"
+
+// wasMultiComponentExecution records whether the most recent terraformRunWithOptions call
+// was routed to ExecuteTerraformQuery. Read in plan.go PostRunE to suppress the global
+// CI hook call when per-component hooks already fired inside the component walker.
+var wasMultiComponentExecution bool
 
 func runHooks(event h.HookEvent, cmd_ *cobra.Command, args []string) error {
 	return runHooksWithOutput(event, cmd_, args, "")
@@ -181,6 +187,35 @@ func runCIHooksForDeploy(event h.HookEvent, cmd_ *cobra.Command, _ []string, inf
 		ForceCIMode: forceCIMode,
 	}); err != nil {
 		log.Warn("CI hook execution failed", "error", err)
+	}
+}
+
+// runCIHooksForPlanComponent fires CI hooks for a single component after it completes
+// in multi-component mode. Uses already-resolved info to avoid a second
+// ProcessCommandLineArgs call (same pattern as runCIHooksForDeploy).
+// rawOutput is the combined stdout+stderr from that component; ANSI codes are stripped here.
+func runCIHooksForPlanComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
+	atmosConfig, err := cfg.InitCliConfig(*info, true)
+	if err != nil {
+		log.Warn("CI hook config init failed", "component", info.Component, "error", err)
+		return
+	}
+
+	forceCIMode, _ := actualCmd.Flags().GetBool("ci")
+	if !forceCIMode {
+		forceCIMode = viper.GetBool("ci")
+	}
+
+	if err := h.RunCIHooks(&h.RunCIHooksOptions{
+		Event:        h.AfterTerraformPlan,
+		AtmosConfig:  &atmosConfig,
+		Info:         info,
+		Output:       ansi.Strip(rawOutput),
+		ForceCIMode:  forceCIMode,
+		CommandError: execErr,
+		ExitCode:     errUtils.GetExitCode(execErr),
+	}); err != nil {
+		log.Warn("CI hook execution failed", "component", info.Component, "error", err)
 	}
 }
 
@@ -406,12 +441,22 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 
 	// Route to appropriate execution path.
 	if info.Affected {
+		wasMultiComponentExecution = false
 		return executeAffectedCommand(parentCmd, args, &info)
 	}
 	if isMultiComponentExecution(&info) {
+		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
+		// Wire per-component CI hooks for plan so each component gets its own
+		// summary entry instead of a single misattributed global call in PostRunE.
+		if subCommand == "plan" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+			}
+		}
 		return e.ExecuteTerraformQuery(&info)
 	}
+	wasMultiComponentExecution = false
 
 	// Verify stored planfile matches current state before deploying.
 	if subCommand == "deploy" && info.VerifyPlan {

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -126,3 +126,25 @@ func TestRunCIHooksForDeploy_DemoStacks(t *testing.T) {
 	// construction path with a wired info struct.
 	runCIHooksForDeploy(hooks.BeforeTerraformDeploy, cmd, []string{"myapp"}, info, "")
 }
+
+// TestRunCIHooksForPlanComponent_DemoStacks exercises the per-component plan
+// CI hook wrapper introduced by issue #2397. The demo-stacks fixture has
+// ci.enabled=false so RunCIHooks short-circuits cleanly — the test verifies
+// no panic on option construction for both the success and failure paths.
+func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	// Success path: execErr is nil, exit code forwarded as 0.
+	runCIHooksForPlanComponent(cmd, info, "plan output", nil)
+
+	// Failure path: non-nil execErr is forwarded with its exit code.
+	runCIHooksForPlanComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+}

--- a/internal/exec/terraform_executor.go
+++ b/internal/exec/terraform_executor.go
@@ -13,6 +13,10 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
+// execTerraformFn is the function used to execute a Terraform command.
+// Package-level variable to allow test injection without gomonkey.
+var execTerraformFn = ExecuteTerraform
+
 // executeTerraformForNode executes terraform for a single dependency graph node.
 func executeTerraformForNode(
 	node *dependency.Node,
@@ -124,7 +128,7 @@ func executeNodeCommand(node *dependency.Node, info *schema.ConfigAndStacksInfo)
 	// its own CI summary entry rather than sharing the final global call.
 	if info.PerComponentHook != nil {
 		var stdoutBuf, stderrBuf bytes.Buffer
-		execErr := ExecuteTerraform(*info, WithStdoutCapture(&stdoutBuf), WithStderrCapture(&stderrBuf))
+		execErr := execTerraformFn(*info, WithStdoutCapture(&stdoutBuf), WithStderrCapture(&stderrBuf))
 		combined := stdoutBuf.String()
 		if s := stderrBuf.String(); s != "" {
 			combined += "\n" + s
@@ -138,7 +142,7 @@ func executeNodeCommand(node *dependency.Node, info *schema.ConfigAndStacksInfo)
 	}
 
 	// Execute the terraform command.
-	if err := ExecuteTerraform(*info); err != nil {
+	if err := execTerraformFn(*info); err != nil {
 		return fmt.Errorf("%w: %w", errUtils.ErrTerraformExecFailed, err)
 	}
 

--- a/internal/exec/terraform_executor.go
+++ b/internal/exec/terraform_executor.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"fmt"
 
 	log "github.com/charmbracelet/log"
@@ -117,6 +118,24 @@ func executeNodeCommand(node *dependency.Node, info *schema.ConfigAndStacksInfo)
 	}
 
 	log.Debug("Executing", "command", command)
+
+	// When a per-component hook is registered, capture this component's output
+	// and invoke the hook immediately after execution so each component receives
+	// its own CI summary entry rather than sharing the final global call.
+	if info.PerComponentHook != nil {
+		var stdoutBuf, stderrBuf bytes.Buffer
+		execErr := ExecuteTerraform(*info, WithStdoutCapture(&stdoutBuf), WithStderrCapture(&stderrBuf))
+		combined := stdoutBuf.String()
+		if s := stderrBuf.String(); s != "" {
+			combined += "\n" + s
+		}
+		compInfo := *info // snapshot with this component's Component/Stack values set.
+		info.PerComponentHook(&compInfo, combined, execErr)
+		if execErr != nil {
+			return fmt.Errorf("%w: %w", errUtils.ErrTerraformExecFailed, execErr)
+		}
+		return nil
+	}
 
 	// Execute the terraform command.
 	if err := ExecuteTerraform(*info); err != nil {

--- a/internal/exec/terraform_executor_test.go
+++ b/internal/exec/terraform_executor_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -157,4 +158,39 @@ func TestExecuteTerraformForNode_DryRun(t *testing.T) {
 	// Verify info was updated.
 	assert.Equal(t, "vpc", info.Component)
 	assert.Equal(t, "dev", info.Stack)
+}
+
+func TestExecuteNodeCommand_PerComponentHook(t *testing.T) {
+	node := &dependency.Node{
+		ID: "vpc-dev", Component: "vpc", Stack: "dev",
+		Metadata: map[string]any{},
+	}
+
+	hookCalled := false
+	var hookComponent, hookStack string
+	var hookErr error
+
+	// Mirror what executeTerraformForNode does via updateInfoFromNode so that
+	// compInfo snapshot contains the expected component and stack values.
+	info := &schema.ConfigAndStacksInfo{
+		SubCommand: "plan",
+		Component:  "vpc",
+		Stack:      "dev",
+		PerComponentHook: func(ci *schema.ConfigAndStacksInfo, output string, execErr error) {
+			hookCalled = true
+			hookComponent = ci.Component
+			hookStack = ci.Stack
+			hookErr = execErr
+		},
+	}
+
+	// ExecuteTerraform will fail (no valid stack config in the test environment),
+	// but the hook fires before the error is propagated — that is the contract under test.
+	err := executeNodeCommand(node, info)
+
+	assert.True(t, hookCalled, "hook must fire even when ExecuteTerraform fails")
+	assert.Equal(t, "vpc", hookComponent)
+	assert.Equal(t, "dev", hookStack)
+	assert.Error(t, hookErr, "hook receives the executor error")
+	assert.ErrorIs(t, err, errUtils.ErrTerraformExecFailed)
 }

--- a/internal/exec/terraform_executor_test.go
+++ b/internal/exec/terraform_executor_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,31 +167,61 @@ func TestExecuteNodeCommand_PerComponentHook(t *testing.T) {
 		Metadata: map[string]any{},
 	}
 
-	hookCalled := false
-	var hookComponent, hookStack string
-	var hookErr error
+	// newInfo builds a ConfigAndStacksInfo with a PerComponentHook that records its invocation.
+	newInfo := func(onHook func(ci *schema.ConfigAndStacksInfo, output string, execErr error)) *schema.ConfigAndStacksInfo {
+		return &schema.ConfigAndStacksInfo{
+			SubCommand:       "plan",
+			Component:        "vpc",
+			Stack:            "dev",
+			PerComponentHook: onHook,
+		}
+	}
 
-	// Mirror what executeTerraformForNode does via updateInfoFromNode so that
-	// compInfo snapshot contains the expected component and stack values.
-	info := &schema.ConfigAndStacksInfo{
-		SubCommand: "plan",
-		Component:  "vpc",
-		Stack:      "dev",
-		PerComponentHook: func(ci *schema.ConfigAndStacksInfo, output string, execErr error) {
+	t.Run("hook fires before error is returned", func(t *testing.T) {
+		sentinel := errors.New("injected terraform error")
+		orig := execTerraformFn
+		execTerraformFn = func(_ schema.ConfigAndStacksInfo, _ ...ShellCommandOption) error { return sentinel }
+		defer func() { execTerraformFn = orig }()
+
+		hookCalled := false
+		var hookComponent, hookStack string
+		var hookErr error
+
+		// Mirror what executeTerraformForNode does via updateInfoFromNode so that
+		// the compInfo snapshot contains the expected component and stack values.
+		info := newInfo(func(ci *schema.ConfigAndStacksInfo, _ string, execErr error) {
 			hookCalled = true
 			hookComponent = ci.Component
 			hookStack = ci.Stack
 			hookErr = execErr
-		},
-	}
+		})
 
-	// ExecuteTerraform will fail (no valid stack config in the test environment),
-	// but the hook fires before the error is propagated — that is the contract under test.
-	err := executeNodeCommand(node, info)
+		err := executeNodeCommand(node, info)
 
-	assert.True(t, hookCalled, "hook must fire even when ExecuteTerraform fails")
-	assert.Equal(t, "vpc", hookComponent)
-	assert.Equal(t, "dev", hookStack)
-	assert.Error(t, hookErr, "hook receives the executor error")
-	assert.ErrorIs(t, err, errUtils.ErrTerraformExecFailed)
+		assert.True(t, hookCalled, "hook must fire even when ExecuteTerraform fails")
+		assert.Equal(t, "vpc", hookComponent)
+		assert.Equal(t, "dev", hookStack)
+		assert.ErrorIs(t, hookErr, sentinel)
+		assert.ErrorIs(t, err, errUtils.ErrTerraformExecFailed)
+	})
+
+	t.Run("hook fires with nil error on success", func(t *testing.T) {
+		orig := execTerraformFn
+		execTerraformFn = func(_ schema.ConfigAndStacksInfo, _ ...ShellCommandOption) error { return nil }
+		defer func() { execTerraformFn = orig }()
+
+		hookCalled := false
+		var hookErr error
+
+		info := newInfo(func(_ *schema.ConfigAndStacksInfo, _ string, execErr error) {
+			hookCalled = true
+			hookErr = execErr
+		})
+
+		err := executeNodeCommand(node, info)
+
+		assert.True(t, hookCalled)
+		assert.NoError(t, hookErr)
+		assert.NoError(t, err)
+	})
 }

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -351,6 +352,21 @@ func processTerraformComponent(
 	info.ComponentFromArg = componentName
 	info.Stack = stackName
 	info.StackFromArg = stackName
+
+	// When a per-component hook is registered, capture this component's output
+	// and invoke the hook immediately after execution so each component receives
+	// its own CI summary entry rather than sharing the final global call.
+	if info.PerComponentHook != nil {
+		var stdoutBuf, stderrBuf bytes.Buffer
+		execErr := executeFn(*info, WithStdoutCapture(&stdoutBuf), WithStderrCapture(&stderrBuf))
+		combined := stdoutBuf.String()
+		if s := stderrBuf.String(); s != "" {
+			combined += "\n" + s
+		}
+		compInfo := *info // snapshot with this component's Component/Stack values set.
+		info.PerComponentHook(&compInfo, combined, execErr)
+		return true, execErr
+	}
 
 	if err := executeFn(*info); err != nil {
 		return true, err

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -487,6 +488,73 @@ func TestProcessTerraformComponent(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, processed)
 		assert.True(t, called)
+	})
+
+	t.Run("per-component hook fires on success with captured output", func(t *testing.T) {
+		section := newSection(map[string]any{"enabled": true})
+		hookCalled := false
+		var hookComponent, hookStack, hookOutput string
+		var hookErr error
+
+		info := schema.ConfigAndStacksInfo{
+			SubCommand: "plan",
+			PerComponentHook: func(ci *schema.ConfigAndStacksInfo, output string, execErr error) {
+				hookCalled = true
+				hookComponent = ci.Component
+				hookStack = ci.Stack
+				hookOutput = output
+				hookErr = execErr
+			},
+		}
+
+		// Executor writes to the capture buffers provided via ShellCommandOption.
+		executor := func(_ schema.ConfigAndStacksInfo, opts ...ShellCommandOption) error {
+			c := &shellCommandConfig{}
+			for _, opt := range opts {
+				opt(c)
+			}
+			if c.stdoutCapture != nil {
+				fmt.Fprint(c.stdoutCapture, "plan-stdout")
+			}
+			if c.stderrCapture != nil {
+				fmt.Fprint(c.stderrCapture, "plan-stderr")
+			}
+			return nil
+		}
+
+		processed, err := processTerraformComponent(&atmosConfig, &info, stack, component, section, logFunc, executor)
+
+		assert.NoError(t, err)
+		assert.True(t, processed)
+		assert.True(t, hookCalled)
+		assert.Equal(t, component, hookComponent)
+		assert.Equal(t, stack, hookStack)
+		assert.Contains(t, hookOutput, "plan-stdout")
+		assert.Contains(t, hookOutput, "plan-stderr")
+		assert.NoError(t, hookErr)
+	})
+
+	t.Run("per-component hook fires before error is returned", func(t *testing.T) {
+		section := newSection(map[string]any{"enabled": true})
+		expectedErr := errors.New("terraform failed")
+		hookCalled := false
+		var hookErr error
+
+		info := schema.ConfigAndStacksInfo{
+			SubCommand: "plan",
+			PerComponentHook: func(ci *schema.ConfigAndStacksInfo, output string, execErr error) {
+				hookCalled = true
+				hookErr = execErr
+			},
+		}
+
+		_, err := processTerraformComponent(&atmosConfig, &info, stack, component, section, logFunc,
+			func(_ schema.ConfigAndStacksInfo, _ ...ShellCommandOption) error { return expectedErr },
+		)
+
+		assert.ErrorIs(t, err, expectedErr)
+		assert.True(t, hookCalled, "hook must fire even when executor fails")
+		assert.ErrorIs(t, hookErr, expectedErr)
 	})
 }
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1084,6 +1084,12 @@ type ConfigAndStacksInfo struct {
 	Identity                  string
 	ClusterName               string // EKS cluster name from --cluster-name flag.
 	NeedsPathResolution       bool   // True if ComponentFromArg is a path that needs resolution.
+
+	// PerComponentHook is called after each component executes in multi-component mode
+	// (--all, --query, --components). Receives a snapshot of info with Component/Stack
+	// set to the executed component, combined stdout+stderr output, and the execution
+	// error (nil on success). Nil means no per-component callback.
+	PerComponentHook func(info *ConfigAndStacksInfo, output string, execErr error)
 }
 
 // GetComponentEnvSection returns the component's env section map.


### PR DESCRIPTION
## what

- Fixes `atmos terraform plan --all` (and `--query`, `--components`, stack-without-component) producing only a single CI summary entry for the last component instead of one entry per component
- Adds an optional `PerComponentHook` callback to `ConfigAndStacksInfo` that fires after each component executes in multi-component mode, with that component's captured stdout+stderr and exit code
- Wires `runCIHooksForPlanComponent` as the per-component hook for the `plan` subcommand so `$GITHUB_STEP_SUMMARY` receives one entry per component with the correct component/stack context
- Adds a `wasMultiComponentExecution` sentinel so the global `PostRunE` CI hook call is suppressed when per-component hooks have already fired, preventing double-firing

## why

- In multi-component mode, `terraformRunWithOptions` routes to `ExecuteTerraformQuery` and discards the `shellOpts` capture buffers passed by `plan.go RunE`, so `capturedPlanOutput` was always empty
- `PostRunE` fired once after all components completed, calling `RunCIHooks` with an empty output buffer and the last component's `info.Component`/`info.Stack`, misattributing the summary
- For stacks with 5 components, only 1 summary entry appeared (or none) instead of 5 — silently hiding the plan result for every component except the last

## references

Closes #2397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-component CI hook execution for terraform plan in multi-component runs, with captured, cleaned plan output passed to each hook.

* **Bug Fixes**
  * Ensure CI plan output capture and hook invocation behave consistently across early exits and multi-component executions to avoid duplicate/incorrect hooks.

* **Tests**
  * Added tests validating per-component hook behavior, output handling, and multi-component execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->