### PR TITLE
Add process and I/O execution foundation

### DIFF
--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,7 @@ import (
 	ioLayer "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
+	process "github.com/cloudposse/atmos/pkg/process"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui/theme"
 	u "github.com/cloudposse/atmos/pkg/utils"
@@ -41,6 +43,8 @@ type shellCommandConfig struct {
 	stdoutCapture  io.Writer
 	stderrCapture  io.Writer
 	stdoutOverride io.Writer
+	streams        *process.Streams
+	ctx            context.Context
 	// processEnv replaces os.Environ() as the process environment.
 	// When set, ExecuteShellCommand uses this instead of re-reading os.Environ().
 	// This is used when auth has already sanitized the environment (e.g., removed IRSA vars).
@@ -69,6 +73,20 @@ func WithStderrCapture(w io.Writer) ShellCommandOption {
 func WithStdoutOverride(w io.Writer) ShellCommandOption {
 	return func(c *shellCommandConfig) {
 		c.stdoutOverride = w
+	}
+}
+
+// WithProcessStreams provides the subprocess standard streams.
+func WithProcessStreams(streams process.Streams) ShellCommandOption {
+	return func(c *shellCommandConfig) {
+		c.streams = &streams
+	}
+}
+
+// WithProcessContext provides the context used for subprocess execution.
+func WithProcessContext(ctx context.Context) ShellCommandOption {
+	return func(c *shellCommandConfig) {
+		c.ctx = ctx
 	}
 }
 
@@ -107,7 +125,6 @@ func ExecuteShellCommand(
 		return err
 	}
 
-	cmd := exec.Command(command, args...)
 	// Build environment: process env + global env (atmos.yaml) + command-specific env.
 	// When auth has sanitized the environment, cfg.processEnv is used instead of
 	// os.Environ() to avoid reintroducing problematic vars (e.g., IRSA credentials).
@@ -128,48 +145,60 @@ func ExecuteShellCommand(
 		cmdEnv = append(cmdEnv, "ATMOS_FORCE_TTY=true")
 	}
 
-	cmd.Env = cmdEnv
-	cmd.Dir = dir
-	cmd.Stdin = os.Stdin
+	streams := process.OSStreams()
+	if cfg.streams != nil {
+		streams = *cfg.streams
+		if streams.Stdin == nil {
+			streams.Stdin = os.Stdin
+		}
+		if streams.Stdout == nil {
+			streams.Stdout = os.Stdout
+		}
+		if streams.Stderr == nil {
+			streams.Stderr = os.Stderr
+		}
+	}
 
 	// Set up stdout: masked output to terminal, optionally tee'd to a capture writer.
 	// When stdoutOverride is set, use it instead of os.Stdout (e.g., redirect to stderr
 	// for workspace select so it doesn't pollute data-producing commands like output).
-	var stdoutTarget io.Writer = os.Stdout
+	var stdoutTarget io.Writer = streams.Stdout
 	if cfg.stdoutOverride != nil {
 		stdoutTarget = cfg.stdoutOverride
 	}
 	maskedStdout := ioLayer.MaskWriter(stdoutTarget)
+	var stdout io.Writer
 	if cfg.stdoutCapture != nil {
-		cmd.Stdout = io.MultiWriter(maskedStdout, cfg.stdoutCapture)
+		stdout = io.MultiWriter(maskedStdout, cfg.stdoutCapture)
 	} else {
-		cmd.Stdout = maskedStdout
+		stdout = maskedStdout
 	}
 
 	if runtime.GOOS == "windows" && redirectStdError == "/dev/null" {
 		redirectStdError = "NUL"
 	}
 
+	var stderr io.Writer
 	if redirectStdError == "/dev/stderr" {
-		maskedStderr := ioLayer.MaskWriter(os.Stderr)
+		maskedStderr := ioLayer.MaskWriter(streams.Stderr)
 		if cfg.stderrCapture != nil {
-			cmd.Stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
+			stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
 		} else {
-			cmd.Stderr = maskedStderr
+			stderr = maskedStderr
 		}
 	} else if redirectStdError == "/dev/stdout" {
-		maskedStderr := ioLayer.MaskWriter(os.Stdout)
+		maskedStderr := ioLayer.MaskWriter(stdoutTarget)
 		if cfg.stderrCapture != nil {
-			cmd.Stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
+			stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
 		} else {
-			cmd.Stderr = maskedStderr
+			stderr = maskedStderr
 		}
 	} else if redirectStdError == "" {
-		maskedStderr := ioLayer.MaskWriter(os.Stderr)
+		maskedStderr := ioLayer.MaskWriter(streams.Stderr)
 		if cfg.stderrCapture != nil {
-			cmd.Stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
+			stderr = io.MultiWriter(maskedStderr, cfg.stderrCapture)
 		} else {
-			cmd.Stderr = maskedStderr
+			stderr = maskedStderr
 		}
 	} else {
 		f, err := os.OpenFile(redirectStdError, os.O_WRONLY|os.O_CREATE, 0o644)
@@ -185,31 +214,43 @@ func ExecuteShellCommand(
 			}
 		}(f)
 
-		cmd.Stderr = ioLayer.MaskWriter(f)
+		stderr = ioLayer.MaskWriter(f)
 	}
-	log.Debug("Executing", "command", cmd.String())
+	log.Debug("Executing", "command", command, "args", args)
 
 	if dryRun {
 		return nil
 	}
 
-	err = cmd.Run()
-	if err != nil {
-		// Extract exit code from error to preserve it.
-		// This is critical for commands like `terraform plan -detailed-exitcode`
-		// which use exit code 2 to indicate changes detected.
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode := exitError.ExitCode()
-			log.Debug("Command exited with non-zero code", "code", exitCode)
-
-			// Return a typed error that preserves the exit code.
-			// main.go will check for this type and exit with the correct code.
-			return errUtils.ExitCodeError{Code: exitCode}
-		}
-		// If we can't extract exit code, return the original error.
-		return err
+	ctx := cfg.ctx
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	return nil
+
+	result := process.DefaultRunner{}.Run(ctx, process.TaskSpec{
+		Command: command,
+		Args:    args,
+		Dir:     dir,
+		Env:     cmdEnv,
+		Streams: process.Streams{
+			Stdin:  streams.Stdin,
+			Stdout: stdout,
+			Stderr: stderr,
+		},
+	})
+	if result.Err == nil {
+		return nil
+	}
+
+	if result.Canceled {
+		return result.Err
+	}
+
+	if result.ExitCode >= 0 {
+		log.Debug("Command exited with non-zero code", "code", result.ExitCode)
+		return errUtils.ExitCodeError{Code: result.ExitCode}
+	}
+	return result.Err
 }
 
 // ExecuteShell runs a shell script.

--- a/internal/exec/shell_utils_test.go
+++ b/internal/exec/shell_utils_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
+	process "github.com/cloudposse/atmos/pkg/process"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -184,6 +186,55 @@ func TestDecrementAtmosShellLevel(t *testing.T) {
 			os.Unsetenv(atmosShellLevelEnvVar)
 		})
 	}
+}
+
+func TestExecuteShellCommandUsesInjectedStreamsAndCapture(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+
+	var terminalOut, terminalErr, captureOut, captureErr bytes.Buffer
+	err := ExecuteShellCommand(
+		schema.AtmosConfiguration{},
+		"/bin/sh",
+		[]string{"-c", "printf stdout; printf stderr >&2"},
+		"",
+		nil,
+		false,
+		"",
+		WithProcessStreams(process.Streams{
+			Stdout: &terminalOut,
+			Stderr: &terminalErr,
+		}),
+		WithStdoutCapture(&captureOut),
+		WithStderrCapture(&captureErr),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "stdout", terminalOut.String())
+	assert.Equal(t, "stderr", terminalErr.String())
+	assert.Equal(t, "stdout", captureOut.String())
+	assert.Equal(t, "stderr", captureErr.String())
+}
+
+func TestExecuteShellCommandPreservesDetailedExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+
+	err := ExecuteShellCommand(
+		schema.AtmosConfiguration{},
+		"/bin/sh",
+		[]string{"-c", "exit 2"},
+		"",
+		nil,
+		false,
+		"",
+	)
+
+	var exitErr errUtils.ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 2, exitErr.Code)
 }
 
 func TestConvertEnvMapToSlice(t *testing.T) {

--- a/internal/exec/terraform_plan_diff.go
+++ b/internal/exec/terraform_plan_diff.go
@@ -26,6 +26,8 @@ var (
 	ErrNoJSONOutput = errors.New("no JSON output found in terraform show output")
 )
 
+var executeTerraformForPlanDiff = ExecuteTerraform
+
 // PlanFileOptions contains parameters for plan file operations.
 type PlanFileOptions struct {
 	ComponentPath string
@@ -272,25 +274,7 @@ func copyPlanFileIfNeeded(planFile, componentPath string) (string, func(), error
 
 // runTerraformShow runs the terraform show command and captures its output.
 func runTerraformShow(info *schema.ConfigAndStacksInfo, planFile string) (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", fmt.Errorf("error creating pipe: %w", err)
-	}
-	defer r.Close()
-	defer w.Close()
-
-	// Save original stdout and replace it with the pipe
-	origStdout := os.Stdout
-	os.Stdout = w
-	defer func() { os.Stdout = origStdout }()
-
-	// Use a goroutine to read from the pipe
 	var outputBuf bytes.Buffer
-	readDone := make(chan error)
-	go func() {
-		_, err := io.Copy(&outputBuf, r)
-		readDone <- err
-	}()
 
 	// Set up the show command
 	showInfo := *info
@@ -298,19 +282,8 @@ func runTerraformShow(info *schema.ConfigAndStacksInfo, planFile string) (string
 	showInfo.AdditionalArgsAndFlags = []string{"-json", planFile}
 
 	// Run the command
-	execErr := ExecuteTerraform(showInfo)
-
-	// Close writer to signal EOF to reader
-	w.Close()
-
-	// Wait for reader to finish
-	readErr := <-readDone
-
-	if execErr != nil {
+	if execErr := executeTerraformForPlanDiff(showInfo, WithStdoutOverride(&outputBuf)); execErr != nil {
 		return "", fmt.Errorf("error running terraform show: %w", execErr)
-	}
-	if readErr != nil {
-		return "", fmt.Errorf("error reading output: %w", readErr)
 	}
 
 	return outputBuf.String(), nil

--- a/internal/exec/terraform_plan_diff_test.go
+++ b/internal/exec/terraform_plan_diff_test.go
@@ -618,6 +618,35 @@ trailing text`
 	})
 }
 
+func TestRunTerraformShowCapturesWithInjectedStdout(t *testing.T) {
+	origStdout := os.Stdout
+	origExec := executeTerraformForPlanDiff
+	t.Cleanup(func() {
+		executeTerraformForPlanDiff = origExec
+	})
+
+	executeTerraformForPlanDiff = func(info schema.ConfigAndStacksInfo, opts ...ShellCommandOption) error {
+		assert.Equal(t, "show", info.SubCommand)
+		assert.Equal(t, []string{"-json", "plan.tfplan"}, info.AdditionalArgsAndFlags)
+		assert.Same(t, origStdout, os.Stdout)
+
+		var cfg shellCommandConfig
+		for _, opt := range opts {
+			opt(&cfg)
+		}
+		require.NotNil(t, cfg.stdoutOverride)
+		_, err := cfg.stdoutOverride.Write([]byte("terraform noise\n{\"format_version\":\"1.0\"}"))
+		require.NoError(t, err)
+		return nil
+	}
+
+	output, err := runTerraformShow(&schema.ConfigAndStacksInfo{}, "plan.tfplan")
+
+	require.NoError(t, err)
+	assert.Equal(t, "terraform noise\n{\"format_version\":\"1.0\"}", output)
+	assert.Same(t, origStdout, os.Stdout)
+}
+
 // TestMockTerraformPlanDiff tests the generatePlanDiff function directly.
 func TestMockTerraformPlanDiff(t *testing.T) {
 	// Create JSON content for the original plan

--- a/pkg/io/node_streams.go
+++ b/pkg/io/node_streams.go
@@ -1,0 +1,122 @@
+package io
+
+import (
+	stdio "io"
+	"os"
+	"strings"
+	"sync"
+)
+
+// NodeStreams contains composed stdout/stderr writers for one execution node.
+type NodeStreams struct {
+	Stdout stdio.Writer
+	Stderr stdio.Writer
+}
+
+// NodeStreamSinks are the destinations for one node stream.
+type NodeStreamSinks struct {
+	Terminal stdio.Writer
+	File     stdio.Writer
+	Capture  stdio.Writer
+}
+
+// NodeStreamsOptions configures per-node stream composition.
+type NodeStreamsOptions struct {
+	NodeID string
+	Stdout NodeStreamSinks
+	Stderr NodeStreamSinks
+}
+
+// NewNodeStreams creates masked per-node stdout/stderr writers that can fan out
+// to terminal, file, and capture sinks.
+func NewNodeStreams(opts NodeStreamsOptions) NodeStreams {
+	stdout := opts.Stdout
+	stderr := opts.Stderr
+	if stdout.Terminal == nil && stdout.File == nil && stdout.Capture == nil {
+		stdout.Terminal = os.Stdout
+	}
+	if stderr.Terminal == nil && stderr.File == nil && stderr.Capture == nil {
+		stderr.Terminal = os.Stderr
+	}
+
+	return NodeStreams{
+		Stdout: composeNodeStream(opts.NodeID, stdout),
+		Stderr: composeNodeStream(opts.NodeID, stderr),
+	}
+}
+
+func composeNodeStream(nodeID string, sinks NodeStreamSinks) stdio.Writer {
+	writers := make([]stdio.Writer, 0, 3)
+	addSink := func(w stdio.Writer) {
+		if w == nil {
+			return
+		}
+		writers = append(writers, MaskWriter(NewPrefixedWriter(nodeID, w)))
+	}
+	addSink(sinks.Terminal)
+	addSink(sinks.File)
+	addSink(sinks.Capture)
+
+	if len(writers) == 0 {
+		return stdio.Discard
+	}
+	if len(writers) == 1 {
+		return writers[0]
+	}
+	return stdio.MultiWriter(writers...)
+}
+
+// NewPrefixedWriter returns a writer that prefixes each line with [prefix].
+func NewPrefixedWriter(prefix string, w stdio.Writer) stdio.Writer {
+	if prefix == "" {
+		return w
+	}
+	return &prefixedWriter{
+		prefix: "[" + prefix + "] ",
+		w:      w,
+	}
+}
+
+type prefixedWriter struct {
+	mu              sync.Mutex
+	prefix          string
+	w               stdio.Writer
+	wroteLastByte   bool
+	lastByteNewline bool
+}
+
+func (w *prefixedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	var b strings.Builder
+	b.Grow(len(p) + len(w.prefix))
+	atLineStart := !w.wroteLastByte || w.lastByteNewline
+	for _, c := range p {
+		if atLineStart {
+			b.WriteString(w.prefix)
+			atLineStart = false
+		}
+		b.WriteByte(c)
+		if c == '\n' {
+			atLineStart = true
+		}
+	}
+
+	out := b.String()
+	n, err := stdio.WriteString(w.w, out)
+	if err != nil {
+		return 0, err
+	}
+	if n < len(out) {
+		return 0, stdio.ErrShortWrite
+	}
+
+	w.wroteLastByte = true
+	w.lastByteNewline = p[len(p)-1] == '\n'
+	return len(p), nil
+}

--- a/pkg/io/node_streams_test.go
+++ b/pkg/io/node_streams_test.go
@@ -1,0 +1,76 @@
+package io
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixedWriterPrefixesEachLine(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewPrefixedWriter("stack/component", &buf)
+
+	n, err := w.Write([]byte("one\ntwo\n"))
+	require.NoError(t, err)
+	assert.Equal(t, len("one\ntwo\n"), n)
+	assert.Equal(t, "[stack/component] one\n[stack/component] two\n", buf.String())
+}
+
+func TestPrefixedWriterHandlesPartialLines(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewPrefixedWriter("node", &buf)
+
+	_, err := w.Write([]byte("one"))
+	require.NoError(t, err)
+	_, err = w.Write([]byte(" two\nthree"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "[node] one two\n[node] three", buf.String())
+}
+
+func TestNewNodeStreamsWritesTerminalFileAndCaptureSinks(t *testing.T) {
+	var terminal, file, capture bytes.Buffer
+	streams := NewNodeStreams(NodeStreamsOptions{
+		NodeID: "node-a",
+		Stdout: NodeStreamSinks{
+			Terminal: &terminal,
+			File:     &file,
+			Capture:  &capture,
+		},
+	})
+
+	_, err := streams.Stdout.Write([]byte("hello\n"))
+	require.NoError(t, err)
+
+	expected := "[node-a] hello\n"
+	assert.Equal(t, expected, terminal.String())
+	assert.Equal(t, expected, file.String())
+	assert.Equal(t, expected, capture.String())
+}
+
+func TestNewNodeStreamsMasksAllSinks(t *testing.T) {
+	_ = Initialize()
+	RegisterSecret("secret-value")
+
+	var terminal, file, capture bytes.Buffer
+	streams := NewNodeStreams(NodeStreamsOptions{
+		NodeID: "node-a",
+		Stdout: NodeStreamSinks{
+			Terminal: &terminal,
+			File:     &file,
+			Capture:  &capture,
+		},
+	})
+
+	_, err := streams.Stdout.Write([]byte("secret-value\n"))
+	require.NoError(t, err)
+
+	assert.NotContains(t, terminal.String(), "secret-value")
+	assert.NotContains(t, file.String(), "secret-value")
+	assert.NotContains(t, capture.String(), "secret-value")
+	assert.Contains(t, terminal.String(), MaskReplacement)
+	assert.Contains(t, file.String(), MaskReplacement)
+	assert.Contains(t, capture.String(), MaskReplacement)
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,131 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Runner executes a task and returns the observed process result.
+type Runner interface {
+	Run(ctx context.Context, spec TaskSpec) Result
+}
+
+// TaskSpec describes a subprocess invocation.
+type TaskSpec struct {
+	Command string
+	Args    []string
+	Dir     string
+	Env     []string
+	Streams Streams
+	DryRun  bool
+}
+
+// Streams contains the standard streams passed to a subprocess.
+type Streams struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Result contains the outcome of a subprocess invocation.
+type Result struct {
+	Command    string
+	Args       []string
+	ExitCode   int
+	Err        error
+	Started    bool
+	Canceled   bool
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// Success reports whether the subprocess completed with exit code 0.
+func (r Result) Success() bool {
+	return r.Err == nil && r.ExitCode == 0
+}
+
+// DefaultRunner executes tasks with os/exec.
+type DefaultRunner struct{}
+
+// NewDefaultRunner returns a Runner backed by os/exec.
+func NewDefaultRunner() Runner {
+	return DefaultRunner{}
+}
+
+// Run executes spec with context-aware cancellation and exit-code preservation.
+func (r DefaultRunner) Run(ctx context.Context, spec TaskSpec) (result Result) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result = Result{
+		Command:   spec.Command,
+		Args:      append([]string{}, spec.Args...),
+		ExitCode:  0,
+		StartedAt: time.Now(),
+	}
+	defer func() {
+		result.FinishedAt = time.Now()
+	}()
+
+	if spec.DryRun {
+		return result
+	}
+
+	cmd := exec.CommandContext(ctx, spec.Command, spec.Args...)
+	cmd.Dir = spec.Dir
+	if spec.Env != nil {
+		cmd.Env = append([]string{}, spec.Env...)
+	}
+	cmd.Stdin = spec.Streams.Stdin
+	cmd.Stdout = writerOrDiscard(spec.Streams.Stdout)
+	cmd.Stderr = writerOrDiscard(spec.Streams.Stderr)
+
+	if err := cmd.Start(); err != nil {
+		result.Err = err
+		result.ExitCode = -1
+		return result
+	}
+	result.Started = true
+
+	err := cmd.Wait()
+	if err == nil {
+		return result
+	}
+
+	result.Err = err
+	result.ExitCode = exitCode(err)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		result.Canceled = true
+		result.Err = errors.Join(err, ctxErr)
+	}
+	return result
+}
+
+func writerOrDiscard(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
+}
+
+func exitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// OSStreams returns streams connected to the current process standard streams.
+func OSStreams() Streams {
+	return Streams{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,83 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRunnerUsesInjectedStreams(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+
+	var stdout, stderr bytes.Buffer
+	result := DefaultRunner{}.Run(context.Background(), TaskSpec{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "printf stdout; printf stderr >&2"},
+		Streams: Streams{
+			Stdout: &stdout,
+			Stderr: &stderr,
+		},
+	})
+
+	require.NoError(t, result.Err)
+	assert.True(t, result.Success())
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "stdout", stdout.String())
+	assert.Equal(t, "stderr", stderr.String())
+}
+
+func TestDefaultRunnerPreservesExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+
+	result := DefaultRunner{}.Run(context.Background(), TaskSpec{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "exit 7"},
+	})
+
+	require.Error(t, result.Err)
+	assert.Equal(t, 7, result.ExitCode)
+
+	var exitErr *exec.ExitError
+	assert.True(t, errors.As(result.Err, &exitErr))
+}
+
+func TestDefaultRunnerCancelsWithContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	result := DefaultRunner{}.Run(ctx, TaskSpec{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "sleep 2"},
+	})
+
+	require.Error(t, result.Err)
+	assert.True(t, result.Canceled)
+	assert.NotEqual(t, 0, result.ExitCode)
+	assert.ErrorIs(t, result.Err, context.DeadlineExceeded)
+}
+
+func TestDefaultRunnerDryRunDoesNotStartProcess(t *testing.T) {
+	result := DefaultRunner{}.Run(context.Background(), TaskSpec{
+		Command: "command-that-should-not-exist",
+		DryRun:  true,
+	})
+
+	require.NoError(t, result.Err)
+	assert.False(t, result.Started)
+	assert.Equal(t, 0, result.ExitCode)
+}


### PR DESCRIPTION
## Summary

This is PR 1 for the DAG concurrent execution rollout. It introduces the reusable process and stream-isolation foundation without enabling scheduler behavior or changing Terraform bulk routing.

Changes:
- Add `pkg/process` with `Runner`, `TaskSpec`, `Streams`, `Result`, default `os/exec` runner, context-aware execution, cancellation reporting, and exit-code preservation.
- Extend `pkg/io` with prefixed per-node stream composition for terminal, file, and capture sinks.
- Refactor `internal/exec.ExecuteShellCommand()` into a backward-compatible wrapper over `pkg/process` while preserving CI stdout/stderr capture options.
- Replace the `runTerraformShow()` global `os.Stdout` swap with injected stdout capture.

## Scope

No scheduler, CLI routing consolidation, concurrency flags, or Terraform adapter behavior is enabled in this PR.

## Validation

```sh
rtk env GOCACHE=/private/tmp/atmos-gocache GOMODCACHE=/private/tmp/atmos-gomodcache go test ./pkg/process ./pkg/io ./internal/exec ./cmd/terraform
```

## Next PR

PR 2 should branch from `codex/dag-process-io-foundation` and add the generic `pkg/scheduler` core with ready-queue scheduling, bounded workers, deterministic aggregate results, and isolated unit tests only.