### PR TITLE
Track DAG concurrent execution rollout

### DIFF
--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -1,6 +1,35 @@
 # DAG Concurrent Execution Rollout Tracker
 
-This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`.
+This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`; this file describes how the work is split, what each PR owns, and which behavior must remain unchanged until the correct layer is ready.
+
+## Implementation Strategy
+
+The rollout is intentionally stacked. Each PR introduces one architectural layer or one routing change, with tests at that layer, before the next PR depends on it. This keeps review focused and prevents concurrency behavior from being mixed with unrelated Terraform routing, auth, store, or CI lifecycle changes.
+
+The implementation layers are:
+
+1. `pkg/process` and `pkg/io` foundations: subprocess lifecycle, stream injection, masking, and per-node stream composition.
+2. `pkg/scheduler` core: generic DAG scheduling with ready queues, bounded workers, deterministic results, and no Terraform coupling.
+3. `pkg/scheduler/adapters`: Terraform-first adapter code that translates Atmos component execution into scheduler-dispatched work.
+4. Terraform bulk routing consolidation: move `--all`, `--components`, and `--query` onto one graph-backed path while keeping execution sequential.
+5. Concurrency enablement: turn on `--max-concurrency` first for plan, then apply/destroy after safety and finalize semantics are implemented.
+6. Selector unification and expansion: move `--affected` onto the shared path, then add mixed-type adapters.
+7. Operational enhancements: diagnostics, per-type pools, resumability, richer progress UX, and graph visualization.
+
+Concurrency must not become user-visible until the Terraform bulk routing path is consolidated. The current general CLI path still uses `ExecuteTerraformQuery()` for multi-component execution, so enabling the scheduler too early would create a parallel implementation that is hard to reach, hard to validate, and likely to miss auth/store behavior from the query path.
+
+## Cross-Cutting Rules
+
+- Use `dependencies.components` as the primary dependency source. Use `settings.depends_on` only as a compatibility fallback.
+- Keep `pkg/dependency` as graph/data infrastructure. Do not put orchestration behavior there.
+- Keep scheduler nodes as scheduling data. Execution work belongs behind dispatchers/adapters, not closures embedded in nodes.
+- Use ready-queue scheduling from the first scheduler PR. Do not add a level-based interim scheduler.
+- Preserve `--max-concurrency 1` as equivalent to current sequential behavior.
+- Preserve native CI plan/apply/deploy capture and finalize behavior from the existing CI integration.
+- Do not add new files under `internal/exec`; use existing files there only as shims or integration points.
+- Concurrent apply/destroy must be non-interactive and require `-auto-approve`.
+- Terraform node completion means subprocess execution, hooks, store writes, and CI finalize work have all completed.
+- Keep each PR reviewable: tests should prove the layer being introduced, and later PR behavior should not leak into earlier PRs.
 
 ## Branching
 
@@ -21,6 +50,104 @@ This tracker coordinates the DAG concurrent execution rollout as a sequence of s
 | PR 6 | `codex/dag-affected-scheduler-routing` | TBD | Route `--affected` onto the shared scheduler-backed executor | Planned |
 | PR 7 | `codex/dag-mixed-type-adapters` | TBD | Packer and provider-backed component adapters for mixed-type DAGs | Planned |
 | PR 8 | `codex/dag-scheduler-diagnostics` | TBD | Additive scheduling diagnostics, progress UX, pools, resumability, and graph visualization as justified | Planned |
+
+## PR Details
+
+### PR 1: Process and I/O Foundation
+
+Owns subprocess and stream primitives only. `ExecuteShellCommand()` remains backward compatible but delegates to `pkg/process`, and `runTerraformShow()` stops mutating global `os.Stdout`. This is the safety prerequisite for later concurrent workers because subprocess output cannot rely on shared global stdout/stderr.
+
+Review focus:
+
+- Exit code preservation for Terraform detailed exit codes.
+- Context-aware process execution and cancellation reporting.
+- Existing CI stdout/stderr capture remains a tee, not a redirect.
+- Per-node stream primitives can label and fan out to terminal, file, and capture sinks.
+
+### PR 2: Scheduler Core
+
+Adds the generic scheduler without touching Terraform routing. The scheduler owns dependency-aware orchestration, ready queues, bounded workers, fail-fast and keep-going behavior, destroy reverse blocking semantics, and deterministic aggregate result ordering.
+
+Review focus:
+
+- No Terraform imports or command assumptions.
+- Nodes remain data only.
+- Dispatcher is the execution boundary.
+- Tests cover graph shapes and failure behavior in isolation.
+
+### PR 3: Terraform Graph-Backed Bulk Path Consolidation
+
+Introduces the Terraform adapter and moves non-affected bulk selectors onto one graph-backed executor while keeping concurrency fixed at one worker. This PR is where existing query-path behavior must be preserved: auth setup, store resolver bridging, YAML function processing, per-component command construction, hooks, and current sequential UX.
+
+Review focus:
+
+- `--all`, `--components`, and `--query` share one path.
+- Dependency ordering prefers `dependencies.components`.
+- Existing auth/store behavior from `ExecuteTerraformQuery()` remains intact.
+- No visible concurrency or `--max-concurrency` behavior is introduced.
+
+### PR 4: Concurrent Terraform Plan
+
+Adds `--max-concurrency` for the consolidated Terraform bulk path and enables concurrent `plan` only. This is the first user-visible concurrency PR because plan is the safest Terraform command surface.
+
+Review focus:
+
+- Workdir and non-interactive auth preflight validation.
+- Per-node output labeling, log files, and capture remain isolated.
+- Plan exit codes preserve `0`, `2`, and failure semantics.
+- `--max-concurrency 1` remains behaviorally sequential.
+
+### PR 5: Concurrent Terraform Apply and Destroy
+
+Extends concurrency to mutating Terraform commands after safety checks are in place. Apply/destroy require non-interactive execution and `-auto-approve` when concurrency is greater than one. Destroy uses reverse dependency blocking so prerequisites are not destroyed after dependent failure.
+
+Review focus:
+
+- Dependents release only after full node finalize completion.
+- CI finalize and store writes are part of node completion.
+- Signal handling cancels gracefully.
+- Unsupported interactive combinations fail before any execution starts.
+
+### PR 6: Affected Routing
+
+Routes `--affected` through the same scheduler-backed executor while preserving the existing DescribeAffected selector behavior and `--include-dependents` semantics.
+
+Review focus:
+
+- Affected-set semantics remain unchanged.
+- Dependency closure is explicit and tested.
+- Fail-fast and keep-going behavior is consistent with other selectors.
+
+### PR 7: Mixed-Type DAGs
+
+Adds Packer and provider-backed component adapters after Terraform concurrency is correct. This makes the scheduler component-type agnostic without changing scheduler internals.
+
+Review focus:
+
+- Mixed Terraform + Packer DAGs work.
+- Mixed Terraform + provider-backed DAGs work.
+- `dependencies.components.kind` drives cross-type graph construction.
+
+### PR 8: Advanced Scheduling and Diagnostics
+
+Adds operational features only after the core path is correct. Candidate features include per-type concurrency pools, resumability, richer progress UX, graph visualization, and critical-path prioritization if profiling justifies it.
+
+Review focus:
+
+- Features are additive.
+- Core scheduler semantics do not regress.
+- Diagnostics explain graph and execution state without changing outcomes.
+
+## Review and Merge Model
+
+The PRs can be reviewed as a stack, but each PR should have its own clear validation. If the stack becomes too large, rebase later PRs as earlier PRs merge. Avoid combining PR 3 and PR 4 unless there is no practical alternative, because routing consolidation and first concurrency enablement exercise different risk areas.
+
+Before moving from one PR to the next, confirm:
+
+- The previous PR's package-level tests pass.
+- New abstractions are used only by their intended integration point.
+- No out-of-scope CLI behavior has changed.
+- The next PR branches from the previous rollout branch unless the stack has been merged and rebased onto `upstream/main`.
 
 ## Next Step Prompt
 

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -1,0 +1,35 @@
+# DAG Concurrent Execution Rollout Tracker
+
+This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`.
+
+## Branching
+
+- PR 1 starts from `upstream/main`.
+- PR 2 starts from `codex/dag-process-io-foundation`.
+- Each later PR starts from the previous rollout branch until the stack is ready to merge or rebase.
+- Keep each PR self-contained and avoid enabling concurrency before the graph-backed Terraform bulk path is consolidated.
+
+## Rollout
+
+| Step | Branch | PR | Scope | Status |
+| --- | --- | --- | --- | --- |
+| PR 1 | `codex/dag-process-io-foundation` | cloudposse/atmos#2459 | `pkg/process`, `pkg/io` stream foundations, shell wrapper integration, `runTerraformShow` stdout injection | Open |
+| PR 2 | `codex/dag-scheduler-core` | TBD | Generic `pkg/scheduler` ready-queue scheduler, orchestrator, deterministic aggregate results, unit tests | Next |
+| PR 3 | `codex/dag-terraform-graph-bulk-path` | TBD | Terraform adapter and graph-backed sequential consolidation for `--all`, `--components`, and `--query` | Planned |
+| PR 4 | `codex/dag-concurrent-terraform-plan` | TBD | `--max-concurrency` for concurrent Terraform plan on the consolidated path | Planned |
+| PR 5 | `codex/dag-concurrent-terraform-apply-destroy` | TBD | Concurrent apply/destroy safety, auto-approve validation, finalize semantics, reverse destroy blocking | Planned |
+| PR 6 | `codex/dag-affected-scheduler-routing` | TBD | Route `--affected` onto the shared scheduler-backed executor | Planned |
+| PR 7 | `codex/dag-mixed-type-adapters` | TBD | Packer and provider-backed component adapters for mixed-type DAGs | Planned |
+| PR 8 | `codex/dag-scheduler-diagnostics` | TBD | Additive scheduling diagnostics, progress UX, pools, resumability, and graph visualization as justified | Planned |
+
+## Next Step Prompt
+
+Start from `codex/dag-process-io-foundation` and implement PR 2 only:
+
+- Add `pkg/scheduler` with `Node`, `Status`, `NodeResult`, `AggregateResult`, `Dispatcher`, `Scheduler`, and `Orchestrator`.
+- Use a ready-queue scheduler with a bounded worker pool from the beginning.
+- Keep scheduler nodes as scheduling data only; do not put execution closures on nodes.
+- Keep the scheduler generic with no Terraform coupling.
+- Add deterministic result ordering for JSON summaries.
+- Cover linear chain, diamond, fan-out, fan-in, fail-fast, keep-going, and destroy reverse blocking semantics with unit tests.
+- Do not change Terraform CLI routing, add Terraform adapters, or expose concurrency flags in PR 2.


### PR DESCRIPTION
## Summary

Expands the DAG concurrent execution rollout tracker into a broader implementation plan for splitting the work across separate PRs.

The tracker now documents:
- the layered implementation strategy from process/I/O primitives through scheduler, adapters, Terraform routing, concurrency, affected routing, mixed-type DAGs, and diagnostics
- cross-cutting rules that must hold across the whole stack, including `dependencies.components`, ready-queue scheduling, no new `internal/exec` files, finalize semantics, and sequential parity for `--max-concurrency 1`
- why concurrency must not become user-visible before Terraform bulk routing is consolidated away from the current `ExecuteTerraformQuery()` path
- the branch/stacking model for PR 1 through PR 8
- per-PR ownership, review focus, and behavior boundaries
- current PR 3 validation findings from temporary local concurrency experiments

## Active PRs

| Step | PR | Status | Branch | Scope |
| --- | --- | --- | --- | --- |
| PR 1 | [cloudposse/atmos#2459](https://github.com/cloudposse/atmos/pull/2459) | Open draft, base `main` | `codex/dag-process-io-foundation` | Process runner, stream injection, shell wrapper integration, `runTerraformShow` stdout capture fix |
| PR 2 | [cloudposse/atmos#2461](https://github.com/cloudposse/atmos/pull/2461) | Open draft, base `codex/dag-process-io-foundation` | `codex/dag-scheduler-core` | Generic `pkg/scheduler` core with ready-queue scheduling and isolated tests |
| PR 3 | [cloudposse/atmos#2462](https://github.com/cloudposse/atmos/pull/2462) | Open draft, base `codex/dag-scheduler-core` | `codex/dag-terraform-graph-bulk-path` | Terraform `--all`, `--components`, and `--query` graph-backed routing; includes temporary concurrency validation hooks and discovered safety prerequisites |
| Tracking | [cloudposse/atmos#2460](https://github.com/cloudposse/atmos/pull/2460) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan, findings, and PR coordination document |

The stack branches now also exist on `cloudposse/atmos`, and PR bases are chained directly. GitHub's official stacked-PR feature is not currently enabled for this repository, so the stack is represented through normal chained PR base branches rather than `gh stack` metadata.

## Planned PRs

| Step | Intended base | Proposed branch | Scope | Key gates / non-goals |
| --- | --- | --- | --- | --- |
| PR 4 | PR 3 | `codex/dag-terraform-plan-concurrency` | Enable user-visible bounded concurrency for Terraform `plan` on the graph-backed path. Wire `--max-concurrency` for plan-only execution and add output orchestration sufficient for readable CLI behavior. | Requires PR 3 review decision on physical-path locking. Must not enable concurrent apply/destroy. Must preserve `--max-concurrency 1` parity. |
| PR 5 | PR 4 | `codex/dag-terraform-apply-destroy-concurrency` | Extend concurrency to Terraform `apply`/`destroy` with explicit safety rules, failure handling, cancellation, and finalize semantics. | Requires settled plan concurrency behavior. Must define apply/destroy risk controls before implementation. No mixed-type DAGs. |
| PR 6 | PR 5 | `codex/dag-affected-scheduler-route` | Route `--affected` onto the scheduler/orchestrator path after non-affected Terraform bulk execution is stable. | Must preserve current affected detection, deletion handling, store/auth behavior, and existing affected UX. No new concurrency semantics beyond what PR 4/5 already established. |
| PR 7 | PR 6 | `codex/dag-mixed-type-adapters` | Add mixed-type DAG adapter support after Terraform-only scheduling is stable. Include explicit adapter boundaries for Terraform and future component types. | Requires repo-owner agreement on mixed-type ordering semantics. Do not rewrite unrelated executors. |
| PR 8 | PR 7 | `codex/dag-scheduling-diagnostics` | Add advanced scheduling diagnostics, graph/debug output, and operator-facing troubleshooting aids. | Should not change scheduling semantics. Keep diagnostics opt-in and safe for CI logs. |
| Follow-up / design | Before or alongside PR 4 | TBD | Decide whether true same-folder alias parallelism should use isolated per-node workdirs, isolated `TF_DATA_DIR`, and retained debug artifacts. | Needs repo-owner decision because it changes the operator debugging model and `atmos terraform shell` expectations. |

## Rollout Shape

1. PR 1: [Process and I/O foundation](https://github.com/cloudposse/atmos/pull/2459) - open draft, base `main`
2. PR 2: [Generic scheduler core](https://github.com/cloudposse/atmos/pull/2461) - open draft, base `codex/dag-process-io-foundation`
3. PR 3: [Terraform graph-backed bulk path consolidation](https://github.com/cloudposse/atmos/pull/2462) - open draft, base `codex/dag-scheduler-core`; currently includes validation-only concurrency override that must be removed or fixed back to sequential before review-ready state
4. PR 4: Concurrent Terraform plan - planned, depends on PR 3 review decisions and output orchestration
5. PR 5: Concurrent Terraform apply/destroy with safety and finalize semantics - planned
6. PR 6: Route `--affected` onto the scheduler path - planned
7. PR 7: Mixed-type DAG adapters - planned
8. PR 8: Advanced scheduling and diagnostics - planned

## Current Findings

PR 3 local validation used a temporary `ATMOS_EXPERIMENTAL_DAG_MAX_CONCURRENCY` override to exercise the scheduler path before exposing any user-visible concurrency. Findings so far:

- The active PRs are now stacked through chained base branches in `cloudposse/atmos`: PR 1 -> PR 2 -> PR 3. The official `gh-stack` CLI extension is installed locally, but `gh stack link` reported that stacked PRs are not enabled for this repository.
- Concurrency 1 preserved the sequential baseline.
- Concurrency 2 and 4 successfully reduced wall time in downstream validation after fixing credential-store initialization.
- The first concurrency-4 run exposed an auth race: per-component credential-store initialization called global `viper.BindEnv`, causing `fatal error: concurrent map writes`. PR 3 now fixes this narrowly in `pkg/auth/credentials` by resolving keyring type directly with precedence `ATMOS_KEYRING_TYPE > auth.keyring.type > system`.
- The first concurrency-8 run exposed local Terraform working-directory contention: logical aliases sharing one physical Terraform component directory raced on generated files and `.terraform/terraform.tfstate`. PR 3 now adds Terraform-adapter resource locking keyed by physical component path, preserving parallelism across distinct folders while serializing aliases sharing one folder.
- True parallelism for aliases sharing one physical Terraform directory likely requires isolated per-node workdirs plus isolated `TF_DATA_DIR` and generated files. That needs repo-owner discussion because it changes the debugging/operator model, including retained execution copies and how `atmos terraform shell` should map to them.
- Output remains heavily interleaved at concurrency greater than 1, so output orchestration is still required before any user-visible concurrency is shipped.

## Validation

Tracker update only. Implementation validation is tracked in the linked PRs, especially [PR 3](https://github.com/cloudposse/atmos/pull/2462).

## Next Step

Bring PR 3 back to its intended review shape: keep Terraform `--all`, `--components`, and `--query` on the graph-backed scheduler path, preserve auth/store/YAML-function behavior, retain the narrow safety prerequisites discovered during validation, and force effective execution back to sequential for review.

Before PR 4 starts, discuss the longer-term isolated-workdir model with repo owners and decide how debugging artifacts, cleanup, and `atmos terraform shell` should behave if true same-folder alias parallelism is introduced. If the repository later enables GitHub stacked PRs, the existing chained-base branches can be linked into official stack metadata.
