### PR TITLE
[codex] add dag scheduler core

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,477 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/cloudposse/atmos/pkg/dependency"
+)
+
+var (
+	ErrNilGraph      = errors.New("scheduler graph cannot be nil")
+	ErrNilDispatcher = errors.New("scheduler dispatcher cannot be nil")
+	ErrNodeSkipped   = errors.New("scheduler node skipped")
+	ErrNodeNotFound  = errors.New("scheduler node not found")
+	ErrInvalidGraph  = errors.New("scheduler graph is invalid")
+	ErrInvalidWorker = errors.New("scheduler max concurrency must be greater than zero")
+)
+
+// Status describes the scheduler outcome for a node.
+type Status string
+
+const (
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusSkipped   Status = "skipped"
+)
+
+// Dispatcher executes one scheduler node. Tool-specific execution belongs behind
+// this interface so the scheduler remains component-type agnostic.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, node *dependency.Node) (Result, error)
+}
+
+// DispatcherFunc adapts a function into a Dispatcher.
+type DispatcherFunc func(ctx context.Context, node *dependency.Node) (Result, error)
+
+// Dispatch calls f(ctx, node).
+func (f DispatcherFunc) Dispatch(ctx context.Context, node *dependency.Node) (Result, error) {
+	return f(ctx, node)
+}
+
+// Result is the deterministic per-node outcome returned in AggregateResult.
+type Result struct {
+	NodeID string
+	Node   dependency.Node
+	Status Status
+	Value  any
+	Err    error
+}
+
+// Success reports whether the node completed successfully.
+func (r Result) Success() bool {
+	return r.Status == StatusSucceeded && r.Err == nil
+}
+
+// AggregateResult contains one result per graph node in stable topological order.
+type AggregateResult struct {
+	Results []Result
+	Err     error
+}
+
+// Success reports whether all scheduled nodes completed successfully.
+func (r *AggregateResult) Success() bool {
+	return r != nil && r.Err == nil
+}
+
+// ResultFor returns the result for a node ID.
+func (r *AggregateResult) ResultFor(nodeID string) (Result, bool) {
+	if r == nil {
+		return Result{}, false
+	}
+	for _, result := range r.Results {
+		if result.NodeID == nodeID {
+			return result, true
+		}
+	}
+	return Result{}, false
+}
+
+// Scheduler manages ready-queue DAG execution with a bounded worker pool.
+type Scheduler struct {
+	graph          *dependency.Graph
+	dispatcher     Dispatcher
+	maxConcurrency int
+	failFast       bool
+	onNodeStart    func(*dependency.Node)
+	onNodeComplete func(*dependency.Node, Result)
+}
+
+// Option configures a Scheduler.
+type Option func(*Scheduler)
+
+// WithMaxConcurrency sets the number of workers allowed to run at once.
+func WithMaxConcurrency(maxConcurrency int) Option {
+	return func(s *Scheduler) {
+		s.maxConcurrency = maxConcurrency
+	}
+}
+
+// WithFailFast controls whether the scheduler stops scheduling after a node error.
+func WithFailFast(failFast bool) Option {
+	return func(s *Scheduler) {
+		s.failFast = failFast
+	}
+}
+
+// WithNodeStartHook registers a callback before a node is dispatched.
+func WithNodeStartHook(hook func(*dependency.Node)) Option {
+	return func(s *Scheduler) {
+		s.onNodeStart = hook
+	}
+}
+
+// WithNodeCompleteHook registers a callback after a node dispatch finishes.
+func WithNodeCompleteHook(hook func(*dependency.Node, Result)) Option {
+	return func(s *Scheduler) {
+		s.onNodeComplete = hook
+	}
+}
+
+// New creates a scheduler for graph and dispatcher.
+func New(graph *dependency.Graph, dispatcher Dispatcher, opts ...Option) *Scheduler {
+	s := &Scheduler{
+		graph:          graph,
+		dispatcher:     dispatcher,
+		maxConcurrency: 1,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Run executes the graph with ready-queue scheduling.
+func (s *Scheduler) Run(ctx context.Context) *AggregateResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	orderedIDs, err := s.validate()
+	if err != nil {
+		return &AggregateResult{Err: err}
+	}
+	if len(orderedIDs) == 0 {
+		return &AggregateResult{}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ready := newReadyQueue(rootNodeIDs(s.graph))
+	inDegree := nodeInDegrees(s.graph)
+	states := make(map[string]nodeState, len(s.graph.Nodes))
+	results := make(map[string]Result, len(s.graph.Nodes))
+	for id := range s.graph.Nodes {
+		states[id] = statePending
+	}
+
+	workCh := make(chan string)
+	eventCh := make(chan runEvent)
+	workerCount := min(s.maxConcurrency, len(s.graph.Nodes))
+
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go s.worker(runCtx, workCh, eventCh, &workers)
+	}
+
+	running := 0
+	finished := 0
+	stopping := false
+
+	for finished < len(s.graph.Nodes) {
+		var nextID string
+		var out chan<- string
+		if !stopping && running < workerCount && ready.Len() > 0 {
+			nextID = ready.Peek()
+			for ready.Len() > 0 && states[nextID] != statePending {
+				ready.Pop()
+				if ready.Len() > 0 {
+					nextID = ready.Peek()
+				}
+			}
+			if ready.Len() > 0 && states[nextID] == statePending {
+				out = workCh
+			}
+		}
+		var done <-chan struct{}
+		if !stopping {
+			done = runCtx.Done()
+		}
+
+		select {
+		case out <- nextID:
+			ready.Pop()
+			states[nextID] = stateRunning
+			running++
+		case event := <-eventCh:
+			running--
+			finished++
+			s.recordEvent(event, states, results, inDegree, ready)
+			if event.result.Status == StatusFailed {
+				if s.failFast {
+					stopping = true
+					cancel()
+					finished += skipPending(states, results, s.graph, fmt.Errorf("%w: fail-fast after %s failed", ErrNodeSkipped, event.nodeID))
+				} else {
+					finished += skipBlocked(event.nodeID, states, results, s.graph, fmt.Errorf("%w: dependency %s failed", ErrNodeSkipped, event.nodeID))
+				}
+			}
+		case <-done:
+			stopping = true
+			finished += skipPending(states, results, s.graph, runCtx.Err())
+		}
+	}
+
+	close(workCh)
+	workers.Wait()
+
+	aggregate := &AggregateResult{
+		Results: orderedResults(orderedIDs, results),
+	}
+	aggregate.Err = aggregateError(aggregate.Results)
+	return aggregate
+}
+
+func (s *Scheduler) validate() ([]string, error) {
+	if s == nil {
+		return nil, ErrNilGraph
+	}
+	if s.graph == nil {
+		return nil, ErrNilGraph
+	}
+	if s.dispatcher == nil {
+		return nil, ErrNilDispatcher
+	}
+	if s.maxConcurrency <= 0 {
+		return nil, ErrInvalidWorker
+	}
+	if hasCycle, cyclePath := s.graph.HasCycles(); hasCycle {
+		return nil, fmt.Errorf("%w: %w: %v", ErrInvalidGraph, dependency.ErrCircularDependency, cyclePath)
+	}
+	return topologicalNodeIDs(s.graph)
+}
+
+func (s *Scheduler) worker(ctx context.Context, workCh <-chan string, eventCh chan<- runEvent, workers *sync.WaitGroup) {
+	defer workers.Done()
+	for nodeID := range workCh {
+		node, ok := s.graph.GetNode(nodeID)
+		if !ok {
+			eventCh <- runEvent{nodeID: nodeID, result: failedResult(nodeID, dependency.Node{ID: nodeID}, ErrNodeNotFound)}
+			continue
+		}
+		if s.onNodeStart != nil {
+			s.onNodeStart(node)
+		}
+
+		result, err := s.dispatcher.Dispatch(ctx, node)
+		result = normalizeResult(node, result, err)
+
+		if s.onNodeComplete != nil {
+			s.onNodeComplete(node, result)
+		}
+		eventCh <- runEvent{nodeID: nodeID, result: result}
+	}
+}
+
+func (s *Scheduler) recordEvent(event runEvent, states map[string]nodeState, results map[string]Result, inDegree map[string]int, ready *readyQueue) {
+	states[event.nodeID] = stateFinished
+	results[event.nodeID] = event.result
+
+	if event.result.Status != StatusSucceeded {
+		return
+	}
+
+	node := s.graph.Nodes[event.nodeID]
+	for _, dependentID := range sortedCopy(node.Dependents) {
+		if states[dependentID] != statePending {
+			continue
+		}
+		inDegree[dependentID]--
+		if inDegree[dependentID] == 0 {
+			ready.Push(dependentID)
+		}
+	}
+}
+
+func normalizeResult(node *dependency.Node, result Result, err error) Result {
+	if result.NodeID == "" {
+		result.NodeID = node.ID
+	}
+	result.Node = *node
+	if err != nil {
+		result.Err = err
+	}
+	if result.Err != nil {
+		result.Status = StatusFailed
+		return result
+	}
+	if result.Status == "" {
+		result.Status = StatusSucceeded
+	}
+	return result
+}
+
+func failedResult(nodeID string, node dependency.Node, err error) Result {
+	return Result{
+		NodeID: nodeID,
+		Node:   node,
+		Status: StatusFailed,
+		Err:    err,
+	}
+}
+
+func skippedResult(node *dependency.Node, err error) Result {
+	return Result{
+		NodeID: node.ID,
+		Node:   *node,
+		Status: StatusSkipped,
+		Err:    err,
+	}
+}
+
+func skipPending(states map[string]nodeState, results map[string]Result, graph *dependency.Graph, err error) int {
+	skipped := 0
+	for _, nodeID := range sortedNodeIDs(graph) {
+		if states[nodeID] != statePending {
+			continue
+		}
+		states[nodeID] = stateFinished
+		results[nodeID] = skippedResult(graph.Nodes[nodeID], err)
+		skipped++
+	}
+	return skipped
+}
+
+func skipBlocked(failedID string, states map[string]nodeState, results map[string]Result, graph *dependency.Graph, err error) int {
+	skipped := 0
+	var visit func(string)
+	visit = func(nodeID string) {
+		node := graph.Nodes[nodeID]
+		for _, dependentID := range sortedCopy(node.Dependents) {
+			if states[dependentID] != statePending {
+				continue
+			}
+			states[dependentID] = stateFinished
+			results[dependentID] = skippedResult(graph.Nodes[dependentID], err)
+			skipped++
+			visit(dependentID)
+		}
+	}
+	visit(failedID)
+	return skipped
+}
+
+func aggregateError(results []Result) error {
+	errs := make([]error, 0)
+	for _, result := range results {
+		if (result.Status == StatusFailed || result.Status == StatusSkipped) && result.Err != nil {
+			errs = append(errs, result.Err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func orderedResults(orderedIDs []string, results map[string]Result) []Result {
+	ordered := make([]Result, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		if result, ok := results[id]; ok {
+			ordered = append(ordered, result)
+		}
+	}
+	return ordered
+}
+
+func topologicalNodeIDs(graph *dependency.Graph) ([]string, error) {
+	inDegree := nodeInDegrees(graph)
+	ready := newReadyQueue(rootNodeIDs(graph))
+	ordered := make([]string, 0, len(graph.Nodes))
+
+	for ready.Len() > 0 {
+		nodeID := ready.Pop()
+		ordered = append(ordered, nodeID)
+		for _, dependentID := range sortedCopy(graph.Nodes[nodeID].Dependents) {
+			inDegree[dependentID]--
+			if inDegree[dependentID] == 0 {
+				ready.Push(dependentID)
+			}
+		}
+	}
+
+	if len(ordered) != len(graph.Nodes) {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidGraph, dependency.ErrCircularDependency)
+	}
+	return ordered, nil
+}
+
+func nodeInDegrees(graph *dependency.Graph) map[string]int {
+	inDegree := make(map[string]int, len(graph.Nodes))
+	for id, node := range graph.Nodes {
+		inDegree[id] = len(node.Dependencies)
+	}
+	return inDegree
+}
+
+func rootNodeIDs(graph *dependency.Graph) []string {
+	roots := make([]string, 0)
+	for id, node := range graph.Nodes {
+		if len(node.Dependencies) == 0 {
+			roots = append(roots, id)
+		}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func sortedNodeIDs(graph *dependency.Graph) []string {
+	ids := make([]string, 0, len(graph.Nodes))
+	for id := range graph.Nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sortedCopy(values []string) []string {
+	copied := append([]string{}, values...)
+	sort.Strings(copied)
+	return copied
+}
+
+type runEvent struct {
+	nodeID string
+	result Result
+}
+
+type nodeState int
+
+const (
+	statePending nodeState = iota
+	stateRunning
+	stateFinished
+)
+
+type readyQueue struct {
+	ids []string
+}
+
+func newReadyQueue(ids []string) *readyQueue {
+	q := &readyQueue{}
+	for _, id := range ids {
+		q.Push(id)
+	}
+	return q
+}
+
+func (q *readyQueue) Len() int {
+	return len(q.ids)
+}
+
+func (q *readyQueue) Push(id string) {
+	q.ids = append(q.ids, id)
+	sort.Strings(q.ids)
+}
+
+func (q *readyQueue) Peek() string {
+	return q.ids[0]
+}
+
+func (q *readyQueue) Pop() string {
+	id := q.ids[0]
+	q.ids = q.ids[1:]
+	return id
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,487 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunExecutesLinearChainInDependencyOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"b"},
+	})
+
+	var mu sync.Mutex
+	started := make([]string, 0, 3)
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		started = append(started, node.ID)
+		mu.Unlock()
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(4)))
+
+	require.NoError(t, result.Err)
+	assert.True(t, result.Success())
+	assert.Equal(t, []string{"a", "b", "c"}, started)
+	assertResultOrder(t, result, "a", "b", "c")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesSingleNode(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+	})
+
+	result := runWithTimeout(t, New(graph, DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		return Result{Value: node.ID}, nil
+	})))
+
+	require.NoError(t, result.Err)
+	require.Len(t, result.Results, 1)
+	assert.True(t, result.Success())
+	assert.Equal(t, "a", result.Results[0].NodeID)
+	assert.Equal(t, StatusSucceeded, result.Results[0].Status)
+	assert.Equal(t, "a", result.Results[0].Value)
+}
+
+func TestRunExecutesDiamondDAGInStableOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"a"},
+		"d": {"b", "c"},
+	})
+
+	result := runWithTimeout(t, New(graph, successfulDispatcher(), WithMaxConcurrency(2)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+		"d": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesFanOutDAGInStableOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"a"},
+		"d": {"a"},
+	})
+
+	result := runWithTimeout(t, New(graph, successfulDispatcher(), WithMaxConcurrency(3)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+		"d": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesFanInDAGOnlyAfterAllDependenciesComplete(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+		"d": {"a", "b", "c"},
+	})
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	started := make(chan string, 4)
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		started <- node.ID
+		switch node.ID {
+		case "a":
+			select {
+			case <-releaseA:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		case "b":
+			select {
+			case <-releaseB:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		}
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(4)).Run(ctx)
+	}()
+
+	seen := waitForStartedSet(t, started, nil, "a", "b", "c")
+	assertNoStart(t, started, 50*time.Millisecond)
+	close(releaseA)
+	assertNoStart(t, started, 50*time.Millisecond)
+	close(releaseB)
+	waitForStartedSet(t, started, seen, "d")
+
+	result := <-done
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+}
+
+func TestRunUsesReadyQueueWithoutWaitingForUnrelatedRoot(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": {"b"},
+	})
+
+	releaseA := make(chan struct{})
+	started := make(chan string, 3)
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		started <- node.ID
+		if node.ID == "a" {
+			select {
+			case <-releaseA:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		}
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(2)).Run(ctx)
+	}()
+
+	seen := waitForStartedSet(t, started, nil, "a", "b")
+	waitForStartedSet(t, started, seen, "c")
+	close(releaseA)
+
+	result := <-done
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c")
+}
+
+func TestRunBoundsConcurrentWorkers(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+		"d": nil,
+	})
+
+	release := make(chan struct{})
+	started := make(chan string, 4)
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		started <- node.ID
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		}
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(2)).Run(ctx)
+	}()
+
+	waitForAnyStart(t, started)
+	waitForAnyStart(t, started)
+	assertNoStart(t, started, 50*time.Millisecond)
+
+	close(release)
+	result := <-done
+	require.NoError(t, result.Err)
+	assert.Equal(t, 2, maxActive)
+}
+
+func TestRunReturnsDeterministicAggregateResults(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	})
+
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		switch node.ID {
+		case "a":
+			time.Sleep(30 * time.Millisecond)
+		case "b":
+			time.Sleep(20 * time.Millisecond)
+		case "c":
+			time.Sleep(10 * time.Millisecond)
+		}
+		return Result{Value: node.ID}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(3)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c")
+	for _, nodeResult := range result.Results {
+		assert.Equal(t, nodeResult.NodeID, nodeResult.Value)
+	}
+}
+
+func TestRunKeepGoingSkipsBlockedDependentsAndRunsIndependentNodes(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"b"},
+		"z": nil,
+	})
+
+	boom := errors.New("boom")
+	started := map[string]bool{}
+	var mu sync.Mutex
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		started[node.ID] = true
+		mu.Unlock()
+		if node.ID == "a" {
+			return Result{}, boom
+		}
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(2)))
+
+	require.ErrorIs(t, result.Err, boom)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusFailed,
+		"b": StatusSkipped,
+		"c": StatusSkipped,
+		"z": StatusSucceeded,
+	})
+	assert.True(t, started["a"])
+	assert.True(t, started["z"])
+	assert.False(t, started["b"])
+	assert.False(t, started["c"])
+}
+
+func TestRunFailFastSkipsPendingWorkAfterFirstError(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	})
+
+	boom := errors.New("boom")
+	started := map[string]bool{}
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		started[node.ID] = true
+		if node.ID == "a" {
+			return Result{}, boom
+		}
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(1), WithFailFast(true)))
+
+	require.ErrorIs(t, result.Err, boom)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusFailed,
+		"b": StatusSkipped,
+		"c": StatusSkipped,
+	})
+	assert.True(t, started["a"])
+	assert.False(t, started["b"])
+	assert.False(t, started["c"])
+}
+
+func TestRunValidatesInputs(t *testing.T) {
+	result := New(nil, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
+		return Result{}, nil
+	})).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrNilGraph)
+
+	graph := testGraph(t, map[string][]string{"a": nil})
+	result = New(graph, nil).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrNilDispatcher)
+
+	result = New(graph, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
+		return Result{}, nil
+	}), WithMaxConcurrency(0)).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrInvalidWorker)
+}
+
+func TestRunRejectsCyclicGraph(t *testing.T) {
+	graph := dependency.NewGraph()
+	require.NoError(t, graph.AddNode(&dependency.Node{ID: "a"}))
+	require.NoError(t, graph.AddNode(&dependency.Node{ID: "b"}))
+	require.NoError(t, graph.AddDependency("a", "b"))
+	require.NoError(t, graph.AddDependency("b", "a"))
+
+	result := New(graph, successfulDispatcher()).Run(context.Background())
+
+	require.ErrorIs(t, result.Err, ErrInvalidGraph)
+	require.ErrorIs(t, result.Err, dependency.ErrCircularDependency)
+}
+
+func TestRunInvokesNodeHooks(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+	})
+
+	var mu sync.Mutex
+	started := make([]string, 0, 2)
+	completed := make([]string, 0, 2)
+	result := runWithTimeout(t, New(
+		graph,
+		successfulDispatcher(),
+		WithNodeStartHook(func(node *dependency.Node) {
+			mu.Lock()
+			defer mu.Unlock()
+			started = append(started, node.ID)
+		}),
+		WithNodeCompleteHook(func(node *dependency.Node, result Result) {
+			mu.Lock()
+			defer mu.Unlock()
+			completed = append(completed, node.ID+":"+string(result.Status))
+		}),
+	))
+
+	require.NoError(t, result.Err)
+	assert.Equal(t, []string{"a", "b"}, started)
+	assert.Equal(t, []string{"a:succeeded", "b:succeeded"}, completed)
+}
+
+func successfulDispatcher() Dispatcher {
+	return DispatcherFunc(func(_ context.Context, _ *dependency.Node) (Result, error) {
+		return Result{}, nil
+	})
+}
+
+func testGraph(t *testing.T, deps map[string][]string) *dependency.Graph {
+	t.Helper()
+
+	builder := dependency.NewBuilder()
+	for id := range deps {
+		require.NoError(t, builder.AddNode(&dependency.Node{ID: id, Component: id, Stack: "test", Type: "test"}))
+	}
+	for id, dependencies := range deps {
+		for _, dep := range dependencies {
+			require.NoError(t, builder.AddDependency(id, dep))
+		}
+	}
+	graph, err := builder.Build()
+	require.NoError(t, err)
+	return graph
+}
+
+func runWithTimeout(t *testing.T, scheduler *Scheduler) *AggregateResult {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return scheduler.Run(ctx)
+}
+
+func assertResultOrder(t *testing.T, result *AggregateResult, ids ...string) {
+	t.Helper()
+
+	got := make([]string, 0, len(result.Results))
+	for _, nodeResult := range result.Results {
+		got = append(got, nodeResult.NodeID)
+	}
+	assert.Equal(t, ids, got)
+}
+
+func assertStatuses(t *testing.T, result *AggregateResult, expected map[string]Status) {
+	t.Helper()
+
+	for id, status := range expected {
+		nodeResult, ok := result.ResultFor(id)
+		require.True(t, ok, "missing result for %s", id)
+		assert.Equal(t, status, nodeResult.Status, "status for %s", id)
+	}
+}
+
+func waitForStartedSet(t *testing.T, started <-chan string, seen map[string]bool, wants ...string) map[string]bool {
+	t.Helper()
+
+	if seen == nil {
+		seen = map[string]bool{}
+	}
+	deadline := time.After(time.Second)
+	for {
+		allSeen := true
+		for _, want := range wants {
+			if !seen[want] {
+				allSeen = false
+				break
+			}
+		}
+		if allSeen {
+			return seen
+		}
+
+		select {
+		case got := <-started:
+			seen[got] = true
+		case <-deadline:
+			t.Fatalf("timed out waiting for nodes to start: %v", wants)
+		}
+	}
+}
+
+func waitForAnyStart(t *testing.T, started <-chan string) {
+	t.Helper()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for node to start")
+	}
+}
+
+func assertNoStart(t *testing.T, started <-chan string, duration time.Duration) {
+	t.Helper()
+
+	select {
+	case id := <-started:
+		t.Fatalf("unexpected node start while workers were saturated: %s", id)
+	case <-time.After(duration):
+	}
+}


### PR DESCRIPTION
## Summary

Adds the PR 2 scheduler foundation as a new generic pkg/scheduler package.

This is stacked on #2459 (process and I/O execution foundation). GitHub cannot target the fork-only foundation branch as an upstream base, so this draft targets main for now; after #2459 merges, this PR's diff should reduce to the scheduler-only changes.

The scheduler consumes the existing dependency graph package and delegates node execution through a generic dispatcher interface. It implements ready-queue DAG scheduling, bounded workers, fail-fast and keep-going behavior, skipped dependent propagation, deterministic aggregate result ordering, and lifecycle hooks for future orchestration layers.

## Scope

- Added pkg/scheduler with generic scheduling types and Scheduler.Run.
- Added isolated unit tests for single node, linear chain, diamond, fan-out, fan-in, ready-queue behavior, worker bounds, deterministic aggregate ordering, error propagation, fail-fast, keep-going, validation, cycle rejection, and hooks.
- Intentionally did not change Terraform routing, add tool adapters, or expose concurrency flags.

## Validation

```bash
GOCACHE=/private/tmp/atmos-go-cache go test -count=20 ./pkg/scheduler
GOCACHE=/private/tmp/atmos-go-cache go test ./pkg/scheduler ./pkg/process ./pkg/io ./pkg/dependency
GOCACHE=/private/tmp/atmos-go-cache go test -race ./pkg/scheduler
```