### PR TITLE
[codex] add dag scheduler core

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -208,6 +208,14 @@ var (
 	ErrInvalidFormat  = errors.New("invalid format")
 	ErrOutputFormat   = errors.New("output format error")
 
+	// Scheduler errors.
+	ErrNilGraph      = errors.New("scheduler graph cannot be nil")
+	ErrNilDispatcher = errors.New("scheduler dispatcher cannot be nil")
+	ErrNodeSkipped   = errors.New("scheduler node skipped")
+	ErrNodeNotFound  = errors.New("scheduler node not found")
+	ErrInvalidGraph  = errors.New("scheduler graph is invalid")
+	ErrInvalidWorker = errors.New("scheduler max concurrency must be greater than zero")
+
 	// Slice utility errors.
 	ErrNilInput         = errors.New("input must not be nil")
 	ErrNonStringElement = errors.New("element is not a string")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -211,6 +211,7 @@ var (
 	// Scheduler errors.
 	ErrNilGraph      = errors.New("scheduler graph cannot be nil")
 	ErrNilDispatcher = errors.New("scheduler dispatcher cannot be nil")
+	ErrNodeFailed    = errors.New("scheduler node failed")
 	ErrNodeSkipped   = errors.New("scheduler node skipped")
 	ErrNodeNotFound  = errors.New("scheduler node not found")
 	ErrInvalidGraph  = errors.New("scheduler graph is invalid")

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,477 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/cloudposse/atmos/pkg/dependency"
+)
+
+var (
+	ErrNilGraph      = errors.New("scheduler graph cannot be nil")
+	ErrNilDispatcher = errors.New("scheduler dispatcher cannot be nil")
+	ErrNodeSkipped   = errors.New("scheduler node skipped")
+	ErrNodeNotFound  = errors.New("scheduler node not found")
+	ErrInvalidGraph  = errors.New("scheduler graph is invalid")
+	ErrInvalidWorker = errors.New("scheduler max concurrency must be greater than zero")
+)
+
+// Status describes the scheduler outcome for a node.
+type Status string
+
+const (
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusSkipped   Status = "skipped"
+)
+
+// Dispatcher executes one scheduler node. Tool-specific execution belongs behind
+// this interface so the scheduler remains component-type agnostic.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, node *dependency.Node) (Result, error)
+}
+
+// DispatcherFunc adapts a function into a Dispatcher.
+type DispatcherFunc func(ctx context.Context, node *dependency.Node) (Result, error)
+
+// Dispatch calls f(ctx, node).
+func (f DispatcherFunc) Dispatch(ctx context.Context, node *dependency.Node) (Result, error) {
+	return f(ctx, node)
+}
+
+// Result is the deterministic per-node outcome returned in AggregateResult.
+type Result struct {
+	NodeID string
+	Node   dependency.Node
+	Status Status
+	Value  any
+	Err    error
+}
+
+// Success reports whether the node completed successfully.
+func (r Result) Success() bool {
+	return r.Status == StatusSucceeded && r.Err == nil
+}
+
+// AggregateResult contains one result per graph node in stable topological order.
+type AggregateResult struct {
+	Results []Result
+	Err     error
+}
+
+// Success reports whether all scheduled nodes completed successfully.
+func (r *AggregateResult) Success() bool {
+	return r != nil && r.Err == nil
+}
+
+// ResultFor returns the result for a node ID.
+func (r *AggregateResult) ResultFor(nodeID string) (Result, bool) {
+	if r == nil {
+		return Result{}, false
+	}
+	for _, result := range r.Results {
+		if result.NodeID == nodeID {
+			return result, true
+		}
+	}
+	return Result{}, false
+}
+
+// Scheduler manages ready-queue DAG execution with a bounded worker pool.
+type Scheduler struct {
+	graph          *dependency.Graph
+	dispatcher     Dispatcher
+	maxConcurrency int
+	failFast       bool
+	onNodeStart    func(*dependency.Node)
+	onNodeComplete func(*dependency.Node, Result)
+}
+
+// Option configures a Scheduler.
+type Option func(*Scheduler)
+
+// WithMaxConcurrency sets the number of workers allowed to run at once.
+func WithMaxConcurrency(maxConcurrency int) Option {
+	return func(s *Scheduler) {
+		s.maxConcurrency = maxConcurrency
+	}
+}
+
+// WithFailFast controls whether the scheduler stops scheduling after a node error.
+func WithFailFast(failFast bool) Option {
+	return func(s *Scheduler) {
+		s.failFast = failFast
+	}
+}
+
+// WithNodeStartHook registers a callback before a node is dispatched.
+func WithNodeStartHook(hook func(*dependency.Node)) Option {
+	return func(s *Scheduler) {
+		s.onNodeStart = hook
+	}
+}
+
+// WithNodeCompleteHook registers a callback after a node dispatch finishes.
+func WithNodeCompleteHook(hook func(*dependency.Node, Result)) Option {
+	return func(s *Scheduler) {
+		s.onNodeComplete = hook
+	}
+}
+
+// New creates a scheduler for graph and dispatcher.
+func New(graph *dependency.Graph, dispatcher Dispatcher, opts ...Option) *Scheduler {
+	s := &Scheduler{
+		graph:          graph,
+		dispatcher:     dispatcher,
+		maxConcurrency: 1,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Run executes the graph with ready-queue scheduling.
+func (s *Scheduler) Run(ctx context.Context) *AggregateResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	orderedIDs, err := s.validate()
+	if err != nil {
+		return &AggregateResult{Err: err}
+	}
+	if len(orderedIDs) == 0 {
+		return &AggregateResult{}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ready := newReadyQueue(rootNodeIDs(s.graph))
+	inDegree := nodeInDegrees(s.graph)
+	states := make(map[string]nodeState, len(s.graph.Nodes))
+	results := make(map[string]Result, len(s.graph.Nodes))
+	for id := range s.graph.Nodes {
+		states[id] = statePending
+	}
+
+	workCh := make(chan string)
+	eventCh := make(chan runEvent)
+	workerCount := min(s.maxConcurrency, len(s.graph.Nodes))
+
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go s.worker(runCtx, workCh, eventCh, &workers)
+	}
+
+	running := 0
+	finished := 0
+	stopping := false
+
+	for finished < len(s.graph.Nodes) {
+		var nextID string
+		var out chan<- string
+		if !stopping && running < workerCount && ready.Len() > 0 {
+			nextID = ready.Peek()
+			for ready.Len() > 0 && states[nextID] != statePending {
+				ready.Pop()
+				if ready.Len() > 0 {
+					nextID = ready.Peek()
+				}
+			}
+			if ready.Len() > 0 && states[nextID] == statePending {
+				out = workCh
+			}
+		}
+		var done <-chan struct{}
+		if !stopping {
+			done = runCtx.Done()
+		}
+
+		select {
+		case out <- nextID:
+			ready.Pop()
+			states[nextID] = stateRunning
+			running++
+		case event := <-eventCh:
+			running--
+			finished++
+			s.recordEvent(event, states, results, inDegree, ready)
+			if event.result.Status == StatusFailed {
+				if s.failFast {
+					stopping = true
+					cancel()
+					finished += skipPending(states, results, s.graph, fmt.Errorf("%w: fail-fast after %s failed", ErrNodeSkipped, event.nodeID))
+				} else {
+					finished += skipBlocked(event.nodeID, states, results, s.graph, fmt.Errorf("%w: dependency %s failed", ErrNodeSkipped, event.nodeID))
+				}
+			}
+		case <-done:
+			stopping = true
+			finished += skipPending(states, results, s.graph, runCtx.Err())
+		}
+	}
+
+	close(workCh)
+	workers.Wait()
+
+	aggregate := &AggregateResult{
+		Results: orderedResults(orderedIDs, results),
+	}
+	aggregate.Err = aggregateError(aggregate.Results)
+	return aggregate
+}
+
+func (s *Scheduler) validate() ([]string, error) {
+	if s == nil {
+		return nil, ErrNilGraph
+	}
+	if s.graph == nil {
+		return nil, ErrNilGraph
+	}
+	if s.dispatcher == nil {
+		return nil, ErrNilDispatcher
+	}
+	if s.maxConcurrency <= 0 {
+		return nil, ErrInvalidWorker
+	}
+	if hasCycle, cyclePath := s.graph.HasCycles(); hasCycle {
+		return nil, fmt.Errorf("%w: %w: %v", ErrInvalidGraph, dependency.ErrCircularDependency, cyclePath)
+	}
+	return topologicalNodeIDs(s.graph)
+}
+
+func (s *Scheduler) worker(ctx context.Context, workCh <-chan string, eventCh chan<- runEvent, workers *sync.WaitGroup) {
+	defer workers.Done()
+	for nodeID := range workCh {
+		node, ok := s.graph.GetNode(nodeID)
+		if !ok {
+			eventCh <- runEvent{nodeID: nodeID, result: failedResult(nodeID, dependency.Node{ID: nodeID}, ErrNodeNotFound)}
+			continue
+		}
+		if s.onNodeStart != nil {
+			s.onNodeStart(node)
+		}
+
+		result, err := s.dispatcher.Dispatch(ctx, node)
+		result = normalizeResult(node, result, err)
+
+		if s.onNodeComplete != nil {
+			s.onNodeComplete(node, result)
+		}
+		eventCh <- runEvent{nodeID: nodeID, result: result}
+	}
+}
+
+func (s *Scheduler) recordEvent(event runEvent, states map[string]nodeState, results map[string]Result, inDegree map[string]int, ready *readyQueue) {
+	states[event.nodeID] = stateFinished
+	results[event.nodeID] = event.result
+
+	if event.result.Status != StatusSucceeded {
+		return
+	}
+
+	node := s.graph.Nodes[event.nodeID]
+	for _, dependentID := range sortedCopy(node.Dependents) {
+		if states[dependentID] != statePending {
+			continue
+		}
+		inDegree[dependentID]--
+		if inDegree[dependentID] == 0 {
+			ready.Push(dependentID)
+		}
+	}
+}
+
+func normalizeResult(node *dependency.Node, result Result, err error) Result {
+	if result.NodeID == "" {
+		result.NodeID = node.ID
+	}
+	result.Node = *node
+	if err != nil {
+		result.Err = err
+	}
+	if result.Err != nil {
+		result.Status = StatusFailed
+		return result
+	}
+	if result.Status == "" {
+		result.Status = StatusSucceeded
+	}
+	return result
+}
+
+func failedResult(nodeID string, node dependency.Node, err error) Result {
+	return Result{
+		NodeID: nodeID,
+		Node:   node,
+		Status: StatusFailed,
+		Err:    err,
+	}
+}
+
+func skippedResult(node *dependency.Node, err error) Result {
+	return Result{
+		NodeID: node.ID,
+		Node:   *node,
+		Status: StatusSkipped,
+		Err:    err,
+	}
+}
+
+func skipPending(states map[string]nodeState, results map[string]Result, graph *dependency.Graph, err error) int {
+	skipped := 0
+	for _, nodeID := range sortedNodeIDs(graph) {
+		if states[nodeID] != statePending {
+			continue
+		}
+		states[nodeID] = stateFinished
+		results[nodeID] = skippedResult(graph.Nodes[nodeID], err)
+		skipped++
+	}
+	return skipped
+}
+
+func skipBlocked(failedID string, states map[string]nodeState, results map[string]Result, graph *dependency.Graph, err error) int {
+	skipped := 0
+	var visit func(string)
+	visit = func(nodeID string) {
+		node := graph.Nodes[nodeID]
+		for _, dependentID := range sortedCopy(node.Dependents) {
+			if states[dependentID] != statePending {
+				continue
+			}
+			states[dependentID] = stateFinished
+			results[dependentID] = skippedResult(graph.Nodes[dependentID], err)
+			skipped++
+			visit(dependentID)
+		}
+	}
+	visit(failedID)
+	return skipped
+}
+
+func aggregateError(results []Result) error {
+	errs := make([]error, 0)
+	for _, result := range results {
+		if (result.Status == StatusFailed || result.Status == StatusSkipped) && result.Err != nil {
+			errs = append(errs, result.Err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func orderedResults(orderedIDs []string, results map[string]Result) []Result {
+	ordered := make([]Result, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		if result, ok := results[id]; ok {
+			ordered = append(ordered, result)
+		}
+	}
+	return ordered
+}
+
+func topologicalNodeIDs(graph *dependency.Graph) ([]string, error) {
+	inDegree := nodeInDegrees(graph)
+	ready := newReadyQueue(rootNodeIDs(graph))
+	ordered := make([]string, 0, len(graph.Nodes))
+
+	for ready.Len() > 0 {
+		nodeID := ready.Pop()
+		ordered = append(ordered, nodeID)
+		for _, dependentID := range sortedCopy(graph.Nodes[nodeID].Dependents) {
+			inDegree[dependentID]--
+			if inDegree[dependentID] == 0 {
+				ready.Push(dependentID)
+			}
+		}
+	}
+
+	if len(ordered) != len(graph.Nodes) {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidGraph, dependency.ErrCircularDependency)
+	}
+	return ordered, nil
+}
+
+func nodeInDegrees(graph *dependency.Graph) map[string]int {
+	inDegree := make(map[string]int, len(graph.Nodes))
+	for id, node := range graph.Nodes {
+		inDegree[id] = len(node.Dependencies)
+	}
+	return inDegree
+}
+
+func rootNodeIDs(graph *dependency.Graph) []string {
+	roots := make([]string, 0)
+	for id, node := range graph.Nodes {
+		if len(node.Dependencies) == 0 {
+			roots = append(roots, id)
+		}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func sortedNodeIDs(graph *dependency.Graph) []string {
+	ids := make([]string, 0, len(graph.Nodes))
+	for id := range graph.Nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sortedCopy(values []string) []string {
+	copied := append([]string{}, values...)
+	sort.Strings(copied)
+	return copied
+}
+
+type runEvent struct {
+	nodeID string
+	result Result
+}
+
+type nodeState int
+
+const (
+	statePending nodeState = iota
+	stateRunning
+	stateFinished
+)
+
+type readyQueue struct {
+	ids []string
+}
+
+func newReadyQueue(ids []string) *readyQueue {
+	q := &readyQueue{}
+	for _, id := range ids {
+		q.Push(id)
+	}
+	return q
+}
+
+func (q *readyQueue) Len() int {
+	return len(q.ids)
+}
+
+func (q *readyQueue) Push(id string) {
+	q.ids = append(q.ids, id)
+	sort.Strings(q.ids)
+}
+
+func (q *readyQueue) Peek() string {
+	return q.ids[0]
+}
+
+func (q *readyQueue) Pop() string {
+	id := q.ids[0]
+	q.ids = q.ids[1:]
+	return id
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,21 +2,14 @@ package scheduler
 
 import (
 	"context"
-	"errors"
+	stdErrors "errors"
 	"fmt"
 	"sort"
 	"sync"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/dependency"
-)
-
-var (
-	ErrNilGraph      = errors.New("scheduler graph cannot be nil")
-	ErrNilDispatcher = errors.New("scheduler dispatcher cannot be nil")
-	ErrNodeSkipped   = errors.New("scheduler node skipped")
-	ErrNodeNotFound  = errors.New("scheduler node not found")
-	ErrInvalidGraph  = errors.New("scheduler graph is invalid")
-	ErrInvalidWorker = errors.New("scheduler max concurrency must be greater than zero")
+	"github.com/cloudposse/atmos/pkg/perf"
 )
 
 // Status describes the scheduler outcome for a node.
@@ -136,6 +129,8 @@ func New(graph *dependency.Graph, dispatcher Dispatcher, opts ...Option) *Schedu
 
 // Run executes the graph with ready-queue scheduling.
 func (s *Scheduler) Run(ctx context.Context) *AggregateResult {
+	defer perf.Track(nil, "scheduler.Run")()
+
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -205,11 +200,12 @@ func (s *Scheduler) Run(ctx context.Context) *AggregateResult {
 			if event.result.Status == StatusFailed {
 				if s.failFast {
 					stopping = true
-					cancel()
-					finished += skipPending(states, results, s.graph, fmt.Errorf("%w: fail-fast after %s failed", ErrNodeSkipped, event.nodeID))
+					finished += skipPending(states, results, s.graph, fmt.Errorf("%w: fail-fast after %s failed", errUtils.ErrNodeSkipped, event.nodeID))
 				} else {
-					finished += skipBlocked(event.nodeID, states, results, s.graph, fmt.Errorf("%w: dependency %s failed", ErrNodeSkipped, event.nodeID))
+					finished += skipBlocked(event.nodeID, states, results, s.graph, fmt.Errorf("%w: dependency %s failed", errUtils.ErrNodeSkipped, event.nodeID))
 				}
+			} else if event.result.Status == StatusSkipped {
+				finished += skipBlocked(event.nodeID, states, results, s.graph, skipCause(event))
 			}
 		case <-done:
 			stopping = true
@@ -229,19 +225,19 @@ func (s *Scheduler) Run(ctx context.Context) *AggregateResult {
 
 func (s *Scheduler) validate() ([]string, error) {
 	if s == nil {
-		return nil, ErrNilGraph
+		return nil, errUtils.ErrNilGraph
 	}
 	if s.graph == nil {
-		return nil, ErrNilGraph
+		return nil, errUtils.ErrNilGraph
 	}
 	if s.dispatcher == nil {
-		return nil, ErrNilDispatcher
+		return nil, errUtils.ErrNilDispatcher
 	}
 	if s.maxConcurrency <= 0 {
-		return nil, ErrInvalidWorker
+		return nil, errUtils.ErrInvalidWorker
 	}
 	if hasCycle, cyclePath := s.graph.HasCycles(); hasCycle {
-		return nil, fmt.Errorf("%w: %w: %v", ErrInvalidGraph, dependency.ErrCircularDependency, cyclePath)
+		return nil, fmt.Errorf("%w: %w: %v", errUtils.ErrInvalidGraph, dependency.ErrCircularDependency, cyclePath)
 	}
 	return topologicalNodeIDs(s.graph)
 }
@@ -251,7 +247,7 @@ func (s *Scheduler) worker(ctx context.Context, workCh <-chan string, eventCh ch
 	for nodeID := range workCh {
 		node, ok := s.graph.GetNode(nodeID)
 		if !ok {
-			eventCh <- runEvent{nodeID: nodeID, result: failedResult(nodeID, dependency.Node{ID: nodeID}, ErrNodeNotFound)}
+			eventCh <- runEvent{nodeID: nodeID, result: failedResult(nodeID, dependency.Node{ID: nodeID}, errUtils.ErrNodeNotFound)}
 			continue
 		}
 		if s.onNodeStart != nil {
@@ -296,6 +292,9 @@ func normalizeResult(node *dependency.Node, result Result, err error) Result {
 	if err != nil {
 		result.Err = err
 	}
+	if result.Status == StatusSkipped {
+		return result
+	}
 	if result.Err != nil {
 		result.Status = StatusFailed
 		return result
@@ -322,6 +321,13 @@ func skippedResult(node *dependency.Node, err error) Result {
 		Status: StatusSkipped,
 		Err:    err,
 	}
+}
+
+func skipCause(event runEvent) error {
+	if event.result.Err != nil {
+		return fmt.Errorf("%w: dependency %s skipped: %w", errUtils.ErrNodeSkipped, event.nodeID, event.result.Err)
+	}
+	return fmt.Errorf("%w: dependency %s skipped", errUtils.ErrNodeSkipped, event.nodeID)
 }
 
 func skipPending(states map[string]nodeState, results map[string]Result, graph *dependency.Graph, err error) int {
@@ -363,7 +369,7 @@ func aggregateError(results []Result) error {
 			errs = append(errs, result.Err)
 		}
 	}
-	return errors.Join(errs...)
+	return stdErrors.Join(errs...)
 }
 
 func orderedResults(orderedIDs []string, results map[string]Result) []Result {
@@ -393,7 +399,7 @@ func topologicalNodeIDs(graph *dependency.Graph) ([]string, error) {
 	}
 
 	if len(ordered) != len(graph.Nodes) {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidGraph, dependency.ErrCircularDependency)
+		return nil, fmt.Errorf("%w: %w", errUtils.ErrInvalidGraph, dependency.ErrCircularDependency)
 	}
 	return ordered, nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -57,7 +57,15 @@ type AggregateResult struct {
 
 // Success reports whether all scheduled nodes completed successfully.
 func (r *AggregateResult) Success() bool {
-	return r != nil && r.Err == nil
+	if r == nil || r.Err != nil {
+		return false
+	}
+	for _, result := range r.Results {
+		if !result.Success() {
+			return false
+		}
+	}
+	return true
 }
 
 // ResultFor returns the result for a node ID.
@@ -293,6 +301,9 @@ func normalizeResult(node *dependency.Node, result Result, err error) Result {
 		result.Err = err
 	}
 	if result.Status == StatusSkipped {
+		if result.Err == nil {
+			result.Err = nonSuccessResultError(result)
+		}
 		return result
 	}
 	if result.Err != nil {
@@ -302,7 +313,21 @@ func normalizeResult(node *dependency.Node, result Result, err error) Result {
 	if result.Status == "" {
 		result.Status = StatusSucceeded
 	}
+	if result.Status != StatusSucceeded && result.Err == nil {
+		result.Err = nonSuccessResultError(result)
+	}
 	return result
+}
+
+func nonSuccessResultError(result Result) error {
+	switch result.Status {
+	case StatusFailed:
+		return fmt.Errorf("%w: node %s failed", errUtils.ErrNodeFailed, result.NodeID)
+	case StatusSkipped:
+		return fmt.Errorf("%w: node %s skipped", errUtils.ErrNodeSkipped, result.NodeID)
+	default:
+		return fmt.Errorf("scheduler node %s finished with status %q", result.NodeID, result.Status)
+	}
 }
 
 func failedResult(nodeID string, node dependency.Node, err error) Result {
@@ -365,9 +390,14 @@ func skipBlocked(failedID string, states map[string]nodeState, results map[strin
 func aggregateError(results []Result) error {
 	errs := make([]error, 0)
 	for _, result := range results {
-		if (result.Status == StatusFailed || result.Status == StatusSkipped) && result.Err != nil {
-			errs = append(errs, result.Err)
+		if result.Status == StatusSucceeded {
+			continue
 		}
+		if result.Err != nil {
+			errs = append(errs, result.Err)
+			continue
+		}
+		errs = append(errs, nonSuccessResultError(result))
 	}
 	return stdErrors.Join(errs...)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -329,20 +330,109 @@ func TestRunFailFastSkipsPendingWorkAfterFirstError(t *testing.T) {
 	assert.False(t, started["c"])
 }
 
+func TestRunFailFastLetsAlreadyRunningNodesDrain(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": {"b"},
+	})
+
+	boom := errors.New("boom")
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	started := make(chan string, 2)
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		started <- node.ID
+		switch node.ID {
+		case "a":
+			select {
+			case <-releaseA:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+			return Result{}, boom
+		case "b":
+			select {
+			case <-releaseB:
+				return Result{}, nil
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		default:
+			return Result{}, nil
+		}
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(2), WithFailFast(true)).Run(ctx)
+	}()
+
+	waitForStartedSet(t, started, nil, "a", "b")
+	close(releaseA)
+	assertNoResult(t, done, 50*time.Millisecond)
+	close(releaseB)
+
+	result := <-done
+	require.ErrorIs(t, result.Err, boom)
+	require.NotErrorIs(t, result.Err, context.Canceled)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusFailed,
+		"b": StatusSucceeded,
+		"c": StatusSkipped,
+	})
+}
+
+func TestRunPropagatesSkippedStatusToDependents(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"b"},
+		"z": nil,
+	})
+
+	skipErr := errors.New("skip a")
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		if node.ID == "a" {
+			return Result{Status: StatusSkipped, Err: skipErr}, nil
+		}
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(2)))
+
+	require.ErrorIs(t, result.Err, skipErr)
+	require.ErrorIs(t, result.Err, errUtils.ErrNodeSkipped)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSkipped,
+		"b": StatusSkipped,
+		"c": StatusSkipped,
+		"z": StatusSucceeded,
+	})
+	for _, id := range []string{"b", "c"} {
+		nodeResult, ok := result.ResultFor(id)
+		require.True(t, ok)
+		require.ErrorIs(t, nodeResult.Err, skipErr)
+		require.ErrorIs(t, nodeResult.Err, errUtils.ErrNodeSkipped)
+	}
+}
+
 func TestRunValidatesInputs(t *testing.T) {
 	result := New(nil, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
 		return Result{}, nil
 	})).Run(context.Background())
-	require.ErrorIs(t, result.Err, ErrNilGraph)
+	require.ErrorIs(t, result.Err, errUtils.ErrNilGraph)
 
 	graph := testGraph(t, map[string][]string{"a": nil})
 	result = New(graph, nil).Run(context.Background())
-	require.ErrorIs(t, result.Err, ErrNilDispatcher)
+	require.ErrorIs(t, result.Err, errUtils.ErrNilDispatcher)
 
 	result = New(graph, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
 		return Result{}, nil
 	}), WithMaxConcurrency(0)).Run(context.Background())
-	require.ErrorIs(t, result.Err, ErrInvalidWorker)
+	require.ErrorIs(t, result.Err, errUtils.ErrInvalidWorker)
 }
 
 func TestRunRejectsCyclicGraph(t *testing.T) {
@@ -354,7 +444,7 @@ func TestRunRejectsCyclicGraph(t *testing.T) {
 
 	result := New(graph, successfulDispatcher()).Run(context.Background())
 
-	require.ErrorIs(t, result.Err, ErrInvalidGraph)
+	require.ErrorIs(t, result.Err, errUtils.ErrInvalidGraph)
 	require.ErrorIs(t, result.Err, dependency.ErrCircularDependency)
 }
 
@@ -482,6 +572,16 @@ func assertNoStart(t *testing.T, started <-chan string, duration time.Duration) 
 	select {
 	case id := <-started:
 		t.Fatalf("unexpected node start while workers were saturated: %s", id)
+	case <-time.After(duration):
+	}
+}
+
+func assertNoResult(t *testing.T, done <-chan *AggregateResult, duration time.Duration) {
+	t.Helper()
+
+	select {
+	case result := <-done:
+		t.Fatalf("scheduler finished before running workers drained: %#v", result)
 	case <-time.After(duration):
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -59,6 +59,44 @@ func TestRunExecutesSingleNode(t *testing.T) {
 	assert.Equal(t, "a", result.Results[0].Value)
 }
 
+func TestRunTreatsNonSuccessStatusWithoutErrorAsFailure(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  Status
+		wantErr error
+	}{
+		{
+			name:    "failed",
+			status:  StatusFailed,
+			wantErr: errUtils.ErrNodeFailed,
+		},
+		{
+			name:    "skipped",
+			status:  StatusSkipped,
+			wantErr: errUtils.ErrNodeSkipped,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph := testGraph(t, map[string][]string{
+				"a": nil,
+			})
+			result := runWithTimeout(t, New(graph, DispatcherFunc(func(_ context.Context, _ *dependency.Node) (Result, error) {
+				return Result{Status: tt.status}, nil
+			})))
+
+			require.ErrorIs(t, result.Err, tt.wantErr)
+			assert.False(t, result.Success())
+
+			nodeResult, ok := result.ResultFor("a")
+			require.True(t, ok)
+			require.ErrorIs(t, nodeResult.Err, tt.wantErr)
+			assert.False(t, nodeResult.Success())
+		})
+	}
+}
+
 func TestRunExecutesDiamondDAGInStableOrder(t *testing.T) {
 	graph := testGraph(t, map[string][]string{
 		"a": nil,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,487 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudposse/atmos/pkg/dependency"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunExecutesLinearChainInDependencyOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"b"},
+	})
+
+	var mu sync.Mutex
+	started := make([]string, 0, 3)
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		started = append(started, node.ID)
+		mu.Unlock()
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(4)))
+
+	require.NoError(t, result.Err)
+	assert.True(t, result.Success())
+	assert.Equal(t, []string{"a", "b", "c"}, started)
+	assertResultOrder(t, result, "a", "b", "c")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesSingleNode(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+	})
+
+	result := runWithTimeout(t, New(graph, DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		return Result{Value: node.ID}, nil
+	})))
+
+	require.NoError(t, result.Err)
+	require.Len(t, result.Results, 1)
+	assert.True(t, result.Success())
+	assert.Equal(t, "a", result.Results[0].NodeID)
+	assert.Equal(t, StatusSucceeded, result.Results[0].Status)
+	assert.Equal(t, "a", result.Results[0].Value)
+}
+
+func TestRunExecutesDiamondDAGInStableOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"a"},
+		"d": {"b", "c"},
+	})
+
+	result := runWithTimeout(t, New(graph, successfulDispatcher(), WithMaxConcurrency(2)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+		"d": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesFanOutDAGInStableOrder(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"a"},
+		"d": {"a"},
+	})
+
+	result := runWithTimeout(t, New(graph, successfulDispatcher(), WithMaxConcurrency(3)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusSucceeded,
+		"b": StatusSucceeded,
+		"c": StatusSucceeded,
+		"d": StatusSucceeded,
+	})
+}
+
+func TestRunExecutesFanInDAGOnlyAfterAllDependenciesComplete(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+		"d": {"a", "b", "c"},
+	})
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	started := make(chan string, 4)
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		started <- node.ID
+		switch node.ID {
+		case "a":
+			select {
+			case <-releaseA:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		case "b":
+			select {
+			case <-releaseB:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		}
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(4)).Run(ctx)
+	}()
+
+	seen := waitForStartedSet(t, started, nil, "a", "b", "c")
+	assertNoStart(t, started, 50*time.Millisecond)
+	close(releaseA)
+	assertNoStart(t, started, 50*time.Millisecond)
+	close(releaseB)
+	waitForStartedSet(t, started, seen, "d")
+
+	result := <-done
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c", "d")
+}
+
+func TestRunUsesReadyQueueWithoutWaitingForUnrelatedRoot(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": {"b"},
+	})
+
+	releaseA := make(chan struct{})
+	started := make(chan string, 3)
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		started <- node.ID
+		if node.ID == "a" {
+			select {
+			case <-releaseA:
+			case <-ctx.Done():
+				return Result{}, ctx.Err()
+			}
+		}
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(2)).Run(ctx)
+	}()
+
+	seen := waitForStartedSet(t, started, nil, "a", "b")
+	waitForStartedSet(t, started, seen, "c")
+	close(releaseA)
+
+	result := <-done
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c")
+}
+
+func TestRunBoundsConcurrentWorkers(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+		"d": nil,
+	})
+
+	release := make(chan struct{})
+	started := make(chan string, 4)
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	dispatcher := DispatcherFunc(func(ctx context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		started <- node.ID
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		}
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+		return Result{}, nil
+	})
+
+	done := make(chan *AggregateResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		done <- New(graph, dispatcher, WithMaxConcurrency(2)).Run(ctx)
+	}()
+
+	waitForAnyStart(t, started)
+	waitForAnyStart(t, started)
+	assertNoStart(t, started, 50*time.Millisecond)
+
+	close(release)
+	result := <-done
+	require.NoError(t, result.Err)
+	assert.Equal(t, 2, maxActive)
+}
+
+func TestRunReturnsDeterministicAggregateResults(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	})
+
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		switch node.ID {
+		case "a":
+			time.Sleep(30 * time.Millisecond)
+		case "b":
+			time.Sleep(20 * time.Millisecond)
+		case "c":
+			time.Sleep(10 * time.Millisecond)
+		}
+		return Result{Value: node.ID}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(3)))
+
+	require.NoError(t, result.Err)
+	assertResultOrder(t, result, "a", "b", "c")
+	for _, nodeResult := range result.Results {
+		assert.Equal(t, nodeResult.NodeID, nodeResult.Value)
+	}
+}
+
+func TestRunKeepGoingSkipsBlockedDependentsAndRunsIndependentNodes(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+		"c": {"b"},
+		"z": nil,
+	})
+
+	boom := errors.New("boom")
+	started := map[string]bool{}
+	var mu sync.Mutex
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		mu.Lock()
+		started[node.ID] = true
+		mu.Unlock()
+		if node.ID == "a" {
+			return Result{}, boom
+		}
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(2)))
+
+	require.ErrorIs(t, result.Err, boom)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusFailed,
+		"b": StatusSkipped,
+		"c": StatusSkipped,
+		"z": StatusSucceeded,
+	})
+	assert.True(t, started["a"])
+	assert.True(t, started["z"])
+	assert.False(t, started["b"])
+	assert.False(t, started["c"])
+}
+
+func TestRunFailFastSkipsPendingWorkAfterFirstError(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	})
+
+	boom := errors.New("boom")
+	started := map[string]bool{}
+	dispatcher := DispatcherFunc(func(_ context.Context, node *dependency.Node) (Result, error) {
+		started[node.ID] = true
+		if node.ID == "a" {
+			return Result{}, boom
+		}
+		return Result{}, nil
+	})
+
+	result := runWithTimeout(t, New(graph, dispatcher, WithMaxConcurrency(1), WithFailFast(true)))
+
+	require.ErrorIs(t, result.Err, boom)
+	assertStatuses(t, result, map[string]Status{
+		"a": StatusFailed,
+		"b": StatusSkipped,
+		"c": StatusSkipped,
+	})
+	assert.True(t, started["a"])
+	assert.False(t, started["b"])
+	assert.False(t, started["c"])
+}
+
+func TestRunValidatesInputs(t *testing.T) {
+	result := New(nil, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
+		return Result{}, nil
+	})).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrNilGraph)
+
+	graph := testGraph(t, map[string][]string{"a": nil})
+	result = New(graph, nil).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrNilDispatcher)
+
+	result = New(graph, DispatcherFunc(func(context.Context, *dependency.Node) (Result, error) {
+		return Result{}, nil
+	}), WithMaxConcurrency(0)).Run(context.Background())
+	require.ErrorIs(t, result.Err, ErrInvalidWorker)
+}
+
+func TestRunRejectsCyclicGraph(t *testing.T) {
+	graph := dependency.NewGraph()
+	require.NoError(t, graph.AddNode(&dependency.Node{ID: "a"}))
+	require.NoError(t, graph.AddNode(&dependency.Node{ID: "b"}))
+	require.NoError(t, graph.AddDependency("a", "b"))
+	require.NoError(t, graph.AddDependency("b", "a"))
+
+	result := New(graph, successfulDispatcher()).Run(context.Background())
+
+	require.ErrorIs(t, result.Err, ErrInvalidGraph)
+	require.ErrorIs(t, result.Err, dependency.ErrCircularDependency)
+}
+
+func TestRunInvokesNodeHooks(t *testing.T) {
+	graph := testGraph(t, map[string][]string{
+		"a": nil,
+		"b": {"a"},
+	})
+
+	var mu sync.Mutex
+	started := make([]string, 0, 2)
+	completed := make([]string, 0, 2)
+	result := runWithTimeout(t, New(
+		graph,
+		successfulDispatcher(),
+		WithNodeStartHook(func(node *dependency.Node) {
+			mu.Lock()
+			defer mu.Unlock()
+			started = append(started, node.ID)
+		}),
+		WithNodeCompleteHook(func(node *dependency.Node, result Result) {
+			mu.Lock()
+			defer mu.Unlock()
+			completed = append(completed, node.ID+":"+string(result.Status))
+		}),
+	))
+
+	require.NoError(t, result.Err)
+	assert.Equal(t, []string{"a", "b"}, started)
+	assert.Equal(t, []string{"a:succeeded", "b:succeeded"}, completed)
+}
+
+func successfulDispatcher() Dispatcher {
+	return DispatcherFunc(func(_ context.Context, _ *dependency.Node) (Result, error) {
+		return Result{}, nil
+	})
+}
+
+func testGraph(t *testing.T, deps map[string][]string) *dependency.Graph {
+	t.Helper()
+
+	builder := dependency.NewBuilder()
+	for id := range deps {
+		require.NoError(t, builder.AddNode(&dependency.Node{ID: id, Component: id, Stack: "test", Type: "test"}))
+	}
+	for id, dependencies := range deps {
+		for _, dep := range dependencies {
+			require.NoError(t, builder.AddDependency(id, dep))
+		}
+	}
+	graph, err := builder.Build()
+	require.NoError(t, err)
+	return graph
+}
+
+func runWithTimeout(t *testing.T, scheduler *Scheduler) *AggregateResult {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return scheduler.Run(ctx)
+}
+
+func assertResultOrder(t *testing.T, result *AggregateResult, ids ...string) {
+	t.Helper()
+
+	got := make([]string, 0, len(result.Results))
+	for _, nodeResult := range result.Results {
+		got = append(got, nodeResult.NodeID)
+	}
+	assert.Equal(t, ids, got)
+}
+
+func assertStatuses(t *testing.T, result *AggregateResult, expected map[string]Status) {
+	t.Helper()
+
+	for id, status := range expected {
+		nodeResult, ok := result.ResultFor(id)
+		require.True(t, ok, "missing result for %s", id)
+		assert.Equal(t, status, nodeResult.Status, "status for %s", id)
+	}
+}
+
+func waitForStartedSet(t *testing.T, started <-chan string, seen map[string]bool, wants ...string) map[string]bool {
+	t.Helper()
+
+	if seen == nil {
+		seen = map[string]bool{}
+	}
+	deadline := time.After(time.Second)
+	for {
+		allSeen := true
+		for _, want := range wants {
+			if !seen[want] {
+				allSeen = false
+				break
+			}
+		}
+		if allSeen {
+			return seen
+		}
+
+		select {
+		case got := <-started:
+			seen[got] = true
+		case <-deadline:
+			t.Fatalf("timed out waiting for nodes to start: %v", wants)
+		}
+	}
+}
+
+func waitForAnyStart(t *testing.T, started <-chan string) {
+	t.Helper()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for node to start")
+	}
+}
+
+func assertNoStart(t *testing.T, started <-chan string, duration time.Duration) {
+	t.Helper()
+
+	select {
+	case id := <-started:
+		t.Fatalf("unexpected node start while workers were saturated: %s", id)
+	case <-time.After(duration):
+	}
+}


### PR DESCRIPTION
## Summary

Adds the PR 2 scheduler foundation as a new generic `pkg/scheduler` package.

The scheduler consumes the existing dependency graph package and delegates node execution through a generic dispatcher interface. It implements ready-queue DAG scheduling, bounded workers, fail-fast and keep-going behavior, skipped dependent propagation, deterministic aggregate result ordering, and lifecycle hooks for future orchestration layers.

## Scope

- Added `pkg/scheduler` with generic scheduling types and `Scheduler.Run`.
- Added isolated unit tests for single node, linear chain, diamond, fan-out, fan-in, ready-queue behavior, worker bounds, deterministic aggregate ordering, error propagation, fail-fast, keep-going, validation, cycle rejection, and hooks.
- Intentionally did not change Terraform routing, add tool adapters, or expose concurrency flags.

## Stacking

This PR is stacked on PR 1 and targets `codex/dag-process-io-foundation`.

Supersedes the earlier fork-headed draft #2461 now that the stack branches exist in `cloudposse/atmos`.

## Validation

```bash
GOCACHE=/private/tmp/atmos-go-cache go test -count=20 ./pkg/scheduler
GOCACHE=/private/tmp/atmos-go-cache go test ./pkg/scheduler ./pkg/process ./pkg/io ./pkg/dependency
GOCACHE=/private/tmp/atmos-go-cache go test -race ./pkg/scheduler
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DAG scheduler for deterministic execution of dependency graphs with configurable concurrency.
  * Supports fail-fast and continue-on-error modes; dependent tasks are automatically skipped when prerequisites fail.
  * Execution hooks for task start and completion and deterministic aggregated results with combined error reporting.

* **Tests**
  * Comprehensive test suite validating ordering, concurrency bounds, error propagation, hooks, and input validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->