### PR TITLE
Track DAG rollout after v1.221.0 release

### DIFF
--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -1,6 +1,35 @@
 # DAG Concurrent Execution Rollout Tracker
 
-This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`.
+This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`; this file describes how the work is split, what each PR owns, and which behavior must remain unchanged until the correct layer is ready.
+
+## Implementation Strategy
+
+The rollout is intentionally stacked. Each PR introduces one architectural layer or one routing change, with tests at that layer, before the next PR depends on it. This keeps review focused and prevents concurrency behavior from being mixed with unrelated Terraform routing, auth, store, or CI lifecycle changes.
+
+The implementation layers are:
+
+1. `pkg/process` and `pkg/io` foundations: subprocess lifecycle, stream injection, masking, and per-node stream composition.
+2. `pkg/scheduler` core: generic DAG scheduling with ready queues, bounded workers, deterministic results, and no Terraform coupling.
+3. `pkg/scheduler/adapters`: Terraform-first adapter code that translates Atmos component execution into scheduler-dispatched work.
+4. Terraform bulk routing consolidation: move `--all`, `--components`, and `--query` onto one graph-backed path while keeping execution sequential.
+5. Concurrency enablement: turn on `--max-concurrency` first for plan, then apply/destroy after safety and finalize semantics are implemented.
+6. Selector unification and expansion: move `--affected` onto the shared path, then add mixed-type adapters.
+7. Operational enhancements: diagnostics, per-type pools, resumability, richer progress UX, and graph visualization.
+
+Concurrency must not become user-visible until the Terraform bulk routing path is consolidated. The current general CLI path still uses `ExecuteTerraformQuery()` for multi-component execution, so enabling the scheduler too early would create a parallel implementation that is hard to reach, hard to validate, and likely to miss auth/store behavior from the query path.
+
+## Cross-Cutting Rules
+
+- Use `dependencies.components` as the primary dependency source. Use `settings.depends_on` only as a compatibility fallback.
+- Keep `pkg/dependency` as graph/data infrastructure. Do not put orchestration behavior there.
+- Keep scheduler nodes as scheduling data. Execution work belongs behind dispatchers/adapters, not closures embedded in nodes.
+- Use ready-queue scheduling from the first scheduler PR. Do not add a level-based interim scheduler.
+- Preserve `--max-concurrency 1` as equivalent to current sequential behavior.
+- Preserve native CI plan/apply/deploy capture and finalize behavior from the existing CI integration.
+- Do not add new files under `internal/exec`; use existing files there only as shims or integration points.
+- Concurrent apply/destroy must be non-interactive and require `-auto-approve`.
+- Terraform node completion means subprocess execution, hooks, store writes, and CI finalize work have all completed.
+- Keep each PR reviewable: tests should prove the layer being introduced, and later PR behavior should not leak into earlier PRs.
 
 ## Branching
 
@@ -21,6 +50,104 @@ This tracker coordinates the DAG concurrent execution rollout as a sequence of s
 | PR 6 | `codex/dag-affected-scheduler-routing` | TBD | Route `--affected` onto the shared scheduler-backed executor | Planned |
 | PR 7 | `codex/dag-mixed-type-adapters` | TBD | Packer and provider-backed component adapters for mixed-type DAGs | Planned |
 | PR 8 | `codex/dag-scheduler-diagnostics` | TBD | Additive scheduling diagnostics, progress UX, pools, resumability, and graph visualization as justified | Planned |
+
+## PR Details
+
+### PR 1: Process and I/O Foundation
+
+Owns subprocess and stream primitives only. `ExecuteShellCommand()` remains backward compatible but delegates to `pkg/process`, and `runTerraformShow()` stops mutating global `os.Stdout`. This is the safety prerequisite for later concurrent workers because subprocess output cannot rely on shared global stdout/stderr.
+
+Review focus:
+
+- Exit code preservation for Terraform detailed exit codes.
+- Context-aware process execution and cancellation reporting.
+- Existing CI stdout/stderr capture remains a tee, not a redirect.
+- Per-node stream primitives can label and fan out to terminal, file, and capture sinks.
+
+### PR 2: Scheduler Core
+
+Adds the generic scheduler without touching Terraform routing. The scheduler owns dependency-aware orchestration, ready queues, bounded workers, fail-fast and keep-going behavior, destroy reverse blocking semantics, and deterministic aggregate result ordering.
+
+Review focus:
+
+- No Terraform imports or command assumptions.
+- Nodes remain data only.
+- Dispatcher is the execution boundary.
+- Tests cover graph shapes and failure behavior in isolation.
+
+### PR 3: Terraform Graph-Backed Bulk Path Consolidation
+
+Introduces the Terraform adapter and moves non-affected bulk selectors onto one graph-backed executor while keeping concurrency fixed at one worker. This PR is where existing query-path behavior must be preserved: auth setup, store resolver bridging, YAML function processing, per-component command construction, hooks, and current sequential UX.
+
+Review focus:
+
+- `--all`, `--components`, and `--query` share one path.
+- Dependency ordering prefers `dependencies.components`.
+- Existing auth/store behavior from `ExecuteTerraformQuery()` remains intact.
+- No visible concurrency or `--max-concurrency` behavior is introduced.
+
+### PR 4: Concurrent Terraform Plan
+
+Adds `--max-concurrency` for the consolidated Terraform bulk path and enables concurrent `plan` only. This is the first user-visible concurrency PR because plan is the safest Terraform command surface.
+
+Review focus:
+
+- Workdir and non-interactive auth preflight validation.
+- Per-node output labeling, log files, and capture remain isolated.
+- Plan exit codes preserve `0`, `2`, and failure semantics.
+- `--max-concurrency 1` remains behaviorally sequential.
+
+### PR 5: Concurrent Terraform Apply and Destroy
+
+Extends concurrency to mutating Terraform commands after safety checks are in place. Apply/destroy require non-interactive execution and `-auto-approve` when concurrency is greater than one. Destroy uses reverse dependency blocking so prerequisites are not destroyed after dependent failure.
+
+Review focus:
+
+- Dependents release only after full node finalize completion.
+- CI finalize and store writes are part of node completion.
+- Signal handling cancels gracefully.
+- Unsupported interactive combinations fail before any execution starts.
+
+### PR 6: Affected Routing
+
+Routes `--affected` through the same scheduler-backed executor while preserving the existing DescribeAffected selector behavior and `--include-dependents` semantics.
+
+Review focus:
+
+- Affected-set semantics remain unchanged.
+- Dependency closure is explicit and tested.
+- Fail-fast and keep-going behavior is consistent with other selectors.
+
+### PR 7: Mixed-Type DAGs
+
+Adds Packer and provider-backed component adapters after Terraform concurrency is correct. This makes the scheduler component-type agnostic without changing scheduler internals.
+
+Review focus:
+
+- Mixed Terraform + Packer DAGs work.
+- Mixed Terraform + provider-backed DAGs work.
+- `dependencies.components.kind` drives cross-type graph construction.
+
+### PR 8: Advanced Scheduling and Diagnostics
+
+Adds operational features only after the core path is correct. Candidate features include per-type concurrency pools, resumability, richer progress UX, graph visualization, and critical-path prioritization if profiling justifies it.
+
+Review focus:
+
+- Features are additive.
+- Core scheduler semantics do not regress.
+- Diagnostics explain graph and execution state without changing outcomes.
+
+## Review and Merge Model
+
+The PRs can be reviewed as a stack, but each PR should have its own clear validation. If the stack becomes too large, rebase later PRs as earlier PRs merge. Avoid combining PR 3 and PR 4 unless there is no practical alternative, because routing consolidation and first concurrency enablement exercise different risk areas.
+
+Before moving from one PR to the next, confirm:
+
+- The previous PR's package-level tests pass.
+- New abstractions are used only by their intended integration point.
+- No out-of-scope CLI behavior has changed.
+- The next PR branches from the previous rollout branch unless the stack has been merged and rebased onto `upstream/main`.
 
 ## Next Step Prompt
 

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -1,0 +1,35 @@
+# DAG Concurrent Execution Rollout Tracker
+
+This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`.
+
+## Branching
+
+- PR 1 starts from `upstream/main`.
+- PR 2 starts from `codex/dag-process-io-foundation`.
+- Each later PR starts from the previous rollout branch until the stack is ready to merge or rebase.
+- Keep each PR self-contained and avoid enabling concurrency before the graph-backed Terraform bulk path is consolidated.
+
+## Rollout
+
+| Step | Branch | PR | Scope | Status |
+| --- | --- | --- | --- | --- |
+| PR 1 | `codex/dag-process-io-foundation` | cloudposse/atmos#2459 | `pkg/process`, `pkg/io` stream foundations, shell wrapper integration, `runTerraformShow` stdout injection | Open |
+| PR 2 | `codex/dag-scheduler-core` | TBD | Generic `pkg/scheduler` ready-queue scheduler, orchestrator, deterministic aggregate results, unit tests | Next |
+| PR 3 | `codex/dag-terraform-graph-bulk-path` | TBD | Terraform adapter and graph-backed sequential consolidation for `--all`, `--components`, and `--query` | Planned |
+| PR 4 | `codex/dag-concurrent-terraform-plan` | TBD | `--max-concurrency` for concurrent Terraform plan on the consolidated path | Planned |
+| PR 5 | `codex/dag-concurrent-terraform-apply-destroy` | TBD | Concurrent apply/destroy safety, auto-approve validation, finalize semantics, reverse destroy blocking | Planned |
+| PR 6 | `codex/dag-affected-scheduler-routing` | TBD | Route `--affected` onto the shared scheduler-backed executor | Planned |
+| PR 7 | `codex/dag-mixed-type-adapters` | TBD | Packer and provider-backed component adapters for mixed-type DAGs | Planned |
+| PR 8 | `codex/dag-scheduler-diagnostics` | TBD | Additive scheduling diagnostics, progress UX, pools, resumability, and graph visualization as justified | Planned |
+
+## Next Step Prompt
+
+Start from `codex/dag-process-io-foundation` and implement PR 2 only:
+
+- Add `pkg/scheduler` with `Node`, `Status`, `NodeResult`, `AggregateResult`, `Dispatcher`, `Scheduler`, and `Orchestrator`.
+- Use a ready-queue scheduler with a bounded worker pool from the beginning.
+- Keep scheduler nodes as scheduling data only; do not put execution closures on nodes.
+- Keep the scheduler generic with no Terraform coupling.
+- Add deterministic result ordering for JSON summaries.
+- Cover linear chain, diamond, fan-out, fan-in, fail-fast, keep-going, and destroy reverse blocking semantics with unit tests.
+- Do not change Terraform CLI routing, add Terraform adapters, or expose concurrency flags in PR 2.

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -4,7 +4,7 @@ This tracker coordinates the DAG concurrent execution rollout as a sequence of s
 
 ## Implementation Strategy
 
-The execution foundation and GitHub CI verification path are now merged into `main`. PR 1 through PR 7 established process stream injection, the generic scheduler, graph-backed Terraform routing, plan/apply/destroy concurrency, affected routing, and aggregate GitHub Actions output for concurrent Terraform plans. Remaining work should focus on making concurrent execution understandable from local terminals and extending DAG support without changing scheduler semantics.
+The execution foundation and GitHub CI verification path are now merged into `main` and shipped in Atmos [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0). PR 1 through PR 7 established process stream injection, the generic scheduler, graph-backed Terraform routing, plan/apply/destroy concurrency, affected routing, and aggregate GitHub Actions output for concurrent Terraform plans. Remaining work should focus on making concurrent execution understandable from local terminals and extending DAG support without changing scheduler semantics.
 
 Remaining near-term layers are:
 
@@ -33,7 +33,7 @@ Remaining near-term layers are:
 | PR 4 | [cloudposse/atmos#2468](https://github.com/cloudposse/atmos/pull/2468) | Merged into `main` | `codex/dag-terraform-plan-concurrency` | Plan-only `--max-concurrency`, grouped/stream output, per-node logs, no-change hiding, and execution summaries |
 | PR 5 | [cloudposse/atmos#2474](https://github.com/cloudposse/atmos/pull/2474) | Merged into `main` | `codex/dag-terraform-apply-destroy-concurrency` | Concurrent Terraform `apply`/`destroy` safety model with auto-approve gates, cancellation propagation, and reverse destroy ordering |
 | PR 6 | [cloudposse/atmos#2519](https://github.com/cloudposse/atmos/pull/2519) | Merged into `main` | `codex/dag-terraform-affected-scheduler` | Routes Terraform `--affected` through the scheduler and adds `--fail-fast`/`--keep-going` controls |
-| PR 7 | [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) | Merged into `main` | `codex/dag-github-concurrent-output` | GitHub Actions-oriented output for concurrent Terraform plans, aggregate CI summaries, output variables, optional status contexts, and optional PR comments |
+| PR 7 | [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) | Merged into `main`; released in [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0) | `codex/dag-github-concurrent-output` | GitHub Actions-oriented output for concurrent Terraform plans, aggregate CI summaries, output variables, optional status contexts, and optional PR comments |
 | Tracking | [cloudposse/atmos#2467](https://github.com/cloudposse/atmos/pull/2467) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan, findings, and PR coordination document |
 
 ## Planned PRs
@@ -46,7 +46,7 @@ Remaining near-term layers are:
 
 ## Current Findings
 
-- The implementation stack PRs 1 through 7 have merged into `main`. PR 8 should start from current `main` and focus on local interactive/TUI output.
+- The implementation stack PRs 1 through 7 have merged into `main` and shipped in Atmos [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0), released on June 10, 2026. PR 8 should start from current `main` and focus on local interactive/TUI output.
 - `--ci` uses native CI provider detection. GitHub Actions auto-detects through `GITHUB_ACTIONS=true`; explicit `--ci` forces CI mode and falls back to the generic provider when no platform is detected.
 - GitHub Actions output is written through provider output writers to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`. Concurrent Terraform plan CI now writes aggregate artifacts once after the scheduler finishes to avoid concurrent writes to those files.
 - Terraform CI plugin behavior remains compatibility-critical for single-component plan/apply/deploy. Multi-component plan CI uses the aggregate collector path; single-component and non-plan behavior continue through the existing hook path.
@@ -60,6 +60,8 @@ Remaining near-term layers are:
 ## PR 7: GitHub Actions Output For Concurrent Terraform Plans
 
 Merged PR: [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577)
+
+Released in Atmos [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0), published on June 10, 2026.
 
 PR 7 makes concurrent Terraform plan verification usable in GitHub Actions with minimal friction.
 
@@ -96,7 +98,7 @@ Review focus:
 
 ## Review and Merge Model
 
-The first seven rollout PRs have merged into `main`, and PR 8 should branch from current `main`. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
+The first seven rollout PRs have merged into `main` and shipped in Atmos [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0). PR 8 should branch from current `main`. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
 
 Before moving from one PR to the next, confirm:
 

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -1,162 +1,114 @@
 # DAG Concurrent Execution Rollout Tracker
 
-This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`; this file describes how the work is split, what each PR owns, and which behavior must remain unchanged until the correct layer is ready.
+This tracker coordinates the DAG concurrent execution rollout as a sequence of small, reviewable PRs. The primary design source remains `docs/prd/dag-concurrent-execution.md`; this file describes current rollout state, what each PR owns, and which behavior must remain unchanged while output and diagnostics work continues.
 
 ## Implementation Strategy
 
-The rollout is intentionally stacked. Each PR introduces one architectural layer or one routing change, with tests at that layer, before the next PR depends on it. This keeps review focused and prevents concurrency behavior from being mixed with unrelated Terraform routing, auth, store, or CI lifecycle changes.
+The execution foundation is now merged into `main`. PR 1 through PR 6 established process stream injection, the generic scheduler, graph-backed Terraform routing, plan/apply/destroy concurrency, and affected routing. Remaining work should focus on making concurrent execution understandable and easy to verify without changing scheduler semantics.
 
-The implementation layers are:
+Near-term layers are:
 
-1. `pkg/process` and `pkg/io` foundations: subprocess lifecycle, stream injection, masking, and per-node stream composition.
-2. `pkg/scheduler` core: generic DAG scheduling with ready queues, bounded workers, deterministic results, and no Terraform coupling.
-3. `pkg/scheduler/adapters`: Terraform-first adapter code that translates Atmos component execution into scheduler-dispatched work.
-4. Terraform bulk routing consolidation: move `--all`, `--components`, and `--query` onto one graph-backed path while keeping execution sequential.
-5. Concurrency enablement: turn on `--max-concurrency` first for plan, then apply/destroy after safety and finalize semantics are implemented.
-6. Selector unification and expansion: move `--affected` onto the shared path, then add mixed-type adapters.
-7. Operational enhancements: diagnostics, per-type pools, resumability, richer progress UX, and graph visualization.
-
-Concurrency must not become user-visible until the Terraform bulk routing path is consolidated. The current general CLI path still uses `ExecuteTerraformQuery()` for multi-component execution, so enabling the scheduler too early would create a parallel implementation that is hard to reach, hard to validate, and likely to miss auth/store behavior from the query path.
+1. GitHub Actions CI output for concurrent Terraform plan verification.
+2. TUI/interactive output for non-CI Terraform plan/apply/destroy runs.
+3. Mixed-type DAG adapter support after Terraform-only execution and output UX are stable.
+4. Advanced scheduling diagnostics and operator troubleshooting aids.
 
 ## Cross-Cutting Rules
 
 - Use `dependencies.components` as the primary dependency source. Use `settings.depends_on` only as a compatibility fallback.
 - Keep `pkg/dependency` as graph/data infrastructure. Do not put orchestration behavior there.
-- Keep scheduler nodes as scheduling data. Execution work belongs behind dispatchers/adapters, not closures embedded in nodes.
-- Use ready-queue scheduling from the first scheduler PR. Do not add a level-based interim scheduler.
+- Keep scheduler nodes as scheduling data. Execution work belongs behind dispatchers/adapters.
 - Preserve `--max-concurrency 1` as equivalent to current sequential behavior.
-- Preserve native CI plan/apply/deploy capture and finalize behavior from the existing CI integration.
+- Preserve native CI plan/apply/deploy capture, hooks, summaries, outputs, status contexts, comments, and planfile behavior unless a PR explicitly changes that surface.
 - Do not add new files under `internal/exec`; use existing files there only as shims or integration points.
-- Concurrent apply/destroy must be non-interactive and require `-auto-approve`.
-- Terraform node completion means subprocess execution, hooks, store writes, and CI finalize work have all completed.
+- Terraform node completion means subprocess execution, hooks, store writes, CI finalize work, and per-node output capture have all completed.
 - Keep each PR reviewable: tests should prove the layer being introduced, and later PR behavior should not leak into earlier PRs.
 
-## Branching
+## Active PRs
 
-- PR 1 starts from `upstream/main`.
-- PR 2 starts from `codex/dag-process-io-foundation`.
-- Each later PR starts from the previous rollout branch until the stack is ready to merge or rebase.
-- Keep each PR self-contained and avoid enabling concurrency before the graph-backed Terraform bulk path is consolidated.
-
-## Rollout
-
-| Step | Branch | PR | Scope | Status |
+| Step | PR | Status | Branch | Scope |
 | --- | --- | --- | --- | --- |
-| PR 1 | `codex/dag-process-io-foundation` | cloudposse/atmos#2459 | `pkg/process`, `pkg/io` stream foundations, shell wrapper integration, `runTerraformShow` stdout injection | Open |
-| PR 2 | `codex/dag-scheduler-core` | TBD | Generic `pkg/scheduler` ready-queue scheduler, orchestrator, deterministic aggregate results, unit tests | Next |
-| PR 3 | `codex/dag-terraform-graph-bulk-path` | TBD | Terraform adapter and graph-backed sequential consolidation for `--all`, `--components`, and `--query` | Planned |
-| PR 4 | `codex/dag-concurrent-terraform-plan` | TBD | `--max-concurrency` for concurrent Terraform plan on the consolidated path | Planned |
-| PR 5 | `codex/dag-concurrent-terraform-apply-destroy` | TBD | Concurrent apply/destroy safety, auto-approve validation, finalize semantics, reverse destroy blocking | Planned |
-| PR 6 | `codex/dag-affected-scheduler-routing` | TBD | Route `--affected` onto the shared scheduler-backed executor | Planned |
-| PR 7 | `codex/dag-mixed-type-adapters` | TBD | Packer and provider-backed component adapters for mixed-type DAGs | Planned |
-| PR 8 | `codex/dag-scheduler-diagnostics` | TBD | Additive scheduling diagnostics, progress UX, pools, resumability, and graph visualization as justified | Planned |
+| PR 1 | [cloudposse/atmos#2464](https://github.com/cloudposse/atmos/pull/2464) | Merged into `main` | `codex/dag-process-io-foundation` | Process runner, stream injection, shell wrapper integration, `runTerraformShow` stdout capture fix |
+| PR 2 | [cloudposse/atmos#2465](https://github.com/cloudposse/atmos/pull/2465) | Merged into `main` | `codex/dag-scheduler-core` | Generic `pkg/scheduler` ready-queue scheduler with deterministic aggregate results |
+| PR 3 | [cloudposse/atmos#2466](https://github.com/cloudposse/atmos/pull/2466) | Merged into `main` | `codex/dag-terraform-graph-bulk-path` | Terraform `--all`, `--components`, and `--query` graph-backed routing with effective concurrency fixed at `1`; includes discovered auth safety prerequisite |
+| PR 4 | [cloudposse/atmos#2468](https://github.com/cloudposse/atmos/pull/2468) | Merged into `main` | `codex/dag-terraform-plan-concurrency` | Plan-only `--max-concurrency`, grouped/stream output, per-node logs, no-change hiding, and execution summaries |
+| PR 5 | [cloudposse/atmos#2474](https://github.com/cloudposse/atmos/pull/2474) | Merged into `main` | `codex/dag-terraform-apply-destroy-concurrency` | Concurrent Terraform `apply`/`destroy` safety model with auto-approve gates, cancellation propagation, and reverse destroy ordering |
+| PR 6 | [cloudposse/atmos#2519](https://github.com/cloudposse/atmos/pull/2519) | Merged into `main` | `codex/dag-terraform-affected-scheduler` | Routes Terraform `--affected` through the scheduler and adds `--fail-fast`/`--keep-going` controls |
+| Tracking | [cloudposse/atmos#2467](https://github.com/cloudposse/atmos/pull/2467) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan, findings, and PR coordination document |
 
-## PR Details
+## Planned PRs
 
-### PR 1: Process and I/O Foundation
+| Step | Intended base | Proposed branch | Scope | Key gates / non-goals |
+| --- | --- | --- | --- | --- |
+| PR 7 | `main` | `codex/dag-github-concurrent-output` | Add GitHub Actions-oriented output for concurrent Terraform plans so CI summaries, output variables, optional status contexts, and optional PR comments render clearly for verification. | CI-focused. Preserve scheduler semantics and existing public config/flags. Do not change local interactive output or migrate GitHub Status API support to Checks API. |
+| PR 8 | PR 7 / `main` after PR 7 merges | `codex/dag-terraform-interactive-output` | Add TUI/interactive output for non-CI Terraform plan/apply/destroy runs so concurrent execution is usable from a terminal. | Applies outside CI. Preserve GitHub CI rendering and native CI hooks. Do not introduce new execution semantics. |
+| PR 9 | PR 8 | `codex/dag-mixed-type-adapters` | Add mixed-type DAG adapter support after Terraform-only execution and output UX are stable. Include explicit adapter boundaries for Terraform and future component types. | Requires repo-owner agreement on mixed-type ordering semantics. Do not rewrite unrelated executors. |
+| PR 10 | PR 9 | `codex/dag-scheduling-diagnostics` | Add advanced scheduling diagnostics, graph/debug output, and operator-facing troubleshooting aids. | Should not change scheduling semantics. Keep diagnostics opt-in and safe for CI logs. |
 
-Owns subprocess and stream primitives only. `ExecuteShellCommand()` remains backward compatible but delegates to `pkg/process`, and `runTerraformShow()` stops mutating global `os.Stdout`. This is the safety prerequisite for later concurrent workers because subprocess output cannot rely on shared global stdout/stderr.
+## Current Findings
 
-Review focus:
+- The implementation stack PRs 1 through 6 have merged into `main`, so PR 7 should branch from current `main` rather than from PR 6.
+- `--ci` uses native CI provider detection. GitHub Actions auto-detects through `GITHUB_ACTIONS=true`; explicit `--ci` forces CI mode and falls back to the generic provider when no platform is detected.
+- GitHub Actions output is currently written through provider output writers to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`.
+- Terraform CI plugin behavior is single-component shaped today: after-plan hooks parse one component's captured output, append one rendered summary, write output variables, optionally upload one planfile, optionally update one status context, and optionally post or update one PR comment.
+- Multi-component Terraform plan/apply/deploy currently suppress the global PostRun hook and install `Info.PerComponentHook`, which runs inside each scheduled component. That keeps single-component attribution correct, but concurrent plan mode can produce nondeterministic GitHub output unless writes are centralized or serialized.
+- The GitHub provider currently uses the commit Status API for status contexts. PR 7 should not depend on richer Checks API annotations or output.
+- PR comment markers are per component (`<!-- atmos:ci:<command>:<component>:<stack> -->`). Aggregate comments, if added, need a distinct aggregate marker so they do not collide with existing component comments.
+- The Terraform scheduler adapter already captures per-node stdout/stderr, exit code, changed state, status, timings, and log file paths; PR 7 should build CI aggregation from those existing outputs instead of scraping interleaved GitHub logs.
 
-- Exit code preservation for Terraform detailed exit codes.
-- Context-aware process execution and cancellation reporting.
-- Existing CI stdout/stderr capture remains a tee, not a redirect.
-- Per-node stream primitives can label and fan out to terminal, file, and capture sinks.
+## PR 7: GitHub Actions Output For Concurrent Terraform Plans
 
-### PR 2: Scheduler Core
-
-Adds the generic scheduler without touching Terraform routing. The scheduler owns dependency-aware orchestration, ready queues, bounded workers, fail-fast and keep-going behavior, destroy reverse blocking semantics, and deterministic aggregate result ordering.
-
-Review focus:
-
-- No Terraform imports or command assumptions.
-- Nodes remain data only.
-- Dispatcher is the execution boundary.
-- Tests cover graph shapes and failure behavior in isolation.
-
-### PR 3: Terraform Graph-Backed Bulk Path Consolidation
-
-Introduces the Terraform adapter and moves non-affected bulk selectors onto one graph-backed executor while keeping concurrency fixed at one worker. This PR is where existing query-path behavior must be preserved: auth setup, store resolver bridging, YAML function processing, per-component command construction, hooks, and current sequential UX.
+PR 7 makes concurrent Terraform plan verification usable in GitHub Actions with minimal friction.
 
 Review focus:
 
-- `--all`, `--components`, and `--query` share one path.
-- Dependency ordering prefers `dependencies.components`.
-- Existing auth/store behavior from `ExecuteTerraformQuery()` remains intact.
-- No visible concurrency or `--max-concurrency` behavior is introduced.
+- Keep existing public config and flags: no new CLI flag or `atmos.yaml` setting for v1.
+- Add an aggregate CI path for multi-component `plan` runs only. Single-component plan/apply/deploy behavior remains unchanged.
+- Collect per-node plan output/results during DAG execution, then write GitHub CI artifacts once after the scheduler finishes.
+- Write one deterministic job summary with component counts, aggregate resource counts, failed/changed/no-change/skipped grouping, per-component rows, and details for failed/changed components.
+- Write aggregate output variables once: `has_changes`, `has_errors`, `exit_code`, `resources_to_create`, `resources_to_change`, `resources_to_replace`, `resources_to_destroy`, `components_total`, `components_succeeded`, `components_failed`, `components_changed`, `components_no_changes`, `components_skipped`, `summary`, `command`, `stack`, and `component`.
+- Define aggregate exit-code semantics as `1` if any component failed, else `2` if any component changed, else `0`.
+- Preserve optional PR comments and status contexts behind existing `ci.comments` and `ci.checks` settings, with deterministic serialized writes.
+- Avoid concurrent writes to `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY`.
 
-### PR 4: Concurrent Terraform Plan
+Validation focus:
 
-Adds `--max-concurrency` for the consolidated Terraform bulk path and enables concurrent `plan` only. This is the first user-visible concurrency PR because plan is the safest Terraform command surface.
+- Unit-test aggregate Terraform CI rendering with mixed no-change, changed, failed, skipped, and output-only results.
+- Unit-test aggregate output variables and exit-code rules.
+- Unit-test command wiring so multi-component plan CI uses aggregate output while single-component plan still uses the existing hook path.
+- Unit-test optional comments/statuses with mock providers to prove deterministic serialized calls and existing config gates.
+- Regression-test `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT` temp files under `GITHUB_ACTIONS=true`.
+- Race-test the aggregate collector and relevant scheduler adapter paths.
 
-Review focus:
+## PR 8: TUI/Interactive Terraform Output
 
-- Workdir and non-interactive auth preflight validation.
-- Per-node output labeling, log files, and capture remain isolated.
-- Plan exit codes preserve `0`, `2`, and failure semantics.
-- `--max-concurrency 1` remains behaviorally sequential.
-
-### PR 5: Concurrent Terraform Apply and Destroy
-
-Extends concurrency to mutating Terraform commands after safety checks are in place. Apply/destroy require non-interactive execution and `-auto-approve` when concurrency is greater than one. Destroy uses reverse dependency blocking so prerequisites are not destroyed after dependent failure.
-
-Review focus:
-
-- Dependents release only after full node finalize completion.
-- CI finalize and store writes are part of node completion.
-- Signal handling cancels gracefully.
-- Unsupported interactive combinations fail before any execution starts.
-
-### PR 6: Affected Routing
-
-Routes `--affected` through the same scheduler-backed executor while preserving the existing DescribeAffected selector behavior and `--include-dependents` semantics.
+PR 8 moves after GitHub CI output so developer verification in CI is stable first. It should focus on non-CI interactive plan/apply/destroy rendering without changing CI output behavior.
 
 Review focus:
 
-- Affected-set semantics remain unchanged.
-- Dependency closure is explicit and tested.
-- Fail-fast and keep-going behavior is consistent with other selectors.
-
-### PR 7: Mixed-Type DAGs
-
-Adds Packer and provider-backed component adapters after Terraform concurrency is correct. This makes the scheduler component-type agnostic without changing scheduler internals.
-
-Review focus:
-
-- Mixed Terraform + Packer DAGs work.
-- Mixed Terraform + provider-backed DAGs work.
-- `dependencies.components.kind` drives cross-type graph construction.
-
-### PR 8: Advanced Scheduling and Diagnostics
-
-Adds operational features only after the core path is correct. Candidate features include per-type concurrency pools, resumability, richer progress UX, graph visualization, and critical-path prioritization if profiling justifies it.
-
-Review focus:
-
-- Features are additive.
-- Core scheduler semantics do not regress.
-- Diagnostics explain graph and execution state without changing outcomes.
+- Keep GitHub CI rendering unchanged.
+- Preserve scheduler semantics, hooks, summaries, logs, and sequential UX.
+- Make local terminal output understandable for concurrent plan/apply/destroy runs.
+- Do not introduce new execution semantics or mixed-type behavior.
 
 ## Review and Merge Model
 
-The PRs can be reviewed as a stack, but each PR should have its own clear validation. If the stack becomes too large, rebase later PRs as earlier PRs merge. Avoid combining PR 3 and PR 4 unless there is no practical alternative, because routing consolidation and first concurrency enablement exercise different risk areas.
+The first six rollout PRs have merged into `main`, so future PRs should branch from current `main` unless a preceding planned PR is still open and explicitly becomes the base. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
 
 Before moving from one PR to the next, confirm:
 
 - The previous PR's package-level tests pass.
 - New abstractions are used only by their intended integration point.
 - No out-of-scope CLI behavior has changed.
-- The next PR branches from the previous rollout branch unless the stack has been merged and rebased onto `upstream/main`.
+- The next PR branches from `main` unless the prior planned branch is intentionally still open.
 
 ## Next Step Prompt
 
-Start from `codex/dag-process-io-foundation` and implement PR 2 only:
+Start from current `origin/main` and implement PR 7 only:
 
-- Add `pkg/scheduler` with `Node`, `Status`, `NodeResult`, `AggregateResult`, `Dispatcher`, `Scheduler`, and `Orchestrator`.
-- Use a ready-queue scheduler with a bounded worker pool from the beginning.
-- Keep scheduler nodes as scheduling data only; do not put execution closures on nodes.
-- Keep the scheduler generic with no Terraform coupling.
-- Add deterministic result ordering for JSON summaries.
-- Cover linear chain, diamond, fan-out, fan-in, fail-fast, keep-going, and destroy reverse blocking semantics with unit tests.
-- Do not change Terraform CLI routing, add Terraform adapters, or expose concurrency flags in PR 2.
+- Create branch `codex/dag-github-concurrent-output`.
+- Add aggregate Terraform CI rendering/output-variable logic in `pkg/ci/plugins/terraform` using existing provider interfaces and Terraform parsing/template helpers.
+- Adjust `cmd/terraform` multi-component plan wiring so CI mode installs a collector instead of firing full per-component CI writes from scheduler workers.
+- Build aggregation from scheduler node outcomes, captured stdout/stderr, node status, exit code, timings, and log file paths already produced by the Terraform scheduler adapter.
+- Keep scheduler semantics unchanged: fail-fast, keep-going, skipped dependents, concurrency limits, workdir locking, and plan exit-code handling must not change.
+- Do not change interactive/TUI output in PR 7.

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -4,14 +4,13 @@ This tracker coordinates the DAG concurrent execution rollout as a sequence of s
 
 ## Implementation Strategy
 
-The execution foundation is now merged into `main`. PR 1 through PR 6 established process stream injection, the generic scheduler, graph-backed Terraform routing, plan/apply/destroy concurrency, and affected routing. Remaining work should focus on making concurrent execution understandable and easy to verify without changing scheduler semantics.
+The execution foundation and GitHub CI verification path are now merged into `main`. PR 1 through PR 7 established process stream injection, the generic scheduler, graph-backed Terraform routing, plan/apply/destroy concurrency, affected routing, and aggregate GitHub Actions output for concurrent Terraform plans. Remaining work should focus on making concurrent execution understandable from local terminals and extending DAG support without changing scheduler semantics.
 
-Near-term layers are:
+Remaining near-term layers are:
 
-1. GitHub Actions CI output for concurrent Terraform plan verification.
-2. TUI/interactive output for non-CI Terraform plan/apply/destroy runs.
-3. Mixed-type DAG adapter support after Terraform-only execution and output UX are stable.
-4. Advanced scheduling diagnostics and operator troubleshooting aids.
+1. TUI/interactive output for non-CI Terraform plan/apply/destroy runs.
+2. Mixed-type DAG adapter support after Terraform-only execution and output UX are stable.
+3. Advanced scheduling diagnostics and operator troubleshooting aids.
 
 ## Cross-Cutting Rules
 
@@ -34,35 +33,37 @@ Near-term layers are:
 | PR 4 | [cloudposse/atmos#2468](https://github.com/cloudposse/atmos/pull/2468) | Merged into `main` | `codex/dag-terraform-plan-concurrency` | Plan-only `--max-concurrency`, grouped/stream output, per-node logs, no-change hiding, and execution summaries |
 | PR 5 | [cloudposse/atmos#2474](https://github.com/cloudposse/atmos/pull/2474) | Merged into `main` | `codex/dag-terraform-apply-destroy-concurrency` | Concurrent Terraform `apply`/`destroy` safety model with auto-approve gates, cancellation propagation, and reverse destroy ordering |
 | PR 6 | [cloudposse/atmos#2519](https://github.com/cloudposse/atmos/pull/2519) | Merged into `main` | `codex/dag-terraform-affected-scheduler` | Routes Terraform `--affected` through the scheduler and adds `--fail-fast`/`--keep-going` controls |
-| PR 7 | [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) | Open draft | `codex/dag-github-concurrent-output` | GitHub Actions-oriented output for concurrent Terraform plans, aggregate CI summaries, output variables, optional status contexts, and optional PR comments |
+| PR 7 | [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) | Merged into `main` | `codex/dag-github-concurrent-output` | GitHub Actions-oriented output for concurrent Terraform plans, aggregate CI summaries, output variables, optional status contexts, and optional PR comments |
 | Tracking | [cloudposse/atmos#2467](https://github.com/cloudposse/atmos/pull/2467) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan, findings, and PR coordination document |
 
 ## Planned PRs
 
 | Step | Intended base | Proposed branch | Scope | Key gates / non-goals |
 | --- | --- | --- | --- | --- |
-| PR 8 | PR 7 / `main` after PR 7 merges | `codex/dag-terraform-interactive-output` | Add TUI/interactive output for non-CI Terraform plan/apply/destroy runs so concurrent execution is usable from a terminal. | Applies outside CI. Preserve GitHub CI rendering and native CI hooks. Do not introduce new execution semantics. |
+| PR 8 | `main` after PR 7 merge | `codex/dag-terraform-interactive-output` | Add TUI/interactive output for non-CI Terraform plan/apply/destroy runs so concurrent execution is usable from a terminal. | Applies outside CI. Preserve GitHub CI rendering and native CI hooks. Do not introduce new execution semantics. |
 | PR 9 | PR 8 | `codex/dag-mixed-type-adapters` | Add mixed-type DAG adapter support after Terraform-only execution and output UX are stable. Include explicit adapter boundaries for Terraform and future component types. | Requires repo-owner agreement on mixed-type ordering semantics. Do not rewrite unrelated executors. |
 | PR 10 | PR 9 | `codex/dag-scheduling-diagnostics` | Add advanced scheduling diagnostics, graph/debug output, and operator-facing troubleshooting aids. | Should not change scheduling semantics. Keep diagnostics opt-in and safe for CI logs. |
 
 ## Current Findings
 
-- The implementation stack PRs 1 through 6 have merged into `main`, and PR 7 is now open as draft [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) from current `main`.
+- The implementation stack PRs 1 through 7 have merged into `main`. PR 8 should start from current `main` and focus on local interactive/TUI output.
 - `--ci` uses native CI provider detection. GitHub Actions auto-detects through `GITHUB_ACTIONS=true`; explicit `--ci` forces CI mode and falls back to the generic provider when no platform is detected.
-- GitHub Actions output is currently written through provider output writers to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`.
-- Terraform CI plugin behavior is single-component shaped today: after-plan hooks parse one component's captured output, append one rendered summary, write output variables, optionally upload one planfile, optionally update one status context, and optionally post or update one PR comment.
-- Multi-component Terraform plan/apply/deploy currently suppress the global PostRun hook and install `Info.PerComponentHook`, which runs inside each scheduled component. That keeps single-component attribution correct, but concurrent plan mode can produce nondeterministic GitHub output unless writes are centralized or serialized.
-- The GitHub provider currently uses the commit Status API for status contexts. PR 7 should not depend on richer Checks API annotations or output.
-- PR comment markers are per component (`<!-- atmos:ci:<command>:<component>:<stack> -->`). Aggregate comments, if added, need a distinct aggregate marker so they do not collide with existing component comments.
-- The Terraform scheduler adapter already captures per-node stdout/stderr, exit code, changed state, status, timings, and log file paths; PR 7 should build CI aggregation from those existing outputs instead of scraping interleaved GitHub logs.
+- GitHub Actions output is written through provider output writers to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`. Concurrent Terraform plan CI now writes aggregate artifacts once after the scheduler finishes to avoid concurrent writes to those files.
+- Terraform CI plugin behavior remains compatibility-critical for single-component plan/apply/deploy. Multi-component plan CI uses the aggregate collector path; single-component and non-plan behavior continue through the existing hook path.
+- Multi-component Terraform plan/apply/deploy suppress the global PostRun hook and install `Info.PerComponentHook` for per-component attribution. PR 7 centralizes CI artifact writes only for multi-component plan CI; later PRs should preserve that separation.
+- The GitHub provider currently uses the commit Status API for status contexts. PR 7 preserved that path; later CI work should not depend on richer Checks API annotations or output without a separate design.
+- Aggregate PR comments use a distinct marker from per-component comments (`<!-- atmos:ci:<command>:<component>:<stack> -->`) so they do not collide with existing component comments.
+- The Terraform scheduler adapter captures per-node stdout/stderr, exit code, changed state, status, timings, and log file paths. CI aggregation should continue to use those structured outputs instead of scraping interleaved GitHub logs.
+- GitHub Actions step summaries have a practical size limit of 1 MiB. Bulk operations should keep summaries bounded and rely on component logs, plan output files, and generated artifacts for full detail.
+- PR 7 hardening found and fixed concurrency issues around identity-backed secret resolution, credential materialization, Terraform/OpenTofu provider cache access, and long CI output truncation. These findings should stay part of the DAG rollout risk model.
 
 ## PR 7: GitHub Actions Output For Concurrent Terraform Plans
 
-Draft PR: [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577)
+Merged PR: [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577)
 
 PR 7 makes concurrent Terraform plan verification usable in GitHub Actions with minimal friction.
 
-Review focus:
+Merged scope:
 
 - Keep existing public config and flags: no new CLI flag or `atmos.yaml` setting for v1.
 - Add an aggregate CI path for multi-component `plan` runs only. Single-component plan/apply/deploy behavior remains unchanged.
@@ -73,7 +74,7 @@ Review focus:
 - Preserve optional PR comments and status contexts behind existing `ci.comments` and `ci.checks` settings, with deterministic serialized writes.
 - Avoid concurrent writes to `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY`.
 
-Validation focus:
+Validation focus preserved for regressions:
 
 - Unit-test aggregate Terraform CI rendering with mixed no-change, changed, failed, skipped, and output-only results.
 - Unit-test aggregate output variables and exit-code rules.
@@ -84,7 +85,7 @@ Validation focus:
 
 ## PR 8: TUI/Interactive Terraform Output
 
-PR 8 moves after GitHub CI output so developer verification in CI is stable first. It should focus on non-CI interactive plan/apply/destroy rendering without changing CI output behavior.
+PR 8 follows the merged GitHub CI output work. It should focus on non-CI interactive plan/apply/destroy rendering without changing CI output behavior.
 
 Review focus:
 
@@ -95,7 +96,7 @@ Review focus:
 
 ## Review and Merge Model
 
-The first six rollout PRs have merged into `main`, and PR 7 is now open as a draft against `main`. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
+The first seven rollout PRs have merged into `main`, and PR 8 should branch from current `main`. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
 
 Before moving from one PR to the next, confirm:
 
@@ -106,9 +107,9 @@ Before moving from one PR to the next, confirm:
 
 ## Next Step Prompt
 
-Continue PR 7 review and hardening from draft [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577):
+Start PR 8 from current `main` on `codex/dag-terraform-interactive-output`:
 
-- Verify the GitHub Actions aggregate summary/output shape against a real concurrent Terraform plan job.
-- Confirm optional `ci.comments` and `ci.checks` behavior remains gated and deterministic.
-- Keep scheduler semantics unchanged: fail-fast, keep-going, skipped dependents, concurrency limits, workdir locking, and plan exit-code handling must not change.
-- Do not change interactive/TUI output in PR 7; that remains PR 8.
+- Build TUI/interactive Terraform output for non-CI plan/apply/destroy runs.
+- Preserve merged GitHub CI rendering and native CI hooks.
+- Keep scheduler semantics unchanged: fail-fast, keep-going, skipped dependents, concurrency limits, workdir locking, destroy reverse ordering, and plan exit-code handling must not change.
+- Do not introduce mixed-type DAG adapter behavior in PR 8; that remains PR 9.

--- a/docs/prd/dag-concurrent-execution-rollout-tracker.md
+++ b/docs/prd/dag-concurrent-execution-rollout-tracker.md
@@ -34,20 +34,20 @@ Near-term layers are:
 | PR 4 | [cloudposse/atmos#2468](https://github.com/cloudposse/atmos/pull/2468) | Merged into `main` | `codex/dag-terraform-plan-concurrency` | Plan-only `--max-concurrency`, grouped/stream output, per-node logs, no-change hiding, and execution summaries |
 | PR 5 | [cloudposse/atmos#2474](https://github.com/cloudposse/atmos/pull/2474) | Merged into `main` | `codex/dag-terraform-apply-destroy-concurrency` | Concurrent Terraform `apply`/`destroy` safety model with auto-approve gates, cancellation propagation, and reverse destroy ordering |
 | PR 6 | [cloudposse/atmos#2519](https://github.com/cloudposse/atmos/pull/2519) | Merged into `main` | `codex/dag-terraform-affected-scheduler` | Routes Terraform `--affected` through the scheduler and adds `--fail-fast`/`--keep-going` controls |
+| PR 7 | [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) | Open draft | `codex/dag-github-concurrent-output` | GitHub Actions-oriented output for concurrent Terraform plans, aggregate CI summaries, output variables, optional status contexts, and optional PR comments |
 | Tracking | [cloudposse/atmos#2467](https://github.com/cloudposse/atmos/pull/2467) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan, findings, and PR coordination document |
 
 ## Planned PRs
 
 | Step | Intended base | Proposed branch | Scope | Key gates / non-goals |
 | --- | --- | --- | --- | --- |
-| PR 7 | `main` | `codex/dag-github-concurrent-output` | Add GitHub Actions-oriented output for concurrent Terraform plans so CI summaries, output variables, optional status contexts, and optional PR comments render clearly for verification. | CI-focused. Preserve scheduler semantics and existing public config/flags. Do not change local interactive output or migrate GitHub Status API support to Checks API. |
 | PR 8 | PR 7 / `main` after PR 7 merges | `codex/dag-terraform-interactive-output` | Add TUI/interactive output for non-CI Terraform plan/apply/destroy runs so concurrent execution is usable from a terminal. | Applies outside CI. Preserve GitHub CI rendering and native CI hooks. Do not introduce new execution semantics. |
 | PR 9 | PR 8 | `codex/dag-mixed-type-adapters` | Add mixed-type DAG adapter support after Terraform-only execution and output UX are stable. Include explicit adapter boundaries for Terraform and future component types. | Requires repo-owner agreement on mixed-type ordering semantics. Do not rewrite unrelated executors. |
 | PR 10 | PR 9 | `codex/dag-scheduling-diagnostics` | Add advanced scheduling diagnostics, graph/debug output, and operator-facing troubleshooting aids. | Should not change scheduling semantics. Keep diagnostics opt-in and safe for CI logs. |
 
 ## Current Findings
 
-- The implementation stack PRs 1 through 6 have merged into `main`, so PR 7 should branch from current `main` rather than from PR 6.
+- The implementation stack PRs 1 through 6 have merged into `main`, and PR 7 is now open as draft [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577) from current `main`.
 - `--ci` uses native CI provider detection. GitHub Actions auto-detects through `GITHUB_ACTIONS=true`; explicit `--ci` forces CI mode and falls back to the generic provider when no platform is detected.
 - GitHub Actions output is currently written through provider output writers to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`.
 - Terraform CI plugin behavior is single-component shaped today: after-plan hooks parse one component's captured output, append one rendered summary, write output variables, optionally upload one planfile, optionally update one status context, and optionally post or update one PR comment.
@@ -57,6 +57,8 @@ Near-term layers are:
 - The Terraform scheduler adapter already captures per-node stdout/stderr, exit code, changed state, status, timings, and log file paths; PR 7 should build CI aggregation from those existing outputs instead of scraping interleaved GitHub logs.
 
 ## PR 7: GitHub Actions Output For Concurrent Terraform Plans
+
+Draft PR: [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577)
 
 PR 7 makes concurrent Terraform plan verification usable in GitHub Actions with minimal friction.
 
@@ -93,7 +95,7 @@ Review focus:
 
 ## Review and Merge Model
 
-The first six rollout PRs have merged into `main`, so future PRs should branch from current `main` unless a preceding planned PR is still open and explicitly becomes the base. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
+The first six rollout PRs have merged into `main`, and PR 7 is now open as a draft against `main`. If GitHub stacked PRs later become available for this repository, the remaining planned branches can be linked into official stack metadata, but this tracker should continue to represent the work in normal PR terms.
 
 Before moving from one PR to the next, confirm:
 
@@ -104,11 +106,9 @@ Before moving from one PR to the next, confirm:
 
 ## Next Step Prompt
 
-Start from current `origin/main` and implement PR 7 only:
+Continue PR 7 review and hardening from draft [cloudposse/atmos#2577](https://github.com/cloudposse/atmos/pull/2577):
 
-- Create branch `codex/dag-github-concurrent-output`.
-- Add aggregate Terraform CI rendering/output-variable logic in `pkg/ci/plugins/terraform` using existing provider interfaces and Terraform parsing/template helpers.
-- Adjust `cmd/terraform` multi-component plan wiring so CI mode installs a collector instead of firing full per-component CI writes from scheduler workers.
-- Build aggregation from scheduler node outcomes, captured stdout/stderr, node status, exit code, timings, and log file paths already produced by the Terraform scheduler adapter.
+- Verify the GitHub Actions aggregate summary/output shape against a real concurrent Terraform plan job.
+- Confirm optional `ci.comments` and `ci.checks` behavior remains gated and deterministic.
 - Keep scheduler semantics unchanged: fail-fast, keep-going, skipped dependents, concurrency limits, workdir locking, and plan exit-code handling must not change.
-- Do not change interactive/TUI output in PR 7.
+- Do not change interactive/TUI output in PR 7; that remains PR 8.


### PR DESCRIPTION
## Summary

Refreshes the DAG concurrent execution rollout tracker after PR 7 merged into `main` and shipped in Atmos [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0).

The tracker now documents:

- PR 1 through PR 7 as merged and available in Atmos v1.221.0: #2464, #2465, #2466, #2468, #2474, #2519, and #2577
- PR 8 as the next planned work from current `main` on `codex/dag-terraform-interactive-output`
- GitHub Actions CI output findings from PR 7: native `--ci` provider detection, aggregate writes to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`, serialized optional comments/status contexts, and single-component compatibility
- DAG hardening findings from PR 7: identity-backed secret resolution, credential materialization, Terraform/OpenTofu provider cache access, and bounded/truncated CI output handling
- the maintainer note that GitHub step summaries have a practical 1 MiB limit, so bulk operations need bounded summaries plus logs/artifacts for full detail

## Current rollout

| Step | PR | Status | Branch | Scope |
| --- | --- | --- | --- | --- |
| PR 1 | [#2464](https://github.com/cloudposse/atmos/pull/2464) | Merged into `main` | `codex/dag-process-io-foundation` | Process runner and stream injection foundation |
| PR 2 | [#2465](https://github.com/cloudposse/atmos/pull/2465) | Merged into `main` | `codex/dag-scheduler-core` | Generic scheduler core |
| PR 3 | [#2466](https://github.com/cloudposse/atmos/pull/2466) | Merged into `main` | `codex/dag-terraform-graph-bulk-path` | Terraform graph-backed bulk routing |
| PR 4 | [#2468](https://github.com/cloudposse/atmos/pull/2468) | Merged into `main` | `codex/dag-terraform-plan-concurrency` | Concurrent Terraform plan output/logging/summary support |
| PR 5 | [#2474](https://github.com/cloudposse/atmos/pull/2474) | Merged into `main` | `codex/dag-terraform-apply-destroy-concurrency` | Concurrent Terraform apply/destroy safety model |
| PR 6 | [#2519](https://github.com/cloudposse/atmos/pull/2519) | Merged into `main` | `codex/dag-terraform-affected-scheduler` | Terraform affected scheduler route and failure modes |
| PR 7 | [#2577](https://github.com/cloudposse/atmos/pull/2577) | Merged into `main`; released in [v1.221.0](https://github.com/cloudposse/atmos/releases/tag/v1.221.0) | `codex/dag-github-concurrent-output` | GitHub Actions output for concurrent Terraform plan CI verification |
| Tracking | [#2467](https://github.com/cloudposse/atmos/pull/2467) | Open draft | `codex/dag-concurrent-execution-tracker` | Rollout plan and coordination document |

## Planned PRs

| Step | Intended base | Proposed branch | Scope |
| --- | --- | --- | --- |
| PR 8 | `main` after PR 7 merge | `codex/dag-terraform-interactive-output` | TUI/interactive output for non-CI Terraform plan/apply/destroy |
| PR 9 | PR 8 | `codex/dag-mixed-type-adapters` | Mixed-type DAG adapters |
| PR 10 | PR 9 | `codex/dag-scheduling-diagnostics` | Advanced scheduling diagnostics |

## Validation

Tracker update only. Verified the v1.221.0 release exists and is published; local `go build -buildvcs=false -o build/atmos .` succeeds.
