### PR TITLE
PR5: Concurrent Terraform apply and destroy

### DIFF
--- a/cmd/terraform/apply.go
+++ b/cmd/terraform/apply.go
@@ -31,7 +31,7 @@ This will prompt for confirmation before making changes unless -auto-approve is 
 
 For complete Terraform/OpenTofu documentation, see:
   https://developer.hashicorp.com/terraform/cli/commands/apply
-  https://opentofu.org/docs/cli/commands/apply`,
+	https://opentofu.org/docs/cli/commands/apply`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return runHooks(h.BeforeTerraformApply, cmd, args)
 	},
@@ -121,9 +121,11 @@ func init() {
 		flags.WithStringFlag("planfile", "", "", "Set the plan file to use"),
 		flags.WithBoolFlag("affected", "", false, "Apply the affected components in dependency order"),
 		flags.WithBoolFlag("all", "", false, "Apply all components in all stacks"),
+		flags.WithIntFlag("max-concurrency", "", 1, "Maximum number of Terraform apply components to execute concurrently"),
 		flags.WithBoolFlag("ci", "", false, "Enable CI mode for automated pipelines (writes job summary, outputs)"),
 		flags.WithEnvVars("from-plan", "ATMOS_TERRAFORM_APPLY_FROM_PLAN"),
 		flags.WithEnvVars("planfile", "ATMOS_TERRAFORM_APPLY_PLANFILE"),
+		flags.WithEnvVars("max-concurrency", "ATMOS_TERRAFORM_APPLY_MAX_CONCURRENCY"),
 		flags.WithEnvVars("ci", "ATMOS_CI", "CI"),
 	)
 

--- a/cmd/terraform/destroy.go
+++ b/cmd/terraform/destroy.go
@@ -2,9 +2,14 @@ package terraform
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/cloudposse/atmos/cmd/internal"
+	"github.com/cloudposse/atmos/pkg/flags"
 )
+
+// destroyParser handles flag parsing for destroy command.
+var destroyParser *flags.StandardParser
 
 // destroyCmd represents the terraform destroy command.
 var destroyCmd = &cobra.Command{
@@ -16,11 +21,31 @@ For complete Terraform/OpenTofu documentation, see:
   https://developer.hashicorp.com/terraform/cli/commands/destroy
   https://opentofu.org/docs/cli/commands/destroy`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return terraformRun(terraformCmd, cmd, args)
+		v := viper.GetViper()
+		if err := terraformParser.BindFlagsToViper(cmd, v); err != nil {
+			return err
+		}
+		if err := destroyParser.BindFlagsToViper(cmd, v); err != nil {
+			return err
+		}
+		opts := ParseTerraformRunOptions(v)
+		return terraformRunWithOptions(terraformCmd, cmd, args, opts)
 	},
 }
 
 func init() {
+	destroyParser = flags.NewStandardParser(
+		WithBackendExecutionFlags(),
+		flags.WithBoolFlag("all", "", false, "Destroy all components in all stacks"),
+		flags.WithIntFlag("max-concurrency", "", 1, "Maximum number of Terraform destroy components to execute concurrently"),
+		flags.WithEnvVars("all", "ATMOS_TERRAFORM_DESTROY_ALL"),
+		flags.WithEnvVars("max-concurrency", "ATMOS_TERRAFORM_DESTROY_MAX_CONCURRENCY"),
+	)
+	destroyParser.RegisterFlags(destroyCmd)
+	if err := destroyParser.BindToViper(viper.GetViper()); err != nil {
+		panic(err)
+	}
+
 	// Register completions for destroy command.
 	RegisterTerraformCompletions(destroyCmd)
 

--- a/cmd/terraform/options.go
+++ b/cmd/terraform/options.go
@@ -35,7 +35,7 @@ type TerraformRunOptions struct {
 	All        bool
 	Affected   bool
 
-	// Plan concurrency.
+	// Graph-backed Terraform concurrency.
 	MaxConcurrency    int
 	PlanLogOrder      string
 	PlanHideNoChanges bool

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -404,7 +404,7 @@ func newTerraformPassthroughSubcommand(parent *cobra.Command, name, short string
 
 // terraformRun is for simple subcommands without their own parsers.
 // It binds terraformParser and delegates to terraformRunWithOptions.
-func terraformRun(parentCmd *cobra.Command, actualCmd *cobra.Command, args []string) error {
+func terraformRun(parentCmd, actualCmd *cobra.Command, args []string) error {
 	v := viper.GetViper()
 	if err := terraformParser.BindFlagsToViper(actualCmd, v); err != nil {
 		return err

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -222,16 +222,16 @@ func runCIHooksForDeployComponent(actualCmd *cobra.Command, info *schema.ConfigA
 	}
 }
 
-// runCIHooksForPlanComponent fires CI hooks for a single component after it completes
-// in multi-component mode. Uses already-resolved info to avoid a second
+// runCIHooksForPlanComponent fires CI hooks for a single component after it completes.
+// It runs in multi-component mode. Uses already-resolved info to avoid a second
 // ProcessCommandLineArgs call (same pattern as runCIHooksForDeploy).
 // rawOutput is the combined stdout+stderr from that component; ANSI codes are stripped here.
 func runCIHooksForPlanComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
 	runCIHooksForTerraformComponent(actualCmd, h.AfterTerraformPlan, info, rawOutput, execErr)
 }
 
-// runCIHooksForApplyComponent fires CI hooks for a single apply component after it completes
-// in multi-component mode.
+// runCIHooksForApplyComponent fires CI hooks for a single apply component after it completes.
+// It runs in multi-component mode.
 func runCIHooksForApplyComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
 	runCIHooksForTerraformComponent(actualCmd, h.AfterTerraformApply, info, rawOutput, execErr)
 }

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -1,11 +1,14 @@
 package terraform
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -224,33 +227,16 @@ func runCIHooksForDeployComponent(actualCmd *cobra.Command, info *schema.ConfigA
 // ProcessCommandLineArgs call (same pattern as runCIHooksForDeploy).
 // rawOutput is the combined stdout+stderr from that component; ANSI codes are stripped here.
 func runCIHooksForPlanComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
-	atmosConfig, err := cfg.InitCliConfig(*info, true)
-	if err != nil {
-		log.Warn("CI hook config init failed", "component", info.Component, "error", err)
-		return
-	}
-
-	forceCIMode, _ := actualCmd.Flags().GetBool("ci")
-	if !forceCIMode {
-		forceCIMode = viper.GetBool("ci")
-	}
-
-	if err := h.RunCIHooks(&h.RunCIHooksOptions{
-		Event:        h.AfterTerraformPlan,
-		AtmosConfig:  &atmosConfig,
-		Info:         info,
-		Output:       ansi.Strip(rawOutput),
-		ForceCIMode:  forceCIMode,
-		CommandError: execErr,
-		ExitCode:     errUtils.GetExitCode(execErr),
-	}); err != nil {
-		log.Warn("CI hook execution failed", "component", info.Component, "error", err)
-	}
+	runCIHooksForTerraformComponent(actualCmd, h.AfterTerraformPlan, info, rawOutput, execErr)
 }
 
-// runCIHooksForApplyComponent fires CI hooks for a single component after it completes
-// in multi-component apply mode. Mirrors runCIHooksForPlanComponent using AfterTerraformApply.
+// runCIHooksForApplyComponent fires CI hooks for a single apply component after it completes
+// in multi-component mode.
 func runCIHooksForApplyComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
+	runCIHooksForTerraformComponent(actualCmd, h.AfterTerraformApply, info, rawOutput, execErr)
+}
+
+func runCIHooksForTerraformComponent(actualCmd *cobra.Command, event h.HookEvent, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
 	atmosConfig, err := cfg.InitCliConfig(*info, true)
 	if err != nil {
 		log.Warn("CI hook config init failed", "component", info.Component, "error", err)
@@ -263,7 +249,7 @@ func runCIHooksForApplyComponent(actualCmd *cobra.Command, info *schema.ConfigAn
 	}
 
 	if err := h.RunCIHooks(&h.RunCIHooksOptions{
-		Event:        h.AfterTerraformApply,
+		Event:        event,
 		AtmosConfig:  &atmosConfig,
 		Info:         info,
 		Output:       ansi.Strip(rawOutput),
@@ -535,13 +521,17 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformAll (dependency-ordered)")
 		wirePerComponentHook(&info, subCommand, actualCmd)
-		return e.ExecuteTerraformAll(&info)
+		ctx, stop := terraformSignalContext(actualCmd)
+		defer stop()
+		return e.ExecuteTerraformAllWithContext(ctx, &info)
 	}
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
 		wirePerComponentHook(&info, subCommand, actualCmd)
-		return e.ExecuteTerraformQuery(&info)
+		ctx, stop := terraformSignalContext(actualCmd)
+		defer stop()
+		return e.ExecuteTerraformQueryWithContext(ctx, &info)
 	}
 	wasMultiComponentExecution = false
 
@@ -562,6 +552,14 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	}
 
 	return executeSingleComponent(&info, shellOpts...)
+}
+
+func terraformSignalContext(actualCmd *cobra.Command) (context.Context, context.CancelFunc) {
+	ctx := actualCmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 }
 
 // hasMultiComponentFlags checks if any multi-component flags are set.

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -28,8 +28,6 @@ func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 // ExecuteTerraformAllWithContext executes all selected Terraform components through
 // the graph-backed scheduler using the provided cancellation context.
 func ExecuteTerraformAllWithContext(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
-	defer perf.Track(nil, "exec.ExecuteTerraformAllWithContext")()
-
 	// Validate inputs for --all flag usage.
 	// When no stack is given, --all processes every stack — matching the documented
 	// behavior of `atmos terraform apply --all` (see website/docs/cli/commands/terraform).
@@ -41,6 +39,7 @@ func ExecuteTerraformAllWithContext(ctx context.Context, info *schema.ConfigAndS
 	if err != nil {
 		return fmt.Errorf(errWrapFmt, errUtils.ErrInitializeCLIConfig, err)
 	}
+	defer perf.Track(&atmosConfig, "exec.ExecuteTerraformAllWithContext")()
 
 	log.Debug("Executing terraform command for all components in dependency order", "command", info.SubCommand)
 

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -22,6 +22,13 @@ const errWrapFmt = "%w: %w"
 // ExecuteTerraformAll executes terraform commands for all components in dependency order.
 func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 	defer perf.Track(nil, "exec.ExecuteTerraformAll")()
+	return ExecuteTerraformAllWithContext(context.Background(), info)
+}
+
+// ExecuteTerraformAllWithContext executes all selected Terraform components through
+// the graph-backed scheduler using the provided cancellation context.
+func ExecuteTerraformAllWithContext(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
+	defer perf.Track(nil, "exec.ExecuteTerraformAllWithContext")()
 
 	// Validate inputs for --all flag usage.
 	// When no stack is given, --all processes every stack — matching the documented
@@ -72,7 +79,7 @@ func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 		ui.Info("Processing components in dependency order")
 	}
 
-	return scheduleradapters.ExecuteTerraform(context.Background(), scheduleradapters.TerraformOptions{
+	return scheduleradapters.ExecuteTerraform(ctx, scheduleradapters.TerraformOptions{
 		AtmosConfig: &atmosConfig,
 		Info:        info,
 		Stacks:      stacks,

--- a/internal/exec/terraform_query.go
+++ b/internal/exec/terraform_query.go
@@ -28,6 +28,12 @@ var authManagerFactory = func(identity string, authConfig schema.AuthConfig, fla
 // ExecuteTerraformQuery executes `atmos terraform <command> --query <yq-expression --stack <stack>`.
 func ExecuteTerraformQuery(info *schema.ConfigAndStacksInfo) error {
 	defer perf.Track(nil, "exec.ExecuteTerraformQuery")()
+	return ExecuteTerraformQueryWithContext(context.Background(), info)
+}
+
+// ExecuteTerraformQueryWithContext executes graph-backed multi-component Terraform work.
+func ExecuteTerraformQueryWithContext(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
+	defer perf.Track(nil, "exec.ExecuteTerraformQueryWithContext")()
 
 	atmosConfig, err := cfg.InitCliConfig(*info, true)
 	if err != nil {
@@ -67,7 +73,7 @@ func ExecuteTerraformQuery(info *schema.ConfigAndStacksInfo) error {
 		return err
 	}
 
-	return scheduleradapters.ExecuteTerraform(context.Background(), scheduleradapters.TerraformOptions{
+	return scheduleradapters.ExecuteTerraform(ctx, scheduleradapters.TerraformOptions{
 		AtmosConfig: &atmosConfig,
 		Info:        info,
 		Stacks:      stacks,
@@ -104,7 +110,7 @@ func createQueryAuthManager(info *schema.ConfigAndStacksInfo, atmosConfig *schem
 // executeTerraformQueryComponent runs one scheduled Terraform component and captures optional output.
 func executeTerraformQueryComponent(execution scheduleradapters.TerraformExecution) (scheduleradapters.TerraformExecutionResult, error) {
 	info := execution.Info
-	var opts []ShellCommandOption
+	opts := []ShellCommandOption{WithProcessContext(execution.Context)}
 	if execution.Stdout != nil || execution.Stderr != nil {
 		opts = append(opts, WithProcessStreams(process.Streams{
 			Stdin:  os.Stdin,

--- a/internal/exec/terraform_query.go
+++ b/internal/exec/terraform_query.go
@@ -33,12 +33,11 @@ func ExecuteTerraformQuery(info *schema.ConfigAndStacksInfo) error {
 
 // ExecuteTerraformQueryWithContext executes graph-backed multi-component Terraform work.
 func ExecuteTerraformQueryWithContext(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
-	defer perf.Track(nil, "exec.ExecuteTerraformQueryWithContext")()
-
 	atmosConfig, err := cfg.InitCliConfig(*info, true)
 	if err != nil {
 		return err
 	}
+	defer perf.Track(&atmosConfig, "exec.ExecuteTerraformQueryWithContext")()
 
 	// Create auth manager for YAML function processing during stack description.
 	// Without this, YAML functions like !terraform.state fail when using --all

--- a/pkg/scheduler/adapters/terraform.go
+++ b/pkg/scheduler/adapters/terraform.go
@@ -310,7 +310,15 @@ func containsTerraformFlag(args []string, flag string) bool {
 	normalizedFlag := strings.TrimLeft(flag, "-")
 	for _, arg := range args {
 		normalizedArg := strings.TrimLeft(arg, "-")
-		if normalizedArg == normalizedFlag || strings.HasPrefix(normalizedArg, normalizedFlag+"=") {
+		if normalizedArg == normalizedFlag {
+			return true
+		}
+		if !strings.HasPrefix(normalizedArg, normalizedFlag+"=") {
+			continue
+		}
+		value := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(normalizedArg, normalizedFlag+"=")))
+		switch value {
+		case "", "1", "t", "true", "y", "yes", "on":
 			return true
 		}
 	}

--- a/pkg/scheduler/adapters/terraform.go
+++ b/pkg/scheduler/adapters/terraform.go
@@ -38,6 +38,7 @@ const (
 
 // TerraformExecution contains the execution context for one Terraform component.
 type TerraformExecution struct {
+	Context       context.Context
 	Info          schema.ConfigAndStacksInfo
 	Stdout        io.Writer
 	Stderr        io.Writer
@@ -111,15 +112,12 @@ func ExecuteTerraform(ctx context.Context, opts TerraformOptions) error {
 		return nil
 	}
 
-	if opts.Info.SubCommand == "destroy" {
-		graph, err = reverseTerraformGraph(graph)
-		if err != nil {
-			return fmt.Errorf("%w: reverse terraform graph: %w", errUtils.ErrBuildDepGraph, err)
-		}
+	maxConcurrency := effectiveTerraformMaxConcurrency(opts.Info)
+	if graph, err = prepareTerraformGraphForCommand(opts.Info, graph); err != nil {
+		return err
 	}
 
-	maxConcurrency := effectiveTerraformMaxConcurrency(opts.Info)
-	if err := validateTerraformConcurrentPlan(opts.Info, graph); err != nil {
+	if err := validateTerraformConcurrentExecution(opts.AtmosConfig, opts.Info, graph); err != nil {
 		return err
 	}
 	output, err := newTerraformOutput(opts.AtmosConfig, opts.Info, maxConcurrency)
@@ -200,50 +198,6 @@ func BuildTerraformGraph(stacks map[string]any) (*dependency.Graph, error) {
 	return graph, nil
 }
 
-// reverseTerraformGraph reverses dependency edges so destroy runs dependents first.
-func reverseTerraformGraph(graph *dependency.Graph) (*dependency.Graph, error) {
-	builder := dependency.NewBuilder()
-
-	for _, id := range sortedGraphNodeIDs(graph) {
-		node := graph.Nodes[id]
-		if err := builder.AddNode(&dependency.Node{
-			ID:        node.ID,
-			Component: node.Component,
-			Stack:     node.Stack,
-			Type:      node.Type,
-			Metadata:  cloneTerraformNodeMetadata(node.Metadata),
-		}); err != nil {
-			return nil, err
-		}
-	}
-
-	for _, id := range sortedGraphNodeIDs(graph) {
-		node := graph.Nodes[id]
-		for _, dependencyID := range sortedStringValues(node.Dependencies) {
-			if _, ok := graph.Nodes[dependencyID]; !ok {
-				continue
-			}
-			if err := builder.AddDependency(dependencyID, id); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return builder.Build()
-}
-
-// cloneTerraformNodeMetadata shallow-copies node metadata for graph rewrites.
-func cloneTerraformNodeMetadata(metadata map[string]any) map[string]any {
-	if metadata == nil {
-		return nil
-	}
-	cloned := make(map[string]any, len(metadata))
-	for key, value := range metadata {
-		cloned[key] = value
-	}
-	return cloned
-}
-
 // FilterTerraformGraph narrows graph nodes to the user-selected bulk operation set.
 func FilterTerraformGraph(atmosConfig *schema.AtmosConfiguration, graph *dependency.Graph, info *schema.ConfigAndStacksInfo) (*dependency.Graph, error) {
 	defer perf.Track(atmosConfig, "scheduler.adapters.FilterTerraformGraph")()
@@ -262,15 +216,105 @@ func FilterTerraformGraph(atmosConfig *schema.AtmosConfiguration, graph *depende
 	}), nil
 }
 
-// validateTerraformConcurrentPlan enforces constraints for concurrent plan runs.
-func validateTerraformConcurrentPlan(info *schema.ConfigAndStacksInfo, _ *dependency.Graph) error {
+// prepareTerraformGraphForCommand adjusts graph ordering for command-specific execution.
+func prepareTerraformGraphForCommand(info *schema.ConfigAndStacksInfo, graph *dependency.Graph) (*dependency.Graph, error) {
+	if info == nil || graph == nil || info.SubCommand != "destroy" {
+		return graph, nil
+	}
+	return reverseTerraformGraph(graph)
+}
+
+// reverseTerraformGraph reverses dependency edges so destroy runs dependents first.
+func reverseTerraformGraph(graph *dependency.Graph) (*dependency.Graph, error) {
+	builder := dependency.NewBuilder()
+	for _, nodeID := range sortedGraphNodeIDs(graph) {
+		node := graph.Nodes[nodeID]
+		if node == nil {
+			continue
+		}
+		if err := builder.AddNode(&dependency.Node{
+			ID:        node.ID,
+			Component: node.Component,
+			Stack:     node.Stack,
+			Type:      node.Type,
+			Metadata:  cloneTerraformNodeMetadata(node.Metadata),
+		}); err != nil {
+			return nil, err
+		}
+	}
+	for _, nodeID := range sortedGraphNodeIDs(graph) {
+		node := graph.Nodes[nodeID]
+		if node == nil {
+			continue
+		}
+		for _, dependencyID := range sortedCopy(node.Dependencies) {
+			if _, ok := graph.Nodes[dependencyID]; !ok {
+				continue
+			}
+			if err := builder.AddDependency(dependencyID, node.ID); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return builder.Build()
+}
+
+// cloneTerraformNodeMetadata shallow-copies node metadata for graph rewrites.
+func cloneTerraformNodeMetadata(metadata map[string]any) map[string]any {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+// validateTerraformConcurrentExecution enforces constraints for concurrent Terraform runs.
+func validateTerraformConcurrentExecution(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, _ *dependency.Graph) error {
 	if effectiveTerraformMaxConcurrency(info) <= 1 {
 		return nil
 	}
 	if info.Identity == cfg.IdentityFlagSelectValue {
 		return fmt.Errorf("%w: --max-concurrency requires a non-interactive identity value", errUtils.ErrInvalidConfig)
 	}
+	if requiresTerraformAutoApprove(info) && !hasTerraformAutoApprove(atmosConfig, info) {
+		return fmt.Errorf("%w: concurrent Terraform %s requires -auto-approve", errUtils.ErrInvalidConfig, info.SubCommand)
+	}
 	return nil
+}
+
+// requiresTerraformAutoApprove reports whether concurrent execution must be explicitly approved.
+func requiresTerraformAutoApprove(info *schema.ConfigAndStacksInfo) bool {
+	return info != nil && (info.SubCommand == "apply" || info.SubCommand == "destroy")
+}
+
+// hasTerraformAutoApprove detects auto-approve from config, CLI flags, or Terraform env flags.
+func hasTerraformAutoApprove(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) bool {
+	if info == nil {
+		return false
+	}
+	if info.SubCommand == "apply" && atmosConfig != nil && atmosConfig.Components.Terraform.ApplyAutoApprove {
+		return true
+	}
+	if containsTerraformFlag(info.AdditionalArgsAndFlags, "-auto-approve") {
+		return true
+	}
+	//nolint:forbidigo // TF_CLI_ARGS is Terraform's native non-interactive flag path.
+	return containsTerraformFlag(strings.Fields(os.Getenv("TF_CLI_ARGS")), "-auto-approve")
+}
+
+// containsTerraformFlag matches Terraform flags with either one or two leading dashes.
+func containsTerraformFlag(args []string, flag string) bool {
+	normalizedFlag := strings.TrimLeft(flag, "-")
+	for _, arg := range args {
+		normalizedArg := strings.TrimLeft(arg, "-")
+		if normalizedArg == normalizedFlag || strings.HasPrefix(normalizedArg, normalizedFlag+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // TerraformDispatcher adapts scheduler nodes to Terraform component execution.
@@ -283,9 +327,12 @@ type TerraformDispatcher struct {
 }
 
 // Dispatch executes one Terraform scheduler node.
-func (d *TerraformDispatcher) Dispatch(_ context.Context, node *dependency.Node) (scheduler.Result, error) {
+func (d *TerraformDispatcher) Dispatch(ctx context.Context, node *dependency.Node) (scheduler.Result, error) {
 	if node == nil {
 		return scheduler.Result{}, fmt.Errorf("%w: node is nil", errUtils.ErrInvalidConfig)
+	}
+	if err := ctx.Err(); err != nil {
+		return scheduler.Result{NodeID: node.ID, Status: scheduler.StatusFailed}, err
 	}
 	if d.shouldSkipByQuery(node) {
 		return scheduler.Result{NodeID: node.ID, Status: scheduler.StatusSucceeded, Value: false}, nil
@@ -309,7 +356,8 @@ func (d *TerraformDispatcher) Dispatch(_ context.Context, node *dependency.Node)
 	defer unlock()
 
 	execution := TerraformExecution{
-		Info: nodeInfo,
+		Context: ctx,
+		Info:    nodeInfo,
 	}
 	outcome := TerraformNodeOutcome{
 		Processed: true,
@@ -628,12 +676,11 @@ func sortedGraphNodeIDs(graph *dependency.Graph) []string {
 	return ids
 }
 
-// sortedStringValues returns a sorted copy of values.
-func sortedStringValues(values []string) []string {
-	sorted := make([]string, len(values))
-	copy(sorted, values)
-	sort.Strings(sorted)
-	return sorted
+// sortedCopy returns a sorted copy of values.
+func sortedCopy(values []string) []string {
+	copied := append([]string{}, values...)
+	sort.Strings(copied)
+	return copied
 }
 
 // containsString reports whether values contains value.
@@ -744,6 +791,7 @@ func metadataComponent(metadata map[string]any) string {
 }
 
 type terraformOutput struct {
+	command       string
 	logOrder      string
 	hideNoChanges bool
 	logDir        string
@@ -754,7 +802,7 @@ type terraformOutput struct {
 
 // newTerraformOutput configures concurrent Terraform output streaming or grouping.
 func newTerraformOutput(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, maxConcurrency int) (*terraformOutput, error) {
-	hideNoChanges := info != nil && info.TerraformPlanHideNoChanges
+	hideNoChanges := info != nil && info.SubCommand == "plan" && info.TerraformPlanHideNoChanges
 	if maxConcurrency <= 1 && !hideNoChanges {
 		return nil, nil
 	}
@@ -770,8 +818,10 @@ func newTerraformOutput(atmosConfig *schema.AtmosConfiguration, info *schema.Con
 	default:
 		return nil, fmt.Errorf("%w: unsupported Terraform plan log order %q", errUtils.ErrInvalidConfig, logOrder)
 	}
-	logDir := terraformLogDir(atmosConfig)
+	command := terraformOutputCommand(info)
+	logDir := terraformLogDir(atmosConfig, command)
 	return &terraformOutput{
+		command:       command,
 		logOrder:      logOrder,
 		hideNoChanges: hideNoChanges,
 		logDir:        logDir,
@@ -814,7 +864,7 @@ func (o *terraformOutput) openNodeLogFiles(node *dependency.Node) (*os.File, *os
 		return nil, nil, nil
 	}
 	if err := os.MkdirAll(o.logDir, 0o755); err != nil {
-		log.Warn("Failed to create Terraform plan log directory", "dir", o.logDir, "error", err)
+		log.Warn("Failed to create Terraform log directory", "dir", o.logDir, "error", err)
 		return nil, nil, nil
 	}
 	nodeName := safeTerraformLogName(terraformNodeLabel(node))
@@ -822,11 +872,11 @@ func (o *terraformOutput) openNodeLogFiles(node *dependency.Node) (*os.File, *os
 	stderrPath := filepath.Join(o.logDir, nodeName+".stderr.log")
 	stdoutFile, stdoutErr := os.Create(stdoutPath)
 	if stdoutErr != nil {
-		log.Warn("Failed to create Terraform plan stdout log", "file", stdoutPath, "error", stdoutErr)
+		log.Warn("Failed to create Terraform stdout log", "file", stdoutPath, "error", stdoutErr)
 	}
 	stderrFile, stderrErr := os.Create(stderrPath)
 	if stderrErr != nil {
-		log.Warn("Failed to create Terraform plan stderr log", "file", stderrPath, "error", stderrErr)
+		log.Warn("Failed to create Terraform stderr log", "file", stderrPath, "error", stderrErr)
 	}
 	logFiles := make(map[string]string)
 	if stdoutFile != nil {
@@ -868,8 +918,8 @@ func closeTerraformLogFiles(files ...*os.File) func() error {
 	}
 }
 
-// terraformLogDir returns the base directory for Terraform plan logs.
-func terraformLogDir(atmosConfig *schema.AtmosConfiguration) string {
+// terraformLogDir returns the base directory for Terraform command logs.
+func terraformLogDir(atmosConfig *schema.AtmosConfiguration, command string) string {
 	if atmosConfig == nil {
 		return ""
 	}
@@ -880,7 +930,15 @@ func terraformLogDir(atmosConfig *schema.AtmosConfiguration) string {
 	if basePath == "" {
 		return ""
 	}
-	return filepath.Join(basePath, ".atmos", "logs", "terraform", "plan")
+	return filepath.Join(basePath, ".atmos", "logs", "terraform", command)
+}
+
+// terraformOutputCommand returns the command name used in log paths and messages.
+func terraformOutputCommand(info *schema.ConfigAndStacksInfo) string {
+	if info == nil || info.SubCommand == "" {
+		return "terraform"
+	}
+	return info.SubCommand
 }
 
 // safeTerraformLogName converts a node label into a filesystem-safe log prefix.
@@ -910,10 +968,14 @@ func (o *terraformOutput) finishNode(node *dependency.Node, result TerraformExec
 		status = "failed"
 	}
 	stderr := ioLayer.MaskWriter(os.Stderr)
-	fmt.Fprintf(stderr, "\n[%s] terraform plan %s\n", label, status)
+	command := o.command
+	if command == "" {
+		command = "terraform"
+	}
+	fmt.Fprintf(stderr, "\n[%s] %s output %s\n", label, command, status)
 	replayGroupedOutput(ioLayer.MaskWriter(os.Stdout), result.Stdout)
 	replayGroupedOutput(stderr, result.Stderr)
-	fmt.Fprintf(stderr, "[%s] end terraform plan output\n", label)
+	fmt.Fprintf(stderr, "[%s] end %s output\n", label, command)
 }
 
 // replayGroupedOutput writes captured output and ensures it ends with a newline.
@@ -1111,8 +1173,18 @@ func terraformNodeLabel(node *dependency.Node) string {
 
 // effectiveTerraformMaxConcurrency returns the scheduler concurrency for Terraform plan.
 func effectiveTerraformMaxConcurrency(info *schema.ConfigAndStacksInfo) int {
-	if info == nil || info.SubCommand != "plan" || info.MaxConcurrency <= 1 {
+	if info == nil || !supportsTerraformConcurrency(info.SubCommand) || info.MaxConcurrency <= 1 {
 		return 1
 	}
 	return info.MaxConcurrency
+}
+
+// supportsTerraformConcurrency reports whether subCommand can run through the scheduler concurrently.
+func supportsTerraformConcurrency(subCommand string) bool {
+	switch subCommand {
+	case "plan", "apply", "destroy":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/scheduler/adapters/terraform.go
+++ b/pkg/scheduler/adapters/terraform.go
@@ -29,11 +29,19 @@ import (
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
-const terraformNodeIDFormat = "%s-%s"
+const (
+	terraformDefaultCommand = "terraform"
+	terraformNodeIDFormat   = "%s-%s"
+)
 
 const (
 	terraformPlanLogOrderStream  = "stream"
 	terraformPlanLogOrderGrouped = "grouped"
+)
+
+const (
+	terraformCLIArgsEnv       = "TF_CLI_ARGS"
+	terraformCLIArgsEnvPrefix = "TF_CLI_ARGS_"
 )
 
 // TerraformExecution contains the execution context for one Terraform component.
@@ -301,8 +309,19 @@ func hasTerraformAutoApprove(atmosConfig *schema.AtmosConfiguration, info *schem
 	if containsTerraformFlag(info.AdditionalArgsAndFlags, "-auto-approve") {
 		return true
 	}
-	//nolint:forbidigo // TF_CLI_ARGS is Terraform's native non-interactive flag path.
-	return containsTerraformFlag(strings.Fields(os.Getenv("TF_CLI_ARGS")), "-auto-approve")
+	return hasTerraformAutoApproveEnv(info.SubCommand)
+}
+
+func hasTerraformAutoApproveEnv(subcommand string) bool {
+	//nolint:forbidigo // TF_CLI_ARGS* are Terraform's native non-interactive flag paths.
+	if containsTerraformFlag(strings.Fields(os.Getenv(terraformCLIArgsEnv)), "-auto-approve") {
+		return true
+	}
+	if subcommand == "" {
+		return false
+	}
+	//nolint:forbidigo // TF_CLI_ARGS_<subcommand> is Terraform's native command-specific flag path.
+	return containsTerraformFlag(strings.Fields(os.Getenv(terraformCLIArgsEnvPrefix+subcommand)), "-auto-approve")
 }
 
 // containsTerraformFlag matches Terraform flags with either one or two leading dashes.
@@ -944,7 +963,7 @@ func terraformLogDir(atmosConfig *schema.AtmosConfiguration, command string) str
 // terraformOutputCommand returns the command name used in log paths and messages.
 func terraformOutputCommand(info *schema.ConfigAndStacksInfo) string {
 	if info == nil || info.SubCommand == "" {
-		return "terraform"
+		return terraformDefaultCommand
 	}
 	return info.SubCommand
 }
@@ -978,12 +997,16 @@ func (o *terraformOutput) finishNode(node *dependency.Node, result TerraformExec
 	stderr := ioLayer.MaskWriter(os.Stderr)
 	command := o.command
 	if command == "" {
-		command = "terraform"
+		command = terraformDefaultCommand
 	}
-	fmt.Fprintf(stderr, "\n[%s] %s output %s\n", label, command, status)
+	writeGroupedOutputMarker(stderr, "\n["+label+"] "+command+" output "+status+"\n")
 	replayGroupedOutput(ioLayer.MaskWriter(os.Stdout), result.Stdout)
 	replayGroupedOutput(stderr, result.Stderr)
-	fmt.Fprintf(stderr, "[%s] end %s output\n", label, command)
+	writeGroupedOutputMarker(stderr, "["+label+"] end "+command+" output\n")
+}
+
+func writeGroupedOutputMarker(w io.Writer, marker string) {
+	_, _ = io.WriteString(w, marker)
 }
 
 // replayGroupedOutput writes captured output and ensures it ends with a newline.

--- a/pkg/scheduler/adapters/terraform_test.go
+++ b/pkg/scheduler/adapters/terraform_test.go
@@ -235,40 +235,48 @@ func TestExecuteTerraformAllowsParallelPlanForDifferentPhysicalComponentPaths(t 
 }
 
 func TestExecuteTerraformSerializesAliasesForSharedPhysicalComponentPathWithoutWorkdir(t *testing.T) {
-	stacks := map[string]any{
-		"dev": map[string]any{
-			cfg.ComponentsSectionName: map[string]any{
-				cfg.TerraformSectionName: map[string]any{
-					"service-api":    terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
-					"service-worker": terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
-					"service-cron":   terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
+	for _, subcommand := range []string{"plan", "apply", "destroy"} {
+		t.Run(subcommand, func(t *testing.T) {
+			stacks := map[string]any{
+				"dev": map[string]any{
+					cfg.ComponentsSectionName: map[string]any{
+						cfg.TerraformSectionName: map[string]any{
+							"service-api":    terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
+							"service-worker": terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
+							"service-cron":   terraformAdapterComponentWithPathNoWorkdir("selected", terraformAdapterPath("shared-service")),
+						},
+					},
 				},
-			},
-		},
+			}
+
+			var active atomic.Int32
+			var maxActive atomic.Int32
+			info := &schema.ConfigAndStacksInfo{
+				All:            true,
+				SubCommand:     subcommand,
+				MaxConcurrency: 3,
+			}
+			if requiresTerraformAutoApprove(info) {
+				info.AdditionalArgsAndFlags = []string{"-auto-approve"}
+			}
+
+			err := ExecuteTerraform(context.Background(), TerraformOptions{
+				AtmosConfig: &schema.AtmosConfiguration{},
+				Info:        info,
+				Stacks:      stacks,
+				Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+					current := active.Add(1)
+					updateMaxActive(&maxActive, current)
+					time.Sleep(20 * time.Millisecond)
+					active.Add(-1)
+					return TerraformExecutionResult{}, nil
+				},
+			})
+
+			require.NoError(t, err)
+			require.EqualValues(t, 1, maxActive.Load())
+		})
 	}
-
-	var active atomic.Int32
-	var maxActive atomic.Int32
-
-	err := ExecuteTerraform(context.Background(), TerraformOptions{
-		AtmosConfig: &schema.AtmosConfiguration{},
-		Info: &schema.ConfigAndStacksInfo{
-			All:            true,
-			SubCommand:     "plan",
-			MaxConcurrency: 3,
-		},
-		Stacks: stacks,
-		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
-			current := active.Add(1)
-			updateMaxActive(&maxActive, current)
-			time.Sleep(20 * time.Millisecond)
-			active.Add(-1)
-			return TerraformExecutionResult{}, nil
-		},
-	})
-
-	require.NoError(t, err)
-	require.EqualValues(t, 1, maxActive.Load())
 }
 
 func TestExecuteTerraformAllowsParallelPlanForSharedPhysicalComponentPathWhenWorkdirEnabled(t *testing.T) {
@@ -379,6 +387,7 @@ func TestTerraformOutputConfiguration(t *testing.T) {
 	require.Nil(t, output)
 
 	output, err = newTerraformOutput(&schema.AtmosConfiguration{BasePathAbsolute: t.TempDir()}, &schema.ConfigAndStacksInfo{
+		SubCommand:                 "plan",
 		TerraformPlanHideNoChanges: true,
 	}, 1)
 	require.NoError(t, err)
@@ -457,7 +466,7 @@ func TestTerraformOutputFinishNodeGroupedOutput(t *testing.T) {
 		os.Stderr = oldStderr
 	}()
 
-	output := &terraformOutput{logOrder: terraformPlanLogOrderGrouped}
+	output := &terraformOutput{command: "plan", logOrder: terraformPlanLogOrderGrouped}
 	output.finishNode(&dependency.Node{Component: "app", Stack: "dev"}, TerraformExecutionResult{
 		Stdout: "stdout",
 		Stderr: "stderr",
@@ -471,9 +480,9 @@ func TestTerraformOutputFinishNodeGroupedOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, string(stdoutBytes), "stdout")
-	require.Contains(t, string(stderrBytes), "terraform plan succeeded")
+	require.Contains(t, string(stderrBytes), "plan output succeeded")
 	require.Contains(t, string(stderrBytes), "stderr")
-	require.Contains(t, string(stderrBytes), "end terraform plan output")
+	require.Contains(t, string(stderrBytes), "end plan output")
 }
 
 func TestTerraformOutputFinishNodeSkipsNoChangesWhenHidden(t *testing.T) {
@@ -510,9 +519,9 @@ func TestTerraformOutputFinishNodeSkipsNoChangesWhenHidden(t *testing.T) {
 }
 
 func TestTerraformOutputHelpers(t *testing.T) {
-	require.Equal(t, "", terraformLogDir(nil))
-	require.Equal(t, "", terraformLogDir(&schema.AtmosConfiguration{}))
-	require.Equal(t, filepath.Join("base", ".atmos", "logs", "terraform", "plan"), terraformLogDir(&schema.AtmosConfiguration{BasePath: "base"}))
+	require.Equal(t, "", terraformLogDir(nil, "plan"))
+	require.Equal(t, "", terraformLogDir(&schema.AtmosConfiguration{}, "plan"))
+	require.Equal(t, filepath.Join("base", ".atmos", "logs", "terraform", "plan"), terraformLogDir(&schema.AtmosConfiguration{BasePath: "base"}, "plan"))
 	require.Equal(t, "terraform", safeTerraformLogName(" "))
 	require.Equal(t, "dev__app_bad_name", safeTerraformLogName("dev/app:bad name"))
 
@@ -537,7 +546,7 @@ func TestTerraformSummaryHelperBranches(t *testing.T) {
 	require.Equal(t, "dev/app", terraformNodeLabel(&dependency.Node{Stack: "dev", Component: "app"}))
 
 	require.Equal(t, 1, effectiveTerraformMaxConcurrency(nil))
-	require.Equal(t, 1, effectiveTerraformMaxConcurrency(&schema.ConfigAndStacksInfo{SubCommand: "apply", MaxConcurrency: 4}))
+	require.Equal(t, 4, effectiveTerraformMaxConcurrency(&schema.ConfigAndStacksInfo{SubCommand: "apply", MaxConcurrency: 4}))
 	require.Equal(t, 1, effectiveTerraformMaxConcurrency(&schema.ConfigAndStacksInfo{SubCommand: "plan", MaxConcurrency: 1}))
 	require.Equal(t, 4, effectiveTerraformMaxConcurrency(&schema.ConfigAndStacksInfo{SubCommand: "plan", MaxConcurrency: 4}))
 
@@ -556,7 +565,7 @@ func TestTerraformSummaryHelperBranches(t *testing.T) {
 	require.True(t, terraformPlanChanged(&scheduler.AggregateResult{Results: []scheduler.Result{{Value: TerraformNodeOutcome{Changed: true}}}}))
 }
 
-func TestExecuteTerraformIgnoresMaxConcurrencyForNonPlan(t *testing.T) {
+func TestExecuteTerraformAllowsParallelApplyWithAutoApprove(t *testing.T) {
 	stacks := map[string]any{
 		"dev": map[string]any{
 			cfg.ComponentsSectionName: map[string]any{
@@ -575,9 +584,10 @@ func TestExecuteTerraformIgnoresMaxConcurrencyForNonPlan(t *testing.T) {
 	err := ExecuteTerraform(context.Background(), TerraformOptions{
 		AtmosConfig: &schema.AtmosConfiguration{},
 		Info: &schema.ConfigAndStacksInfo{
-			All:            true,
-			SubCommand:     "apply",
-			MaxConcurrency: 3,
+			All:                    true,
+			SubCommand:             "apply",
+			MaxConcurrency:         3,
+			AdditionalArgsAndFlags: []string{"-auto-approve"},
 		},
 		Stacks: stacks,
 		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
@@ -590,7 +600,156 @@ func TestExecuteTerraformIgnoresMaxConcurrencyForNonPlan(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.EqualValues(t, 1, maxActive.Load())
+	require.Greater(t, maxActive.Load(), int32(1))
+}
+
+func TestExecuteTerraformRejectsConcurrentApplyWithoutAutoApprove(t *testing.T) {
+	err := ExecuteTerraform(context.Background(), TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{},
+		Info: &schema.ConfigAndStacksInfo{
+			All:            true,
+			SubCommand:     "apply",
+			MaxConcurrency: 2,
+		},
+		Stacks: terraformAdapterTestStacksWithWorkdir(),
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires -auto-approve")
+}
+
+func TestExecuteTerraformAcceptsDoubleDashAutoApprove(t *testing.T) {
+	err := ExecuteTerraform(context.Background(), TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{},
+		Info: &schema.ConfigAndStacksInfo{
+			All:                    true,
+			SubCommand:             "destroy",
+			MaxConcurrency:         2,
+			AdditionalArgsAndFlags: []string{"--auto-approve"},
+		},
+		Stacks: terraformAdapterTestStacksWithWorkdir(),
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestExecuteTerraformAllowsConcurrentApplyWithConfiguredAutoApprove(t *testing.T) {
+	stacks := map[string]any{
+		"dev": map[string]any{
+			cfg.ComponentsSectionName: map[string]any{
+				cfg.TerraformSectionName: map[string]any{
+					"app":      terraformAdapterComponentWithPath("selected", terraformAdapterPath("app")),
+					"database": terraformAdapterComponentWithPath("selected", terraformAdapterPath("database")),
+				},
+			},
+		},
+	}
+	var active atomic.Int32
+	var maxActive atomic.Int32
+
+	err := ExecuteTerraform(context.Background(), TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{
+			Components: schema.Components{
+				Terraform: schema.Terraform{
+					ApplyAutoApprove: true,
+				},
+			},
+		},
+		Info: &schema.ConfigAndStacksInfo{
+			All:            true,
+			SubCommand:     "apply",
+			MaxConcurrency: 2,
+		},
+		Stacks: stacks,
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			current := active.Add(1)
+			updateMaxActive(&maxActive, current)
+			time.Sleep(20 * time.Millisecond)
+			active.Add(-1)
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, maxActive.Load(), int32(1))
+}
+
+func TestExecuteTerraformRunsDestroyInReverseDependencyOrder(t *testing.T) {
+	var executed []string
+
+	err := ExecuteTerraform(context.Background(), TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{},
+		Info: &schema.ConfigAndStacksInfo{
+			All:                    true,
+			SubCommand:             "destroy",
+			MaxConcurrency:         1,
+			AdditionalArgsAndFlags: []string{"-auto-approve"},
+		},
+		Stacks: terraformAdapterTestStacks(),
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			info := execution.Info
+			executed = append(executed, info.Component+"@"+info.Stack)
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"app@dev", "database@dev", "vpc@dev"}, executed)
+}
+
+func TestExecuteTerraformDestroyFailureBlocksPrerequisites(t *testing.T) {
+	var executed []string
+
+	err := ExecuteTerraform(context.Background(), TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{},
+		Info: &schema.ConfigAndStacksInfo{
+			All:                    true,
+			SubCommand:             "destroy",
+			MaxConcurrency:         2,
+			AdditionalArgsAndFlags: []string{"-auto-approve"},
+		},
+		Stacks: terraformAdapterTestStacksWithWorkdir(),
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			info := execution.Info
+			executed = append(executed, info.Component+"@"+info.Stack)
+			if info.Component == "app" {
+				return TerraformExecutionResult{}, errors.New("destroy failed")
+			}
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, []string{"app@dev"}, executed)
+	require.Contains(t, err.Error(), "dependency app-dev failed")
+}
+
+func TestExecuteTerraformPassesSchedulerContextToExecutor(t *testing.T) {
+	type contextKey string
+	ctx := context.WithValue(context.Background(), contextKey("trace"), "expected")
+	var sawContext bool
+
+	err := ExecuteTerraform(ctx, TerraformOptions{
+		AtmosConfig: &schema.AtmosConfiguration{},
+		Info: &schema.ConfigAndStacksInfo{
+			All:        true,
+			SubCommand: "plan",
+		},
+		Stacks: terraformAdapterTestStacks(),
+		Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
+			sawContext = execution.Context.Value(contextKey("trace")) == "expected"
+			return TerraformExecutionResult{}, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.True(t, sawContext)
 }
 
 func TestExecuteTerraformConcurrentStreamLogOrderInjectsStreams(t *testing.T) {
@@ -757,14 +916,19 @@ func TestExecuteTerraformTreatsPlanExitTwoAsChangedSuccess(t *testing.T) {
 func TestExecuteTerraformDoesNotRequireWorkdirForPlanApplyDestroy(t *testing.T) {
 	for _, subcommand := range []string{"plan", "apply", "destroy"} {
 		t.Run(subcommand, func(t *testing.T) {
+			info := &schema.ConfigAndStacksInfo{
+				All:            true,
+				SubCommand:     subcommand,
+				MaxConcurrency: 2,
+			}
+			if requiresTerraformAutoApprove(info) {
+				info.AdditionalArgsAndFlags = []string{"-auto-approve"}
+			}
+
 			err := ExecuteTerraform(context.Background(), TerraformOptions{
 				AtmosConfig: &schema.AtmosConfiguration{},
-				Info: &schema.ConfigAndStacksInfo{
-					All:            true,
-					SubCommand:     subcommand,
-					MaxConcurrency: 2,
-				},
-				Stacks: terraformAdapterTestStacks(),
+				Info:        info,
+				Stacks:      terraformAdapterTestStacks(),
 				Executor: func(execution TerraformExecution) (TerraformExecutionResult, error) {
 					return TerraformExecutionResult{}, nil
 				},
@@ -916,6 +1080,23 @@ func terraformAdapterTestStacks() map[string]any {
 			},
 		},
 	}
+}
+
+func terraformAdapterTestStacksWithWorkdir() map[string]any {
+	stacks := terraformAdapterTestStacks()
+	terraformComponents := stacks["dev"].(map[string]any)[cfg.ComponentsSectionName].(map[string]any)[cfg.TerraformSectionName].(map[string]any)
+	for componentName, component := range terraformComponents {
+		componentMap := component.(map[string]any)
+		componentMap["component_info"] = map[string]any{
+			cfg.ComponentPathSectionName: terraformAdapterPath(componentName),
+		}
+		componentMap["provision"] = map[string]any{
+			"workdir": map[string]any{
+				"enabled": true,
+			},
+		}
+	}
+	return stacks
 }
 
 func terraformAdapterComponent(group string, dependenciesComponents, settingsDependsOn []any) map[string]any {

--- a/pkg/scheduler/adapters/terraform_test.go
+++ b/pkg/scheduler/adapters/terraform_test.go
@@ -639,6 +639,61 @@ func TestExecuteTerraformAcceptsDoubleDashAutoApprove(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestContainsTerraformFlagParsesBooleanValues(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "bare flag",
+			args: []string{"-auto-approve"},
+			want: true,
+		},
+		{
+			name: "double dash true",
+			args: []string{"--auto-approve=true"},
+			want: true,
+		},
+		{
+			name: "numeric true",
+			args: []string{"-auto-approve=1"},
+			want: true,
+		},
+		{
+			name: "yes true",
+			args: []string{"-auto-approve=yes"},
+			want: true,
+		},
+		{
+			name: "false value",
+			args: []string{"-auto-approve=false"},
+			want: false,
+		},
+		{
+			name: "numeric false",
+			args: []string{"-auto-approve=0"},
+			want: false,
+		},
+		{
+			name: "no value",
+			args: []string{"-auto-approve=no"},
+			want: false,
+		},
+		{
+			name: "unrelated flag",
+			args: []string{"-lock=false"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, containsTerraformFlag(tt.args, "-auto-approve"))
+		})
+	}
+}
+
 func TestExecuteTerraformAllowsConcurrentApplyWithConfiguredAutoApprove(t *testing.T) {
 	stacks := map[string]any{
 		"dev": map[string]any{

--- a/pkg/scheduler/adapters/terraform_test.go
+++ b/pkg/scheduler/adapters/terraform_test.go
@@ -694,6 +694,30 @@ func TestContainsTerraformFlagParsesBooleanValues(t *testing.T) {
 	}
 }
 
+func TestHasTerraformAutoApproveEnvChecksGlobalAndSubcommandArgs(t *testing.T) {
+	t.Run("global", func(t *testing.T) {
+		t.Setenv(terraformCLIArgsEnv, "-auto-approve")
+		require.True(t, hasTerraformAutoApproveEnv("apply"))
+	})
+
+	t.Run("apply specific", func(t *testing.T) {
+		t.Setenv(terraformCLIArgsEnvPrefix+"apply", "-auto-approve")
+		require.True(t, hasTerraformAutoApproveEnv("apply"))
+		require.False(t, hasTerraformAutoApproveEnv("destroy"))
+	})
+
+	t.Run("destroy specific", func(t *testing.T) {
+		t.Setenv(terraformCLIArgsEnvPrefix+"destroy", "--auto-approve=true")
+		require.True(t, hasTerraformAutoApproveEnv("destroy"))
+		require.False(t, hasTerraformAutoApproveEnv("apply"))
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		t.Setenv(terraformCLIArgsEnvPrefix+"apply", "-auto-approve=false")
+		require.False(t, hasTerraformAutoApproveEnv("apply"))
+	})
+}
+
 func TestExecuteTerraformAllowsConcurrentApplyWithConfiguredAutoApprove(t *testing.T) {
 	stacks := map[string]any{
 		"dev": map[string]any{

--- a/tests/cli_auth_console_test.go
+++ b/tests/cli_auth_console_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestAuthConsole tests the `atmos auth console` command integration.
@@ -22,14 +20,7 @@ import (
 // Success paths require real cloud provider credentials and browser interaction.
 // These are tested manually and in production environments.
 func TestAuthConsole(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for auth console test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("command exists and shows help", func(t *testing.T) {
 		cmd := atmosRunner.Command("auth", "console", "--help")

--- a/tests/cli_auth_login_provider_test.go
+++ b/tests/cli_auth_login_provider_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestAuthLoginProvider tests the `atmos auth login --provider <provider>` command integration.
@@ -21,14 +19,7 @@ import (
 //
 // Success paths require real cloud provider credentials and are tested manually and in production environments.
 func TestAuthLoginProvider(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for auth login provider test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("command shows help with provider flag", func(t *testing.T) {
 		cmd := atmosRunner.Command("auth", "login", "--help")

--- a/tests/cli_describe_identity_test.go
+++ b/tests/cli_describe_identity_test.go
@@ -5,21 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestDescribeCommandsWithIdentityFlag verifies that describe commands handle the --identity flag correctly.
 // These tests cover the code paths where identity flag is parsed and CreateAuthManagerFromIdentity is called.
 func TestDescribeCommandsWithIdentityFlag(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for describe identity test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	tests := []struct {
 		name string
@@ -82,12 +73,7 @@ func TestDescribeCommandsWithIdentityFlag(t *testing.T) {
 
 // TestDescribeCommandsWithoutAuthWork verifies that commands work normally without --identity flag.
 func TestDescribeCommandsWithoutAuthWork(t *testing.T) {
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("describe stacks without auth should work", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/basic")

--- a/tests/cli_double_hyphen_test.go
+++ b/tests/cli_double_hyphen_test.go
@@ -6,21 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestDoubleHyphenSeparator tests that args after "--" are correctly passed through
 // to the underlying terraform command without being parsed by Atmos.
 // This is the fix for GitHub issue #1967.
 func TestDoubleHyphenSeparator(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -104,13 +96,7 @@ func TestDoubleHyphenSeparator(t *testing.T) {
 // TestDoubleHyphenWithConsolidateWarnings specifically tests the exact scenario
 // from GitHub issue #1967 where -consolidate-warnings=false caused stack corruption.
 func TestDoubleHyphenWithConsolidateWarnings(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	if skipReason != "" {
 		t.Skipf("Skipping test: %s", skipReason)
@@ -155,13 +141,7 @@ func TestDoubleHyphenWithConsolidateWarnings(t *testing.T) {
 // TestDoubleHyphenStackNotOverwritten ensures that args after -- don't
 // accidentally overwrite the stack value.
 func TestDoubleHyphenStackNotOverwritten(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	if skipReason != "" {
 		t.Skipf("Skipping test: %s", skipReason)

--- a/tests/cli_identity_flag_test.go
+++ b/tests/cli_identity_flag_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestIdentityFlagExplicitValue verifies that when an explicit identity value is provided
@@ -14,14 +12,7 @@ import (
 // This is a regression test for the bug where Cobra's NoOptDefVal behavior with positional
 // args caused explicit identity values to be ignored.
 func TestIdentityFlagExplicitValue(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for identity flag test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("terraform plan with explicit identity should not show selector", func(t *testing.T) {
 		// Change to a basic test directory.
@@ -131,14 +122,7 @@ func TestIdentityFlagExplicitValue(t *testing.T) {
 // TestIdentityFlagWithEnvironmentVariable verifies that ATMOS_IDENTITY environment
 // variable is respected when --identity flag is not provided.
 func TestIdentityFlagWithEnvironmentVariable(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for identity env var test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("terraform plan uses ATMOS_IDENTITY when flag not provided", func(t *testing.T) {
 		// Change to a basic test directory.

--- a/tests/cli_interactive_test.go
+++ b/tests/cli_interactive_test.go
@@ -8,21 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestInteractiveIdentitySelection tests the interactive identity selection behavior
 // with different stdin/stdout/CI configurations.
 func TestInteractiveIdentitySelection(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for interactive test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("explicit identity value should work even with piped output", func(t *testing.T) {
 		// Scenario: build/atmos auth login --identity asd
@@ -183,14 +174,7 @@ func TestInteractiveIdentitySelection(t *testing.T) {
 // TestCIEnvironmentDetection tests that various CI environment variables properly
 // disable interactive mode.
 func TestCIEnvironmentDetection(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for CI detection test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	ciEnvironments := []struct {
 		name string
@@ -320,14 +304,7 @@ func TestStdoutPipingDoesNotBlockInteraction(t *testing.T) {
 // TestExplicitIdentityAlwaysWorks verifies that explicit identity values
 // work in all environments (TTY, non-TTY, CI, piped).
 func TestExplicitIdentityAlwaysWorks(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for explicit identity test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	scenarios := []struct {
 		name     string

--- a/tests/cli_plugin_cache_test.go
+++ b/tests/cli_plugin_cache_test.go
@@ -8,21 +8,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestTerraformPluginCache verifies that Terraform provider caching works correctly.
 // It runs terraform init on two components that use the same provider and verifies
 // that the provider is cached in the XDG cache directory.
 func TestTerraformPluginCache(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -85,13 +77,7 @@ func TestTerraformPluginCache(t *testing.T) {
 
 // TestTerraformPluginCacheClean verifies that `terraform clean --cache` works correctly.
 func TestTerraformPluginCacheClean(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -153,13 +139,7 @@ func TestTerraformPluginCacheClean(t *testing.T) {
 
 // TestTerraformPluginCacheDisabled verifies that plugin cache can be disabled.
 func TestTerraformPluginCacheDisabled(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -204,13 +184,7 @@ func TestTerraformPluginCacheDisabled(t *testing.T) {
 
 // TestTerraformPluginCacheUserOverride verifies that user's TF_PLUGIN_CACHE_DIR takes precedence.
 func TestTerraformPluginCacheUserOverride(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {

--- a/tests/cli_profile_test.go
+++ b/tests/cli_profile_test.go
@@ -8,20 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestProfileListCommand verifies that profile list command works correctly.
 func TestProfileListCommand(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for profile list test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("profile list with profiles returns table output", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/config-profiles")
@@ -150,14 +141,7 @@ func TestProfileListCommand(t *testing.T) {
 
 // TestProfileShowCommand verifies that profile show command works correctly.
 func TestProfileShowCommand(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for profile show test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("profile show with existing profile", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/config-profiles")
@@ -271,14 +255,7 @@ func TestProfileShowCommand(t *testing.T) {
 
 // TestProfileFlagIntegration verifies that --profile flag is accepted by commands.
 func TestProfileFlagIntegration(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for profile flag integration test", "coverageEnabled", coverDir != "")
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("profile flag is accepted without error", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/config-profiles")

--- a/tests/cli_skip_init_test.go
+++ b/tests/cli_skip_init_test.go
@@ -8,20 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestSkipInitFlag tests that the --skip-init flag prevents terraform init from running.
 // This test addresses DEV-3847: Atmos version 1.202.0 ignores --skip-init for terraform output.
 func TestSkipInitFlag(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {

--- a/tests/cli_terraform_test.go
+++ b/tests/cli_terraform_test.go
@@ -8,18 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 func TestCLITerraformClean(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -49,7 +49,9 @@ var (
 	repoRoot            string                   // Repository root directory for path normalization
 	skipReason          string                   // Package-level variable to track why tests should be skipped
 	atmosRunner         *testhelpers.AtmosRunner // Global runner for executing Atmos with coverage support (lazy initialized)
-	coverDir            string                   // GOCOVERDIR environment variable value
+	atmosRunnerOnce     sync.Once
+	atmosRunnerErr      error
+	coverDir            string // GOCOVERDIR environment variable value
 	sandboxRegistry     = make(map[string]*testhelpers.SandboxEnvironment)
 	sandboxMutex        sync.RWMutex
 )
@@ -781,6 +783,24 @@ func prepareAtmosCommand(t *testing.T, ctx context.Context, args ...string) *exe
 	return atmosRunner.CommandContext(ctx, args...)
 }
 
+func ensureAtmosRunner(t *testing.T) {
+	t.Helper()
+
+	atmosRunnerOnce.Do(func() {
+		if atmosRunner != nil {
+			return
+		}
+		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
+		atmosRunnerErr = atmosRunner.Build()
+		if atmosRunnerErr == nil {
+			logger.Info("Atmos runner initialized for test", "coverageEnabled", coverDir != "")
+		}
+	})
+	if atmosRunnerErr != nil {
+		t.Skipf("Failed to initialize Atmos: %v", atmosRunnerErr)
+	}
+}
+
 func runCLICommandTest(t *testing.T, tc TestCase) {
 	// Skip long tests in short mode
 	if testing.Short() && tc.Short != nil && !*tc.Short {
@@ -791,12 +811,8 @@ func runCLICommandTest(t *testing.T, tc TestCase) {
 	checkPreconditions(t, tc.Preconditions)
 
 	// Initialize AtmosRunner early, before any directory changes, so it can build from the git repo
-	if tc.Command == "atmos" && atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-		logger.Info("Atmos runner initialized for test", "coverageEnabled", coverDir != "")
+	if tc.Command == "atmos" {
+		ensureAtmosRunner(t)
 	}
 
 	// Create a context with timeout if specified, defaulting to 10 minutes

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -51,7 +51,7 @@ var (
 	atmosRunner         *testhelpers.AtmosRunner // Global runner for executing Atmos with coverage support (lazy initialized)
 	atmosRunnerOnce     sync.Once
 	atmosRunnerErr      error
-	coverDir            string // GOCOVERDIR environment variable value
+	coverDir            string // GOCOVERDIR environment variable value.
 	sandboxRegistry     = make(map[string]*testhelpers.SandboxEnvironment)
 	sandboxMutex        sync.RWMutex
 )

--- a/tests/cli_workdir_test.go
+++ b/tests/cli_workdir_test.go
@@ -10,19 +10,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cloudposse/atmos/tests/testhelpers"
 )
 
 // TestCLIWorkdirCommands tests the workdir CLI commands using the workdir fixture.
 func TestCLIWorkdirCommands(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -235,13 +227,7 @@ func testWorkdirCleanAll(t *testing.T) {
 
 // TestCLIWorkdirListFormats tests different output formats.
 func TestCLIWorkdirListFormats(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	// Skip if there's a skip reason.
 	if skipReason != "" {
@@ -301,13 +287,7 @@ func TestCLIWorkdirListFormats(t *testing.T) {
 
 // TestCLIWorkdirHelp tests that help commands work.
 func TestCLIWorkdirHelp(t *testing.T) {
-	// Initialize atmosRunner if not already done.
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		if err := atmosRunner.Build(); err != nil {
-			t.Skipf("Failed to initialize Atmos: %v", err)
-		}
-	}
+	ensureAtmosRunner(t)
 
 	t.Run("workdir_help", func(t *testing.T) {
 		stdout, stderr, err := runWorkdirCommand(t, "--help")

--- a/tests/fixtures/scenarios/terraform-floci-dag/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-floci-dag/atmos.yaml
@@ -1,0 +1,22 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+    command: terraform
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.stage }}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info

--- a/tests/fixtures/scenarios/terraform-floci-dag/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-floci-dag/atmos.yaml
@@ -18,5 +18,4 @@ stacks:
   name_template: "{{ .vars.stage }}"
 
 logs:
-  file: "/dev/stderr"
   level: Info

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/alias-shared/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/alias-shared/main.tf
@@ -16,6 +16,10 @@ resource "terraform_data" "alias_probe" {
       active="${var.alias_lock_dir}/active"
       overlap="${var.alias_lock_dir}/overlap"
       events="${var.alias_lock_dir}/events.log"
+      cleanup() {
+        rm -f "$active"
+      }
+      trap cleanup EXIT INT TERM
       if ! ( set -C; echo "${var.alias_name}" > "$active" ) 2>/dev/null; then
         echo "${var.alias_name}" > "$overlap"
       fi

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/alias-shared/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/alias-shared/main.tf
@@ -1,0 +1,32 @@
+variable "alias_name" {
+  type = string
+}
+
+variable "alias_lock_dir" {
+  type = string
+}
+
+resource "terraform_data" "alias_probe" {
+  input = var.alias_name
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -eu
+      mkdir -p "${var.alias_lock_dir}"
+      active="${var.alias_lock_dir}/active"
+      overlap="${var.alias_lock_dir}/overlap"
+      events="${var.alias_lock_dir}/events.log"
+      if ! ( set -C; echo "${var.alias_name}" > "$active" ) 2>/dev/null; then
+        echo "${var.alias_name}" > "$overlap"
+      fi
+      echo "start ${var.alias_name} $(date +%s)" >> "$events"
+      sleep 2
+      echo "end ${var.alias_name} $(date +%s)" >> "$events"
+      rm -f "$active"
+    EOT
+  }
+}
+
+output "alias_name" {
+  value = terraform_data.alias_probe.output
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/bucket-marker/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/bucket-marker/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ssm = var.aws_endpoint_url
+  }
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_endpoint_url" {
+  type = string
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "marker_key" {
+  type = string
+}
+
+variable "marker_value" {
+  type = string
+}
+
+resource "aws_ssm_parameter" "marker" {
+  name  = "/atmos/pr5/floci/${var.test_id}/${var.marker_key}"
+  type  = "String"
+  value = var.marker_value
+}
+
+output "marker_name" {
+  value = aws_ssm_parameter.marker.name
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/final-marker/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/final-marker/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ssm = var.aws_endpoint_url
+  }
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_endpoint_url" {
+  type = string
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "marker_key" {
+  type = string
+}
+
+variable "marker_value" {
+  type = string
+}
+
+resource "aws_ssm_parameter" "marker" {
+  name  = "/atmos/pr5/floci/${var.test_id}/${var.marker_key}"
+  type  = "String"
+  value = var.marker_value
+}
+
+output "marker_name" {
+  value = aws_ssm_parameter.marker.name
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/queue-marker/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/queue-marker/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ssm = var.aws_endpoint_url
+  }
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_endpoint_url" {
+  type = string
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "marker_key" {
+  type = string
+}
+
+variable "marker_value" {
+  type = string
+}
+
+resource "aws_ssm_parameter" "marker" {
+  name  = "/atmos/pr5/floci/${var.test_id}/${var.marker_key}"
+  type  = "String"
+  value = var.marker_value
+}
+
+output "marker_name" {
+  value = aws_ssm_parameter.marker.name
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/seed/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/seed/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ssm = var.aws_endpoint_url
+  }
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_endpoint_url" {
+  type = string
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "marker_key" {
+  type = string
+}
+
+variable "marker_value" {
+  type = string
+}
+
+resource "aws_ssm_parameter" "marker" {
+  name  = "/atmos/pr5/floci/${var.test_id}/${var.marker_key}"
+  type  = "String"
+  value = var.marker_value
+}
+
+output "marker_name" {
+  value = aws_ssm_parameter.marker.name
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/topic-marker/main.tf
+++ b/tests/fixtures/scenarios/terraform-floci-dag/components/terraform/topic-marker/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ssm = var.aws_endpoint_url
+  }
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_endpoint_url" {
+  type = string
+}
+
+variable "test_id" {
+  type = string
+}
+
+variable "marker_key" {
+  type = string
+}
+
+variable "marker_value" {
+  type = string
+}
+
+resource "aws_ssm_parameter" "marker" {
+  name  = "/atmos/pr5/floci/${var.test_id}/${var.marker_key}"
+  type  = "String"
+  value = var.marker_value
+}
+
+output "marker_name" {
+  value = aws_ssm_parameter.marker.name
+}

--- a/tests/fixtures/scenarios/terraform-floci-dag/stacks/deploy/local.yaml
+++ b/tests/fixtures/scenarios/terraform-floci-dag/stacks/deploy/local.yaml
@@ -1,0 +1,60 @@
+vars:
+  stage: local
+  aws_region: us-east-1
+  aws_endpoint_url: !env FLOCI_ENDPOINT_URL
+  test_id: !env ATMOS_FLOCI_TEST_ID
+
+components:
+  terraform:
+    seed:
+      vars:
+        marker_key: seed
+        marker_value: seed
+
+    bucket-marker:
+      vars:
+        marker_key: bucket-marker
+        marker_value: bucket
+      dependencies:
+        components:
+          - component: seed
+
+    queue-marker:
+      vars:
+        marker_key: queue-marker
+        marker_value: queue
+      dependencies:
+        components:
+          - component: seed
+
+    topic-marker:
+      vars:
+        marker_key: topic-marker
+        marker_value: topic
+      dependencies:
+        components:
+          - component: seed
+
+    final-marker:
+      vars:
+        marker_key: final-marker
+        marker_value: final
+      dependencies:
+        components:
+          - component: bucket-marker
+          - component: queue-marker
+          - component: topic-marker
+
+    alias-one:
+      metadata:
+        component: alias-shared
+      vars:
+        alias_name: alias-one
+        alias_lock_dir: !env ATMOS_FLOCI_ALIAS_LOCK_DIR
+
+    alias-two:
+      metadata:
+        component: alias-shared
+      vars:
+        alias_name: alias-two
+        alias_lock_dir: !env ATMOS_FLOCI_ALIAS_LOCK_DIR

--- a/tests/snapshots/TestCLICommands_atmos_terraform_apply_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_apply_--help.stdout.golden
@@ -41,6 +41,9 @@ FLAGS
 
       --init-run-reconfigure string        Override init_run_reconfigure setting from atmos.yaml (true/false)
 
+      --max-concurrency int                Maximum number of Terraform apply components to execute concurrently
+                                           (default 1)
+
       --planfile string                    Set the plan file to use
 
 

--- a/tests/snapshots/TestCLICommands_atmos_terraform_apply_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_apply_help.stdout.golden
@@ -41,6 +41,9 @@ FLAGS
 
       --init-run-reconfigure string        Override init_run_reconfigure setting from atmos.yaml (true/false)
 
+      --max-concurrency int                Maximum number of Terraform apply components to execute concurrently
+                                           (default 1)
+
       --planfile string                    Set the plan file to use
 
 

--- a/tests/terraform_floci_dag_test.go
+++ b/tests/terraform_floci_dag_test.go
@@ -59,7 +59,8 @@ func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
 		sandbox := setupFlociSandbox(t, absWorkdir)
 		env := flociCommandEnv(t, endpoint, absWorkdir, sandbox, uniqueFlociTestID(t))
 
-		stdout, stderr, err := runFlociAtmos(t, env, 2*time.Minute,
+		stdout, stderr, err := runFlociAtmos(
+			t, env, 2*time.Minute,
 			"terraform", "apply", "--all", "-s", "local", "--max-concurrency", "2", "-i", "false",
 		)
 
@@ -104,7 +105,8 @@ func runFlociLifecycle(t *testing.T, endpoint, absWorkdir string, maxConcurrency
 
 	defer bestEffortFlociDestroy(t, env)
 
-	_, stderr, err := runFlociAtmos(t, env, 5*time.Minute,
+	_, stderr, err := runFlociAtmos(
+		t, env, 5*time.Minute,
 		"terraform", "apply", "--all", "-s", "local",
 		"--max-concurrency", fmt.Sprintf("%d", maxConcurrency),
 		"-i", "false",
@@ -113,7 +115,8 @@ func runFlociLifecycle(t *testing.T, endpoint, absWorkdir string, maxConcurrency
 	require.NoError(t, err, "apply failed:\n%s", stderr)
 	requireFlociParametersExist(t, client, parameterNames)
 
-	_, stderr, err = runFlociAtmos(t, env, 5*time.Minute,
+	_, stderr, err = runFlociAtmos(
+		t, env, 5*time.Minute,
 		"terraform", "destroy", "--all", "-s", "local",
 		"--max-concurrency", fmt.Sprintf("%d", maxConcurrency),
 		"-i", "false",
@@ -134,7 +137,8 @@ func runFlociAliasSequentialProbe(t *testing.T, endpoint, absWorkdir string) {
 
 	defer bestEffortFlociAliasDestroy(t, env)
 
-	_, stderr, err := runFlociAtmos(t, env, 5*time.Minute,
+	_, stderr, err := runFlociAtmos(
+		t, env, 5*time.Minute,
 		"terraform", "apply",
 		"--components=alias-one,alias-two",
 		"-s", "local",
@@ -353,7 +357,8 @@ func flociParameterExists(client *ssm.Client, name string) (bool, error) {
 func bestEffortFlociDestroy(t *testing.T, env map[string]string) {
 	t.Helper()
 
-	_, stderr, err := runFlociAtmos(t, env, 3*time.Minute,
+	_, stderr, err := runFlociAtmos(
+		t, env, 3*time.Minute,
 		"terraform", "destroy", "--all", "-s", "local",
 		"--max-concurrency", "4",
 		"-i", "false",
@@ -367,7 +372,8 @@ func bestEffortFlociDestroy(t *testing.T, env map[string]string) {
 func bestEffortFlociAliasDestroy(t *testing.T, env map[string]string) {
 	t.Helper()
 
-	_, stderr, err := runFlociAtmos(t, env, 3*time.Minute,
+	_, stderr, err := runFlociAtmos(
+		t, env, 3*time.Minute,
 		"terraform", "destroy",
 		"--components=alias-one,alias-two",
 		"-s", "local",

--- a/tests/terraform_floci_dag_test.go
+++ b/tests/terraform_floci_dag_test.go
@@ -1,0 +1,374 @@
+//nolint:forbidigo // This opt-in integration test is configured through environment variables.
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/tests/testhelpers"
+)
+
+const (
+	flociDefaultEndpoint = "http://localhost:4566"
+	flociAWSRegion       = "us-east-1"
+)
+
+var flociMarkerKeys = []string{
+	"seed",
+	"bucket-marker",
+	"queue-marker",
+	"topic-marker",
+	"final-marker",
+}
+
+func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
+	endpoint := requireFlociEndpoint(t)
+	RequireTerraform(t)
+
+	if atmosRunner == nil {
+		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
+		require.NoError(t, atmosRunner.Build())
+	}
+
+	workdir := filepath.Join("fixtures", "scenarios", "terraform-floci-dag")
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	t.Run("rejects concurrent apply without auto approve", func(t *testing.T) {
+		sandbox := setupFlociSandbox(t, absWorkdir)
+		env := flociCommandEnv(t, endpoint, absWorkdir, sandbox, uniqueFlociTestID(t))
+
+		stdout, stderr, err := runFlociAtmos(t, env, 2*time.Minute,
+			"terraform", "apply", "--all", "-s", "local", "--max-concurrency", "2", "-i", "false",
+		)
+
+		require.Error(t, err)
+		require.Contains(t, stdout+stderr, "requires -auto-approve")
+	})
+
+	t.Run("sequential apply destroy lifecycle", func(t *testing.T) {
+		runFlociLifecycle(t, endpoint, absWorkdir, 1)
+	})
+
+	t.Run("parallel apply destroy lifecycle", func(t *testing.T) {
+		runFlociLifecycle(t, endpoint, absWorkdir, 4)
+	})
+
+	t.Run("aliases sharing source path are sequential without workdir", func(t *testing.T) {
+		runFlociAliasSequentialProbe(t, endpoint, absWorkdir)
+	})
+}
+
+func runFlociLifecycle(t *testing.T, endpoint string, absWorkdir string, maxConcurrency int) {
+	t.Helper()
+
+	sandbox := setupFlociSandbox(t, absWorkdir)
+	testID := uniqueFlociTestID(t)
+	env := flociCommandEnv(t, endpoint, absWorkdir, sandbox, testID)
+	client := newFlociSSMClient(t, endpoint)
+	parameterNames := flociParameterNames(testID)
+
+	defer bestEffortFlociDestroy(t, env)
+
+	_, stderr, err := runFlociAtmos(t, env, 5*time.Minute,
+		"terraform", "apply", "--all", "-s", "local",
+		"--max-concurrency", fmt.Sprintf("%d", maxConcurrency),
+		"-i", "false",
+		"-auto-approve",
+	)
+	require.NoError(t, err, "apply failed:\n%s", stderr)
+	requireFlociParametersExist(t, client, parameterNames)
+
+	_, stderr, err = runFlociAtmos(t, env, 5*time.Minute,
+		"terraform", "destroy", "--all", "-s", "local",
+		"--max-concurrency", fmt.Sprintf("%d", maxConcurrency),
+		"-i", "false",
+		"-auto-approve",
+	)
+	require.NoError(t, err, "destroy failed:\n%s", stderr)
+	requireFlociParametersGone(t, client, parameterNames)
+}
+
+func runFlociAliasSequentialProbe(t *testing.T, endpoint string, absWorkdir string) {
+	t.Helper()
+
+	sandbox := setupFlociSandbox(t, absWorkdir)
+	testID := uniqueFlociTestID(t)
+	aliasLockDir := t.TempDir()
+	env := flociCommandEnv(t, endpoint, absWorkdir, sandbox, testID)
+	env["ATMOS_FLOCI_ALIAS_LOCK_DIR"] = aliasLockDir
+
+	defer bestEffortFlociAliasDestroy(t, env)
+
+	_, stderr, err := runFlociAtmos(t, env, 5*time.Minute,
+		"terraform", "apply",
+		"--components=alias-one,alias-two",
+		"-s", "local",
+		"--max-concurrency", "2",
+		"-i", "false",
+		"-auto-approve",
+	)
+	require.NoError(t, err, "alias apply failed:\n%s", stderr)
+
+	eventsPath := filepath.Join(aliasLockDir, "events.log")
+	events, err := os.ReadFile(eventsPath)
+	require.NoError(t, err, "expected alias probe event log")
+	require.Contains(t, string(events), "start alias-one")
+	require.Contains(t, string(events), "end alias-one")
+	require.Contains(t, string(events), "start alias-two")
+	require.Contains(t, string(events), "end alias-two")
+	require.NoFileExists(t, filepath.Join(aliasLockDir, "overlap"), "aliases sharing one Terraform source path overlapped")
+}
+
+func setupFlociSandbox(t *testing.T, absWorkdir string) *testhelpers.SandboxEnvironment {
+	t.Helper()
+
+	sandbox, err := testhelpers.SetupSandbox(t, absWorkdir)
+	require.NoError(t, err)
+	t.Cleanup(sandbox.Cleanup)
+	t.Chdir(absWorkdir)
+	return sandbox
+}
+
+func requireFlociEndpoint(t *testing.T) string {
+	t.Helper()
+
+	if os.Getenv("ATMOS_TEST_FLOCI") != "true" {
+		t.Skip("set ATMOS_TEST_FLOCI=true and start Floci before running this integration test")
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	if endpoint == "" {
+		endpoint = os.Getenv("FLOCI_ENDPOINT_URL")
+	}
+	if endpoint == "" {
+		endpoint = flociDefaultEndpoint
+	}
+	endpoint = normalizeFlociEndpoint(endpoint)
+
+	parsed, err := url.Parse(endpoint)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed.Host)
+
+	address := parsed.Host
+	if _, _, splitErr := net.SplitHostPort(address); splitErr != nil {
+		port := parsed.Port()
+		if port == "" {
+			port = "4566"
+		}
+		address = net.JoinHostPort(parsed.Hostname(), port)
+	}
+
+	conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+	if err != nil {
+		t.Skipf("Floci is not reachable at %s: %v", endpoint, err)
+	}
+	require.NoError(t, conn.Close())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	require.NoError(t, err)
+	// #nosec G107 -- endpoint is an opt-in local Floci test target.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Skipf("Floci HTTP endpoint is not reachable at %s: %v", endpoint, err)
+	}
+	require.NoError(t, resp.Body.Close())
+
+	return endpoint
+}
+
+func normalizeFlociEndpoint(endpoint string) string {
+	if strings.Contains(endpoint, "://") {
+		return endpoint
+	}
+	return "http://" + endpoint
+}
+
+func flociCommandEnv(t *testing.T, endpoint string, absWorkdir string, sandbox *testhelpers.SandboxEnvironment, testID string) map[string]string {
+	t.Helper()
+
+	env := map[string]string{
+		"ATMOS_CLI_CONFIG_PATH":      absWorkdir,
+		"ATMOS_FLOCI_TEST_ID":        testID,
+		"AWS_ACCESS_KEY_ID":          "test",
+		"AWS_SECRET_ACCESS_KEY":      "test",
+		"AWS_DEFAULT_REGION":         flociAWSRegion,
+		"AWS_REGION":                 flociAWSRegion,
+		"AWS_ENDPOINT_URL":           endpoint,
+		"FLOCI_ENDPOINT_URL":         endpoint,
+		"ATMOS_FLOCI_ALIAS_LOCK_DIR": t.TempDir(),
+		"TF_IN_AUTOMATION":           "1",
+	}
+	for key, value := range sandbox.GetEnvironmentVariables() {
+		env[key] = value
+	}
+	return env
+}
+
+func runFlociAtmos(t *testing.T, env map[string]string, timeout time.Duration, args ...string) (string, string, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := atmosRunner.CommandContext(ctx, args...)
+	cmd.Env = mergeCommandEnv(cmd.Env, env)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return stdout.String(), stderr.String(), ctx.Err()
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func mergeCommandEnv(base []string, overrides map[string]string) []string {
+	if len(base) == 0 {
+		base = os.Environ()
+	}
+	env := append([]string{}, base...)
+	for key, value := range overrides {
+		prefix := key + "="
+		for i := 0; i < len(env); i++ {
+			if strings.HasPrefix(env[i], prefix) {
+				env = append(env[:i], env[i+1:]...)
+				i--
+			}
+		}
+		env = append(env, prefix+value)
+	}
+	return env
+}
+
+func newFlociSSMClient(t *testing.T, endpoint string) *ssm.Client {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cfg, err := awsconfig.LoadDefaultConfig(
+		ctx,
+		awsconfig.WithRegion(flociAWSRegion),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	require.NoError(t, err)
+
+	return ssm.NewFromConfig(cfg, func(options *ssm.Options) {
+		options.BaseEndpoint = aws.String(endpoint)
+	})
+}
+
+func flociParameterNames(testID string) []string {
+	names := make([]string, 0, len(flociMarkerKeys))
+	for _, key := range flociMarkerKeys {
+		names = append(names, "/atmos/pr5/floci/"+testID+"/"+key)
+	}
+	return names
+}
+
+func requireFlociParametersExist(t *testing.T, client *ssm.Client, names []string) {
+	t.Helper()
+
+	for _, name := range names {
+		require.Eventually(t, func() bool {
+			exists, err := flociParameterExists(client, name)
+			if err != nil {
+				t.Logf("checking Floci parameter %s: %v", name, err)
+				return false
+			}
+			return exists
+		}, 10*time.Second, 200*time.Millisecond, "expected Floci parameter %s to exist", name)
+	}
+}
+
+func requireFlociParametersGone(t *testing.T, client *ssm.Client, names []string) {
+	t.Helper()
+
+	for _, name := range names {
+		require.Eventually(t, func() bool {
+			exists, err := flociParameterExists(client, name)
+			if err != nil {
+				t.Logf("checking Floci parameter %s: %v", name, err)
+				return false
+			}
+			return !exists
+		}, 10*time.Second, 200*time.Millisecond, "expected Floci parameter %s to be deleted", name)
+	}
+}
+
+func flociParameterExists(client *ssm.Client, name string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String(name)})
+	if err == nil {
+		return true, nil
+	}
+	var notFound *ssmtypes.ParameterNotFound
+	if errors.As(err, &notFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func bestEffortFlociDestroy(t *testing.T, env map[string]string) {
+	t.Helper()
+
+	_, stderr, err := runFlociAtmos(t, env, 3*time.Minute,
+		"terraform", "destroy", "--all", "-s", "local",
+		"--max-concurrency", "4",
+		"-i", "false",
+		"-auto-approve",
+	)
+	if err != nil {
+		t.Logf("best-effort Floci cleanup failed: %v\n%s", err, stderr)
+	}
+}
+
+func bestEffortFlociAliasDestroy(t *testing.T, env map[string]string) {
+	t.Helper()
+
+	_, stderr, err := runFlociAtmos(t, env, 3*time.Minute,
+		"terraform", "destroy",
+		"--components=alias-one,alias-two",
+		"-s", "local",
+		"--max-concurrency", "2",
+		"-i", "false",
+		"-auto-approve",
+	)
+	if err != nil {
+		t.Logf("best-effort Floci alias cleanup failed: %v\n%s", err, stderr)
+	}
+}
+
+func uniqueFlociTestID(t *testing.T) string {
+	t.Helper()
+
+	name := strings.ToLower(t.Name())
+	name = regexp.MustCompile(`[^a-z0-9-]+`).ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), name)
+}

--- a/tests/terraform_floci_dag_test.go
+++ b/tests/terraform_floci_dag_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -39,11 +38,6 @@ var flociMarkerKeys = []string{
 	"topic-marker",
 	"final-marker",
 }
-
-var (
-	flociAtmosRunnerOnce sync.Once
-	flociAtmosRunnerErr  error
-)
 
 func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
 	endpoint := requireFlociEndpoint(t)
@@ -84,14 +78,7 @@ func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
 func ensureFlociAtmosRunner(t *testing.T) {
 	t.Helper()
 
-	flociAtmosRunnerOnce.Do(func() {
-		if atmosRunner != nil {
-			return
-		}
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		flociAtmosRunnerErr = atmosRunner.Build()
-	})
-	require.NoError(t, flociAtmosRunnerErr)
+	ensureAtmosRunner(t)
 }
 
 func runFlociLifecycle(t *testing.T, endpoint, absWorkdir string, maxConcurrency int) {
@@ -151,10 +138,16 @@ func runFlociAliasSequentialProbe(t *testing.T, endpoint, absWorkdir string) {
 	eventsPath := filepath.Join(aliasLockDir, "events.log")
 	events, err := os.ReadFile(eventsPath)
 	require.NoError(t, err, "expected alias probe event log")
-	require.Contains(t, string(events), "start alias-one")
-	require.Contains(t, string(events), "end alias-one")
-	require.Contains(t, string(events), "start alias-two")
-	require.Contains(t, string(events), "end alias-two")
+	log := string(events)
+	oneStart := strings.Index(log, "start alias-one")
+	oneEnd := strings.Index(log, "end alias-one")
+	twoStart := strings.Index(log, "start alias-two")
+	twoEnd := strings.Index(log, "end alias-two")
+	require.GreaterOrEqual(t, oneStart, 0, "missing start alias-one")
+	require.GreaterOrEqual(t, oneEnd, 0, "missing end alias-one")
+	require.GreaterOrEqual(t, twoStart, 0, "missing start alias-two")
+	require.GreaterOrEqual(t, twoEnd, 0, "missing end alias-two")
+	require.True(t, oneEnd < twoStart || twoEnd < oneStart, "alias execution intervals overlapped")
 	require.NoFileExists(t, filepath.Join(aliasLockDir, "overlap"), "aliases sharing one Terraform source path overlapped")
 }
 
@@ -259,7 +252,7 @@ func runFlociAtmos(t *testing.T, env map[string]string, timeout time.Duration, a
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return stdout.String(), stderr.String(), ctx.Err()
 	}
 	return stdout.String(), stderr.String(), err

--- a/tests/terraform_floci_dag_test.go
+++ b/tests/terraform_floci_dag_test.go
@@ -93,7 +93,7 @@ func ensureFlociAtmosRunner(t *testing.T) {
 	require.NoError(t, flociAtmosRunnerErr)
 }
 
-func runFlociLifecycle(t *testing.T, endpoint string, absWorkdir string, maxConcurrency int) {
+func runFlociLifecycle(t *testing.T, endpoint, absWorkdir string, maxConcurrency int) {
 	t.Helper()
 
 	sandbox := setupFlociSandbox(t, absWorkdir)
@@ -123,7 +123,7 @@ func runFlociLifecycle(t *testing.T, endpoint string, absWorkdir string, maxConc
 	requireFlociParametersGone(t, client, parameterNames)
 }
 
-func runFlociAliasSequentialProbe(t *testing.T, endpoint string, absWorkdir string) {
+func runFlociAliasSequentialProbe(t *testing.T, endpoint, absWorkdir string) {
 	t.Helper()
 
 	sandbox := setupFlociSandbox(t, absWorkdir)
@@ -220,7 +220,7 @@ func normalizeFlociEndpoint(endpoint string) string {
 	return "http://" + endpoint
 }
 
-func flociCommandEnv(t *testing.T, endpoint string, absWorkdir string, sandbox *testhelpers.SandboxEnvironment, testID string) map[string]string {
+func flociCommandEnv(t *testing.T, endpoint, absWorkdir string, sandbox *testhelpers.SandboxEnvironment, testID string) map[string]string {
 	t.Helper()
 
 	env := map[string]string{

--- a/tests/terraform_floci_dag_test.go
+++ b/tests/terraform_floci_dag_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,14 +40,16 @@ var flociMarkerKeys = []string{
 	"final-marker",
 }
 
+var (
+	flociAtmosRunnerOnce sync.Once
+	flociAtmosRunnerErr  error
+)
+
 func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
 	endpoint := requireFlociEndpoint(t)
 	RequireTerraform(t)
 
-	if atmosRunner == nil {
-		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
-		require.NoError(t, atmosRunner.Build())
-	}
+	ensureFlociAtmosRunner(t)
 
 	workdir := filepath.Join("fixtures", "scenarios", "terraform-floci-dag")
 	absWorkdir, err := filepath.Abs(workdir)
@@ -75,6 +78,19 @@ func TestTerraformFlociApplyDestroyDAG(t *testing.T) {
 	t.Run("aliases sharing source path are sequential without workdir", func(t *testing.T) {
 		runFlociAliasSequentialProbe(t, endpoint, absWorkdir)
 	})
+}
+
+func ensureFlociAtmosRunner(t *testing.T) {
+	t.Helper()
+
+	flociAtmosRunnerOnce.Do(func() {
+		if atmosRunner != nil {
+			return
+		}
+		atmosRunner = testhelpers.NewAtmosRunner(coverDir)
+		flociAtmosRunnerErr = atmosRunner.Build()
+	})
+	require.NoError(t, flociAtmosRunnerErr)
 }
 
 func runFlociLifecycle(t *testing.T, endpoint string, absWorkdir string, maxConcurrency int) {


### PR DESCRIPTION
## What

- Enables graph-backed concurrency for Terraform apply and destroy on the consolidated bulk path.
- Keeps `--max-concurrency=1` sequential behavior while allowing bounded execution for `--all`, `--components`, and `--query`.
- Reverses destroy graph execution so dependents are destroyed before prerequisites and failed dependents block prerequisite destruction.
- Requires non-interactive concurrent mutating execution via `-auto-approve`.
- Does not require `provision.workdir.enabled=true`; non-workdir aliases that share one physical Terraform source path are serialized by the adapter resource lock, while unrelated source paths can still run concurrently.
- Propagates scheduler cancellation context into Terraform subprocess execution and runs apply CI hooks per component in multi-component mode.

## Stack

Stacked on PR4 branch: `codex/dag-terraform-plan-concurrency`.

## Notes

PR5 inherits PR4's execution-resource locking model:

- workdir-enabled aliases use isolated stack/component execution resources
- non-workdir aliases sharing one physical Terraform source path share one lock and remain sequential
- unrelated physical Terraform source paths can execute concurrently

The remaining mutating-command safety gate is `-auto-approve` for concurrent `apply` and `destroy`. Interactive concurrent apply/destroy still fails preflight before any component starts.

## Validation

After rebasing on the updated PR4 no-workdir locking behavior:

```bash
GOCACHE=/private/tmp/atmos-go-cache GOMODCACHE=/private/tmp/atmos-go-mod-cache go test ./pkg/scheduler/adapters -run 'TestExecuteTerraformSerializesAliasesForSharedPhysicalComponentPathWithoutWorkdir|TestExecuteTerraformDoesNotRequireWorkdirForPlanApplyDestroy|TestExecuteTerraformAllowsParallelApplyWithAutoApprove|TestExecuteTerraformRejectsConcurrentApplyWithoutAutoApprove|TestExecuteTerraformAcceptsDoubleDashAutoApprove|TestExecuteTerraformAllowsConcurrentApplyWithConfiguredAutoApprove|TestExecuteTerraformRunsDestroyInReverseDependencyOrder|TestExecuteTerraformDestroyFailureBlocksPrerequisites|TestTerraformSummaryHelperBranches|TestTerraformOutputHelpers'
GOCACHE=/private/tmp/atmos-go-cache GOMODCACHE=/private/tmp/atmos-go-mod-cache go test ./pkg/scheduler ./pkg/scheduler/adapters ./cmd/terraform
GOCACHE=/private/tmp/atmos-go-cache GOMODCACHE=/private/tmp/atmos-go-mod-cache go test ./internal/exec -run 'TestExecuteTerraformQuery|TestProcessComponentConfig_PropagatesAuthManager|TestProcessComponentConfig_AuthManagerGuardBranches|TestExecuteShellCommandUsesInjectedStreamsAndCapture|TestCheckTTYRequirement|TestHandleDeploySubcommand'
GOCACHE=/private/tmp/atmos-go-cache GOMODCACHE=/private/tmp/atmos-go-mod-cache go test ./tests -run 'TestCLICommands/(atmos_terraform_apply_help|atmos_terraform_apply_--help)'
GOCACHE=/private/tmp/atmos-go-cache GOMODCACHE=/private/tmp/atmos-go-mod-cache go build -o build/atmos .
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --max-concurrency flag (and env var) to control concurrent Terraform operations; CLI help updated (default 1).

* **Improvements**
  * Concurrency rules now apply to plan/apply/destroy with auto-approve safeguards.
  * Signal-aware cancellation and context propagation for multi-component runs.
  * Per-command log/output handling and clearer grouped messaging.
  * Destroy command unified into shared run-options flow.

* **Tests**
  * New opt-in end-to-end Floci apply/destroy test, expanded fixture tests, and consolidated test-runner setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->