### PR TITLE
fix(ci): fire CI hooks per-component in apply --all mode (#2475)

### DIFF
--- a/cmd/terraform/apply.go
+++ b/cmd/terraform/apply.go
@@ -36,13 +36,17 @@ For complete Terraform/OpenTofu documentation, see:
 		return runHooks(h.BeforeTerraformApply, cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (runErr error) {
-		// Reset captured output for this run.
+		// Reset per-run globals. Both must be initialised before any early return
+		// so that the deferred hook and PostRunE read consistent state.
 		capturedApplyOutput = ""
+		wasMultiComponentExecution = false
 
 		// On failure, run after hooks with error context so CI check runs
 		// are updated to failure status. Cobra skips PostRunE on error.
+		// In multi-component mode the per-component hook already fired for each
+		// component, so the global error call is suppressed to avoid double-firing.
 		defer func() {
-			if runErr != nil {
+			if runErr != nil && !wasMultiComponentExecution {
 				runHooksOnErrorWithOutput(h.AfterTerraformApply, cmd, args, runErr, capturedApplyOutput)
 			}
 		}()
@@ -98,6 +102,12 @@ For complete Terraform/OpenTofu documentation, see:
 		return err
 	},
 	PostRunE: func(cmd *cobra.Command, args []string) error {
+		// In multi-component mode, CI hooks already fired per-component inside
+		// ExecuteTerraformQuery. Calling them again here would double-fire on the
+		// last component or fire with empty/misattributed output.
+		if wasMultiComponentExecution {
+			return nil
+		}
 		return runHooksWithOutput(h.AfterTerraformApply, cmd, args, capturedApplyOutput)
 	},
 }

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -219,6 +219,33 @@ func runCIHooksForPlanComponent(actualCmd *cobra.Command, info *schema.ConfigAnd
 	}
 }
 
+// runCIHooksForApplyComponent fires CI hooks for a single component after it completes
+// in multi-component apply mode. Mirrors runCIHooksForPlanComponent using AfterTerraformApply.
+func runCIHooksForApplyComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
+	atmosConfig, err := cfg.InitCliConfig(*info, true)
+	if err != nil {
+		log.Warn("CI hook config init failed", "component", info.Component, "error", err)
+		return
+	}
+
+	forceCIMode, _ := actualCmd.Flags().GetBool("ci")
+	if !forceCIMode {
+		forceCIMode = viper.GetBool("ci")
+	}
+
+	if err := h.RunCIHooks(&h.RunCIHooksOptions{
+		Event:        h.AfterTerraformApply,
+		AtmosConfig:  &atmosConfig,
+		Info:         info,
+		Output:       ansi.Strip(rawOutput),
+		ForceCIMode:  forceCIMode,
+		CommandError: execErr,
+		ExitCode:     errUtils.GetExitCode(execErr),
+	}); err != nil {
+		log.Warn("CI hook execution failed", "component", info.Component, "error", err)
+	}
+}
+
 // resolveComponentPath resolves a path-based component argument to a component name.
 // It validates the component exists in the specified stack and handles ambiguous paths.
 func resolveComponentPath(info *schema.ConfigAndStacksInfo, commandName string) error {
@@ -448,11 +475,15 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
-		// Wire per-component CI hooks for plan so each component gets its own
-		// summary entry instead of a single misattributed global call in PostRunE.
+		// Wire per-component CI hooks for plan and apply so each component gets
+		// its own summary entry instead of a single misattributed global call in PostRunE.
 		if subCommand == "plan" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+			}
+		} else if subCommand == "apply" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)
 			}
 		}
 		return e.ExecuteTerraformQuery(&info)

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -182,6 +182,7 @@ func TestApplyPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
 	defer func() { wasMultiComponentExecution = orig }()
 
 	cmd := newHookTestCmd()
+	cmd.Use = "apply"
 
 	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
 	// without invoking runHooksWithOutput (which would attempt stack resolution).

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -148,3 +148,84 @@ func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
 	// Failure path: non-nil execErr is forwarded with its exit code.
 	runCIHooksForPlanComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
 }
+
+// TestRunCIHooksForApplyComponent_DemoStacks exercises the per-component apply
+// CI hook wrapper introduced by issue #2475. The demo-stacks fixture has
+// ci.enabled=false so RunCIHooks short-circuits cleanly — the test verifies
+// no panic on option construction for both the success and failure paths.
+func TestRunCIHooksForApplyComponent_DemoStacks(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	// Success path: execErr is nil, exit code forwarded as 0.
+	runCIHooksForApplyComponent(cmd, info, "apply output", nil)
+
+	// Failure path: non-nil execErr is forwarded with its exit code.
+	runCIHooksForApplyComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+}
+
+// TestApplyPostRunE_SuppressedWhenMultiComponent verifies that applyCmd.PostRunE
+// returns nil without error when wasMultiComponentExecution is true (multi-component
+// mode). This is the apply-command equivalent of the plan fix from issue #2397 —
+// it exercises the actual PostRunE closure, not just the sentinel variable.
+func TestApplyPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	orig := wasMultiComponentExecution
+	defer func() { wasMultiComponentExecution = orig }()
+
+	cmd := newHookTestCmd()
+
+	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
+	// without invoking runHooksWithOutput (which would attempt stack resolution).
+	wasMultiComponentExecution = true
+	err := applyCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must be suppressed when wasMultiComponentExecution is true")
+
+	// With wasMultiComponentExecution = false, PostRunE must run normally.
+	// The demo-stacks fixture has no hooks configured, so it completes without error.
+	wasMultiComponentExecution = false
+	err = applyCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
+}
+
+// TestRunCIHooksForApplyComponent_ExitCodeForwarding verifies that the exit code
+// extracted from execErr is forwarded correctly, matching the plan component
+// hook behaviour.
+func TestRunCIHooksForApplyComponent_ExitCodeForwarding(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	tests := []struct {
+		name    string
+		execErr error
+		wantExt int
+	}{
+		{"nil error has exit code 0", nil, 0},
+		{"exit code 1", errUtils.ExitCodeError{Code: 1}, 1},
+		{"exit code 2 (non-standard error)", errUtils.ExitCodeError{Code: 2}, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantExt, errUtils.GetExitCode(tc.execErr),
+				"GetExitCode must extract the wrapped exit code before forwarding to apply hook")
+			// The wrapper must not panic regardless of exit code.
+			runCIHooksForApplyComponent(cmd, info, "apply output", tc.execErr)
+		})
+	}
+}


### PR DESCRIPTION
Extends the per-component CI hook pattern from PR #2430 (plan --all) to apply --all, so each component produces its own CI summary entry instead of a single misattributed entry for the last component.

## what
- Update apply --all to fire per-component CI hooks.
- Preserve per-component CI reporting semantics used by plan --all.

## why
- Prevent CI summaries from being misattributed to only the last component.
- Ensure each component has its own hook and status entry in CI pipelines.

## references
- Fixes behavior introduced in PR #2430 for plan --all.
- Addresses CI reporting bug for apply --all mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate CI hook firing during multi-component Terraform apply runs.
  * Reset per-run state at apply start so deferred and post-run hooks observe consistent values.
  * Suppressed post-run hook execution for multi-component apply to avoid double execution.

* **Tests**
  * Added tests covering CI hook handling and post-run suppression in multi-component apply scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->