### PR TITLE
fix(ci): fire CI hooks per-component in deploy --all mode

### DIFF
--- a/cmd/terraform/deploy.go
+++ b/cmd/terraform/deploy.go
@@ -31,13 +31,17 @@ This ensures that the changes defined in your Terraform configuration are applie
 		return runHooks(h.BeforeTerraformDeploy, cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (runErr error) {
-		// Reset captured output for this run.
+		// Reset per-run globals. Both must be initialised before any early return
+		// so that the deferred hook and PostRunE read consistent state.
 		capturedDeployOutput = ""
+		wasMultiComponentExecution = false
 
 		// On failure, run after hooks with error context so CI check runs
 		// are updated to failure status. Cobra skips PostRunE on error.
+		// In multi-component mode the per-component hook already fired for each
+		// component, so the global error call is suppressed to avoid double-firing.
 		defer func() {
-			if runErr != nil {
+			if runErr != nil && !wasMultiComponentExecution {
 				runHooksOnErrorWithOutput(h.AfterTerraformDeploy, cmd, args, runErr, capturedDeployOutput)
 			}
 		}()
@@ -93,6 +97,12 @@ This ensures that the changes defined in your Terraform configuration are applie
 		return err
 	},
 	PostRunE: func(cmd *cobra.Command, args []string) error {
+		// In multi-component mode, CI hooks already fired per-component inside
+		// ExecuteTerraformQuery. Calling them again here would double-fire on the
+		// last component or fire with empty/misattributed output.
+		if wasMultiComponentExecution {
+			return nil
+		}
 		return runHooksWithOutput(h.AfterTerraformDeploy, cmd, args, capturedDeployOutput)
 	},
 }

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -45,7 +45,9 @@ func runHooksOnError(event h.HookEvent, cmd_ *cobra.Command, args []string, cmdE
 }
 
 // runHooksOnErrorWithOutput runs CI hooks with command error context and captured output.
-func runHooksOnErrorWithOutput(event h.HookEvent, cmd_ *cobra.Command, args []string, cmdErr error, output string) {
+// Declared as a package-level var so tests can stub it to verify the RunE defer-guard
+// in deploy.go suppresses the global error hook in multi-component mode.
+var runHooksOnErrorWithOutput = func(event h.HookEvent, cmd_ *cobra.Command, args []string, cmdErr error, output string) {
 	finalArgs := append([]string{cmd_.Name()}, args...)
 
 	info, err := e.ProcessCommandLineArgs("terraform", cmd_, finalArgs, nil)

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -513,6 +513,7 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 		} else if subCommand == "deploy" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
+			}
 		} else if subCommand == "apply" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -504,8 +504,8 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
-		// Wire per-component CI hooks for plan and apply so each component gets
-		// its own summary entry instead of a single misattributed global call in PostRunE.
+		// Wire per-component CI hooks for plan, deploy, and apply so each component
+		// gets its own summary entry instead of a single misattributed global call in PostRunE.
 		if subCommand == "plan" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -29,8 +29,8 @@ import (
 const errWrapFormat = "%w: %w"
 
 // wasMultiComponentExecution records whether the most recent terraformRunWithOptions call
-// was routed to ExecuteTerraformQuery. Read in plan.go PostRunE to suppress the global
-// CI hook call when per-component hooks already fired inside the component walker.
+// was routed to ExecuteTerraformQuery. Read in plan.go and deploy.go PostRunE to suppress
+// the global CI hook call when per-component hooks already fired inside the component walker.
 var wasMultiComponentExecution bool
 
 func runHooks(event h.HookEvent, cmd_ *cobra.Command, args []string) error {
@@ -187,6 +187,33 @@ func runCIHooksForDeploy(event h.HookEvent, cmd_ *cobra.Command, _ []string, inf
 		ForceCIMode: forceCIMode,
 	}); err != nil {
 		log.Warn("CI hook execution failed", "error", err)
+	}
+}
+
+// runCIHooksForDeployComponent fires CI hooks for a single component after it completes
+// in multi-component deploy mode. Mirrors runCIHooksForPlanComponent using AfterTerraformDeploy.
+func runCIHooksForDeployComponent(actualCmd *cobra.Command, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
+	atmosConfig, err := cfg.InitCliConfig(*info, true)
+	if err != nil {
+		log.Warn("CI hook config init failed", "component", info.Component, "error", err)
+		return
+	}
+
+	forceCIMode, _ := actualCmd.Flags().GetBool("ci")
+	if !forceCIMode {
+		forceCIMode = viper.GetBool("ci")
+	}
+
+	if err := h.RunCIHooks(&h.RunCIHooksOptions{
+		Event:        h.AfterTerraformDeploy,
+		AtmosConfig:  &atmosConfig,
+		Info:         info,
+		Output:       ansi.Strip(rawOutput),
+		ForceCIMode:  forceCIMode,
+		CommandError: execErr,
+		ExitCode:     errUtils.GetExitCode(execErr),
+	}); err != nil {
+		log.Warn("CI hook execution failed", "component", info.Component, "error", err)
 	}
 }
 
@@ -448,11 +475,15 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
-		// Wire per-component CI hooks for plan so each component gets its own
-		// summary entry instead of a single misattributed global call in PostRunE.
+		// Wire per-component CI hooks for plan and deploy so each component gets
+		// its own summary entry instead of a single misattributed global call in PostRunE.
 		if subCommand == "plan" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+			}
+		} else if subCommand == "deploy" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
 			}
 		}
 		return e.ExecuteTerraformQuery(&info)

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -215,7 +215,7 @@ func TestRunCIHooksForDeployComponent_ExitCodeForwarding(t *testing.T) {
 	}{
 		{"nil error has exit code 0", nil, 0},
 		{"exit code 1", errUtils.ExitCodeError{Code: 1}, 1},
-		{"exit code 2 (non-standard error)", errUtils.ExitCodeError{Code: 2}, 2},
+		{"exit code 2 (abnormal termination)", errUtils.ExitCodeError{Code: 2}, 2},
 	}
 
 	for _, tc := range tests {

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -181,6 +181,7 @@ func TestDeployPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
 	defer func() { wasMultiComponentExecution = orig }()
 
 	cmd := newHookTestCmd()
+	cmd.Use = "deploy"
 
 	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
 	// without invoking runHooksWithOutput (which would attempt stack resolution).

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -7,6 +7,11 @@ package terraform
 // forwarding lines added in this PR. The demo-stacks fixture has no
 // ci.enabled config, so RunCIHooks short-circuits cleanly — these tests
 // exercise option construction without invoking real plugin handlers.
+//
+// Note on test isolation: cmd.NewTestKit(t) cannot be used here due to a
+// circular import between cmd/terraform and the cmd package. The package
+// already has a TestMain in testmain_test.go that handles the subprocess
+// env-var pattern, and the wrappers under test don't mutate RootCmd state.
 
 import (
 	"errors"
@@ -19,6 +24,16 @@ import (
 	"github.com/cloudposse/atmos/pkg/hooks"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
+
+// Compile-time sentinel: tests below depend on these schema.ConfigAndStacksInfo
+// fields by name. If any field is renamed upstream, this declaration fails
+// to compile so the rename surfaces before the tests would silently drift.
+var _ = schema.ConfigAndStacksInfo{
+	Stack:            "",
+	Component:        "",
+	ComponentFromArg: "",
+	ComponentType:    "",
+}
 
 // newHookTestCmd constructs a cobra.Command with all the flags
 // ProcessCommandLineArgs reads (base-path, config, config-path, profile,
@@ -143,11 +158,20 @@ func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
 		ComponentType:    "terraform",
 	}
 
-	// Success path: execErr is nil, exit code forwarded as 0.
-	runCIHooksForPlanComponent(cmd, info, "plan output", nil)
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+	}{
+		{name: "success path", output: "plan output", execErr: nil},
+		{name: "failure path forwards exit code", output: "", execErr: errUtils.ExitCodeError{Code: 1}},
+	}
 
-	// Failure path: non-nil execErr is forwarded with its exit code.
-	runCIHooksForPlanComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCIHooksForPlanComponent(cmd, info, tc.output, tc.execErr)
+		})
+	}
 }
 
 // TestRunCIHooksForDeployComponent_DemoStacks exercises the per-component deploy
@@ -155,6 +179,32 @@ func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
 // ci.enabled=false so RunCIHooks short-circuits cleanly — the test verifies
 // no panic on option construction for both the success and failure paths.
 func TestRunCIHooksForDeployComponent_DemoStacks(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+	}{
+		{name: "success path", output: "deploy output", execErr: nil},
+		{name: "failure path forwards exit code", output: "", execErr: errUtils.ExitCodeError{Code: 1}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCIHooksForDeployComponent(cmd, info, tc.output, tc.execErr)
+		})
+	}
+}
+
 // TestRunCIHooksForApplyComponent_DemoStacks exercises the per-component apply
 // CI hook wrapper introduced by issue #2475. The demo-stacks fixture has
 // ci.enabled=false so RunCIHooks short-circuits cleanly — the test verifies
@@ -170,21 +220,45 @@ func TestRunCIHooksForApplyComponent_DemoStacks(t *testing.T) {
 		ComponentType:    "terraform",
 	}
 
-	// Success path: execErr is nil, exit code forwarded as 0.
-	runCIHooksForDeployComponent(cmd, info, "deploy output", nil)
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+	}{
+		{name: "success path", output: "apply output", execErr: nil},
+		{name: "failure path forwards exit code", output: "", execErr: errUtils.ExitCodeError{Code: 1}},
+	}
 
-	// Failure path: non-nil execErr is forwarded with its exit code.
-	runCIHooksForDeployComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCIHooksForApplyComponent(cmd, info, tc.output, tc.execErr)
+		})
+	}
 }
 
 // TestDeployPostRunE_SuppressedWhenMultiComponent verifies that deployCmd.PostRunE
 // returns nil without error when wasMultiComponentExecution is true (multi-component
 // mode). Exercises the actual PostRunE closure in both suppressed and non-suppressed states.
 func TestDeployPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
-	runCIHooksForApplyComponent(cmd, info, "apply output", nil)
+	t.Chdir("../../examples/demo-stacks")
 
-	// Failure path: non-nil execErr is forwarded with its exit code.
-	runCIHooksForApplyComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+	orig := wasMultiComponentExecution
+	defer func() { wasMultiComponentExecution = orig }()
+
+	cmd := newHookTestCmd()
+	cmd.Use = "deploy"
+
+	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
+	// without invoking runHooksWithOutput (which would attempt stack resolution).
+	wasMultiComponentExecution = true
+	err := deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must be suppressed when wasMultiComponentExecution is true")
+
+	// With wasMultiComponentExecution = false, PostRunE must run normally.
+	// The demo-stacks fixture has no hooks configured, so it completes without error.
+	wasMultiComponentExecution = false
+	err = deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
 }
 
 // TestApplyPostRunE_SuppressedWhenMultiComponent verifies that applyCmd.PostRunE
@@ -198,20 +272,18 @@ func TestApplyPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
 	defer func() { wasMultiComponentExecution = orig }()
 
 	cmd := newHookTestCmd()
-	cmd.Use = "deploy"
 	cmd.Use = "apply"
 
 	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
 	// without invoking runHooksWithOutput (which would attempt stack resolution).
 	wasMultiComponentExecution = true
-	err := deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
 	err := applyCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
 	assert.NoError(t, err, "PostRunE must be suppressed when wasMultiComponentExecution is true")
 
 	// With wasMultiComponentExecution = false, PostRunE must run normally.
 	// The demo-stacks fixture has no hooks configured, so it completes without error.
 	wasMultiComponentExecution = false
-	err = deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	err = applyCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
 	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
 }
 
@@ -224,7 +296,7 @@ func TestApplyPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
 // The defer-guard lives inside deployCmd.RunE and is reset to false at the
 // start of RunE, so we can't pre-set wasMultiComponentExecution and invoke
 // RunE directly. Instead, this test mirrors the defer-body inline and
-// verifies both branches using a stubbed runHooksOnErrorWithOutput.
+// verifies every branch using a stubbed runHooksOnErrorWithOutput.
 func TestDeployRunE_DeferGuard(t *testing.T) {
 	origGuard := wasMultiComponentExecution
 	origHook := runHooksOnErrorWithOutput
@@ -256,39 +328,101 @@ func TestDeployRunE_DeferGuard(t *testing.T) {
 		}
 	}
 
-	// Case 1: non-nil error AND single-component mode → hook MUST fire.
-	called = false
-	wasMultiComponentExecution = false
-	runErr := errors.New("terraform deploy failed")
-	invokeDefer(runErr, "captured deploy output")
-	assert.True(t, called, "hook must fire when runErr is non-nil and wasMultiComponentExecution is false")
-	assert.Equal(t, hooks.AfterTerraformDeploy, calledEvent, "hook must fire with AfterTerraformDeploy event")
-	assert.Equal(t, runErr, calledErr, "hook must receive the original runErr")
-	assert.Equal(t, "captured deploy output", calledOutput, "hook must receive the captured deploy output")
+	deployErr := errors.New("terraform deploy failed")
 
-	// Case 2: non-nil error AND multi-component mode → hook MUST be suppressed.
-	called = false
-	wasMultiComponentExecution = true
-	invokeDefer(errors.New("terraform deploy failed"), "captured deploy output")
-	assert.False(t, called, "hook must be suppressed when wasMultiComponentExecution is true")
+	tests := []struct {
+		name              string
+		runErr            error
+		multiComponent    bool
+		expectCalled      bool
+		expectEvent       hooks.HookEvent
+		expectForwardErr  error
+		expectOutput      string
+		expectOutputMatch bool
+	}{
+		{
+			name:              "non-nil error + single-component → hook fires",
+			runErr:            deployErr,
+			multiComponent:    false,
+			expectCalled:      true,
+			expectEvent:       hooks.AfterTerraformDeploy,
+			expectForwardErr:  deployErr,
+			expectOutput:      "captured deploy output",
+			expectOutputMatch: true,
+		},
+		{
+			name:           "non-nil error + multi-component → hook suppressed",
+			runErr:         errors.New("terraform deploy failed"),
+			multiComponent: true,
+			expectCalled:   false,
+		},
+		{
+			name:           "nil error + single-component → hook does not fire",
+			runErr:         nil,
+			multiComponent: false,
+			expectCalled:   false,
+		},
+		{
+			name:           "nil error + multi-component → hook does not fire",
+			runErr:         nil,
+			multiComponent: true,
+			expectCalled:   false,
+		},
+	}
 
-	// Case 3: nil error → hook MUST NOT fire regardless of guard state.
-	called = false
-	wasMultiComponentExecution = false
-	invokeDefer(nil, "captured deploy output")
-	assert.False(t, called, "hook must not fire on success path (nil runErr)")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called = false
+			calledEvent = ""
+			calledErr = nil
+			calledOutput = ""
+			wasMultiComponentExecution = tc.multiComponent
 
-	called = false
-	wasMultiComponentExecution = true
-	invokeDefer(nil, "captured deploy output")
-	assert.False(t, called, "hook must not fire on success path even in multi-component mode")
+			invokeDefer(tc.runErr, "captured deploy output")
+
+			assert.Equal(t, tc.expectCalled, called, "hook firing did not match expectation")
+			if tc.expectCalled {
+				assert.Equal(t, tc.expectEvent, calledEvent, "hook event mismatch")
+				assert.Equal(t, tc.expectForwardErr, calledErr, "hook did not receive original runErr")
+				if tc.expectOutputMatch {
+					assert.Equal(t, tc.expectOutput, calledOutput, "hook did not receive captured output")
+				}
+			}
+		})
+	}
 }
 
 // TestRunCIHooksForDeployComponent_ExitCodeForwarding verifies that the exit code
 // extracted from execErr is forwarded correctly, matching the plan component hook behaviour.
 func TestRunCIHooksForDeployComponent_ExitCodeForwarding(t *testing.T) {
-	err = applyCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
-	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	tests := []struct {
+		name    string
+		execErr error
+		wantExt int
+	}{
+		{"nil error has exit code 0", nil, 0},
+		{"exit code 1", errUtils.ExitCodeError{Code: 1}, 1},
+		{"exit code 2 (abnormal termination)", errUtils.ExitCodeError{Code: 2}, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantExt, errUtils.GetExitCode(tc.execErr),
+				"GetExitCode must extract the wrapped exit code before forwarding to deploy hook")
+			// The wrapper must not panic regardless of exit code.
+			runCIHooksForDeployComponent(cmd, info, "deploy output", tc.execErr)
+		})
+	}
 }
 
 // TestRunCIHooksForApplyComponent_ExitCodeForwarding verifies that the exit code

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -158,20 +158,11 @@ func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
 		ComponentType:    "terraform",
 	}
 
-	tests := []struct {
-		name    string
-		output  string
-		execErr error
-	}{
-		{name: "success path", output: "plan output", execErr: nil},
-		{name: "failure path forwards exit code", output: "", execErr: errUtils.ExitCodeError{Code: 1}},
-	}
+	// Success path: execErr is nil, exit code forwarded as 0.
+	runCIHooksForPlanComponent(cmd, info, "plan output", nil)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			runCIHooksForPlanComponent(cmd, info, tc.output, tc.execErr)
-		})
-	}
+	// Failure path: non-nil execErr is forwarded with its exit code.
+	runCIHooksForPlanComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
 }
 
 // TestRunCIHooksForDeployComponent_DemoStacks exercises the per-component deploy
@@ -220,20 +211,11 @@ func TestRunCIHooksForApplyComponent_DemoStacks(t *testing.T) {
 		ComponentType:    "terraform",
 	}
 
-	tests := []struct {
-		name    string
-		output  string
-		execErr error
-	}{
-		{name: "success path", output: "apply output", execErr: nil},
-		{name: "failure path forwards exit code", output: "", execErr: errUtils.ExitCodeError{Code: 1}},
-	}
+	// Success path: execErr is nil, exit code forwarded as 0.
+	runCIHooksForApplyComponent(cmd, info, "apply output", nil)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			runCIHooksForApplyComponent(cmd, info, tc.output, tc.execErr)
-		})
-	}
+	// Failure path: non-nil execErr is forwarded with its exit code.
+	runCIHooksForApplyComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
 }
 
 // TestDeployPostRunE_SuppressedWhenMultiComponent verifies that deployCmd.PostRunE

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -148,3 +148,82 @@ func TestRunCIHooksForPlanComponent_DemoStacks(t *testing.T) {
 	// Failure path: non-nil execErr is forwarded with its exit code.
 	runCIHooksForPlanComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
 }
+
+// TestRunCIHooksForDeployComponent_DemoStacks exercises the per-component deploy
+// CI hook wrapper introduced by issue #2476. The demo-stacks fixture has
+// ci.enabled=false so RunCIHooks short-circuits cleanly — the test verifies
+// no panic on option construction for both the success and failure paths.
+func TestRunCIHooksForDeployComponent_DemoStacks(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	// Success path: execErr is nil, exit code forwarded as 0.
+	runCIHooksForDeployComponent(cmd, info, "deploy output", nil)
+
+	// Failure path: non-nil execErr is forwarded with its exit code.
+	runCIHooksForDeployComponent(cmd, info, "", errUtils.ExitCodeError{Code: 1})
+}
+
+// TestDeployPostRunE_SuppressedWhenMultiComponent verifies that deployCmd.PostRunE
+// returns nil without error when wasMultiComponentExecution is true (multi-component
+// mode). Exercises the actual PostRunE closure in both suppressed and non-suppressed states.
+func TestDeployPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	orig := wasMultiComponentExecution
+	defer func() { wasMultiComponentExecution = orig }()
+
+	cmd := newHookTestCmd()
+
+	// With wasMultiComponentExecution = true, PostRunE must return nil immediately
+	// without invoking runHooksWithOutput (which would attempt stack resolution).
+	wasMultiComponentExecution = true
+	err := deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must be suppressed when wasMultiComponentExecution is true")
+
+	// With wasMultiComponentExecution = false, PostRunE must run normally.
+	// The demo-stacks fixture has no hooks configured, so it completes without error.
+	wasMultiComponentExecution = false
+	err = deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
+	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
+}
+
+// TestRunCIHooksForDeployComponent_ExitCodeForwarding verifies that the exit code
+// extracted from execErr is forwarded correctly, matching the plan component hook behaviour.
+func TestRunCIHooksForDeployComponent_ExitCodeForwarding(t *testing.T) {
+	t.Chdir("../../examples/demo-stacks")
+
+	cmd := newHookTestCmd()
+	info := &schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		Component:        "myapp",
+		ComponentFromArg: "myapp",
+		ComponentType:    "terraform",
+	}
+
+	tests := []struct {
+		name    string
+		execErr error
+		wantExt int
+	}{
+		{"nil error has exit code 0", nil, 0},
+		{"exit code 1", errUtils.ExitCodeError{Code: 1}, 1},
+		{"exit code 2 (non-standard error)", errUtils.ExitCodeError{Code: 2}, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantExt, errUtils.GetExitCode(tc.execErr),
+				"GetExitCode must extract the wrapped exit code before forwarding to deploy hook")
+			// The wrapper must not panic regardless of exit code.
+			runCIHooksForDeployComponent(cmd, info, "deploy output", tc.execErr)
+		})
+	}
+}

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -9,6 +9,7 @@ package terraform
 // exercise option construction without invoking real plugin handlers.
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -194,6 +195,75 @@ func TestDeployPostRunE_SuppressedWhenMultiComponent(t *testing.T) {
 	wasMultiComponentExecution = false
 	err = deployCmd.PostRunE(cmd, []string{"--stack", "dev", "myapp"})
 	assert.NoError(t, err, "PostRunE must fire normally in single-component mode")
+}
+
+// TestDeployRunE_DeferGuard verifies the RunE defer-guard contract in
+// deploy.go: the global error hook (runHooksOnErrorWithOutput) must fire
+// when runErr is non-nil AND wasMultiComponentExecution is false, and must
+// be suppressed when wasMultiComponentExecution is true (multi-component
+// mode, where per-component hooks already fired inside ExecuteTerraformQuery).
+//
+// The defer-guard lives inside deployCmd.RunE and is reset to false at the
+// start of RunE, so we can't pre-set wasMultiComponentExecution and invoke
+// RunE directly. Instead, this test mirrors the defer-body inline and
+// verifies both branches using a stubbed runHooksOnErrorWithOutput.
+func TestDeployRunE_DeferGuard(t *testing.T) {
+	origGuard := wasMultiComponentExecution
+	origHook := runHooksOnErrorWithOutput
+	defer func() {
+		wasMultiComponentExecution = origGuard
+		runHooksOnErrorWithOutput = origHook
+	}()
+
+	var called bool
+	var calledEvent hooks.HookEvent
+	var calledErr error
+	var calledOutput string
+	runHooksOnErrorWithOutput = func(event hooks.HookEvent, _ *cobra.Command, _ []string, cmdErr error, output string) {
+		called = true
+		calledEvent = event
+		calledErr = cmdErr
+		calledOutput = output
+	}
+
+	cmd := newHookTestCmd()
+	cmd.Use = "deploy"
+	args := []string{"--stack", "dev", "myapp"}
+
+	// invokeDefer mirrors the RunE defer-guard body in deploy.go lines 43-47.
+	// Any change to the production guard must be reflected here.
+	invokeDefer := func(runErr error, capturedOutput string) {
+		if runErr != nil && !wasMultiComponentExecution {
+			runHooksOnErrorWithOutput(hooks.AfterTerraformDeploy, cmd, args, runErr, capturedOutput)
+		}
+	}
+
+	// Case 1: non-nil error AND single-component mode → hook MUST fire.
+	called = false
+	wasMultiComponentExecution = false
+	runErr := errors.New("terraform deploy failed")
+	invokeDefer(runErr, "captured deploy output")
+	assert.True(t, called, "hook must fire when runErr is non-nil and wasMultiComponentExecution is false")
+	assert.Equal(t, hooks.AfterTerraformDeploy, calledEvent, "hook must fire with AfterTerraformDeploy event")
+	assert.Equal(t, runErr, calledErr, "hook must receive the original runErr")
+	assert.Equal(t, "captured deploy output", calledOutput, "hook must receive the captured deploy output")
+
+	// Case 2: non-nil error AND multi-component mode → hook MUST be suppressed.
+	called = false
+	wasMultiComponentExecution = true
+	invokeDefer(errors.New("terraform deploy failed"), "captured deploy output")
+	assert.False(t, called, "hook must be suppressed when wasMultiComponentExecution is true")
+
+	// Case 3: nil error → hook MUST NOT fire regardless of guard state.
+	called = false
+	wasMultiComponentExecution = false
+	invokeDefer(nil, "captured deploy output")
+	assert.False(t, called, "hook must not fire on success path (nil runErr)")
+
+	called = false
+	wasMultiComponentExecution = true
+	invokeDefer(nil, "captured deploy output")
+	assert.False(t, called, "hook must not fire on success path even in multi-component mode")
 }
 
 // TestRunCIHooksForDeployComponent_ExitCodeForwarding verifies that the exit code


### PR DESCRIPTION
## what

- Fixes `atmos terraform deploy --all` (and `--query`, `--components`, stack-without-component) producing only a single CI summary entry for the last component instead of one entry per component
- Adds `runCIHooksForDeployComponent` as the per-component hook for the `deploy` subcommand so `$GITHUB_STEP_SUMMARY` receives one entry per component with the correct component/stack context
- Wires `wasMultiComponentExecution` reset, error-defer guard, and `PostRunE` guard in `deploy.go` — the same three-site pattern applied to `plan` in #2430 and `apply` in #2475

## why

In multi-component mode, `terraformRunWithOptions` routes to `ExecuteTerraformQuery` and sets `wasMultiComponentExecution = true`, but `deploy.go` had no guard on its `PostRunE` or error-path defer. This caused:

- `PostRunE` to fire once after all components completed, calling `RunCIHooks` with an empty output buffer and the last component's `info.Component`/`info.Stack`
- The error-path defer to double-fire when `--all` failed mid-walk (per-component hook already ran for the failed component)
- For stacks with N components, only 1 summary entry appeared instead of N

## references

Closes #2476
Related: #2397 (plan fix), #2475 (apply fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate error-hook execution during multi-component deployments.
  * Ensure per-run state is reset before early exits so deferred error hooks and post-run logic behave consistently.
  * Run CI hooks per-component for deploys to preserve component output and forward correct exit codes.

* **Tests**
  * Added tests for per-component CI hook behavior, suppression of post-run logic in multi-component deploys, defer-guard behavior, and exit-code forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->