### PR TITLE
fix(stacks): honour component-level list_merge_strategy in settings

### DIFF
--- a/internal/exec/stack_processor_merge.go
+++ b/internal/exec/stack_processor_merge.go
@@ -10,15 +10,53 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
+// effectiveAtmosConfig returns an *AtmosConfiguration suitable for merging this
+// component's sections. If any settings layer overrides list_merge_strategy, a
+// shallow copy is returned with the new value; otherwise base is returned as-is
+// (no allocation). Layers are applied in order — later entries win — matching
+// the same precedence used when merging the settings section itself.
+//
+// Only Settings.ListMergeStrategy is written on the copy; all other fields
+// remain shared with base. Do not mutate any other field on the returned copy
+// without converting this to a deep copy first.
+func effectiveAtmosConfig(base *schema.AtmosConfiguration, settingsLayers ...map[string]any) *schema.AtmosConfiguration {
+	strategy := base.Settings.ListMergeStrategy
+	for _, layer := range settingsLayers {
+		if v, ok := layer["list_merge_strategy"].(string); ok && v != "" {
+			strategy = v
+		}
+	}
+	if strategy == base.Settings.ListMergeStrategy {
+		return base
+	}
+	cfgCopy := *base
+	cfgCopy.Settings.ListMergeStrategy = strategy
+	return &cfgCopy
+}
+
 // mergeComponentConfigurations merges component configurations (vars, settings, env, etc.).
 //
 //nolint:gocognit,nestif,revive,cyclop,funlen // Complex configuration merging logic with multiple component types.
 func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *ComponentProcessorOptions, result *ComponentProcessorResult) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.mergeComponentConfigurations")()
 
+	// Resolve the effective list_merge_strategy for this component before any merge.
+	// Component-level settings (at any inheritance level) override the global atmos.yaml
+	// setting, so individual components can opt into a different list merge behavior
+	// without changing the global configuration. The layers are applied lowest-to-highest
+	// priority: global settings → base component settings → component settings → overrides.
+	// Using a local config copy avoids mutating the shared atmosConfig.
+	mergeConfig := effectiveAtmosConfig(
+		atmosConfig,
+		opts.GlobalSettings,
+		result.BaseComponentSettings,
+		result.ComponentSettings,
+		result.ComponentOverridesSettings,
+	)
+
 	// Merge vars using deferred merge to handle YAML functions.
 	finalComponentVars, varsCtx, err := m.MergeWithDeferred(
-		atmosConfig,
+		mergeConfig,
 		[]map[string]any{
 			opts.GlobalVars,
 			result.BaseComponentVars,
@@ -31,13 +69,13 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	}
 
 	// Apply deferred merges for vars (without YAML processing - already done earlier).
-	if err := m.ApplyDeferredMerges(varsCtx, finalComponentVars, atmosConfig, nil); err != nil {
+	if err := m.ApplyDeferredMerges(varsCtx, finalComponentVars, mergeConfig, nil); err != nil {
 		return nil, err
 	}
 
 	// Merge settings using deferred merge to handle YAML functions.
 	finalComponentSettings, settingsCtx, err := m.MergeWithDeferred(
-		atmosConfig,
+		mergeConfig,
 		[]map[string]any{
 			opts.GlobalSettings,
 			result.BaseComponentSettings,
@@ -50,13 +88,13 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	}
 
 	// Apply deferred merges for settings (without YAML processing - already done earlier).
-	if err := m.ApplyDeferredMerges(settingsCtx, finalComponentSettings, atmosConfig, nil); err != nil {
+	if err := m.ApplyDeferredMerges(settingsCtx, finalComponentSettings, mergeConfig, nil); err != nil {
 		return nil, err
 	}
 
 	// Merge env using deferred merge to handle YAML functions.
 	finalComponentEnv, envCtx, err := m.MergeWithDeferred(
-		atmosConfig,
+		mergeConfig,
 		[]map[string]any{
 			opts.GlobalEnv,
 			result.BaseComponentEnv,
@@ -69,13 +107,13 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	}
 
 	// Apply deferred merges for env (without YAML processing - already done earlier).
-	if err := m.ApplyDeferredMerges(envCtx, finalComponentEnv, atmosConfig, nil); err != nil {
+	if err := m.ApplyDeferredMerges(envCtx, finalComponentEnv, mergeConfig, nil); err != nil {
 		return nil, err
 	}
 
 	// Merge auth using deferred merge to handle YAML functions.
 	finalComponentAuth, authCtx, err := m.MergeWithDeferred(
-		atmosConfig,
+		mergeConfig,
 		[]map[string]any{
 			opts.GlobalAuth,
 			result.BaseComponentAuth,
@@ -88,7 +126,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	}
 
 	// Apply deferred merges for auth (without YAML processing - already done earlier).
-	if err := m.ApplyDeferredMerges(authCtx, finalComponentAuth, atmosConfig, nil); err != nil {
+	if err := m.ApplyDeferredMerges(authCtx, finalComponentAuth, mergeConfig, nil); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +135,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	if opts.ComponentType == cfg.TerraformComponentType {
 		var providersCtx *m.DeferredMergeContext
 		finalComponentProviders, providersCtx, err = m.MergeWithDeferred(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.TerraformProviders,
 				result.BaseComponentProviders,
@@ -110,7 +148,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		}
 
 		// Apply deferred merges for providers (without YAML processing - already done earlier).
-		if err := m.ApplyDeferredMerges(providersCtx, finalComponentProviders, atmosConfig, nil); err != nil {
+		if err := m.ApplyDeferredMerges(providersCtx, finalComponentProviders, mergeConfig, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -120,7 +158,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	if opts.ComponentType == cfg.TerraformComponentType {
 		var requiredProvidersCtx *m.DeferredMergeContext
 		finalComponentRequiredProviders, requiredProvidersCtx, err = m.MergeWithDeferred(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.TerraformRequiredProviders,
 				result.BaseComponentRequiredProviders,
@@ -133,7 +171,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		}
 
 		// Apply deferred merges for required_providers (without YAML processing - already done earlier).
-		if err := m.ApplyDeferredMerges(requiredProvidersCtx, finalComponentRequiredProviders, atmosConfig, nil); err != nil {
+		if err := m.ApplyDeferredMerges(requiredProvidersCtx, finalComponentRequiredProviders, mergeConfig, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -161,7 +199,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	if opts.ComponentType == cfg.TerraformComponentType {
 		var hooksCtx *m.DeferredMergeContext
 		finalComponentHooks, hooksCtx, err = m.MergeWithDeferred(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.GlobalAndTerraformHooks,
 				result.BaseComponentHooks,
@@ -174,7 +212,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		}
 
 		// Apply deferred merges for hooks (without YAML processing - already done earlier).
-		if err := m.ApplyDeferredMerges(hooksCtx, finalComponentHooks, atmosConfig, nil); err != nil {
+		if err := m.ApplyDeferredMerges(hooksCtx, finalComponentHooks, mergeConfig, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -189,7 +227,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	if opts.ComponentType == cfg.TerraformComponentType {
 		var generateCtx *m.DeferredMergeContext
 		finalComponentGenerate, generateCtx, err = m.MergeWithDeferred(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.GlobalAndTerraformGenerate,
 				result.BaseComponentGenerate,
@@ -202,7 +240,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		}
 
 		// Apply deferred merges for generate (without YAML processing - already done earlier).
-		if err := m.ApplyDeferredMerges(generateCtx, finalComponentGenerate, atmosConfig, nil); err != nil {
+		if err := m.ApplyDeferredMerges(generateCtx, finalComponentGenerate, mergeConfig, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -235,7 +273,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	}
 
 	// Process settings integrations.
-	finalSettings, err := processSettingsIntegrationsGithub(atmosConfig, finalComponentSettings)
+	finalSettings, err := processSettingsIntegrationsGithub(mergeConfig, finalComponentSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +286,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		// Create a copy of base metadata excluding 'inherits' and 'type' (already excluded during collection).
 		// Then merge with component metadata (component metadata wins on conflicts).
 		finalComponentMetadata, err = m.Merge(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				result.BaseComponentMetadata,
 				result.ComponentMetadata,
@@ -264,7 +302,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	var finalComponentDependencies map[string]any
 	if len(opts.GlobalDependencies) > 0 || len(result.BaseComponentDependencies) > 0 || len(result.ComponentDependencies) > 0 {
 		finalComponentDependencies, err = m.Merge(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.GlobalDependencies,
 				result.BaseComponentDependencies,
@@ -282,7 +320,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 	var finalComponentLocals map[string]any
 	if len(result.BaseComponentLocals) > 0 || len(result.ComponentLocals) > 0 {
 		finalComponentLocals, err = m.Merge(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				result.BaseComponentLocals,
 				result.ComponentLocals,
@@ -356,7 +394,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		}
 
 		// Process auth configuration.
-		mergedAuth, err := processAuthConfig(atmosConfig, opts.AtmosGlobalAuthMap, finalComponentAuth)
+		mergedAuth, err := processAuthConfig(mergeConfig, opts.AtmosGlobalAuthMap, finalComponentAuth)
 		if err != nil {
 			return nil, err
 		}
@@ -396,7 +434,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		opts.ComponentType == cfg.HelmfileComponentType ||
 		opts.ComponentType == cfg.PackerComponentType {
 		finalComponentSource, err := m.Merge(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.GlobalSourceSection,
 				result.BaseComponentSourceSection,
@@ -411,7 +449,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 		// Merge provision from global, base component, and component levels.
 		// Priority (lowest to highest): global → base component → component.
 		finalComponentProvision, err := m.Merge(
-			atmosConfig,
+			mergeConfig,
 			[]map[string]any{
 				opts.GlobalProvisionSection,
 				result.BaseComponentProvisionSection,

--- a/internal/exec/stack_processor_merge_test.go
+++ b/internal/exec/stack_processor_merge_test.go
@@ -2,16 +2,16 @@ package exec
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/schema"
-
-	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 // Compile-time sentinels: if these fields are renamed the build breaks, preventing
@@ -390,10 +390,16 @@ func TestEffectiveAtmosConfig(t *testing.T) {
 		assert.Equal(t, "append", result.Settings.ListMergeStrategy)
 		assert.Equal(t, "replace", base.Settings.ListMergeStrategy, "original must be unchanged")
 
-		// Reverse direction: mutating the copy must not affect the original.
+		// result→src: mutating the copy must not affect the original.
 		result.Settings.ListMergeStrategy = "merge"
 		assert.Equal(t, "replace", base.Settings.ListMergeStrategy,
 			"mutating the copy must not affect the original (result→src isolation)")
+
+		// src→result: mutating the original after the call must not affect the copy.
+		base.Settings.ListMergeStrategy = "append"
+		assert.Equal(t, "merge", result.Settings.ListMergeStrategy,
+			"mutating the source after the call must not affect the copy (src→result isolation)")
+		base.Settings.ListMergeStrategy = "replace" // restore for subsequent subtests
 	})
 
 	t.Run("later layer wins over earlier layer", func(t *testing.T) {
@@ -436,7 +442,7 @@ func TestEffectiveAtmosConfig(t *testing.T) {
 //   - replace-component: inherits base-component, no strategy override
 //     → expected vars.tags: [child-tag].
 func TestComponentLevelListMergeStrategy(t *testing.T) {
-	workDir := "../../tests/fixtures/scenarios/component-list-merge-strategy"
+	workDir := filepath.Join("..", "..", "tests", "fixtures", "scenarios", "component-list-merge-strategy")
 	t.Chdir(workDir)
 	t.Setenv("ATMOS_CLI_CONFIG_PATH", ".")
 	t.Setenv("ATMOS_BASE_PATH", "")

--- a/internal/exec/stack_processor_merge_test.go
+++ b/internal/exec/stack_processor_merge_test.go
@@ -8,8 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/schema"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
+
+// Compile-time sentinels: if these fields are renamed the build breaks, preventing
+// tests that rely on specific field names from silently passing with zero values.
+var _ = schema.AtmosSettings{ListMergeStrategy: ""}
 
 func TestMergeComponentConfigurations(t *testing.T) {
 	tests := []struct {
@@ -359,6 +366,172 @@ func TestMergeComponentConfigurations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEffectiveAtmosConfig verifies that effectiveAtmosConfig returns the
+// correct *AtmosConfiguration given various combinations of settings layers.
+func TestEffectiveAtmosConfig(t *testing.T) {
+	base := &schema.AtmosConfiguration{}
+	base.Settings.ListMergeStrategy = "replace"
+
+	t.Run("no override returns base pointer unchanged", func(t *testing.T) {
+		result := effectiveAtmosConfig(base)
+		assert.Same(t, base, result, "should return the original pointer when no layers override the strategy")
+	})
+
+	t.Run("empty layers return base pointer unchanged", func(t *testing.T) {
+		result := effectiveAtmosConfig(base, nil, map[string]any{}, map[string]any{"other_key": "value"})
+		assert.Same(t, base, result)
+	})
+
+	t.Run("single layer override returns copy with new strategy", func(t *testing.T) {
+		result := effectiveAtmosConfig(base, map[string]any{"list_merge_strategy": "append"})
+		assert.NotSame(t, base, result, "must return a copy, not the original")
+		assert.Equal(t, "append", result.Settings.ListMergeStrategy)
+		assert.Equal(t, "replace", base.Settings.ListMergeStrategy, "original must be unchanged")
+
+		// Reverse direction: mutating the copy must not affect the original.
+		result.Settings.ListMergeStrategy = "merge"
+		assert.Equal(t, "replace", base.Settings.ListMergeStrategy,
+			"mutating the copy must not affect the original (result→src isolation)")
+	})
+
+	t.Run("later layer wins over earlier layer", func(t *testing.T) {
+		result := effectiveAtmosConfig(base,
+			map[string]any{"list_merge_strategy": "append"},
+			map[string]any{"list_merge_strategy": "merge"},
+		)
+		assert.Equal(t, "merge", result.Settings.ListMergeStrategy)
+	})
+
+	t.Run("empty string in later layer does not override earlier non-empty value", func(t *testing.T) {
+		result := effectiveAtmosConfig(base,
+			map[string]any{"list_merge_strategy": "append"},
+			map[string]any{"list_merge_strategy": ""},
+		)
+		assert.Equal(t, "append", result.Settings.ListMergeStrategy)
+	})
+
+	t.Run("override matching the base value returns base pointer unchanged", func(t *testing.T) {
+		result := effectiveAtmosConfig(base, map[string]any{"list_merge_strategy": "replace"})
+		assert.Same(t, base, result, "no copy needed when effective strategy equals the base strategy")
+	})
+
+	t.Run("non-string list_merge_strategy is ignored", func(t *testing.T) {
+		result := effectiveAtmosConfig(base, map[string]any{"list_merge_strategy": 42})
+		assert.Same(t, base, result, "non-string type assertion fails cleanly; base is returned unchanged")
+	})
+}
+
+// TestComponentLevelListMergeStrategy is an integration test that verifies issue
+// #2396: setting list_merge_strategy inside a component's settings section must
+// affect how that component's vars lists are merged, overriding the global config.
+//
+// Fixture (tests/fixtures/scenarios/component-list-merge-strategy):
+//   - atmos.yaml: global list_merge_strategy = "replace"
+//   - catalog/base.yaml: abstract base-component with vars.tags = [base-tag-1, base-tag-2]
+//   - deploy/dev.yaml:
+//   - append-component: inherits base-component, settings.list_merge_strategy = "append"
+//     → expected vars.tags: [base-tag-1, base-tag-2, child-tag]
+//   - replace-component: inherits base-component, no strategy override
+//     → expected vars.tags: [child-tag].
+func TestComponentLevelListMergeStrategy(t *testing.T) {
+	workDir := "../../tests/fixtures/scenarios/component-list-merge-strategy"
+	t.Chdir(workDir)
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", ".")
+	t.Setenv("ATMOS_BASE_PATH", "")
+
+	configInfo := schema.ConfigAndStacksInfo{}
+	atmosConfig, err := cfg.InitCliConfig(configInfo, true)
+	require.NoError(t, err)
+	require.Equal(t, "replace", atmosConfig.Settings.ListMergeStrategy,
+		"global strategy must be 'replace' so the component-level override is meaningful")
+
+	stack := "dev"
+
+	t.Run("component-level append overrides global replace", func(t *testing.T) {
+		result, err := ExecuteDescribeComponent(&ExecuteDescribeComponentParams{
+			AtmosConfig:          &atmosConfig,
+			Component:            "append-component",
+			Stack:                stack,
+			ProcessTemplates:     true,
+			ProcessYamlFunctions: true,
+		})
+		require.NoError(t, err)
+
+		vars, ok := result["vars"].(map[string]any)
+		require.True(t, ok, "vars must be a map")
+		tags, ok := vars["tags"].([]any)
+		require.True(t, ok, "vars.tags must be a list")
+
+		assert.Equal(t, []any{"base-tag-1", "base-tag-2", "child-tag"}, tags,
+			"append strategy must accumulate base tags then child tag")
+	})
+
+	t.Run("component without override uses global replace strategy", func(t *testing.T) {
+		result, err := ExecuteDescribeComponent(&ExecuteDescribeComponentParams{
+			AtmosConfig:          &atmosConfig,
+			Component:            "replace-component",
+			Stack:                stack,
+			ProcessTemplates:     true,
+			ProcessYamlFunctions: true,
+		})
+		require.NoError(t, err)
+
+		vars, ok := result["vars"].(map[string]any)
+		require.True(t, ok, "vars must be a map")
+		tags, ok := vars["tags"].([]any)
+		require.True(t, ok, "vars.tags must be a list")
+
+		assert.Equal(t, []any{"child-tag"}, tags,
+			"replace strategy must discard base tags and keep only child tags")
+	})
+
+	// Verify that list_merge_strategy set in a base component's settings
+	// (result.BaseComponentSettings) is honoured even when the inheriting component
+	// does not set it in its own settings. This exercises the second layer in
+	// effectiveAtmosConfig's precedence scan.
+	t.Run("strategy inherited from base component settings", func(t *testing.T) {
+		result, err := ExecuteDescribeComponent(&ExecuteDescribeComponentParams{
+			AtmosConfig:          &atmosConfig,
+			Component:            "inherit-strategy-component",
+			Stack:                stack,
+			ProcessTemplates:     true,
+			ProcessYamlFunctions: true,
+		})
+		require.NoError(t, err)
+
+		vars, ok := result["vars"].(map[string]any)
+		require.True(t, ok, "vars must be a map")
+		tags, ok := vars["tags"].([]any)
+		require.True(t, ok, "vars.tags must be a list")
+
+		assert.Equal(t, []any{"base-tag-1", "base-tag-2", "child-tag"}, tags,
+			"append strategy from base component settings must be inherited")
+	})
+}
+
+// TestEffectiveAtmosConfig_InvalidStrategy verifies two properties:
+//  1. effectiveAtmosConfig passes an invalid strategy value through without
+//     validating it — validation is pkg/merge's responsibility.
+//  2. When the resulting config is used in a merge call, pkg/merge returns
+//     ErrInvalidListMergeStrategy so the error surfaces correctly.
+func TestEffectiveAtmosConfig_InvalidStrategy(t *testing.T) {
+	base := &schema.AtmosConfiguration{}
+	base.Settings.ListMergeStrategy = "replace"
+
+	result := effectiveAtmosConfig(base, map[string]any{"list_merge_strategy": "foobar"})
+	assert.Equal(t, "foobar", result.Settings.ListMergeStrategy,
+		"effectiveAtmosConfig must pass invalid values through; validation is pkg/merge's responsibility")
+	assert.NotSame(t, base, result)
+
+	// Verify the error surfaces when the config is actually used for a merge.
+	_, _, mergeErr := m.MergeWithDeferred(result, []map[string]any{
+		{"tags": []any{"a"}},
+		{"tags": []any{"b"}},
+	})
+	assert.ErrorIs(t, mergeErr, errUtils.ErrInvalidListMergeStrategy,
+		"pkg/merge must reject the invalid strategy when a merge is attempted")
 }
 
 func TestProcessAuthConfig(t *testing.T) {

--- a/internal/exec/stack_processor_merge_test.go
+++ b/internal/exec/stack_processor_merge_test.go
@@ -18,6 +18,10 @@ import (
 // tests that rely on specific field names from silently passing with zero values.
 var _ = schema.AtmosSettings{ListMergeStrategy: ""}
 
+// TestMergeComponentConfigurations verifies that mergeComponentConfigurations
+// correctly assembles the final component configuration from layered inputs
+// (global, base-component, component, and overrides) for both Terraform and
+// Helmfile component types.
 func TestMergeComponentConfigurations(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -540,6 +544,9 @@ func TestEffectiveAtmosConfig_InvalidStrategy(t *testing.T) {
 		"pkg/merge must reject the invalid strategy when a merge is attempted")
 }
 
+// TestProcessAuthConfig verifies that processAuthConfig merges global and
+// component-level auth configurations, with the component-level settings
+// taking precedence over the global ones.
 func TestProcessAuthConfig(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
@@ -1,0 +1,39 @@
+# Fixture for testing component-level list_merge_strategy override (issue #2396).
+# The global strategy is intentionally "replace" so that tests can confirm that a
+# component-level "append" setting in settings.list_merge_strategy takes effect
+# only for that component, leaving others on "replace".
+base_path: "./"
+
+settings:
+  list_merge_strategy: replace
+
+components:
+  terraform:
+    base_path: "../../components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_pattern: "{stage}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info
+
+templates:
+  settings:
+    enabled: true
+    evaluations: 1
+    sprig:
+      enabled: true
+    gomplate:
+      enabled: true
+      timeout: 10
+      datasources: {}

--- a/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
@@ -24,7 +24,6 @@ stacks:
   name_pattern: "{stage}"
 
 logs:
-  file: "/dev/stderr"
   level: Info
 
 templates:

--- a/tests/fixtures/scenarios/component-list-merge-strategy/components/terraform/mock/main.tf
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/components/terraform/mock/main.tf
@@ -1,0 +1,1 @@
+# Mock terraform component for testing.

--- a/tests/fixtures/scenarios/component-list-merge-strategy/stacks/catalog/base.yaml
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/stacks/catalog/base.yaml
@@ -1,0 +1,27 @@
+# Base catalog: abstract component with list vars that get extended by inheritors.
+components:
+  terraform:
+    base-component:
+      metadata:
+        component: mock
+        type: abstract
+      vars:
+        tags:
+          - base-tag-1
+          - base-tag-2
+        name: base
+
+    # append-base: abstract component that sets list_merge_strategy: append in its
+    # own settings. Components that inherit from it should pick up the strategy via
+    # result.BaseComponentSettings even when they don't set it themselves.
+    append-base:
+      metadata:
+        component: mock
+        type: abstract
+      settings:
+        list_merge_strategy: append
+      vars:
+        tags:
+          - base-tag-1
+          - base-tag-2
+        name: append-base

--- a/tests/fixtures/scenarios/component-list-merge-strategy/stacks/deploy/dev.yaml
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/stacks/deploy/dev.yaml
@@ -1,0 +1,50 @@
+# Dev stack: two components inheriting from base-component.
+# - append-component: opts into list appending via settings.list_merge_strategy
+# - replace-component: uses the global "replace" strategy (no override)
+import:
+  - catalog/base
+
+vars:
+  stage: dev
+
+components:
+  terraform:
+    # This component requests append-merge for its lists via component-level settings.
+    # After the fix for issue #2396, the tags list should be [base-tag-1, base-tag-2, child-tag].
+    append-component:
+      metadata:
+        component: mock
+        inherits:
+          - base-component
+      settings:
+        list_merge_strategy: append
+      vars:
+        tags:
+          - child-tag
+        name: append-child
+
+    # This component uses the global "replace" strategy (no override).
+    # The tags list should be [child-tag] (replace semantics).
+    replace-component:
+      metadata:
+        component: mock
+        inherits:
+          - base-component
+      vars:
+        tags:
+          - child-tag
+        name: replace-child
+
+    # This component inherits from append-base (which sets list_merge_strategy: append
+    # in its own settings) but does NOT set list_merge_strategy in its own settings.
+    # After the fix for issue #2396, the strategy from BaseComponentSettings must be
+    # honoured, so tags should be [base-tag-1, base-tag-2, child-tag].
+    inherit-strategy-component:
+      metadata:
+        component: mock
+        inherits:
+          - append-base
+      vars:
+        tags:
+          - child-tag
+        name: inherit-strategy-child


### PR DESCRIPTION
## what

- Fixes `settings.list_merge_strategy` set at the component level being silently ignored during stack processing
- Adds `effectiveAtmosConfig()` helper that scans the component's settings layers (GlobalSettings → BaseComponentSettings → ComponentSettings → ComponentOverridesSettings) before any merge and returns a shallow config copy with the winning strategy
- `mergeComponentConfigurations` now uses this resolved config for all `m.Merge` / `m.MergeWithDeferred` / `m.ApplyDeferredMerges` calls — covering vars, settings, env, auth, providers, hooks, generate, dependencies, locals, source, and provision

## why

`mergeComponentConfigurations` passed the global `atmosConfig` to every merge call. `pkg/merge` reads `atmosConfig.Settings.ListMergeStrategy` on every call. The component's `settings.list_merge_strategy` lived inside the data being merged, not the config doing the merging — so it was always ignored. The value appeared correctly in `atmos describe component` output (giving false confidence), but the actual list merging behavior was always governed by the global `atmos.yaml` setting or `ATMOS_SETTINGS_LIST_MERGE_STRATEGY` env var.

## references

Closes #2396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component-level list merge strategy overrides are now computed and applied consistently across configuration assembly, honoring inheritance and isolating unchanged configs.

* **Tests**
  * Added integration tests and fixtures covering precedence, inheritance, copy isolation, prevention of empty overrides, and error handling for invalid strategy values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->