### PR TITLE
[codex] Fix verifier auto-install and cosign bundles

### DIFF
--- a/pkg/toolchain/installer/asset.go
+++ b/pkg/toolchain/installer/asset.go
@@ -33,11 +33,15 @@ type assetTemplateData struct {
 func (i *Installer) BuildAssetURL(tool *registry.Tool, version string) (string, error) {
 	defer perf.Track(nil, "Installer.BuildAssetURL")()
 
+	return i.buildAssetURLForPlatform(tool, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func (i *Installer) buildAssetURLForPlatform(tool *registry.Tool, version, goos, goarch string) (string, error) {
 	switch tool.Type {
 	case "http":
-		return i.buildHTTPAssetURL(tool, version)
+		return i.buildHTTPAssetURLForPlatform(tool, version, goos, goarch)
 	case "github_release":
-		return i.buildGitHubReleaseURL(tool, version)
+		return i.buildGitHubReleaseURLForPlatform(tool, version, goos, goarch)
 	default:
 		return "", fmt.Errorf("%w: unsupported tool type: %s", ErrInvalidToolSpec, tool.Type)
 	}
@@ -47,11 +51,15 @@ func (i *Installer) BuildAssetURL(tool *registry.Tool, version string) (string, 
 func (i *Installer) buildHTTPAssetURL(tool *registry.Tool, version string) (string, error) {
 	defer perf.Track(nil, "Installer.buildHTTPAssetURL")()
 
+	return i.buildHTTPAssetURLForPlatform(tool, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func (i *Installer) buildHTTPAssetURLForPlatform(tool *registry.Tool, version, goos, goarch string) (string, error) {
 	if tool.Asset == "" {
 		return "", fmt.Errorf("%w: Asset URL template is required for HTTP type tools", ErrInvalidToolSpec)
 	}
 
-	data := buildTemplateData(tool, version)
+	data := buildTemplateDataForPlatform(tool, version, goos, goarch)
 	url, err := executeAssetTemplate(tool.Asset, tool, data)
 	if err != nil {
 		return "", err
@@ -62,7 +70,7 @@ func (i *Installer) buildHTTPAssetURL(tool *registry.Tool, version string) (stri
 	// Only apply when: not an archive AND has no extension (avoids .msi.exe, etc.).
 	// See: https://aquaproj.github.io/docs/reference/windows-support/.
 	if !hasArchiveExtension(url) && filepath.Ext(url) == "" {
-		url = EnsureWindowsExeExtension(url)
+		url = ensureWindowsExeExtensionForOS(url, goos)
 	}
 
 	return url, nil
@@ -72,6 +80,10 @@ func (i *Installer) buildHTTPAssetURL(tool *registry.Tool, version string) (stri
 func (i *Installer) buildGitHubReleaseURL(tool *registry.Tool, version string) (string, error) {
 	defer perf.Track(nil, "Installer.buildGitHubReleaseURL")()
 
+	return i.buildGitHubReleaseURLForPlatform(tool, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func (i *Installer) buildGitHubReleaseURLForPlatform(tool *registry.Tool, version, goos, goarch string) (string, error) {
 	if tool.RepoOwner == "" || tool.RepoName == "" {
 		return "", fmt.Errorf("%w: RepoOwner and RepoName must be set for github_release type (got RepoOwner=%q, RepoName=%q)",
 			ErrInvalidToolSpec, tool.RepoOwner, tool.RepoName)
@@ -82,7 +94,7 @@ func (i *Installer) buildGitHubReleaseURL(tool *registry.Tool, version string) (
 		assetTemplate = "{{.RepoName}}_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz"
 	}
 
-	data := buildTemplateData(tool, version)
+	data := buildTemplateDataForPlatform(tool, version, goos, goarch)
 	assetName, err := executeAssetTemplate(assetTemplate, tool, data)
 	if err != nil {
 		return "", err
@@ -93,7 +105,7 @@ func (i *Installer) buildGitHubReleaseURL(tool *registry.Tool, version string) (
 	// Only apply when: not an archive AND has no extension (avoids .msi.exe, etc.).
 	// See: https://aquaproj.github.io/docs/reference/windows-support/.
 	if !hasArchiveExtension(assetName) && filepath.Ext(assetName) == "" {
-		assetName = EnsureWindowsExeExtension(assetName)
+		assetName = ensureWindowsExeExtensionForOS(assetName, goos)
 	}
 
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
@@ -126,37 +138,45 @@ func hasArchiveExtension(name string) bool {
 func buildTemplateData(tool *registry.Tool, version string) *assetTemplateData {
 	defer perf.Track(nil, "buildTemplateData")()
 
+	return buildTemplateDataForPlatform(tool, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func buildTemplateDataForPlatform(tool *registry.Tool, version, goos, goarch string) *assetTemplateData {
+	releaseVersion, semVer := versionStringsForTool(tool, version)
+	osVal, archVal := templatePlatformValues(tool, goos, goarch)
+	format := templateFormatForPlatform(tool, goos)
+
+	return &assetTemplateData{
+		Version:   releaseVersion,
+		SemVer:    semVer,
+		OS:        osVal,
+		Arch:      archVal,
+		GOOS:      goos,
+		GOARCH:    goarch,
+		RepoOwner: tool.RepoOwner,
+		RepoName:  tool.RepoName,
+		Format:    format,
+	}
+}
+
+func versionStringsForTool(tool *registry.Tool, version string) (releaseVersion, semVer string) {
 	// Use version_prefix only if explicitly set in registry definition.
 	// This matches Aqua's behavior where version_prefix defaults to empty.
 	prefix := tool.VersionPrefix
-
-	releaseVersion := version
+	releaseVersion = version
 	if prefix != "" && !strings.HasPrefix(releaseVersion, prefix) {
 		releaseVersion = prefix + releaseVersion
 	}
-
-	// SemVer is the version without any prefix.
-	semVer := version
+	semVer = version
 	if prefix != "" {
 		semVer = strings.TrimPrefix(releaseVersion, prefix)
 	}
+	return releaseVersion, semVer
+}
 
-	// Get OS and Arch, applying emulation fallbacks and replacements.
-	osVal := runtime.GOOS
-	archVal := runtime.GOARCH
-
-	// Rosetta 2 fallback: on darwin/arm64, always use amd64 when rosetta2 is enabled.
-	// This matches upstream aquaproj/aqua behavior (no arm64 replacement check).
-	if tool.Rosetta2 && osVal == "darwin" && archVal == "arm64" {
-		archVal = "amd64"
-	}
-
-	// Windows ARM emulation fallback: always use amd64 when enabled on windows/arm64.
-	if tool.WindowsArmEmulation && osVal == "windows" && archVal == "arm64" {
-		archVal = "amd64"
-	}
-
-	// Apply replacements from the tool config.
+func templatePlatformValues(tool *registry.Tool, goos, goarch string) (string, string) {
+	osVal := goos
+	archVal := platformArchForTool(tool, goos, goarch)
 	if tool.Replacements != nil {
 		if replacement, ok := tool.Replacements[osVal]; ok {
 			osVal = replacement
@@ -165,27 +185,28 @@ func buildTemplateData(tool *registry.Tool, version string) *assetTemplateData {
 			archVal = replacement
 		}
 	}
+	return osVal, archVal
+}
 
-	// Apply per-OS format overrides (e.g., zip on Windows, tar.gz on Linux).
+func platformArchForTool(tool *registry.Tool, goos, goarch string) string {
+	if tool.Rosetta2 && goos == "darwin" && goarch == "arm64" {
+		return "amd64"
+	}
+	if tool.WindowsArmEmulation && goos == "windows" && goarch == "arm64" {
+		return "amd64"
+	}
+	return goarch
+}
+
+func templateFormatForPlatform(tool *registry.Tool, goos string) string {
 	format := tool.Format
 	for _, fo := range tool.FormatOverrides {
-		if fo.GOOS == runtime.GOOS {
+		if fo.GOOS == goos {
 			format = fo.Format
 			break
 		}
 	}
-
-	return &assetTemplateData{
-		Version:   releaseVersion,
-		SemVer:    semVer,
-		OS:        osVal,
-		Arch:      archVal,
-		GOOS:      runtime.GOOS,
-		GOARCH:    runtime.GOARCH,
-		RepoOwner: tool.RepoOwner,
-		RepoName:  tool.RepoName,
-		Format:    format,
-	}
+	return format
 }
 
 // assetTemplateFuncs returns the template functions for asset URL templates.

--- a/pkg/toolchain/installer/asset_test.go
+++ b/pkg/toolchain/installer/asset_test.go
@@ -963,3 +963,103 @@ func TestBuildTemplateData_WindowsArmEmulation(t *testing.T) {
 		assert.Equal(t, runtime.GOARCH, data.Arch, "WindowsArmEmulation should not affect Arch on non-windows-arm64")
 	}
 }
+
+func TestBuildAssetURLForPlatform_VerifierWindowsAssets(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    registry.Tool
+		version string
+		wantURL string
+	}{
+		{
+			name: "cosign raw windows binary keeps v tag and gets exe suffix",
+			tool: registry.Tool{
+				Type:                "github_release",
+				RepoOwner:           "sigstore",
+				RepoName:            "cosign",
+				Asset:               "cosign-{{.OS}}-{{.Arch}}",
+				Format:              "raw",
+				WindowsArmEmulation: true,
+			},
+			version: "v3.0.6",
+			wantURL: "https://github.com/sigstore/cosign/releases/download/" +
+				"v3.0.6/cosign-windows-amd64.exe",
+		},
+		{
+			name: "slsa-verifier raw windows binary keeps v tag and gets exe suffix",
+			tool: registry.Tool{
+				Type:      "github_release",
+				RepoOwner: "slsa-framework",
+				RepoName:  "slsa-verifier",
+				Asset:     "slsa-verifier-{{.OS}}-{{.Arch}}",
+				Format:    "raw",
+			},
+			version: "v2.7.1",
+			wantURL: "https://github.com/slsa-framework/slsa-verifier/releases/download/" +
+				"v2.7.1/slsa-verifier-windows-amd64.exe",
+		},
+		{
+			name: "gh windows zip uses trimmed version in asset and v tag in release URL",
+			tool: registry.Tool{
+				Type:      "github_release",
+				RepoOwner: "cli",
+				RepoName:  "cli",
+				Asset:     "gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}",
+				Format:    "zip",
+				Overrides: []registry.Override{
+					{GOOS: "linux", Format: "tar.gz"},
+					{
+						GOOS:  "windows",
+						Files: []registry.File{{Name: "gh", Src: "bin/gh.exe"}},
+					},
+				},
+				Replacements: map[string]string{
+					"darwin": "macOS",
+				},
+			},
+			version: "v2.92.0",
+			wantURL: "https://github.com/cli/cli/releases/download/" +
+				"v2.92.0/gh_2.92.0_windows_amd64.zip",
+		},
+		{
+			name: "minisign windows zip applies registry replacements",
+			tool: registry.Tool{
+				Type:                "github_release",
+				RepoOwner:           "jedisct1",
+				RepoName:            "minisign",
+				Asset:               "minisign-{{.Version}}-{{.OS}}.{{.Format}}",
+				Format:              "zip",
+				WindowsArmEmulation: true,
+				Files: []registry.File{
+					{Name: "minisign", Src: "minisign-{{.OS}}/{{.Arch}}/minisign"},
+				},
+				Replacements: map[string]string{
+					"darwin":  "macos",
+					"windows": "win64",
+					"amd64":   "x86_64",
+					"arm64":   "aarch64",
+				},
+				Overrides: []registry.Override{
+					{GOOS: "linux", Format: "tar.gz"},
+					{GOOS: "darwin", Files: []registry.File{{Name: "minisign"}}},
+				},
+			},
+			version: "0.12",
+			wantURL: "https://github.com/jedisct1/minisign/releases/download/" +
+				"0.12/minisign-0.12-win64.zip",
+		},
+	}
+
+	installer := &Installer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := tt.tool
+			ApplyPlatformOverridesForPlatform(&tool, "windows", "amd64")
+
+			gotURL, err := installer.buildAssetURLForPlatform(&tool, tt.version, "windows", "amd64")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURL, gotURL)
+		})
+	}
+}

--- a/pkg/toolchain/installer/errors.go
+++ b/pkg/toolchain/installer/errors.go
@@ -47,4 +47,7 @@ var (
 
 	// ErrLockfileParse indicates the lockfile contents could not be parsed.
 	ErrLockfileParse = errors.New("toolchain lockfile parse failed")
+
+	// ErrVerifierVersionUnavailable indicates a verifier bootstrap version could not be resolved.
+	ErrVerifierVersionUnavailable = errors.New("verifier version unavailable")
 )

--- a/pkg/toolchain/installer/installer.go
+++ b/pkg/toolchain/installer/installer.go
@@ -52,7 +52,11 @@ const (
 func EnsureWindowsExeExtension(binaryName string) string {
 	defer perf.Track(nil, "installer.EnsureWindowsExeExtension")()
 
-	if runtime.GOOS == "windows" && !strings.HasSuffix(strings.ToLower(binaryName), windowsExeExt) {
+	return ensureWindowsExeExtensionForOS(binaryName, runtime.GOOS)
+}
+
+func ensureWindowsExeExtensionForOS(binaryName, goos string) string {
+	if goos == "windows" && !strings.HasSuffix(strings.ToLower(binaryName), windowsExeExt) {
 		return binaryName + windowsExeExt
 	}
 	return binaryName
@@ -383,19 +387,31 @@ func (r verifierCommandRunner) Run(ctx context.Context, name string, args ...str
 		Signatures:      verification.PolicyDisabled,
 		VerifierInstall: verification.VerifierInstallPathOnly,
 	}
-	version := "latest"
-	if bootstrap.registryFactory != nil {
-		if reg := bootstrap.registryFactory.NewAquaRegistry(); reg != nil {
-			if latest, err := reg.GetLatestVersion(owner, repo); err == nil && latest != "" {
-				version = latest
-			}
-		}
+	version, err := bootstrap.resolveVerifierInstallVersion(owner, repo)
+	if err != nil {
+		return fmt.Errorf("%w: resolve verifier %s version: %w", verification.ErrVerifierCommandRequired, name, err)
 	}
 	binaryPath, err := bootstrap.Install(owner, repo, version)
 	if err != nil {
 		return fmt.Errorf("%w: install verifier %s: %w", verification.ErrVerifierCommandRequired, name, err)
 	}
 	return runVerifierCommand(ctx, binaryPath, args...)
+}
+
+func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, error) {
+	if i.useConfiguredReg && i.configuredReg != nil {
+		if latest, err := i.configuredReg.GetLatestVersion(owner, repo); err == nil && latest != "" {
+			return latest, nil
+		}
+	}
+	if i.registryFactory != nil {
+		if reg := i.registryFactory.NewAquaRegistry(); reg != nil {
+			if latest, err := reg.GetLatestVersion(owner, repo); err == nil && latest != "" {
+				return latest, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("%w: %s/%s", ErrVerifierVersionUnavailable, owner, repo)
 }
 
 func runVerifierCommand(ctx context.Context, path string, args ...string) error {

--- a/pkg/toolchain/installer/installer.go
+++ b/pkg/toolchain/installer/installer.go
@@ -399,19 +399,52 @@ func (r verifierCommandRunner) Run(ctx context.Context, name string, args ...str
 }
 
 func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, error) {
-	if i.useConfiguredReg && i.configuredReg != nil {
-		if latest, err := i.configuredReg.GetLatestVersion(owner, repo); err == nil && latest != "" {
+	var lookupErrs []error
+
+	if i.useConfiguredReg {
+		latest, err := latestVerifierVersion(i.configuredReg, owner, repo, "configured registry")
+		if latest != "" {
 			return latest, nil
 		}
-	}
-	if i.registryFactory != nil {
-		if reg := i.registryFactory.NewAquaRegistry(); reg != nil {
-			if latest, err := reg.GetLatestVersion(owner, repo); err == nil && latest != "" {
-				return latest, nil
-			}
+		if err != nil {
+			lookupErrs = append(lookupErrs, err)
 		}
 	}
-	return "", fmt.Errorf("%w: %s/%s", ErrVerifierVersionUnavailable, owner, repo)
+
+	latest, err := latestVerifierVersion(i.aquaVerifierRegistry(), owner, repo, "aqua registry")
+	if latest != "" {
+		return latest, nil
+	}
+	if err != nil {
+		lookupErrs = append(lookupErrs, err)
+	}
+
+	return "", verifierVersionUnavailableError(owner, repo, lookupErrs)
+}
+
+func (i *Installer) aquaVerifierRegistry() registry.ToolRegistry {
+	if i.registryFactory == nil {
+		return nil
+	}
+	return i.registryFactory.NewAquaRegistry()
+}
+
+func latestVerifierVersion(reg registry.ToolRegistry, owner, repo, source string) (string, error) {
+	if reg == nil {
+		return "", nil
+	}
+	latest, err := reg.GetLatestVersion(owner, repo)
+	if err != nil {
+		return "", fmt.Errorf("%s latest version lookup failed: %w", source, err)
+	}
+	return latest, nil
+}
+
+func verifierVersionUnavailableError(owner, repo string, lookupErrs []error) error {
+	if len(lookupErrs) > 0 {
+		return fmt.Errorf("%w: %s/%s: %w", ErrVerifierVersionUnavailable, owner, repo, errors.Join(lookupErrs...))
+	}
+	return fmt.Errorf("%w: %s/%s", ErrVerifierVersionUnavailable, owner, repo)
 }
 
 func runVerifierCommand(ctx context.Context, path string, args ...string) error {

--- a/pkg/toolchain/installer/override.go
+++ b/pkg/toolchain/installer/override.go
@@ -15,12 +15,15 @@ import (
 func ApplyPlatformOverrides(tool *registry.Tool) {
 	defer perf.Track(nil, "installer.ApplyPlatformOverrides")()
 
+	ApplyPlatformOverridesForPlatform(tool, runtime.GOOS, runtime.GOARCH)
+}
+
+func ApplyPlatformOverridesForPlatform(tool *registry.Tool, goos, goarch string) {
+	defer perf.Track(nil, "installer.ApplyPlatformOverridesForPlatform")()
+
 	if len(tool.Overrides) == 0 {
 		return
 	}
-
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
 
 	for i := range tool.Overrides {
 		override := &tool.Overrides[i]

--- a/pkg/toolchain/installer/verifier_command_test.go
+++ b/pkg/toolchain/installer/verifier_command_test.go
@@ -116,6 +116,39 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 	assert.Equal(t, "v3.0.6", reg.requestedVersion)
 }
 
+func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.T) {
+	reg := &verifierBootstrapRegistry{
+		latest: "",
+		tool: &registry.Tool{
+			Type:       "http",
+			RepoOwner:  "sigstore",
+			RepoName:   "cosign",
+			Asset:      "https://example.com/{{.Version}}/cosign",
+			Format:     "raw",
+			BinaryName: "cosign",
+		},
+	}
+	inst := &Installer{
+		cacheDir:         t.TempDir(),
+		binDir:           t.TempDir(),
+		configuredReg:    reg,
+		useConfiguredReg: true,
+		registryFactory:  verifierBootstrapFactory{registry: reg},
+	}
+
+	t.Setenv("PATH", t.TempDir())
+
+	err := verifierCommandRunner{
+		installer: inst,
+		policy: verification.Policy{
+			VerifierInstall: verification.VerifierInstallAuto,
+		},
+	}.Run(context.Background(), "cosign", "-test.run=TestVerifierCommandHelperProcess", "--", "success")
+
+	require.ErrorIs(t, err, verification.ErrVerifierCommandRequired)
+	assert.Empty(t, reg.requestedVersion, "bootstrap install must not be called with literal latest")
+}
+
 func TestRunVerifierCommandFailure(t *testing.T) {
 	t.Setenv("ATMOS_VERIFIER_HELPER_PROCESS", "1")
 

--- a/pkg/toolchain/installer/verifier_command_test.go
+++ b/pkg/toolchain/installer/verifier_command_test.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,11 @@ import (
 
 	"github.com/cloudposse/atmos/pkg/toolchain/registry"
 	"github.com/cloudposse/atmos/pkg/toolchain/verification"
+)
+
+var (
+	errConfiguredLatest = errors.New("configured latest lookup failed")
+	errAquaLatest       = errors.New("aqua latest lookup failed")
 )
 
 func TestVerifierTool(t *testing.T) {
@@ -149,6 +155,25 @@ func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.
 	assert.Empty(t, reg.requestedVersion, "bootstrap install must not be called with literal latest")
 }
 
+func TestResolveVerifierInstallVersionPreservesLookupErrors(t *testing.T) {
+	configuredReg := &verifierBootstrapRegistry{latestErr: errConfiguredLatest}
+	aquaReg := &verifierBootstrapRegistry{latestErr: errAquaLatest}
+	inst := &Installer{
+		configuredReg:    configuredReg,
+		useConfiguredReg: true,
+		registryFactory:  verifierBootstrapFactory{registry: aquaReg},
+	}
+
+	version, err := inst.resolveVerifierInstallVersion("sigstore", "cosign")
+
+	require.Empty(t, version)
+	require.ErrorIs(t, err, ErrVerifierVersionUnavailable)
+	require.ErrorIs(t, err, errConfiguredLatest)
+	require.ErrorIs(t, err, errAquaLatest)
+	assert.Contains(t, err.Error(), "configured registry latest version lookup failed")
+	assert.Contains(t, err.Error(), "aqua registry latest version lookup failed")
+}
+
 func TestRunVerifierCommandFailure(t *testing.T) {
 	t.Setenv("ATMOS_VERIFIER_HELPER_PROCESS", "1")
 
@@ -180,6 +205,7 @@ func (f verifierBootstrapFactory) NewAquaRegistry() registry.ToolRegistry {
 type verifierBootstrapRegistry struct {
 	mu               sync.Mutex
 	latest           string
+	latestErr        error
 	tool             *registry.Tool
 	requestedVersion string
 }
@@ -196,6 +222,9 @@ func (r *verifierBootstrapRegistry) GetToolWithVersion(_, _, version string) (*r
 }
 
 func (r *verifierBootstrapRegistry) GetLatestVersion(_, _ string) (string, error) {
+	if r.latestErr != nil {
+		return "", r.latestErr
+	}
 	return r.latest, nil
 }
 

--- a/pkg/toolchain/verification/checksum_test.go
+++ b/pkg/toolchain/verification/checksum_test.go
@@ -401,6 +401,76 @@ func TestVerifyChecksumCosignVerifiesChecksumSidecar(t *testing.T) {
 	assert.Equal(t, "sha256", result.ChecksumAlgorithm)
 }
 
+func TestVerifyChecksumCosignCombinesOptsWithBundleSidecar(t *testing.T) {
+	assetPath := writeAsset(t, []byte("hello"))
+	sum := sha256.Sum256([]byte("hello"))
+	checksumData := []byte(fmt.Sprintf("%x  trivy_0.70.0_macOS-ARM64.tar.gz\n", sum))
+	runner := &fakeRunner{}
+
+	result, err := (&Verifier{}).Verify(context.Background(), Request{
+		Tool: &registry.Tool{
+			RepoOwner: "aquasecurity",
+			RepoName:  "trivy",
+			Checksum: registry.ChecksumConfig{
+				Type:      "github_release",
+				Asset:     "trivy_{{trimV .Version}}_checksums.txt",
+				Algorithm: "sha256",
+				Cosign: registry.CosignConfig{
+					Bundle: registry.DownloadedFile{
+						Type:  "github_release",
+						Asset: "trivy_{{trimV .Version}}_checksums.txt.sigstore.json",
+					},
+					Opts: []string{
+						"--certificate-identity",
+						"https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/{{.Version}}",
+						"--certificate-oidc-issuer",
+						"https://token.actions.githubusercontent.com",
+					},
+				},
+			},
+		},
+		Version:   "v0.70.0",
+		AssetURL:  "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_macOS-ARM64.tar.gz",
+		AssetPath: assetPath,
+		Downloader: fakeDownloader{
+			"https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_checksums.txt":               checksumData,
+			"https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_checksums.txt.sigstore.json": []byte("bundle"),
+		},
+		Policy: Policy{
+			Checksums:  PolicyWhenAvailable,
+			Signatures: PolicyWhenAvailable,
+		},
+		Runner: runner,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, runner.calls, 1)
+	assert.Equal(t, "cosign", runner.calls[0].name)
+	assert.Equal(t, []string{
+		"verify-blob",
+		"--certificate-identity",
+		"https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v0.70.0",
+		"--certificate-oidc-issuer",
+		"https://token.actions.githubusercontent.com",
+		"--bundle",
+		writeAssetPathPlaceholder(runner.calls[0].args),
+		writeAssetPathPlaceholder(runner.calls[0].args),
+	}, normalizeLastTwoArgs(runner.calls[0].args))
+	assert.Contains(t, result.SignatureMethods, "cosign")
+	assert.Equal(t, "sha256", result.ChecksumAlgorithm)
+}
+
+func normalizeLastTwoArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	if len(out) > 1 {
+		out[len(out)-2] = writeAssetPathPlaceholder(args)
+	}
+	if len(out) > 0 {
+		out[len(out)-1] = writeAssetPathPlaceholder(args)
+	}
+	return out
+}
+
 func TestVerifyChecksumRequiredMissingMetadata(t *testing.T) {
 	_, err := (&Verifier{}).Verify(context.Background(), Request{
 		Tool:      &registry.Tool{RepoOwner: "owner", RepoName: "tool"},

--- a/pkg/toolchain/verification/signature.go
+++ b/pkg/toolchain/verification/signature.go
@@ -83,11 +83,15 @@ func (v *Verifier) cosignArgs(ctx context.Context, req *Request, cfg *registry.C
 		if err != nil {
 			return nil, nil, err
 		}
-		return append(args, rendered...), nil, nil
+		args = append(args, rendered...)
 	}
 	sidecars, cleanup, err := v.downloadCosignSidecars(ctx, req, cfg)
 	if err == nil {
-		return append(args, sidecars...), cleanup, nil
+		args = append(args, sidecars...)
+		if len(args) == 1 {
+			return nil, cleanup, nil
+		}
+		return args, cleanup, nil
 	}
 	if req.Policy.Signatures != PolicyRequired {
 		result.SkippedReasons = append(result.SkippedReasons, fmt.Sprintf("cosign sidecar unavailable: %v", err))


### PR DESCRIPTION
## what

- Resolve verifier auto-installs to concrete registry versions before bootstrapping, instead of falling back to literal `latest`.
- Add platform-aware installer helpers and regression coverage for Windows verifier asset URLs across cosign, slsa-verifier, gh, and minisign.
- Combine cosign `opts` with downloaded sidecars like `--bundle` so Trivy checksum signature verification works with Aqua metadata.

## why

- Windows CI was failing because cosign release assets exist under `v...` tags and the bootstrap path could construct invalid release URLs.
- Trivy verification failed on macOS because Atmos dropped the sigstore bundle whenever cosign options were present, producing an incomplete `cosign verify-blob` command.
- The added tests cover the failing Windows URL rendering path and the Trivy-shaped checksum signature command.

## references

- Fixes the verifier install failure introduced by package verification.
- Validated with `go test ./pkg/toolchain/installer ./pkg/toolchain/registry/aqua ./pkg/toolchain/verification`, `go test ./pkg/toolchain`, pre-commit hooks, and a live `go run . toolchain install aquasecurity/trivy@v0.70.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signature verification now supports bundle sidecars.
  * Enhanced cross-platform asset resolution, including better Windows ARM and Rosetta2 handling and per-platform overrides.
  * Improved verifier bootstrap resolution with additional fallback behavior.

* **Bug Fixes**
  * Corrected Windows executable extension handling across target platforms.

* **Tests**
  * Added tests for Windows asset URL generation, verifier version resolution failures, and cosign bundle sidecar integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->