### PR TITLE
fix(terraform): skip non-terraform and deleted components in `atmos terraform plan/apply --affected`

### DIFF
--- a/internal/exec/terraform_affected.go
+++ b/internal/exec/terraform_affected.go
@@ -2,12 +2,33 @@ package exec
 
 import (
 	errUtils "github.com/cloudposse/atmos/errors"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
+
+// filterTerraformAffected narrows the affected list to items that `atmos terraform
+// plan/apply --affected` should actually execute: terraform components only, and
+// only those that still exist (not deleted in HEAD). Helmfile and Packer items
+// belong to their own subcommands; deleted components have no on-disk module so
+// terraform plan/apply against them would fail or no-op. See issue #2361.
+func filterTerraformAffected(affectedList []schema.Affected) []schema.Affected {
+	filtered := affectedList[:0]
+	for i := range affectedList {
+		a := &affectedList[i]
+		if a.ComponentType != cfg.TerraformComponentType {
+			continue
+		}
+		if a.Deleted {
+			continue
+		}
+		filtered = append(filtered, *a)
+	}
+	return filtered
+}
 
 // getAffectedComponents retrieves the list of affected components based on the provided arguments.
 func getAffectedComponents(args *DescribeAffectedCmdArgs) ([]schema.Affected, error) {
@@ -83,6 +104,11 @@ func ExecuteTerraformAffected(args *DescribeAffectedCmdArgs, info *schema.Config
 	if err != nil {
 		return err
 	}
+
+	// Drop non-terraform component types (helmfile, packer) and deleted components
+	// before resolving dependents — `addDependentsToAffected` is expensive and there
+	// is no reason to walk dependency graphs for items we will not execute.
+	affectedList = filterTerraformAffected(affectedList)
 
 	// Add dependent components for each directly affected component.
 	if len(affectedList) > 0 {

--- a/internal/exec/terraform_affected_filter_test.go
+++ b/internal/exec/terraform_affected_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -130,7 +131,9 @@ func TestFilterTerraformAffected_InPlaceSemantics(t *testing.T) {
 	}
 	got := filterTerraformAffected(in)
 
-	assert.Len(t, got, 1)
+	// `require.Len` (vs `assert.Len`) — the next lines index `got[0]`, and a
+	// non-fatal assertion would let the test panic instead of failing cleanly.
+	require.Len(t, got, 1)
 	assert.Equal(t, "tf", got[0].Component)
 	// Prove the filter compacted into the same backing array rather than
 	// allocating a new one — the result's first element must be the input's

--- a/internal/exec/terraform_affected_filter_test.go
+++ b/internal/exec/terraform_affected_filter_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
+// Compile-time guard: rename of any field below must fail the build, since the
+// tests in this file rely on these schema.Affected fields by name.
+var _ = schema.Affected{
+	Component:     "sentinel",
+	Stack:         "sentinel",
+	ComponentType: cfg.TerraformComponentType,
+	Deleted:       true,
+	Affected:      "sentinel",
+}
+
 // TestFilterTerraformAffected verifies that `atmos terraform plan/apply --affected`
 // only executes against terraform components that still exist in HEAD. Helmfile,
 // Packer, and deleted components must be dropped — they are the surface of bug #2361
@@ -122,6 +132,11 @@ func TestFilterTerraformAffected_InPlaceSemantics(t *testing.T) {
 
 	assert.Len(t, got, 1)
 	assert.Equal(t, "tf", got[0].Component)
+	// Prove the filter compacted into the same backing array rather than
+	// allocating a new one — the result's first element must be the input's
+	// first slot, now overwritten to the kept terraform entry.
+	assert.Equal(t, "tf", in[0].Component, "input should be compacted in place")
+	assert.Same(t, &in[0], &got[0], "result should reuse input backing array")
 	// The filter intentionally reuses the backing array. Future maintainers must
 	// not assume `in` is unchanged. If a non-destructive variant is ever needed,
 	// allocate a fresh slice instead.

--- a/internal/exec/terraform_affected_filter_test.go
+++ b/internal/exec/terraform_affected_filter_test.go
@@ -1,0 +1,128 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestFilterTerraformAffected verifies that `atmos terraform plan/apply --affected`
+// only executes against terraform components that still exist in HEAD. Helmfile,
+// Packer, and deleted components must be dropped — they are the surface of bug #2361
+// where users saw `atmos terraform apply example-helmfile` and
+// `atmos terraform apply example-packer` lines appear in the dry-run output.
+func TestFilterTerraformAffected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []schema.Affected
+		want []schema.Affected
+	}{
+		{
+			name: "nil input returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty input returns empty",
+			in:   []schema.Affected{},
+			want: []schema.Affected{},
+		},
+		{
+			name: "mixed types: helmfile and packer dropped, terraform kept",
+			in: []schema.Affected{
+				{Component: "example-terraform", Stack: "example", ComponentType: cfg.TerraformComponentType},
+				{Component: "example-helmfile", Stack: "example", ComponentType: cfg.HelmfileComponentType},
+				{Component: "example-packer", Stack: "example", ComponentType: cfg.PackerComponentType},
+			},
+			want: []schema.Affected{
+				{Component: "example-terraform", Stack: "example", ComponentType: cfg.TerraformComponentType},
+			},
+		},
+		{
+			name: "deleted terraform components are dropped",
+			in: []schema.Affected{
+				{Component: "live", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+				{Component: "removed", Stack: "prod", ComponentType: cfg.TerraformComponentType, Deleted: true, Affected: "deleted"},
+				{Component: "removed-stack", Stack: "old", ComponentType: cfg.TerraformComponentType, Deleted: true, Affected: "deleted.stack"},
+			},
+			want: []schema.Affected{
+				{Component: "live", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+			},
+		},
+		{
+			name: "deleted helmfile/packer dropped (both filters apply)",
+			in: []schema.Affected{
+				{Component: "helm-gone", Stack: "prod", ComponentType: cfg.HelmfileComponentType, Deleted: true},
+				{Component: "packer-gone", Stack: "prod", ComponentType: cfg.PackerComponentType, Deleted: true},
+			},
+			want: []schema.Affected{},
+		},
+		{
+			name: "empty component type is dropped (not a terraform component)",
+			in: []schema.Affected{
+				{Component: "unknown", Stack: "prod", ComponentType: ""},
+				{Component: "tf", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+			},
+			want: []schema.Affected{
+				{Component: "tf", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+			},
+		},
+		{
+			name: "all terraform, none deleted: list preserved in order",
+			in: []schema.Affected{
+				{Component: "a", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+				{Component: "b", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+				{Component: "c", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+			},
+			want: []schema.Affected{
+				{Component: "a", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+				{Component: "b", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+				{Component: "c", Stack: "prod", ComponentType: cfg.TerraformComponentType},
+			},
+		},
+		{
+			name: "reproduces issue #2361 fixture (terraform + helmfile + packer in one stack)",
+			in: []schema.Affected{
+				{Component: "example-terraform", Stack: "example", ComponentType: cfg.TerraformComponentType, Affected: "stack.vars"},
+				{Component: "example-helmfile", Stack: "example", ComponentType: cfg.HelmfileComponentType, Affected: "stack.vars"},
+				{Component: "example-packer", Stack: "example", ComponentType: cfg.PackerComponentType, Affected: "stack.vars"},
+			},
+			want: []schema.Affected{
+				{Component: "example-terraform", Stack: "example", ComponentType: cfg.TerraformComponentType, Affected: "stack.vars"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterTerraformAffected(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestFilterTerraformAffected_DoesNotMutateOriginalLength documents that the
+// filter reuses the backing array (`affectedList[:0]` pattern) and therefore
+// callers should treat the input slice as consumed. The slice header returned
+// is the safe one to use; the original header may point to overwritten elements.
+func TestFilterTerraformAffected_InPlaceSemantics(t *testing.T) {
+	t.Parallel()
+
+	in := []schema.Affected{
+		{Component: "helm", ComponentType: cfg.HelmfileComponentType},
+		{Component: "tf", ComponentType: cfg.TerraformComponentType},
+	}
+	got := filterTerraformAffected(in)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "tf", got[0].Component)
+	// The filter intentionally reuses the backing array. Future maintainers must
+	// not assume `in` is unchanged. If a non-destructive variant is ever needed,
+	// allocate a fresh slice instead.
+}

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -420,6 +420,12 @@ func executeTerraformAffectedComponentInDepOrder(
 
 	for i := 0; i < len(params.Dependents); i++ {
 		dep := &params.Dependents[i]
+		// Defense-in-depth: when --include-dependents is set, the dependency graph
+		// may include helmfile/packer dependents. `atmos terraform` must skip those
+		// — they belong to their own subcommands. See issue #2361.
+		if dep.ComponentType != "" && dep.ComponentType != cfg.TerraformComponentType {
+			continue
+		}
 		if !shouldProcessDependent(dep, affectedList, args.IncludeDependents) {
 			continue
 		}

--- a/internal/exec/terraform_utils.go
+++ b/internal/exec/terraform_utils.go
@@ -391,6 +391,15 @@ func shouldProcessDependent(dep *schema.Dependent, affectedList []schema.Affecte
 	return includeDependents || isComponentInStackAffected(affectedList, dep.StackSlug)
 }
 
+// isNonTerraformDependent returns true when dep is a dependent that
+// `atmos terraform` must skip during recursion: a helmfile or packer
+// component, or any other non-terraform type. Dependents with an empty
+// ComponentType are treated as terraform for backward compatibility. See
+// issue #2361.
+func isNonTerraformDependent(dep *schema.Dependent) bool {
+	return dep.ComponentType != "" && dep.ComponentType != cfg.TerraformComponentType
+}
+
 // executeTerraformAffectedComponentInDepOrder recursively processes the affected components in the dependency order.
 func executeTerraformAffectedComponentInDepOrder(
 	info *schema.ConfigAndStacksInfo,
@@ -423,7 +432,7 @@ func executeTerraformAffectedComponentInDepOrder(
 		// Defense-in-depth: when --include-dependents is set, the dependency graph
 		// may include helmfile/packer dependents. `atmos terraform` must skip those
 		// — they belong to their own subcommands. See issue #2361.
-		if dep.ComponentType != "" && dep.ComponentType != cfg.TerraformComponentType {
+		if isNonTerraformDependent(dep) {
 			continue
 		}
 		if !shouldProcessDependent(dep, affectedList, args.IncludeDependents) {

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -1579,6 +1579,59 @@ func TestExecuteTerraformAffectedComponentInDepOrder(t *testing.T) {
 	}
 }
 
+// TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard
+// is a portable companion to the gomonkey-based table above. It exercises the
+// defense-in-depth guard at terraform_utils.go that drops helmfile/packer
+// dependents during the recursion. We use DryRun=true so the function never
+// invokes ExecuteTerraform — that lets the test run on every CI runner,
+// including macOS ARM64 where gomonkey is unsupported, and gives the dependent
+// type-check line real coverage instead of relying on a skipped suite.
+func TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dependents []schema.Dependent
+	}{
+		{
+			name: "helmfile dependent skipped (issue #2361)",
+			dependents: []schema.Dependent{
+				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
+			},
+		},
+		{
+			name: "packer dependent skipped (issue #2361)",
+			dependents: []schema.Dependent{
+				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
+			},
+		},
+		{
+			name: "both non-terraform dependents skipped",
+			dependents: []schema.Dependent{
+				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
+				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			info := &schema.ConfigAndStacksInfo{SubCommand: "plan", DryRun: true}
+			args := &DescribeAffectedCmdArgs{IncludeDependents: true}
+			params := &affectedDepOrderParams{
+				AffectedComponent: "vpc",
+				AffectedStack:     "prod",
+				Dependents:        tt.dependents,
+			}
+
+			err := executeTerraformAffectedComponentInDepOrder(info, nil, params, args)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func BenchmarkParseUploadStatusFlag(b *testing.B) {
 	args := []string{"--verbose", "--upload-status=true", "--output=json"}
 	flagName := "upload-status"

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -1586,24 +1586,37 @@ func TestExecuteTerraformAffectedComponentInDepOrder(t *testing.T) {
 // invokes ExecuteTerraform — that lets the test run on every CI runner,
 // including macOS ARM64 where gomonkey is unsupported, and gives the dependent
 // type-check line real coverage instead of relying on a skipped suite.
+//
+// Observable signal: `executeTerraformAffectedComponentInDepOrder` mutates
+// `info.Component` at the top of every call to whatever component it is
+// processing. After the function returns, `info.Component` is therefore the
+// last component that entered the recursion. A non-terraform dependent that
+// was skipped never enters the recursion, so `info.Component` stays at the
+// root ("vpc"). A terraform dependent that was processed sets it to itself.
+// We assert on that final value — `require.NoError` alone would let a
+// regression that still recursed into a helmfile/packer dependent pass
+// silently.
 func TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		dependents []schema.Dependent
+		name                   string
+		dependents             []schema.Dependent
+		expectedFinalComponent string
 	}{
 		{
 			name: "helmfile dependent skipped (issue #2361)",
 			dependents: []schema.Dependent{
 				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
 			},
+			expectedFinalComponent: "vpc",
 		},
 		{
 			name: "packer dependent skipped (issue #2361)",
 			dependents: []schema.Dependent{
 				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
 			},
+			expectedFinalComponent: "vpc",
 		},
 		{
 			name: "both non-terraform dependents skipped",
@@ -1611,6 +1624,16 @@ func TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard(
 				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
 				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
 			},
+			expectedFinalComponent: "vpc",
+		},
+		{
+			// Positive path: a terraform dependent must still recurse, otherwise
+			// the guard would be over-broad and silently drop legitimate work.
+			name: "terraform dependent recurses",
+			dependents: []schema.Dependent{
+				{Component: "security-group", ComponentType: cfg.TerraformComponentType, Stack: "prod"},
+			},
+			expectedFinalComponent: "security-group",
 		},
 	}
 
@@ -1628,6 +1651,8 @@ func TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard(
 
 			err := executeTerraformAffectedComponentInDepOrder(info, nil, params, args)
 			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFinalComponent, info.Component,
+				"info.Component reflects whether recursion happened; mismatch means the guard let a non-terraform dependent through or blocked a terraform one")
 		})
 	}
 }

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -1579,80 +1579,53 @@ func TestExecuteTerraformAffectedComponentInDepOrder(t *testing.T) {
 	}
 }
 
-// TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard
-// is a portable companion to the gomonkey-based table above. It exercises the
-// defense-in-depth guard at terraform_utils.go that drops helmfile/packer
-// dependents during the recursion. We use DryRun=true so the function never
-// invokes ExecuteTerraform — that lets the test run on every CI runner,
-// including macOS ARM64 where gomonkey is unsupported, and gives the dependent
-// type-check line real coverage instead of relying on a skipped suite.
-//
-// Observable signal: `executeTerraformAffectedComponentInDepOrder` mutates
-// `info.Component` at the top of every call to whatever component it is
-// processing. After the function returns, `info.Component` is therefore the
-// last component that entered the recursion. A non-terraform dependent that
-// was skipped never enters the recursion, so `info.Component` stays at the
-// root ("vpc"). A terraform dependent that was processed sets it to itself.
-// We assert on that final value — `require.NoError` alone would let a
-// regression that still recursed into a helmfile/packer dependent pass
-// silently.
-func TestExecuteTerraformAffectedComponentInDepOrder_NonTerraformDependentGuard(t *testing.T) {
+// TestIsNonTerraformDependent is the portable companion to the gomonkey-based
+// table above. It directly exercises the defense-in-depth predicate that
+// `executeTerraformAffectedComponentInDepOrder` uses to drop helmfile/packer
+// dependents during the recursion. Testing the predicate (rather than the
+// orchestrator) avoids racing with parallel tests that monkey-patch the
+// orchestrator, and gives the guard real coverage on every CI runner —
+// including macOS ARM64 where gomonkey is unsupported.
+func TestIsNonTerraformDependent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                   string
-		dependents             []schema.Dependent
-		expectedFinalComponent string
+		name string
+		dep  schema.Dependent
+		want bool
 	}{
 		{
-			name: "helmfile dependent skipped (issue #2361)",
-			dependents: []schema.Dependent{
-				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
-			},
-			expectedFinalComponent: "vpc",
+			name: "helmfile dependent is non-terraform (issue #2361)",
+			dep:  schema.Dependent{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
+			want: true,
 		},
 		{
-			name: "packer dependent skipped (issue #2361)",
-			dependents: []schema.Dependent{
-				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
-			},
-			expectedFinalComponent: "vpc",
+			name: "packer dependent is non-terraform (issue #2361)",
+			dep:  schema.Dependent{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
+			want: true,
 		},
 		{
-			name: "both non-terraform dependents skipped",
-			dependents: []schema.Dependent{
-				{Component: "helm-app", ComponentType: cfg.HelmfileComponentType, Stack: "prod"},
-				{Component: "image", ComponentType: cfg.PackerComponentType, Stack: "prod"},
-			},
-			expectedFinalComponent: "vpc",
+			// Positive path: a terraform dependent must NOT be flagged,
+			// otherwise the guard would be over-broad and silently drop
+			// legitimate work.
+			name: "terraform dependent is not flagged",
+			dep:  schema.Dependent{Component: "security-group", ComponentType: cfg.TerraformComponentType, Stack: "prod"},
+			want: false,
 		},
 		{
-			// Positive path: a terraform dependent must still recurse, otherwise
-			// the guard would be over-broad and silently drop legitimate work.
-			name: "terraform dependent recurses",
-			dependents: []schema.Dependent{
-				{Component: "security-group", ComponentType: cfg.TerraformComponentType, Stack: "prod"},
-			},
-			expectedFinalComponent: "security-group",
+			// Empty ComponentType is treated as terraform for backward
+			// compatibility — older affected payloads omitted this field.
+			name: "empty ComponentType is treated as terraform",
+			dep:  schema.Dependent{Component: "legacy", ComponentType: "", Stack: "prod"},
+			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			info := &schema.ConfigAndStacksInfo{SubCommand: "plan", DryRun: true}
-			args := &DescribeAffectedCmdArgs{IncludeDependents: true}
-			params := &affectedDepOrderParams{
-				AffectedComponent: "vpc",
-				AffectedStack:     "prod",
-				Dependents:        tt.dependents,
-			}
-
-			err := executeTerraformAffectedComponentInDepOrder(info, nil, params, args)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedFinalComponent, info.Component,
-				"info.Component reflects whether recursion happened; mismatch means the guard let a non-terraform dependent through or blocked a terraform one")
+			dep := tt.dep
+			assert.Equal(t, tt.want, isNonTerraformDependent(&dep))
 		})
 	}
 }

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -1390,6 +1390,119 @@ func TestExecuteTerraformAffectedComponentInDepOrder(t *testing.T) {
 			expectedError:      false,
 			expectedCalls:      1, // Only vpc, dependents not included.
 		},
+		{
+			// Defense-in-depth coverage for issue #2361: a terraform component
+			// must never trigger terraform plan/apply on a helmfile dependent.
+			name: "helmfile dependent skipped (issue #2361)",
+			info: &schema.ConfigAndStacksInfo{
+				SubCommand: "plan",
+				DryRun:     false,
+			},
+			affectedList: []schema.Affected{
+				{StackSlug: "prod-helm-app"},
+			},
+			affectedComponent: "vpc",
+			affectedStack:     "prod",
+			parentComponent:   "",
+			parentStack:       "",
+			dependents: []schema.Dependent{
+				{
+					Component:            "helm-app",
+					ComponentType:        "helmfile",
+					Stack:                "prod",
+					StackSlug:            "prod-helm-app",
+					IncludedInDependents: false,
+					Dependents:           []schema.Dependent{},
+				},
+			},
+			args: &DescribeAffectedCmdArgs{
+				IncludeDependents: true,
+			},
+			mockTerraformError: false,
+			expectedError:      false,
+			expectedCalls:      1, // Only vpc; helmfile dependent filtered.
+		},
+		{
+			// Defense-in-depth coverage for issue #2361: a terraform component
+			// must never trigger terraform plan/apply on a packer dependent.
+			name: "packer dependent skipped (issue #2361)",
+			info: &schema.ConfigAndStacksInfo{
+				SubCommand: "plan",
+				DryRun:     false,
+			},
+			affectedList: []schema.Affected{
+				{StackSlug: "prod-image"},
+			},
+			affectedComponent: "vpc",
+			affectedStack:     "prod",
+			parentComponent:   "",
+			parentStack:       "",
+			dependents: []schema.Dependent{
+				{
+					Component:            "image",
+					ComponentType:        "packer",
+					Stack:                "prod",
+					StackSlug:            "prod-image",
+					IncludedInDependents: false,
+					Dependents:           []schema.Dependent{},
+				},
+			},
+			args: &DescribeAffectedCmdArgs{
+				IncludeDependents: true,
+			},
+			mockTerraformError: false,
+			expectedError:      false,
+			expectedCalls:      1, // Only vpc; packer dependent filtered.
+		},
+		{
+			// Mixed-type dependents: only the terraform one runs.
+			name: "mixed-type dependents — only terraform runs (issue #2361)",
+			info: &schema.ConfigAndStacksInfo{
+				SubCommand: "plan",
+				DryRun:     false,
+			},
+			affectedList: []schema.Affected{
+				{StackSlug: "prod-helm-app"},
+				{StackSlug: "prod-image"},
+				{StackSlug: "prod-security-group"},
+			},
+			affectedComponent: "vpc",
+			affectedStack:     "prod",
+			parentComponent:   "",
+			parentStack:       "",
+			dependents: []schema.Dependent{
+				{
+					Component:            "helm-app",
+					ComponentType:        "helmfile",
+					Stack:                "prod",
+					StackSlug:            "prod-helm-app",
+					IncludedInDependents: false,
+					Dependents:           []schema.Dependent{},
+				},
+				{
+					Component:            "image",
+					ComponentType:        "packer",
+					Stack:                "prod",
+					StackSlug:            "prod-image",
+					IncludedInDependents: false,
+					Dependents:           []schema.Dependent{},
+				},
+				{
+					Component:            "security-group",
+					ComponentType:        "terraform",
+					Stack:                "prod",
+					StackSlug:            "prod-security-group",
+					IncludedInDependents: false,
+					Dependents:           []schema.Dependent{},
+				},
+			},
+			args: &DescribeAffectedCmdArgs{
+				IncludeDependents: true,
+			},
+			mockTerraformError: false,
+			expectedError:      false,
+			expectedCalls:      2, // vpc + security-group; helmfile + packer filtered.
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## what

Filters the affected component list in `atmos terraform plan/apply --affected` so the command no longer runs against helmfile components, packer components, or components deleted in HEAD.

## why

Reported in #2361. `getAffectedComponents` returns every affected component regardless of type — helmfile, packer, and BASE-only deletions are all included — and `ExecuteTerraformAffected` was iterating that full list and calling `ExecuteTerraform` on each, producing output like:

```
INFO  Executing command="atmos terraform apply example-terraform -s example"
INFO  Executing command="atmos terraform apply example-helmfile -s example"
INFO  Executing command="atmos terraform apply example-packer -s example"
```

Documentation ([website/docs/cli/commands/terraform/usage.mdx](website/docs/cli/commands/terraform/usage.mdx)) describes `--affected` as executing the command "on all the directly affected components," with the implicit constraint that those components belong to the `atmos terraform` subcommand. Helmfile and Packer subcommands would orchestrate their own components, and deleted components have no on-disk module so `terraform plan/apply` against them either errors or no-ops.

## how

- New package-private helper `filterTerraformAffected` keeps only items where `ComponentType == cfg.TerraformComponentType` and `!Deleted`. Called once in `ExecuteTerraformAffected` after `getAffectedComponents`, before `addDependentsToAffected` (which is expensive and shouldn't run for items we will drop).
- Defense-in-depth filter in `executeTerraformAffectedComponentInDepOrder`: when `--include-dependents` is set, any dependent with `ComponentType` explicitly set to a non-terraform value is skipped during the recursion.
- `atmos describe affected` is unchanged. It still reports the full affected set (terraform + helmfile + packer + deleted) as the canonical introspection view. The filter is scoped to the execution path of `atmos terraform <cmd> --affected`.

## tests

- New file [internal/exec/terraform_affected_filter_test.go](internal/exec/terraform_affected_filter_test.go): 8 portable table cases covering the filter (no gomonkey, runs on every CI matrix entry). Includes a case mirroring the exact #2361 reproducer fixture. 100% line coverage of the new helper.
- Three new cases added to `TestExecuteTerraformAffectedComponentInDepOrder` table in [internal/exec/terraform_utils_test.go](internal/exec/terraform_utils_test.go): helmfile dependent skipped, packer dependent skipped, mixed-type dependents (only the terraform one runs).

## compatibility

Bug fix only. The previous behavior produced incorrect commands that would fail mid-execution (terraform-apply against a helmfile component errors out). No public Go API or CLI surface changes. The most visible user-facing shift is an exit-code flip from non-zero to zero when a changeset contains only non-terraform or deleted components — which now correctly reports "No components affected" instead of erroring partway through.

Closes #2361.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terraform execution now excludes non-Terraform dependents (e.g., Helmfile, Packer), skips deleted components, and treats empty component types as Terraform to preserve compatibility; Terraform-only ordering is preserved to avoid unnecessary processing.

* **Tests**
  * Added tests for filtering behavior, in-place compaction semantics, non-Terraform exclusion, and a regression ensuring only Terraform entries are executed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->