### PR TITLE
fix(terraform): wire `--all` to `ExecuteTerraformAll` for dependency-ordered execution

### DIFF
--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -506,9 +506,20 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	if info.All {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformAll (dependency-ordered)")
+		// Wire per-component CI hooks for plan/deploy/apply so each component
+		// gets its own summary entry instead of a single misattributed global
+		// call in PostRunE — mirrors the ExecuteTerraformQuery branch below.
 		if subCommand == "plan" {
 			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
 				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+			}
+		} else if subCommand == "deploy" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
+			}
+		} else if subCommand == "apply" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)
 			}
 		}
 		return e.ExecuteTerraformAll(&info)

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -445,6 +445,18 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 		wasMultiComponentExecution = false
 		return executeAffectedCommand(parentCmd, args, &info)
 	}
+	// --all routes to ExecuteTerraformAll for dependency-ordered execution.
+	// --components / --query / bare `-s stack` continue to route to ExecuteTerraformQuery.
+	if info.All {
+		wasMultiComponentExecution = true
+		log.Debug("Routing to ExecuteTerraformAll (dependency-ordered)")
+		if subCommand == "plan" {
+			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+			}
+		}
+		return e.ExecuteTerraformAll(&info)
+	}
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -275,6 +275,29 @@ func runCIHooksForApplyComponent(actualCmd *cobra.Command, info *schema.ConfigAn
 	}
 }
 
+// wirePerComponentHook installs the per-component CI hook on info so each
+// component in a multi-component run (`--all`, `--components`, `--query`) gets
+// its own summary entry instead of a single misattributed global call from
+// PostRunE. The wiring is identical for both ExecuteTerraformAll and
+// ExecuteTerraformQuery dispatch paths; keep it in one place so a new
+// subcommand only needs to be added once.
+func wirePerComponentHook(info *schema.ConfigAndStacksInfo, subCommand string, actualCmd *cobra.Command) {
+	switch subCommand {
+	case "plan":
+		info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+			runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
+		}
+	case "deploy":
+		info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+			runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
+		}
+	case "apply":
+		info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
+			runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)
+		}
+	}
+}
+
 // resolveComponentPath resolves a path-based component argument to a component name.
 // It validates the component exists in the specified stack and handles ambiguous paths.
 func resolveComponentPath(info *schema.ConfigAndStacksInfo, commandName string) error {
@@ -506,42 +529,13 @@ func terraformRunWithOptions(parentCmd, actualCmd *cobra.Command, args []string,
 	if info.All {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformAll (dependency-ordered)")
-		// Wire per-component CI hooks for plan/deploy/apply so each component
-		// gets its own summary entry instead of a single misattributed global
-		// call in PostRunE — mirrors the ExecuteTerraformQuery branch below.
-		if subCommand == "plan" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
-			}
-		} else if subCommand == "deploy" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
-			}
-		} else if subCommand == "apply" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)
-			}
-		}
+		wirePerComponentHook(&info, subCommand, actualCmd)
 		return e.ExecuteTerraformAll(&info)
 	}
 	if isMultiComponentExecution(&info) {
 		wasMultiComponentExecution = true
 		log.Debug("Routing to ExecuteTerraformQuery (multi-component)")
-		// Wire per-component CI hooks for plan, deploy, and apply so each component
-		// gets its own summary entry instead of a single misattributed global call in PostRunE.
-		if subCommand == "plan" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForPlanComponent(actualCmd, compInfo, output, execErr)
-			}
-		} else if subCommand == "deploy" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForDeployComponent(actualCmd, compInfo, output, execErr)
-			}
-		} else if subCommand == "apply" {
-			info.PerComponentHook = func(compInfo *schema.ConfigAndStacksInfo, output string, execErr error) {
-				runCIHooksForApplyComponent(actualCmd, compInfo, output, execErr)
-			}
-		}
+		wirePerComponentHook(&info, subCommand, actualCmd)
 		return e.ExecuteTerraformQuery(&info)
 	}
 	wasMultiComponentExecution = false

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -15,6 +15,7 @@ package terraform
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -439,4 +440,87 @@ func TestRunCIHooksForApplyComponent_ExitCodeForwarding(t *testing.T) {
 			runCIHooksForApplyComponent(cmd, info, "apply output", tc.execErr)
 		})
 	}
+}
+
+// TestWirePerComponentHook pins the per-subcommand hook wiring contract used
+// by both the ExecuteTerraformAll (--all) and ExecuteTerraformQuery
+// (--components/--query) dispatch branches in terraformRunWithOptions. Both
+// branches funnel through this helper, so a regression here would silently
+// drop per-component CI summary entries for one of plan/apply/deploy — which
+// is exactly the bug CodeRabbit caught on an earlier revision of this PR.
+func TestWirePerComponentHook(t *testing.T) {
+	t.Run("plan/deploy/apply install a non-nil hook", func(t *testing.T) {
+		for _, sub := range []string{"plan", "deploy", "apply"} {
+			t.Run(sub, func(t *testing.T) {
+				info := &schema.ConfigAndStacksInfo{}
+				wirePerComponentHook(info, sub, newHookTestCmd())
+				assert.NotNil(t, info.PerComponentHook,
+					"%q subcommand must install a per-component hook", sub)
+			})
+		}
+	})
+
+	t.Run("unknown subcommand leaves the hook unset", func(t *testing.T) {
+		// `destroy`, `init`, etc. are valid terraform subcommands but they do
+		// not have a per-component CI hook today. The helper must be a no-op
+		// for anything outside the {plan, deploy, apply} set so other
+		// subcommands don't accidentally start firing hooks.
+		for _, sub := range []string{"destroy", "init", "validate", ""} {
+			t.Run(sub, func(t *testing.T) {
+				info := &schema.ConfigAndStacksInfo{}
+				wirePerComponentHook(info, sub, newHookTestCmd())
+				assert.Nil(t, info.PerComponentHook,
+					"%q subcommand must NOT install a per-component hook", sub)
+			})
+		}
+	})
+
+	t.Run("installed hook does not panic when invoked", func(t *testing.T) {
+		// Smoke-test the closure body: it must reach RunCIHooks without
+		// panicking even when invoked outside a configured atmos directory.
+		// RunCIHooks short-circuits if the underlying config isn't loadable,
+		// so the closures should fail gracefully (Warn log) rather than crash.
+		t.Chdir("../../examples/demo-stacks")
+		cmd := newHookTestCmd()
+
+		for _, sub := range []string{"plan", "deploy", "apply"} {
+			t.Run(sub, func(t *testing.T) {
+				info := &schema.ConfigAndStacksInfo{
+					Stack:            "dev",
+					Component:        "myapp",
+					ComponentFromArg: "myapp",
+					ComponentType:    "terraform",
+				}
+				wirePerComponentHook(info, sub, cmd)
+				assert.NotPanics(t, func() {
+					info.PerComponentHook(info, "output", nil)
+				})
+			})
+		}
+	})
+
+	t.Run("the three subcommands wire to distinct hook closures", func(t *testing.T) {
+		// Sanity check: a future edit that copy-pastes one case over another
+		// (e.g. apply ends up calling the plan hook) wouldn't be caught by the
+		// nil/non-nil assertions above. Capture the hook for each subcommand
+		// and assert pairwise that they're distinct function values.
+		hookFor := func(sub string) func(*schema.ConfigAndStacksInfo, string, error) {
+			info := &schema.ConfigAndStacksInfo{}
+			wirePerComponentHook(info, sub, newHookTestCmd())
+			return info.PerComponentHook
+		}
+		plan, apply, deploy := hookFor("plan"), hookFor("apply"), hookFor("deploy")
+		// Compare reflect pointer identities (function values are not directly
+		// comparable in Go, but reflect.ValueOf(.).Pointer() returns the
+		// closure's code address).
+		assert.NotEqual(t, hookPointer(plan), hookPointer(apply), "plan and apply must call different CI hook functions")
+		assert.NotEqual(t, hookPointer(plan), hookPointer(deploy), "plan and deploy must call different CI hook functions")
+		assert.NotEqual(t, hookPointer(apply), hookPointer(deploy), "apply and deploy must call different CI hook functions")
+	})
+}
+
+// hookPointer returns the underlying code-pointer of a hook closure for
+// equality comparison. Function values themselves are not comparable in Go.
+func hookPointer(f func(*schema.ConfigAndStacksInfo, string, error)) uintptr {
+	return reflect.ValueOf(f).Pointer()
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -621,7 +621,6 @@ var (
 	ErrDependencyTargetNotFound  = errors.New("dependency target not found")
 
 	// Terraform --all flag errors.
-	ErrStackRequiredWithAllFlag     = errors.New("stack is required when using --all flag")
 	ErrComponentWithAllFlagConflict = errors.New("component argument can't be used with --all flag")
 
 	// Terraform execution errors.

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/cloudposse/atmos/pkg/store/authbridge"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
@@ -20,9 +21,8 @@ func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 	defer perf.Track(nil, "exec.ExecuteTerraformAll")()
 
 	// Validate inputs for --all flag usage.
-	if info.Stack == "" {
-		return errUtils.ErrStackRequiredWithAllFlag
-	}
+	// When no stack is given, --all processes every stack — matching the documented
+	// behavior of `atmos terraform apply --all` (see website/docs/cli/commands/terraform).
 	if info.ComponentFromArg != "" {
 		return errUtils.ErrComponentWithAllFlagConflict
 	}
@@ -33,6 +33,18 @@ func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 	}
 
 	log.Debug("Executing terraform command for all components in dependency order", "command", info.SubCommand)
+
+	// Create auth manager so YAML functions (e.g. !terraform.state) can use authenticated
+	// credentials when ExecuteDescribeStacks processes stack configurations under --all.
+	// Mirrors the behavior added for --query/--components in ExecuteTerraformQuery (#2081).
+	authManager, err := createQueryAuthManager(info, &atmosConfig)
+	if err != nil {
+		return err
+	}
+	if authManager != nil {
+		resolver := authbridge.NewResolver(authManager, info)
+		atmosConfig.Stores.SetAuthContextResolver(resolver)
+	}
 
 	// Get all stacks with terraform components.
 	stacks, err := ExecuteDescribeStacks(
@@ -46,7 +58,7 @@ func ExecuteTerraformAll(info *schema.ConfigAndStacksInfo) error {
 		info.ProcessFunctions,
 		false,
 		info.Skip,
-		nil, // authManager
+		authManager,
 	)
 	if err != nil {
 		return fmt.Errorf(errWrapFmt, errUtils.ErrExecuteDescribeStacks, err)
@@ -212,10 +224,15 @@ func applyFiltersToGraph(graph *dependency.Graph, _ map[string]any, info *schema
 	}
 
 	// Filter the graph.
+	// IncludeDependencies is false to preserve the historical scope of `--all -s <stack>`:
+	// only components in the requested stack are processed. Cross-stack prerequisites are
+	// retained as graph edges within the requested stack (where both endpoints are present)
+	// but components outside the requested stack are not pulled in. A future flag may
+	// opt users in to cross-stack dependency execution.
 	return graph.Filter(dependency.Filter{
 		NodeIDs:             nodeIDs,
-		IncludeDependencies: true,  // Include prerequisites.
-		IncludeDependents:   false, // Exclude reverse deps.
+		IncludeDependencies: false,
+		IncludeDependents:   false,
 	})
 }
 

--- a/internal/exec/terraform_all_simple_test.go
+++ b/internal/exec/terraform_all_simple_test.go
@@ -9,22 +9,14 @@ import (
 )
 
 func TestExecuteTerraformAll_ValidationSimple(t *testing.T) {
+	// --all without a stack is allowed: it processes every stack
+	// (see website/docs/cli/commands/terraform/terraform-apply.mdx).
 	tests := []struct {
 		name        string
 		info        *schema.ConfigAndStacksInfo
 		expectError bool
 		errorMsg    string
 	}{
-		{
-			name: "no stack specified",
-			info: &schema.ConfigAndStacksInfo{
-				ComponentFromArg: "",
-				Stack:            "",
-				SubCommand:       "plan",
-			},
-			expectError: true,
-			errorMsg:    "stack is required",
-		},
 		{
 			name: "component specified with --all",
 			info: &schema.ConfigAndStacksInfo{

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -382,6 +383,41 @@ func TestExecuteTerraformAll_AuthManagerResolverWired(t *testing.T) {
 	// The factory above stored the AuthManager on info via createQueryAuthManager;
 	// this confirms the non-nil path actually ran rather than silently skipping.
 	assert.NotNil(t, info.AuthManager, "non-nil factory should populate info.AuthManager")
+}
+
+// TestExecuteTerraformAll_AuthManagerCreationError verifies that a failure in
+// createQueryAuthManager short-circuits ExecuteTerraformAll with the wrapped
+// error — i.e. we don't silently proceed to ExecuteDescribeStacks with a nil
+// auth manager when the user has clearly configured auth that we couldn't
+// resolve. This pins the error-propagation branch at terraform_all.go:41-43.
+func TestExecuteTerraformAll_AuthManagerCreationError(t *testing.T) {
+	t.Setenv("ATMOS_BASE_PATH", "")
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
+	os.Unsetenv("ATMOS_BASE_PATH")
+	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+
+	t.Chdir(filepath.Join("..", "..", "tests", "fixtures", "scenarios", "terraform-apply-affected"))
+
+	sentinel := errors.New("simulated auth manager init failure")
+	original := authManagerFactory
+	authManagerFactory = func(string, schema.AuthConfig, string, *schema.AtmosConfiguration) (auth.AuthManager, error) {
+		return nil, sentinel
+	}
+	t.Cleanup(func() { authManagerFactory = original })
+
+	info := &schema.ConfigAndStacksInfo{
+		Stack:         "prod",
+		ComponentType: "terraform",
+		SubCommand:    "plan",
+		DryRun:        true,
+	}
+	err := ExecuteTerraformAll(info)
+	require.Error(t, err)
+	// createQueryAuthManager wraps its own error in `create query auth manager: %w`,
+	// which then bubbles up unchanged. Use errors.Is to stay robust against
+	// future re-wrapping in either layer.
+	assert.ErrorIs(t, err, sentinel,
+		"auth manager init failure must propagate from ExecuteTerraformAll")
 }
 
 // TestApplyFiltersToGraph_NoCrossStackPullIn pins the new IncludeDependencies:false

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,6 +278,85 @@ func TestExecuteTerraformAll_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExecuteTerraformAll_DryRunHappyPath exercises the full ExecuteTerraformAll
+// pipeline against a real fixture in dry-run mode. The existing validation tests
+// short-circuit on the very first guard (component-with-all), so the auth-manager
+// bootstrap, ExecuteDescribeStacks, dependency graph build, applyFiltersToGraph,
+// and executeInDependencyOrder branches had no unit-test coverage — codecov
+// flagged 7 missing lines on terraform_all.go for that reason.
+//
+// DryRun=true short-circuits inside executeNodeCommand so terraform itself is
+// never invoked; this means the test runs without requiring the terraform binary
+// and on every CI matrix entry. The fixture `terraform-apply-affected` defines
+// a `vpc → eks/cluster → eks/external-dns → …` dependency chain, which gives
+// us a non-trivial graph to walk so the topological-sort path is also covered.
+func TestExecuteTerraformAll_DryRunHappyPath(t *testing.T) {
+	// ATMOS_* env leak from earlier tests would silently shadow the fixture's
+	// atmos.yaml; clear them up-front so the fixture is the sole source of truth.
+	t.Setenv("ATMOS_BASE_PATH", "")
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
+	os.Unsetenv("ATMOS_BASE_PATH")
+	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+
+	t.Chdir("../../tests/fixtures/scenarios/terraform-apply-affected")
+
+	t.Run("no stack filter walks every stack", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{
+			ComponentType: "terraform",
+			SubCommand:    "plan",
+			DryRun:        true,
+		}
+		// Validation has been dropped for the no-stack case; the call should
+		// proceed end-to-end and short-circuit at the dry-run boundary.
+		assert.NoError(t, ExecuteTerraformAll(info))
+	})
+
+	t.Run("stack filter scopes execution to the requested stack", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{
+			Stack:         "prod",
+			ComponentType: "terraform",
+			SubCommand:    "plan",
+			DryRun:        true,
+		}
+		assert.NoError(t, ExecuteTerraformAll(info))
+	})
+
+	t.Run("destroy reverses order and still completes", func(t *testing.T) {
+		info := &schema.ConfigAndStacksInfo{
+			Stack:         "prod",
+			ComponentType: "terraform",
+			SubCommand:    "destroy",
+			DryRun:        true,
+		}
+		assert.NoError(t, ExecuteTerraformAll(info))
+	})
+}
+
+// TestApplyFiltersToGraph_NoCrossStackPullIn pins the new IncludeDependencies:false
+// contract: when a user asks for `--all -s <stack>`, components in *other* stacks
+// must NOT be pulled in even if they are prerequisites — that would broaden the
+// scope of an existing invocation in a way users would feel as a regression. A
+// future opt-in flag can re-enable cross-stack execution.
+func TestApplyFiltersToGraph_NoCrossStackPullIn(t *testing.T) {
+	graph := dependency.NewGraph()
+	vpcDev := &dependency.Node{ID: "vpc-dev", Component: "vpc", Stack: "dev", Type: config.TerraformComponentType}
+	appProd := &dependency.Node{ID: "app-prod", Component: "app", Stack: "prod", Type: config.TerraformComponentType}
+	require.NoError(t, graph.AddNode(vpcDev))
+	require.NoError(t, graph.AddNode(appProd))
+	// Cross-stack edge: prod's app depends on dev's vpc. With IncludeDependencies=true
+	// this would historically have pulled vpc-dev into a `--all -s prod` run.
+	require.NoError(t, graph.AddDependency("app-prod", "vpc-dev"))
+
+	info := &schema.ConfigAndStacksInfo{Stack: "prod"}
+	filtered := applyFiltersToGraph(graph, nil, info)
+
+	require.Equal(t, 1, filtered.Size(), "only the requested stack's components should remain")
+	_, hasApp := filtered.GetNode("app-prod")
+	assert.True(t, hasApp, "the requested-stack component must still be present")
+	_, hasVPC := filtered.GetNode("vpc-dev")
+	assert.False(t, hasVPC, "cross-stack prerequisite must NOT be pulled in (IncludeDependencies:false)")
 }
 
 // Renamed to avoid conflict.

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -300,7 +301,7 @@ func TestExecuteTerraformAll_DryRunHappyPath(t *testing.T) {
 	os.Unsetenv("ATMOS_BASE_PATH")
 	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
 
-	t.Chdir("../../tests/fixtures/scenarios/terraform-apply-affected")
+	t.Chdir(filepath.Join("..", "..", "tests", "fixtures", "scenarios", "terraform-apply-affected"))
 
 	t.Run("no stack filter walks every stack", func(t *testing.T) {
 		info := &schema.ConfigAndStacksInfo{

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -242,21 +242,14 @@ func TestApplyFiltersToGraph(t *testing.T) {
 }
 
 func TestExecuteTerraformAll_Validation(t *testing.T) {
+	// --all without a stack is allowed: it processes every stack
+	// (see website/docs/cli/commands/terraform/terraform-apply.mdx).
 	tests := []struct {
 		name        string
 		info        *schema.ConfigAndStacksInfo
 		expectError bool
 		errorMsg    string
 	}{
-		{
-			name: "no stack specified",
-			info: &schema.ConfigAndStacksInfo{
-				ComponentFromArg: "",
-				Stack:            "",
-			},
-			expectError: true,
-			errorMsg:    "stack is required",
-		},
 		{
 			name: "component specified with --all",
 			info: &schema.ConfigAndStacksInfo{
@@ -642,18 +635,23 @@ func TestApplyFiltersToGraph_DependencyChain(t *testing.T) {
 		assert.Equal(t, g.Size(), filtered.Size())
 	})
 
-	t.Run("stack filter includes dependencies", func(t *testing.T) {
+	t.Run("stack filter limits scope to stack", func(t *testing.T) {
 		info := &schema.ConfigAndStacksInfo{Stack: "dev"}
 		filtered := applyFiltersToGraph(g, nil, info)
 		// dev has 3 nodes: vpc-dev, rds-dev, app-dev.
 		assert.Equal(t, 3, filtered.Size())
 	})
 
-	t.Run("component filter includes dependencies", func(t *testing.T) {
+	t.Run("component filter limits scope to listed components", func(t *testing.T) {
+		// IncludeDependencies is intentionally false in applyFiltersToGraph
+		// so that --components matches the historical production scope
+		// (only the listed components are planned/applied, no transitive pull-in).
+		// Topological order is still applied to whatever is in scope.
 		info := &schema.ConfigAndStacksInfo{Components: []string{"app"}, Stack: "dev"}
 		filtered := applyFiltersToGraph(g, nil, info)
-		// app-dev depends on rds-dev depends on vpc-dev — all 3 included.
-		assert.Equal(t, 3, filtered.Size())
+		assert.Equal(t, 1, filtered.Size())
+		_, has := filtered.GetNode("app-dev")
+		assert.True(t, has)
 	})
 }
 
@@ -754,9 +752,12 @@ func TestApplyFiltersToGraph_ComponentFilter(t *testing.T) {
 
 	result := applyFiltersToGraph(graph, nil, info)
 	assert.NotNil(t, result)
-	// rds-dev and its dependency vpc-dev should be included.
+	// rds-dev is the only component in scope. Its prerequisite (vpc-dev) is
+	// not pulled in — applyFiltersToGraph preserves the historical scope of
+	// the --components flag (no transitive expansion). The dependency edge
+	// from rds-dev to vpc-dev is dropped because the target node is filtered out.
 	_, hasRDS := result.GetNode("rds-dev")
 	assert.True(t, hasRDS)
 	_, hasVPC := result.GetNode("vpc-dev")
-	assert.True(t, hasVPC)
+	assert.False(t, hasVPC)
 }

--- a/internal/exec/terraform_all_test.go
+++ b/internal/exec/terraform_all_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/cloudposse/atmos/pkg/auth"
+	"github.com/cloudposse/atmos/pkg/auth/types"
 	"github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -333,6 +336,52 @@ func TestExecuteTerraformAll_DryRunHappyPath(t *testing.T) {
 		}
 		assert.NoError(t, ExecuteTerraformAll(info))
 	})
+}
+
+// TestExecuteTerraformAll_AuthManagerResolverWired exercises the
+// `if authManager != nil` branch that was added in this PR to mirror the
+// #2081 fix for `--query`/`--components`. The existing happy-path test
+// hits the nil-authManager branch (the fixture has no auth config), so
+// without this stub the resolver-creation lines were uncovered.
+//
+// We swap authManagerFactory for a stub that returns a gomock-generated
+// AuthManager. The fixture's stacks have no auth-dependent YAML functions,
+// so no AuthManager methods should be invoked downstream — if a future
+// change starts invoking the resolver during describe-stacks, this test
+// will fail loudly with an "unexpected call" message, which is the
+// signal we want.
+func TestExecuteTerraformAll_AuthManagerResolverWired(t *testing.T) {
+	t.Setenv("ATMOS_BASE_PATH", "")
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
+	os.Unsetenv("ATMOS_BASE_PATH")
+	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+
+	t.Chdir(filepath.Join("..", "..", "tests", "fixtures", "scenarios", "terraform-apply-affected"))
+
+	original := authManagerFactory
+	authManagerFactory = func(_ string, _ schema.AuthConfig, _ string, _ *schema.AtmosConfiguration) (auth.AuthManager, error) {
+		ctrl := gomock.NewController(t)
+		mgr := types.NewMockAuthManager(ctrl)
+		// ExecuteDescribeStacks calls GetStackInfo on the auth manager while
+		// processing each stack. The fixture has no auth-dependent YAML
+		// functions, so no other AuthManager methods get invoked — gomock
+		// will surface that explicitly via "unexpected call" failures if
+		// that ever changes.
+		mgr.EXPECT().GetStackInfo().Return(nil).AnyTimes()
+		return mgr, nil
+	}
+	t.Cleanup(func() { authManagerFactory = original })
+
+	info := &schema.ConfigAndStacksInfo{
+		Stack:         "prod",
+		ComponentType: "terraform",
+		SubCommand:    "plan",
+		DryRun:        true,
+	}
+	require.NoError(t, ExecuteTerraformAll(info))
+	// The factory above stored the AuthManager on info via createQueryAuthManager;
+	// this confirms the non-nil path actually ran rather than silently skipping.
+	assert.NotNil(t, info.AuthManager, "non-nil factory should populate info.AuthManager")
 }
 
 // TestApplyFiltersToGraph_NoCrossStackPullIn pins the new IncludeDependencies:false

--- a/internal/exec/terraform_executor.go
+++ b/internal/exec/terraform_executor.go
@@ -10,6 +10,7 @@ import (
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/cloudposse/atmos/pkg/ui"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
@@ -117,7 +118,11 @@ func executeNodeCommand(node *dependency.Node, info *schema.ConfigAndStacksInfo)
 	command := formatNodeCommand(node, info)
 
 	if info.DryRun {
-		log.Info("Would execute", "command", command)
+		// Match the user-facing dry-run message format emitted by ExecuteTerraformQuery
+		// so callers see a consistent "Would <subcmd> `<component>` in `<stack>` (dry run)"
+		// line for both multi-component execution paths.
+		ui.Successf("Would %s `%s` in `%s` (dry run)", info.SubCommand, node.Component, node.Stack)
+		log.Debug("Dry-run", "command", command)
 		return nil
 	}
 

--- a/tests/test-cases/terraform-multi-component-flags.yaml
+++ b/tests/test-cases/terraform-multi-component-flags.yaml
@@ -208,3 +208,36 @@ tests:
         - "--affected"
         - "can't be used"
         - "--all"
+
+  # Verify --all executes components in dependency (topological) order.
+  # Asserts the partial order implied by settings.depends_on in the
+  # terraform-apply-affected prod fixture. The full order is an
+  # implementation detail; these regex patterns only assert correctness.
+  - name: "terraform plan --all executes in dependency order"
+    enabled: true
+    tty: false
+    description: "Verify --all topologically orders components by settings.depends_on"
+    workdir: "fixtures/scenarios/terraform-apply-affected/"
+    command: "atmos"
+    args:
+      - "terraform"
+      - "plan"
+      - "--all"
+      - "-s"
+      - "prod"
+      - "--dry-run"
+    expect:
+      exit_code: 0
+      stderr:
+        # Non-TTY formatter strips backticks from the styled message, so the
+        # match patterns use plain component names. Partial-order assertions
+        # only — the full topological order is an implementation detail.
+        # vpc has no dependencies; eks/cluster depends on vpc.
+        - "(?s)Would plan vpc in prod.*Would plan eks/cluster in prod"
+        # eks/karpenter depends on eks/cluster; eks/karpenter-node-pool depends on eks/karpenter.
+        - "(?s)Would plan eks/cluster in prod.*Would plan eks/karpenter in prod"
+        - "(?s)Would plan eks/karpenter in prod.*Would plan eks/karpenter-node-pool in prod"
+        # eks/istio/base before eks/istio/istiod before eks/istio/test-app.
+        - "(?s)Would plan eks/istio/base in prod.*Would plan eks/istio/istiod in prod"
+        - "(?s)Would plan eks/istio/istiod in prod.*Would plan eks/istio/test-app in prod"
+        - "Processing components in dependency order"

--- a/website/blog/2026-05-23-terraform-all-dependency-order-wired-up.mdx
+++ b/website/blog/2026-05-23-terraform-all-dependency-order-wired-up.mdx
@@ -40,7 +40,7 @@ The PRD for [DAG-based concurrent execution](https://github.com/cloudposse/atmos
 
 A few related changes ride along with the dispatch fix:
 
-- **Stack is no longer required with `--all`.** Running `atmos terraform plan --all` without `-s` now processes every stack, matching what the [terraform-apply docs](/cli/commands/terraform/terraform-apply) describe ("Apply all components in all stacks"). The internal `stack is required when using --all flag` error has been removed.
+- **Stack is no longer required with `--all`.** Running `atmos terraform plan --all` without `-s` now processes every stack, matching what the [terraform-apply docs](/cli/commands/terraform/apply) describe ("Apply all components in all stacks"). The internal `stack is required when using --all flag` error has been removed.
 - **`--all -s <stack>` still scopes to that stack.** Cross-stack prerequisites are not pulled in by default — same scope as before, just ordered. A future opt-in flag will allow cross-stack execution.
 - **Dry-run output is consistent.** Both multi-component paths now emit `Would <subcmd> <component> in <stack> (dry run)` for each component.
 - **Auth-aware YAML functions work under `--all`.** `!terraform.state`, `!store`, and friends now resolve credentials correctly during multi-component runs, the same as `--query` already did (fixes a latent regression of [#2081](https://github.com/cloudposse/atmos/issues/2081) for the `--all` path).

--- a/website/blog/2026-05-23-terraform-all-dependency-order-wired-up.mdx
+++ b/website/blog/2026-05-23-terraform-all-dependency-order-wired-up.mdx
@@ -1,0 +1,62 @@
+---
+slug: terraform-all-dependency-order-wired-up
+title: "Fix: terraform plan/apply --all actually runs in dependency order"
+authors: [atmos]
+tags: [bugfix]
+---
+
+`atmos terraform plan --all` and `apply --all` now execute components in dependency (topological) order, as originally documented. Until this fix, the `--all` flag was processing components in a non-deterministic order — the dependency-graph implementation that landed with [PR #1516](https://github.com/cloudposse/atmos/pull/1516) was reachable from tests but never wired into the CLI dispatcher.
+
+<!--truncate-->
+
+## What Changed
+
+The CLI dispatcher in `cmd/terraform/utils.go` routed every multi-component flag (`--all`, `--components`, `--query`) through `ExecuteTerraformQuery`, which walks components via Go map iteration. Go map iteration order is randomized — there was no topological sort on this path, and `settings.depends_on` was ignored even when defined.
+
+`--all` is now routed to `ExecuteTerraformAll`, the function that builds the dependency graph and executes components in topological order. `--components` and `--query` continue to route to `ExecuteTerraformQuery`; their behavior is unchanged.
+
+```bash
+# Components execute in dependency order, every time.
+$ atmos terraform plan --all -s prod --dry-run
+INFO  Processing components in dependency order count=8
+INFO  Processing component index=1 total=8 component=vpc stack=prod
+✓ Would plan vpc in prod (dry run)
+INFO  Processing component index=2 total=8 component=eks/cluster stack=prod
+✓ Would plan eks/cluster in prod (dry run)
+INFO  Processing component index=3 total=8 component=eks/external-dns stack=prod
+✓ Would plan eks/external-dns in prod (dry run)
+...
+```
+
+`destroy --all` now executes in reverse topological order — dependents are destroyed before their dependencies. Circular dependencies in `depends_on` produce a hard error with the cycle path instead of being silently traversed.
+
+## Why This Matters
+
+Anyone who configured `settings.depends_on` and ran `atmos terraform apply --all` was relying on a feature that didn't exist at the dispatch layer. A database component referencing a VPC's subnet IDs could be applied before the VPC, depending on which order Go decided to iterate the components map that run. The failure looked like a Terraform error, not a missing-feature bug, which is why this took a while to surface.
+
+The PRD for [DAG-based concurrent execution](https://github.com/cloudposse/atmos/blob/main/docs/prd/dag-concurrent-execution.md) was authored on the assumption that this path already worked. That work can now build on a foundation that actually exists.
+
+## Behavior Notes
+
+A few related changes ride along with the dispatch fix:
+
+- **Stack is no longer required with `--all`.** Running `atmos terraform plan --all` without `-s` now processes every stack, matching what the [terraform-apply docs](/cli/commands/terraform/terraform-apply) describe ("Apply all components in all stacks"). The internal `stack is required when using --all flag` error has been removed.
+- **`--all -s <stack>` still scopes to that stack.** Cross-stack prerequisites are not pulled in by default — same scope as before, just ordered. A future opt-in flag will allow cross-stack execution.
+- **Dry-run output is consistent.** Both multi-component paths now emit `Would <subcmd> <component> in <stack> (dry run)` for each component.
+- **Auth-aware YAML functions work under `--all`.** `!terraform.state`, `!store`, and friends now resolve credentials correctly during multi-component runs, the same as `--query` already did (fixes a latent regression of [#2081](https://github.com/cloudposse/atmos/issues/2081) for the `--all` path).
+
+## Known Follow-ups
+
+This fix unblocks several improvements that are still pending:
+
+- The dependency parser only reads the deprecated `settings.depends_on` format. It does not yet read [`dependencies.components`](/stacks/dependencies/components), the preferred format.
+- The parser only recognizes `component` and `stack` keys; documented `namespace`/`tenant`/`environment`/`stage` keys are ignored. A target in another stack must use the explicit `stack:` form.
+- Dependency-resolution failures (e.g., typo in a `component:` reference) are still logged at `Warn` and swallowed. A typo'd dependency silently drops the edge instead of erroring.
+- Execution is sequential. The DAG concurrency work tracked in `docs/prd/dag-concurrent-execution.md` will add `--max-concurrency` to parallelize independent components at the same level.
+
+Tracking issue: [#2485](https://github.com/cloudposse/atmos/issues/2485).
+
+## Get Involved
+
+- Share feedback in the [Atmos Community Slack](https://cloudposse.com/slack)
+- [Report issues](https://github.com/cloudposse/atmos/issues) on GitHub


### PR DESCRIPTION
## What

Routes `atmos terraform plan --all` and `apply --all` through `ExecuteTerraformAll` so components actually execute in dependency (topological) order — as originally documented in the [PR #1516 changelog](https://github.com/cloudposse/atmos/blob/main/website/blog/2025-12-16-terraform-all-dependency-order.mdx) and the [DAG concurrency PRD](https://github.com/cloudposse/atmos/blob/main/docs/prd/dag-concurrent-execution.md#L263-L264).

Until this change, the dispatcher in `cmd/terraform/utils.go` routed all multi-component flags (`--all`, `--components`, `--query`) through `ExecuteTerraformQuery`, which walks components via Go map iteration — randomized order, with `settings.depends_on` ignored entirely. `ExecuteTerraformAll`, the function that builds the dependency graph and runs `TopologicalSort`, was reachable only from unit tests.

## Why

Fixes [#2485](https://github.com/cloudposse/atmos/issues/2485).

Users who configured `settings.depends_on` and ran `atmos terraform apply --all` were relying on a feature that didn't exist at the dispatch layer. Failures looked like Terraform errors (a component applied before its prereqs), not a missing-feature bug. The DAG concurrency PRD was authored on the assumption that this path already worked.

## Changes

**Dispatch**
- `cmd/terraform/utils.go` — `info.All` now routes to `e.ExecuteTerraformAll(&info)`. `--components` / `--query` / bare `-s stack` continue to route to `ExecuteTerraformQuery` (no change).

**`ExecuteTerraformAll` parity with `ExecuteTerraformQuery`**
- `internal/exec/terraform_all.go` — ports `createQueryAuthManager` so YAML functions (e.g. `!terraform.state`) resolve credentials under `--all`. Mirrors the [#2081](https://github.com/cloudposse/atmos/issues/2081) fix that already exists for `--query`.
- Drops the `info.Stack == ""` validation. The terraform-apply docs explicitly state `--all` without `-s` processes every stack, and that's the behavior users see today via `ExecuteTerraformQuery`. Keeping this PR non-breaking required matching that contract.
- Removes the now-unused `ErrStackRequiredWithAllFlag` from `errors/errors.go`.

**Filter scope**
- `applyFiltersToGraph` previously set `IncludeDependencies: true`, which would pull cross-stack prereqs into `--all -s <stack>`. Switched to `false` so the scope of `--all -s <stack>` is identical to today's behavior — components in the requested stack only, but now in topological order. A future opt-in flag can re-enable cross-stack execution.

**Dry-run UX**
- `executeNodeCommand` now emits `Would <subcmd> <component> in <stack> (dry run)` via `ui.Successf`, matching `processTerraformComponent`. Both multi-component paths produce the same user-facing dry-run output. (This also affects the `--affected` path, which had no integration tests asserting dry-run output — verified manually.)

**Tests**
- New integration test in `tests/test-cases/terraform-multi-component-flags.yaml` asserts the partial topological order (`vpc` before `eks/cluster`, `eks/karpenter` before `eks/karpenter-node-pool`, `eks/istio/base` before `eks/istio/istiod` before `eks/istio/test-app`) using the existing `terraform-apply-affected` fixture and regex with `(?s)`. The exact total order is an implementation detail of Kahn's-algorithm tie-breaking; this test only asserts the correctness invariant.
- `internal/exec/terraform_all_test.go` and `terraform_all_simple_test.go` — removed the "no stack specified" cases (the validation is gone) and updated `TestApplyFiltersToGraph_*` to match the new scope contract.

## Compatibility matrix

| Scenario | Before | After |
| --- | --- | --- |
| `apply --all -s dev`, `depends_on` defined | Random order (bug) | Topological order |
| `apply --all -s dev`, no `depends_on` | Random order | Deterministic order |
| `apply --all` (no stack) | All stacks, random order | All stacks, topological order |
| `apply --all -s dev` with cross-stack `depends_on` | Cross-stack components ignored | In-stack topological order; cross-stack still out of scope (opt-in TBD) |
| `destroy --all -s dev` | Random order | Reverse topological order |
| `--all` with circular `depends_on` | Silently random | Hard error with cycle path |
| `apply --components vpc -s dev` | Unchanged | Unchanged |
| `apply --query '...' -s dev` | Unchanged | Unchanged |
| `apply -s dev` (no component, no flag) | Unchanged | Unchanged |
| `--all` with `!terraform.state` YAML function | Worked (via #2081) | Works (auth manager ported) |
| `--all` with per-component CI hooks | Worked (via #2475/#2397) | Works (hook flows through `executeNodeCommand`) |

## Known follow-ups (not in this PR)

These are tracked in [#2485](https://github.com/cloudposse/atmos/issues/2485) and intentionally out of scope for the dispatch fix:

- **Parser**: `DependencyParser` only reads the deprecated `settings.depends_on`. Should also read [`dependencies.components`](https://atmos.tools/stacks/dependencies/components) like `describe_affected_components.go` already does.
- **Parser**: only `component` + `stack` keys are recognized. `namespace`/`tenant`/`environment`/`stage` are documented but ignored.
- **Errors**: missing-target dependency errors are silently logged at `Warn` in `parseDependencyArray`. Should be surfaced.
- **Concurrency**: still sequential. The [DAG concurrency PRD](https://github.com/cloudposse/atmos/blob/main/docs/prd/dag-concurrent-execution.md) describes the planned ready-queue scheduler.
- **Cross-stack scope opt-in**: a `--include-cross-stack-dependencies` flag (or `settings.terraform.dependencies.cross_stack`) to re-enable the original `IncludeDependencies: true` behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/exec/... ./cmd/terraform/... ./errors/...`
- [x] `go test ./internal/exec/ ./pkg/dependency/... ./cmd/terraform/... ./errors/... ./pkg/ui/... -short` — all green
- [x] `go test ./tests -run 'TestCLICommands/terraform_plan_--all|TestCLICommands/terraform_plan_--query|TestCLICommands/terraform_plan_--components' -count=1` — all green
- [x] New ordering test: `go test ./tests -run 'TestCLICommands/terraform_plan_--all_executes_in_dependency_order' -count=1` — green; output confirms `vpc → eks/cluster → eks/external-dns → eks/istio/base → eks/karpenter → eks/istio/istiod → eks/karpenter-node-pool → eks/istio/test-app`
- [x] CI lint (`make lint`)
- [ ] Manual verification with `dependencies.components` (new format) once parser is extended in a follow-up
- [ ] Cross-stack dependency behavior with the deferred opt-in flag

## References

- Closes #2485
- Original feature request: #1242 (closed as COMPLETED in #1516, but the routing was never wired up)
- Implementation PR: #1516
- DAG concurrency PRD: `docs/prd/dag-concurrent-execution.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `terraform plan --all` and `apply --all` run components in dependency (topological) order; `destroy --all` runs in reverse. `--all` may be used without a stack; `--all -s <stack>` scopes to that stack without pulling cross‑stack prerequisites. Per‑component hooks and auth-aware YAML resolution are active during `--all` runs; dry‑run shows clear per‑component success messages.

* **Tests**
  * Expanded tests for `--all` ordering, scoping/filtering, auth wiring, dry‑run flows, and per‑component hook wiring.

* **Documentation**
  * New blog post describing `--all` behavior, caveats, and follow-ups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->