### PR TITLE
fix(vendor): recover OCI pulls on auth rejection and surface rich errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,16 @@ on:
 
   workflow_dispatch:
 
+# Grant `packages: read` so jobs that pull OCI images from ghcr.io
+# (e.g. vendor pulls in mock/acceptance tests) can authenticate with
+# the auto-generated GITHUB_TOKEN. The default PR-event scope is
+# `contents: read` only, which causes ghcr.io to reject the token with
+# `DENIED: denied` whenever credentials are sent (as happens on Windows
+# runners that have no usable Docker keychain entry for ghcr.io).
+permissions:
+  contents: read
+  packages: read
+
 env:
   TERRAFORM_VERSION: "1.9.7"
   OPEN_TOFU_VERSION: "1.9.1"

--- a/internal/exec/oci_utils.go
+++ b/internal/exec/oci_utils.go
@@ -6,12 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/uuid"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -28,6 +31,11 @@ const (
 )
 
 var defaultOCIFileSystem = filesystem.NewOSFileSystem()
+
+// remoteGet is the package-level indirection over remote.Get used by pullImage.
+// Tests override this to simulate registry responses without spinning up an
+// httptest server. Production code must not reassign it.
+var remoteGet = remote.Get
 
 // processOciImage processes an OCI image and extracts its layers to the specified destination directory.
 func processOciImage(atmosConfig *schema.AtmosConfiguration, imageName string, destDir string) error {
@@ -54,7 +62,10 @@ func processOciImageWithFS(atmosConfig *schema.AtmosConfiguration, imageName str
 
 	descriptor, err := pullImage(atmosConfig, ref)
 	if err != nil {
-		return errors.Join(errUtils.ErrPullImage, err)
+		// pullImage already wraps the error with errUtils.ErrPullImage via the
+		// builder, so errors.Is(err, ErrPullImage) is true. Returning it directly
+		// preserves the rich hints/context without double-wrapping the sentinel.
+		return err
 	}
 
 	img, err := descriptor.Image()
@@ -118,15 +129,72 @@ func pullImage(atmosConfig *schema.AtmosConfiguration, ref name.Reference) (*rem
 		authSource = "anonymous"
 	}
 
-	log.Debug("Authenticating to OCI registry", "registry", registry, "method", authSource)
+	log.Info("Authenticating to OCI registry", "registry", registry, "method", authSource)
 
-	descriptor, err := remote.Get(ref, remote.WithAuth(authMethod))
-	if err != nil {
-		log.Error("Failed to pull OCI image", "image", ref.Name(), "registry", registry, "auth", authSource, "error", err)
-		return nil, fmt.Errorf("failed to pull image '%s': %w", ref.Name(), err)
+	descriptor, err := remoteGet(ref, remote.WithAuth(authMethod))
+	if err == nil {
+		return descriptor, nil
 	}
 
-	return descriptor, nil
+	// If credentials were rejected (401/403/DENIED) and we used non-anonymous auth,
+	// retry once with anonymous to recover public-image pulls when the configured
+	// credentials lack the required scope. Non-auth errors (DNS, TLS, timeouts,
+	// 5xx) skip retry — they need a different remediation.
+	if authMethod != authn.Anonymous && isOCIAuthRejection(err) {
+		anonDescriptor, anonErr := remoteGet(ref, remote.WithAuth(authn.Anonymous))
+		if anonErr == nil {
+			log.Warn("OCI auth rejected, succeeded with anonymous fallback",
+				"registry", registry, "auth_attempted", authSource)
+			return anonDescriptor, nil
+		}
+		// Anonymous also failed; fall through and report the original authed
+		// error, which carries the more diagnostic status/body for scope problems.
+	}
+
+	log.Error("Failed to pull OCI image", "image", ref.Name(), "registry", registry, "auth", authSource, "error", err)
+	return nil, buildPullImageError(err, ref, registry, authSource)
+}
+
+// buildPullImageError wraps a remote.Get failure with the project's enriched
+// error builder: sentinel ErrPullImage, structured context (image, registry,
+// auth_attempted, status when available), and three self-contained hints
+// (each renders as its own lightbulb line).
+func buildPullImageError(cause error, ref name.Reference, registry, authSource string) error {
+	builder := errUtils.Build(errUtils.ErrPullImage).
+		WithCause(cause).
+		WithContext("image", ref.Name()).
+		WithContext("registry", registry).
+		WithContext("auth_attempted", authSource).
+		WithHint("If pulling from ghcr.io in GitHub Actions, grant the workflow 'packages: read' permission.").
+		WithHint("Set ATMOS_GITHUB_USERNAME to override the default 'GITHUB_ACTOR' identity used for ghcr.io auth.").
+		WithHint("For public images, remove stale credentials for this registry from ~/.docker/config.json (or run 'docker logout ghcr.io').")
+
+	var transportErr *transport.Error
+	if errors.As(cause, &transportErr) {
+		// Stringify the status here: the ErrorBuilder's SafeDetails formatter
+		// always formats context values with %s, so passing an int yields a
+		// malformed "status=%!s(int=403)" payload.
+		builder = builder.WithContext("status", strconv.Itoa(transportErr.StatusCode))
+	}
+
+	return builder.Err()
+}
+
+// isOCIAuthRejection reports whether err signals a registry auth rejection that
+// is safe to retry anonymously: HTTP 401/403, or a token-endpoint error whose
+// message contains "DENIED" (which is not always a *transport.Error).
+func isOCIAuthRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	var transportErr *transport.Error
+	if errors.As(err, &transportErr) {
+		if transportErr.StatusCode == http.StatusUnauthorized ||
+			transportErr.StatusCode == http.StatusForbidden {
+			return true
+		}
+	}
+	return strings.Contains(err.Error(), "DENIED")
 }
 
 // getGHCRAuth returns authentication credentials for GitHub Container Registry (ghcr.io).
@@ -156,7 +224,7 @@ func getGHCRAuth(atmosConfig *schema.AtmosConfiguration) (authn.Authenticator, s
 	username := githubUsername
 	if username == "" {
 		// No safe implicit fallback here; return nil to allow caller to choose anon/fail.
-		log.Debug("GHCR token found but no username provided; set settings.github_username or ATMOS_GITHUB_USERNAME/GITHUB_ACTOR.")
+		log.Warn("GHCR token found but no username provided; set settings.github_username or ATMOS_GITHUB_USERNAME/GITHUB_ACTOR.")
 		return nil, ""
 	}
 

--- a/internal/exec/oci_utils_test.go
+++ b/internal/exec/oci_utils_test.go
@@ -1,17 +1,23 @@
 package exec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"testing"
 
+	cockroachErrors "github.com/cockroachdb/errors"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
@@ -362,4 +368,212 @@ func (m *MockLayerWithDigestError) Size() (int64, error) {
 
 func (m *MockLayerWithDigestError) MediaType() (types.MediaType, error) {
 	return types.DockerLayer, nil
+}
+
+// pullImageShim records calls and returns a programmed sequence of results from
+// remote.Get. Tests reassign the package-level remoteGet to one of these shims
+// and restore it on teardown.
+type pullImageShim struct {
+	results []pullImageResult
+	calls   int
+}
+
+type pullImageResult struct {
+	descriptor *remote.Descriptor
+	err        error
+}
+
+func (s *pullImageShim) get(_ name.Reference, _ ...remote.Option) (*remote.Descriptor, error) {
+	idx := s.calls
+	s.calls++
+	if idx >= len(s.results) {
+		// Defensive: an unexpected extra call should fail the test loudly.
+		return nil, fmt.Errorf("pullImageShim: unexpected call %d (only %d programmed)", idx+1, len(s.results))
+	}
+	r := s.results[idx]
+	return r.descriptor, r.err
+}
+
+// installPullImageShim swaps remoteGet for the duration of the test.
+func installPullImageShim(t *testing.T, shim *pullImageShim) {
+	t.Helper()
+	original := remoteGet
+	remoteGet = shim.get
+	t.Cleanup(func() { remoteGet = original })
+}
+
+// ghcrConfigWithCreds returns a config that causes getGHCRAuth to resolve a
+// non-anonymous Basic auth for ghcr.io.
+func ghcrConfigWithCreds() *schema.AtmosConfiguration {
+	return &schema.AtmosConfiguration{
+		Settings: schema.AtmosSettings{
+			AtmosGithubToken: "ghp_test_token",
+			GithubUsername:   "tester",
+		},
+	}
+}
+
+// mustParseRef parses ref or fails the test. Uses a public reference so the
+// shim never actually hits the network even if a test misconfigures remoteGet.
+func mustParseRef(t *testing.T, ref string) name.Reference {
+	t.Helper()
+	r, err := name.ParseReference(ref)
+	require.NoError(t, err)
+	return r
+}
+
+func TestPullImage_AnonymousFallback_403(t *testing.T) {
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &transport.Error{StatusCode: 403}},
+			{descriptor: &remote.Descriptor{}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	desc, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.NoError(t, err)
+	assert.NotNil(t, desc)
+	assert.Equal(t, 2, shim.calls, "expected one authed attempt followed by one anonymous retry")
+}
+
+func TestPullImage_AnonymousFallback_401(t *testing.T) {
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &transport.Error{StatusCode: 401}},
+			{descriptor: &remote.Descriptor{}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	desc, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.NoError(t, err)
+	assert.NotNil(t, desc)
+	assert.Equal(t, 2, shim.calls)
+}
+
+func TestPullImage_AnonymousFallback_DeniedString(t *testing.T) {
+	// Token-endpoint denials surface as plain errors (not *transport.Error) with
+	// "DENIED" in the message. The retry path must still kick in.
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: errors.New("GET https://ghcr.io/token: DENIED: insufficient_scope")},
+			{descriptor: &remote.Descriptor{}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	desc, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.NoError(t, err)
+	assert.NotNil(t, desc)
+	assert.Equal(t, 2, shim.calls)
+}
+
+func TestPullImage_NoFallback_DeadlineExceeded(t *testing.T) {
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: context.DeadlineExceeded},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	_, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.Error(t, err)
+	assert.Equal(t, 1, shim.calls, "deadline-exceeded must not trigger anonymous retry")
+	assert.True(t, errors.Is(err, errUtils.ErrPullImage), "error should wrap ErrPullImage")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "original cause must be preserved")
+}
+
+func TestPullImage_NoFallback_500(t *testing.T) {
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &transport.Error{StatusCode: 500}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	_, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.Error(t, err)
+	assert.Equal(t, 1, shim.calls, "5xx must not trigger anonymous retry")
+	assert.True(t, errors.Is(err, errUtils.ErrPullImage))
+}
+
+func TestPullImage_NoFallback_NetOpError(t *testing.T) {
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &net.OpError{Op: "dial", Err: errors.New("no such host")}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	_, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.Error(t, err)
+	assert.Equal(t, 1, shim.calls, "DNS-style errors must not trigger anonymous retry")
+	assert.True(t, errors.Is(err, errUtils.ErrPullImage))
+}
+
+func TestPullImage_NoRetry_WhenAlreadyAnonymous(t *testing.T) {
+	// Empty config + non-ghcr.io registry yields anonymous auth; a 403 must not
+	// retry (would be infinite loop / duplicate attempt).
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &transport.Error{StatusCode: 403}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "registry.example.com/myimage:v1")
+	_, err := pullImage(&schema.AtmosConfiguration{}, ref)
+	require.Error(t, err)
+	assert.Equal(t, 1, shim.calls, "anonymous 403 must not retry anonymously again")
+	assert.True(t, errors.Is(err, errUtils.ErrPullImage))
+}
+
+func TestPullImage_RichError_ContextAndHints(t *testing.T) {
+	// Both attempts fail with 403 — final error must be the rich-builder error.
+	shim := &pullImageShim{
+		results: []pullImageResult{
+			{err: &transport.Error{StatusCode: 403}},
+			{err: &transport.Error{StatusCode: 403}},
+		},
+	}
+	installPullImageShim(t, shim)
+
+	ref := mustParseRef(t, "ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0")
+	_, err := pullImage(ghcrConfigWithCreds(), ref)
+	require.Error(t, err)
+	assert.Equal(t, 2, shim.calls, "expected authed + anonymous-retry attempts before failing")
+
+	// Sentinel and cause preserved.
+	assert.True(t, errors.Is(err, errUtils.ErrPullImage), "should wrap ErrPullImage sentinel")
+	var transportErr *transport.Error
+	assert.True(t, errors.As(err, &transportErr), "should preserve *transport.Error cause")
+	if transportErr != nil {
+		assert.Equal(t, 403, transportErr.StatusCode)
+	}
+
+	// All three required hints are attached, each self-contained.
+	hints := cockroachErrors.GetAllHints(err)
+	joinedHints := strings.Join(hints, "\n")
+	assert.Contains(t, joinedHints, "packages: read", "hint about GitHub Actions permissions missing")
+	assert.Contains(t, joinedHints, "ATMOS_GITHUB_USERNAME", "hint about username override missing")
+	assert.Contains(t, joinedHints, "docker logout ghcr.io", "hint about stale Docker credentials missing")
+
+	// Structured context captured for verbose render / Sentry.
+	var contextBlob string
+	for _, payload := range cockroachErrors.GetAllSafeDetails(err) {
+		for _, d := range payload.SafeDetails {
+			contextBlob += d + " "
+		}
+	}
+	assert.Contains(t, contextBlob, "image=")
+	assert.Contains(t, contextBlob, "registry=ghcr.io")
+	assert.Contains(t, contextBlob, "auth_attempted=")
+	assert.Contains(t, contextBlob, "status=403")
 }


### PR DESCRIPTION
## what

- Vendoring an OCI image (e.g. `oci://ghcr.io/...`) now auto-recovers when configured credentials are rejected (401 / 403 / `DENIED`) by retrying once with anonymous authentication.
- On successful recovery, emits `WARN OCI auth rejected, succeeded with anonymous fallback` and proceeds.
- Terminal pull failures now surface a rich error built with `errUtils.Build(errUtils.ErrPullImage)` — preserves the original cause and attaches structured context (`image`, `registry`, `auth_attempted`, `status`) plus three self-contained remediation hints (Actions `packages: read`, `ATMOS_GITHUB_USERNAME` override, stale `~/.docker/config.json`).
- Bumps the chosen-auth log line from `Debug` → `Info` and the "GHCR token without username" branch from `Debug` → `Warn` so CI logs reveal misconfiguration without `--debug`.
- Non-auth errors (DNS, TLS, deadlines, 5xx) bypass retry — they need different remediation.

## why

- Public test images on `ghcr.io` (e.g. `ghcr.io/cloudposse/atmos/tests/fixtures/components/terraform/mock:v0`) failed hard on Windows CI runners whose `GITHUB_TOKEN` lacked `packages: read` scope, because `pullImage` used the rejecting credentials unconditionally instead of falling back to anonymous.
- The previous error surface was a bare `DENIED: denied` with no auth source, no HTTP status, and no actionable hint — the vendor reporter collapsed it into an opaque tally, making the root cause untraceable.
- Part A of this work — granting `packages: read` in `.github/workflows/test.yml` — already landed; this is Part B, the code change so future users, different workflows, and private registries get a clean diagnosis and an automatic recovery for public images.

## references

- Builds on PR #1647 (3-tier auth precedence).
- Mirrors the error-builder idiom from `pkg/provisioner/source/source.go:88-97`.
- Reuses the existing `errUtils.ErrPullImage` sentinel — no new sentinel introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic fallback to anonymous OCI image pulls when authenticated requests are rejected (401/403 or “DENIED”), preserving original error causes
  * Richer diagnostic errors with contextual hints for troubleshooting image-pull failures
  * Warn when a GHCR token is present but no GitHub username is configured

* **Tests**
  * Expanded test coverage for image-pull auth fallback and varied failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->