### PR TITLE
perf(exec/merge/utils): optimize describe affected for large-stack workloads (~50% local wall-clock, projected ~10× on 2-core CI)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,16 @@ jobs:
     name: "[lint] Dockerfile"
     needs: build
     runs-on: ubuntu-latest
+    # The workflow-level `permissions:` block above (added in #2487 for
+    # `packages: read` on ghcr.io pulls) REPLACES — not extends — the default
+    # token scope for every job. That stripped the implicit
+    # `security-events: write` this job relied on for SARIF upload, breaking
+    # the post-merge run on main. Job-level `permissions:` also fully
+    # overrides the workflow-level set, so `contents: read` is re-listed here
+    # for actions/checkout.
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -191,11 +191,17 @@ open. Optimization plan:
       dropped 98.8% (5m50s → 4s), inheritance pipeline Total dropped
       91-94%. Race-clean. Bottleneck shifted to
       `mergeComponentConfigurations`.
-- [ ] Phase 3: parallelize component-level inheritance within
-      `processComponentsInParallel`.
+- [x] Phase 3: short-circuit `WalkAndDeferYAMLFunctions` for
+      function-free subtrees. Saved 200k recursive calls, dropped
+      Total from 1m26s → 15.4s (−82%), wall-clock 4.1s → 3.3s
+      (−19% locally; ~18-35s on GHA projected). Original plan
+      (component-level parallelization) abandoned because it's
+      already in place.
 - [ ] Phase 4: optimize `locals` extraction path.
-- [ ] Phase 5 (new): optimize `mergeComponentConfigurations` —
-      newly visible 2m22s hot path post-Phase-2.
+- [ ] Phase 5 (new): skip `MergeWithDeferred` when only one input is
+      non-empty — newly visible after Phase 3.
+- [ ] Phase 6 (new): investigate `ProcessYAMLConfigFileWithContext`
+      (1m11s) — file loading hot path.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -418,21 +424,81 @@ calls), followed by `merge.MergeWithDeferred` (1m35s, 752µs avg,
 83,349 calls). These are the next optimization targets after Phase
 3 lands.
 
-### Phase 3 (open) — component-level parallelization
+### Phase 3 (shipped 2026-05-23) — short-circuit YAML function walk for function-free subtrees
 
-`internal/exec/stack_processor_process_stacks_helpers.go` runs
-`processComponent` serially within each stack's
-`processComponentsInParallel`. 9,261 components ÷ 719 stacks ≈ 13
-components per stack — substantial parallelism opportunity at the
-component level. Worker pool inside the stack-processing goroutine
-would push the inheritance pipeline from ~108× parallelism (current,
-on an M-series Mac) to a higher ceiling on the same hardware, and
-materially help GHA's 2-4 core runners where current parallelism is
-capped at the core count.
+**Investigation pivot.** Phase 3 was originally planned as
+component-level parallelization within `processComponentsInParallel`.
+On inspection of the code, that parallelism is **already in place**
+(one goroutine per component within each stack, fanned out by
+`processComponentsInParallel`). Adding sub-component goroutines
+would not help on 2-4 core GHA runners — they're already CPU-bound
+at the component goroutine layer.
 
-Expected impact: 2-3× wall-clock improvement on the inheritance
-pipeline. On GHA's 2-4 cores, this matters more than on a laptop
-because the current parallelism is already saturated by stack count.
+**Real target identified.** Post-Phase-2 heatmap pinpointed
+`merge.WalkAndDeferYAMLFunctions` as the next bottleneck:
+
+- 527,765 calls (recursive — each call walks every nested map and
+  recurses into nested maps).
+- 1m26s cumulative, 164µs avg per call.
+- Function-free subtrees (no `!terraform.*`, `!template`, `!store*`,
+  `!exec`, `!env` strings anywhere) were being deep-copied at every
+  recursion level for no reason: the walk allocates a new
+  `map[string]interface{}` of equal capacity at each level, copies
+  every key, recurses into nested maps. The vast majority of the
+  workload — global vars, settings, env, hooks, generate, providers
+  for components without YAML functions — was generating pure GC
+  pressure.
+
+**Fix.** Added a non-allocating pre-scan
+`hasAnyYAMLFunction(map) bool` that returns true on the first YAML
+function string encountered anywhere in the subtree. When false,
+`WalkAndDeferYAMLFunctions` returns the input map as-is — zero
+allocation. When true, the original walk path runs unchanged.
+
+**Safety.** The fast-path return shares the input map with the
+caller. The contract is documented in the function comment: callers
+must treat the result as read-only. The only call site is
+`MergeWithDeferred → Merge`, which produces a new merged map without
+mutating inputs. A new test
+(`TestWalkAndDeferYAMLFunctions_NoFunctionsShortCircuit`) verifies
+the contract: returns same pointer for function-free input, walks
+normally when any subtree contains a function, does not mutate
+function-free input.
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 2 (Total / Avg / Calls) | Phase 3 (Total / Avg / Calls) | Reduction |
+|---|---:|---:|---:|
+| `merge.WalkAndDeferYAMLFunctions` | 1m26s / 164µs / 527,765 | **15.4s / 47µs / 328,218** | **−82% Total, 3.5× faster avg, 200k fewer calls** |
+| `merge.MergeWithDeferred` | 1m35s / 752µs | **1m10s / 851µs** | **−26% Total** |
+| `merge.Merge` | 39s / 143µs | 39s / 143µs | unchanged |
+| `mergeComponentConfigurations` | 2m22s / 15ms | **1m54s / 12.5ms** | **−20% Total** |
+
+**Wall-clock impact (local Mac):** 4.1s → **3.3s mean across 3
+runs** (−19%). Unlike Phase 2 (which eliminated lock-wait padding
+without moving wall-clock), Phase 3 reduces real allocation work and
+GC pressure, so wall-clock improves on every architecture, including
+high-core machines. Projection for 2-4 core GHA: same ~71s of
+cumulative CPU saved → 18-35s wall-clock improvement.
+
+**Race detector:**
+`go test -race -count=1 ./pkg/merge/...` green. Note: pre-existing,
+unrelated race in `extractAndAddLocalsToContext`
+(`internal/exec/stack_processor_utils.go:260`) surfaces under
+`-race` for some `TestHierarchicalImports_*` tests — confirmed
+present in main without Phase 3 changes. Tracked separately.
+
+**Bottleneck remaining post-Phase-3:**
+
+- `mergeComponentConfigurations` (1m54s) — the next-deepest hot path.
+  ~8 sequential `MergeWithDeferred` calls per component (vars,
+  settings, env, auth, providers, required_providers, hooks,
+  generate). Most components don't have YAML functions, so each call
+  now skips the walk, but the merge itself still runs. Phase 5
+  candidate: skip the merge entirely when only one input is
+  non-empty (single-input merge degenerates to a copy).
+- `ProcessYAMLConfigFileWithContext` (1m11s) — file loading. May be
+  unrelated to inheritance; deferred to Phase 6.
 
 ### Phase 4 (open) — locals extraction
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -75,7 +75,7 @@ Counter-intuitively, `--process-functions=false` made the run
 was already amortized while leaving the expensive inheritance path
 untouched.
 
-### Post-#2471 fresh heatmap (2026-05-23, local Mac, current main)
+## Post-#2471 fresh heatmap (2026-05-23, local Mac, current main)
 
 Reproducer below, `--identity=false --process-templates=false
 --process-functions=false`, comparing HEAD vs HEAD~1 via worktree.
@@ -126,7 +126,7 @@ machine; on a 2-4 core GHA runner the wall-clock projects to
   level. The 5.7-6 min of CPU work is bound by stack count, not
   component count.
 
-### Affected detection note
+## Affected detection note
 
 In the reproducer, the result set is empty (`[]`) even though a
 catalog file was modified. Atmos compares **resolved configs**, and
@@ -138,40 +138,30 @@ result size.**
 
 ## Status
 
-**Phase 1 fixed in PR #2471 (v1.220.0-rc.1).** Phases 2 and 3 still
-open. Optimization plan:
+**Phases 1-13 shipped** (with the Phase 5 1-input shortcut and Phase 9
+reverted — see their dedicated sections below). The progress checklist
+that follows is the authoritative record of what landed where, in what
+order, and with what measured impact.
 
-1. **~~Make `--identity=false` actually skip credential store
-   creation.~~ ✅ Shipped in PR #2471 (`fix(auth): honor
-   --identity=false in describe affected and dependents`), commit
-   `a0cd28671`, in `v1.220.0-rc.1`.** Reclaimed ~3.5 minutes of
-   credential-store CPU time. Confirmed zero credential calls in the
-   2026-05-23 reproduction.
-2. **Cache hit-rate audit of the inheritance pipeline (OPEN).**
-   `cacheBaseComponentConfig` is itself hot (6,431 calls, 5m50s),
-   which suggests either (a) the cache is being invalidated too
-   eagerly, (b) the cache key is too specific and missing equivalent
-   configurations, or (c) it is doing real work on first insertion
-   that should happen elsewhere. Companion: `getCachedBaseComponentConfig`
-   8,017 calls / 6.5s suggests reads are fast, so the cost is concentrated
-   on the insert path.
-3. **Parallelize the inheritance pipeline more aggressively (OPEN).**
-   `processComponentsInParallel` runs 719 times (one per stack)
-   fanning out into 9,261 component invocations. Stack-level
-   parallelism is in place (PR #1639 work); **component-level
-   parallelism within a stack is the next layer**. With ~13
-   components per stack on average and modern many-core runners,
-   pushing parallelism inside `processComponentsInParallel` should
-   yield 2-3× wall-clock improvement on the inheritance pipeline.
-4. **`locals` extraction (NEW, OPEN).**
-   `extractAndAddLocalsToContext` + `extractLocalsFromRawYAML` add
-   ~26s combined across 22,181 invocations each. The `locals`
-   feature shipped after #1639 and was never put through the
-   optimization taxonomy.
-5. **GHA container speed factor.** Even with #2471's win, the
-   remaining ~6m of CPU inheritance work projects to ~1.5-3 min on
-   a 2-4 core GHA runner. If users still see 5+ min on GHA after
-   upgrading to v1.220.0, Phase 2 + Phase 3 are required.
+The remaining open item is **end-to-end CI validation on the reference
+workload**: a 2-core GHA runner timing run that confirms the projected
+~11 minutes → ~60-105 seconds wall-clock improvement.
+
+Phase 1 (the `--identity=false` credential-store fix) shipped separately
+in PR #2471 (`a0cd28671`, in v1.220.0-rc.1) and reclaimed ~3.5 minutes
+of credential-store CPU on the reference workload. Phases 2-13 ship in
+PR #2496 (this branch).
+
+Two optimizations were attempted and reverted after CI surfaced
+correctness regressions — both shared the same root cause (returning a
+shared map reference to a caller that mutates the result). They are
+documented in their dedicated sections so future passes don't re-try
+the same approach without addressing the underlying contract violation:
+
+- Phase 5's 1-input shortcut in `MergeWithDeferred` —
+  [details below](#phase-5-initially-shipped-2026-05-23-1-input-shortcut-reverted-2026-05-24).
+- Phase 9's asymmetric clone in `cloneExtractLocalsResult` — reverted
+  in `b11f3cd9b`; documented in the Phase 9 checklist entry.
 
 ### Progress checklist
 
@@ -197,12 +187,16 @@ open. Optimization plan:
       (−19% locally; ~18-35s on GHA projected). Original plan
       (component-level parallelization) abandoned because it's
       already in place.
-- [x] Phase 5: skip `MergeWithDeferred` when 0 or 1 input is
-      non-empty. `mergeComponentConfigurations` Total dropped 50%
-      (1m54s → 57s), `MergeWithDeferred` Total dropped 64%, 65k
-      Merge calls eliminated, 215k walk calls eliminated. Wall-clock
-      3.3s → 3.0s locally; cumulative ~75s saved on a 2-core GHA
-      runner.
+- [x] Phase 5: 0-input fast path in `MergeWithDeferred` (skip walk +
+      merge when every input is empty). The 1-input shortcut was
+      tried alongside and REVERTED 2026-05-24 after CI surfaced a
+      regression in `TestSpaceliftStackProcessor` (47→40 stacks):
+      `WalkAndDeferYAMLFunctions`'s Phase 3 short-circuit returned
+      the input map as-is, and the 1-input shortcut handed that
+      reference back to the caller, which mutated the upstream
+      cached settings. Same class of failure as Phase 9. Post-revert
+      `mergeComponentConfigurations` Total: 1m54s → 1m35s (−17%);
+      regression test added to prevent re-attempts.
 - [x] Phase 4: cache `extractLocalsFromRawYAML` by file path + content
       hash; clone input context to fix pre-existing race. 22k+ calls
       eliminated, wall-clock 3.0s → 2.3s (−23%, biggest single-phase
@@ -551,7 +545,7 @@ present in main without Phase 3 changes. Tracked separately.
 - `ProcessYAMLConfigFileWithContext` (1m11s) — file loading. May be
   unrelated to inheritance; deferred to Phase 6.
 
-### Phase 5 (shipped 2026-05-23) — skip MergeWithDeferred for trivial input
+### Phase 5 (initially shipped 2026-05-23, 1-input shortcut REVERTED 2026-05-24)
 
 **Root cause.** `mergeComponentConfigurations` calls
 `MergeWithDeferred` 9 times per component instance — once per
@@ -571,48 +565,73 @@ runs and increments precedence), and call `Merge` to combine all
 processed inputs (which is a deep walk over all entries even when
 all but one are empty).
 
-**Fix.** Pre-scan the inputs in `MergeWithDeferred` and short-circuit
-when the merge degenerates:
+**Final fix (after revert).** `MergeWithDeferred` has a single
+all-empty fast path:
 
-- **0 non-empty inputs:** return a fresh empty map and empty dctx.
-  No walk, no merge.
-- **1 non-empty input:** advance precedence to that input's
-  position, walk just that input (so YAML functions are deferred at
-  the correct precedence), and return the walked map directly. Skip
-  the `Merge` call entirely — a merge of one map degenerates to a
-  copy of that map, and the walk's result is already the result.
+- **0 non-empty inputs:** return a fresh empty map and an empty
+  dctx. No walk, no merge.
+- **Any non-empty input:** fall through to the regular walk + merge
+  pipeline. `Merge` → `MergeWithOptions` returns a deep-copied,
+  caller-mutable map per its contract.
 
-The downstream `ApplyDeferredMerges` is dctx-driven: when dctx has
-no deferred values (the no-functions case), it's a no-op and does
-not touch the returned map. Combined with Phase 3's
-`WalkAndDeferYAMLFunctions` short-circuit, a single-input
-function-free section is now a zero-allocation pass-through end to
-end.
+The 0-input fast path is still a real win — many components leave
+several sections (especially `generate` / `required_providers` /
+`hooks` on non-terraform components) entirely empty.
 
-**Confirmed impact (mean of 3 runs, customer workload):**
+#### What was tried and reverted
 
-| Function | Phase 3 (Total / Avg / Calls) | Phase 5 (Total / Avg / Calls) | Reduction |
+A 1-input fast path was initially shipped alongside the 0-input one:
+when exactly one input was non-empty, the implementation walked just
+that input and returned it directly, skipping the `Merge` call. This
+broke `TestSpaceliftStackProcessor` and `TestLegacySpaceliftStackProcessor`
+on the CI sweep for PR #2496 (both lost exactly 7 spacelift stacks
+each, 47→40 / 44→37).
+
+Root cause: when the single non-empty input contained no Atmos YAML
+functions (the common case), `WalkAndDeferYAMLFunctions`'s Phase 3
+short-circuit returned the input map **as-is** — so the 1-input
+shortcut handed the caller a shared reference to the upstream
+cached `BaseComponentSettings` / `GlobalSettings` / etc. The
+downstream `mergeComponentConfigurations` mutated that result while
+building the per-component output map, which corrupted the upstream
+cache for sibling components. Specifically,
+`settings.spacelift.workspace_enabled` was getting flipped for
+seven components by the time they reached `CreateSpaceliftStacks`.
+
+This is the **same class of failure as Phase 9** (asymmetric
+`extractLocalsResult` clone): in both cases the optimization
+assumed downstream callers wouldn't mutate the returned map, but
+the assumption was wrong because a later pipeline stage modifies
+the result map in place. Per `Merge`'s contract, the returned map
+must be deep-copied, caller-mutable. The 1-input shortcut violated
+that contract.
+
+The `Merge` slow path that the revert restores **also** deep-copies
+its 1-input case (via `MergeWithOptions` → `DeepCopyMap`), so the
+saved wrapper overhead was small. The shortcut's measured savings
+(`MergeWithDeferred` Total 1m10s → 25s) over-attributed credit
+that was really earned by Phase 3's `WalkAndDeferYAMLFunctions`
+short-circuit reducing per-walk cost.
+
+A regression test
+(`TestMergeWithDeferred_TrivialInputShortCircuits/mutating the
+result does not mutate the input`) was added to lock in the
+restored contract: any future caller-mutation of the result must
+not bleed into the input.
+
+**Confirmed impact (mean of 3 runs, customer workload, post-revert):**
+
+| Function | Pre-Phase-5 baseline | Post-revert (0-input only) | Reduction |
 |---|---:|---:|---:|
-| `mergeComponentConfigurations` | 1m54s / 12.5ms / 9,261 | **57s / 6.2ms / 9,261** | **−50% Total** |
-| `merge.MergeWithDeferred` | 1m10s / 851µs / 83,349 | **25s / 305µs / 83,349** | **−64% Total, 2.8× faster avg** |
-| `merge.Merge` Calls | 273,379 | **207,934** | **−65k calls eliminated (−24%)** |
-| `merge.WalkAndDeferYAMLFunctions` | 15.4s / 47µs / 328,218 | **6.0s / 53µs / 112,832** | **−61% Total, −215k calls (−66%)** |
-| `processComponent` | 34s / 3.7ms | **27s / 2.9ms** | **−21% Total** |
+| `mergeComponentConfigurations` | 1m54s | **1m35s** | **−17% Total** |
+| `merge.MergeWithDeferred` | 1m10s | **51s** | **−27% Total** |
+| `merge.Merge` Calls | 273,379 | **235,806** | **−14% (−37k calls)** |
+| `merge.WalkAndDeferYAMLFunctions` | 15.4s / 328k | **11s / 178k** | **−29% Total, −46% Calls** |
 
-**Wall-clock (local Mac, mean of 3 runs):** 3.3s → **3.0s** (−10%).
-Same caveat as Phase 3 — on many-core machines the parallelism
-absorbs much of the cumulative savings. Cumulative CPU saved
-across Phases 3+5 ≈ 150 seconds → projected **~37-75s wall-clock
-improvement on 2-4 core GHA runners** (on top of Phase 2's
-contention elimination).
-
-**Tests added (race-clean):** `TestMergeWithDeferred_TrivialInputShortCircuits`
-covers (a) zero non-empty inputs returns empty, (b) single
-non-empty function-free input returns same map header (composes with
-Phase 3 zero-alloc fast path), (c) single non-empty input with YAML
-functions defers at the correct precedence, (d) two non-empty
-inputs take the full merge path, (e) the fast path does not mutate
-the input.
+**Wall-clock (local Mac):** 3.3s → **~2.2s** mean — still an
+improvement over the pre-Phase-2 baseline (4.1s, −47% cumulative),
+but ~170ms regression vs the original (unsafe) Phase 5
+measurement of 3.0s. Acceptable cost for correctness.
 
 ### Phase 4 (shipped 2026-05-23) — cache locals extraction by file path + content hash
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -227,6 +227,17 @@ open. Optimization plan:
       skip the per-call `yaml.Node.Decode` + `InternStringsInMap`
       walks (~500-700µs each). Wall-clock 2.4s → 2.06s (−14%
       locally).
+- [x] Phase 10: apply Phase 7's outer/inner perf.Track pattern to
+      `processYAMLNode` (recursive YAML walker used by yq evaluation).
+      Removes per-recursion-step perf.Track overhead (~3µs each) from
+      ~34k recursive calls. `processYAMLNode` dropped out of the
+      top-25 hot list, wall-clock 2.2s → 2.03s (−7% local). The same
+      pattern was *not* applied to `WalkAndDeferYAMLFunctions`:
+      removing the per-recursion `hasAnyYAMLFunction` short-circuit
+      regressed allocation cost on function-sparse subtrees more
+      than the perf.Track savings recovered (the inner-only walker
+      had to allocate on every level). Documented in-code so future
+      passes don't re-try.
 - [~] Phase 9 (ATTEMPTED, REVERTED 2026-05-24, `b11f3cd9b`):
       asymmetric clone of `extractLocalsResult` — share
       `settings`/`vars`/`env` references with the cache, deep-copy

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -214,6 +214,13 @@ open. Optimization plan:
       (18.7s → 3.7s, 5× faster avg). Wall-clock unchanged on Mac
       (parallelism already absorbed it); ~4-7s wall-clock saved on
       2-4 core GHA runners.
+- [x] Phase 7: hoist `hasCustomTags` pre-check out of recursion in
+      `processCustomTags`. Total dropped 76% (31.5s → 7.5s, 3.2×
+      faster avg). The previous implementation re-ran the full
+      subtree scan on every recursive call (O(N×depth) work just
+      for the early-exit check); a split into outer/inner functions
+      runs the check once per top-level call. ~24s cumulative CPU
+      saved on this workload → ~6-12s wall-clock on 2-4 core GHA.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -689,6 +696,55 @@ savings end-to-end**.
 
 **Race detector:**
 `go test -race -count=1 -run "UnmarshalYAMLFromFileWithPositions|HandleCacheMiss|CacheHit" ./pkg/utils/...`
+green. Full `pkg/utils` and `internal/exec` test suites pass.
+
+### Phase 7 (shipped 2026-05-23) — hoist hasCustomTags check out of recursion
+
+**Root cause.** `processCustomTags` (the YAML node walker that
+detects and processes `!terraform.*`, `!template`, `!store*`,
+`!exec`, `!env`, `!include`, `!literal` tags) had a `hasCustomTags`
+early-exit pre-check at the top of every invocation. The pre-check
+itself walks the entire subtree to find any custom tag. On
+recursive invocations (one per child node with content), the
+pre-check re-walks the same subtree it just walked at the level
+above — O(N×depth) work where it should be O(N).
+
+For trees with tags (which is most of them in the customer
+workload), this meant ~9k top-level `processCustomTags` calls each
+re-walked their tree at every recursion level. Total cumulative
+CPU: 31.5s, 3.4ms avg per top-level call.
+
+**Fix.** Split `processCustomTags` into outer entry + inner worker:
+
+- `processCustomTags` does the `hasCustomTags` check ONCE at the
+  top level. If no tags exist, early-exit. Otherwise, delegate to
+  the inner worker.
+- `processCustomTagsInner` is the recursive worker — no `hasCustomTags`
+  check on each call, just process and recurse. By the time we're
+  inside it, we already know the tree has tags.
+
+`perf.Track` stays on the outer function and is intentionally
+omitted from the inner worker: the outer call wraps the whole walk
+with one tracked frame, so adding per-recursion tracking would
+inflate the metric without yielding insight.
+
+**Confirmed impact (mean of 2 runs, customer workload):**
+
+| Function | Phase 6 (Total / Avg / Calls) | Phase 7 (Total / Avg / Calls) | Reduction |
+|---|---:|---:|---:|
+| `utils.processCustomTags` | 31.5s / 3.4ms / 9,200 | **7.5s / 1.07ms / ~7,000** | **−76% Total, 3.2× faster avg** |
+
+(The call-count drop is mechanical: recursive calls now go through
+the inner worker which lacks `perf.Track`, so only top-level calls
+are counted. The CPU-time drop is the real signal.)
+
+**Wall-clock impact (local Mac):** 2.3s → 2.4s (within noise on a
+many-core machine where parallelism absorbs the saved work).
+Cumulative ~24s CPU saved → projected **~6-12s wall-clock on 2-4
+core GHA runners** on top of Phases 1-6.
+
+**Race detector:**
+`go test -race -count=1 -run "ProcessCustomTags|UnmarshalYAML|TestHasCustomTags" ./pkg/utils/...`
 green. Full `pkg/utils` and `internal/exec` test suites pass.
 
 ### Verification

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -227,13 +227,6 @@ open. Optimization plan:
       skip the per-call `yaml.Node.Decode` + `InternStringsInMap`
       walks (~500-700µs each). Wall-clock 2.4s → 2.06s (−14%
       locally).
-- [x] Phase 9: asymmetric clone in `cloneExtractLocalsResult` — only
-      `locals` is deep-copied (long-term stored in template context),
-      `settings`/`vars`/`env` are shared references (consumed only by
-      `processTemplatesInSection` which doesn't mutate inputs).
-      `extractLocalsFromRawYAML` Total dropped 17% (7.6s → 6.3s),
-      `extractAndAddLocalsToContext` Total dropped 18% (8.9s → 7.3s).
-      Local wall-clock within noise; ~750ms saved on 2-core GHA.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -816,54 +809,6 @@ relative improvement plus the GC win compounded across cores.
 
 **Race detector:** `go test -race -count=1 ./pkg/utils/...` green.
 Full `pkg/utils` and `internal/exec` test suites pass.
-
-### Phase 9 (shipped 2026-05-24) — asymmetric clone for extractLocalsResult
-
-**Root cause.** After Phase 4 cached the parsed locals result,
-`cloneExtractLocalsResult` deep-copied **all four** map fields
-(`locals`, `settings`, `vars`, `env`) on every retrieval to preserve
-the cache's immutability contract. This dominated the cache-hit
-path: 22,181 calls × ~343µs avg = 7.6s of cumulative CPU, with the
-deep-copy work being most of that.
-
-**The deep copy of settings/vars/env is overkill.** The only
-production consumer of those three fields is
-`processTemplatesInSection`, which:
-1. Marshals the section to YAML (read-only).
-2. Parses the YAML back into a *new* map.
-3. Returns the new map.
-
-The input section is never mutated. So sharing the cache's reference
-is safe — the per-caller deep copy was unnecessary overhead.
-
-**Fix.** Refactored `cloneExtractLocalsResult` to be asymmetric:
-
-- `locals` is still deep-copied. This field is stored long-term in
-  the template context (`context[cfg.LocalsSectionName] = ...`)
-  where downstream mutation surface is hard to bound, so the
-  defensive copy stays.
-- `settings`, `vars`, `env` are now shared references. The
-  contract is documented on the function: callers must treat them
-  as read-only.
-
-`TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies` was
-updated to reflect the new contract (only `locals` requires
-post-mutation isolation; settings/vars/env share with the cache).
-
-**Confirmed impact (mean of 3 runs, customer workload):**
-
-| Function | Phase 8 (Total / Avg) | Phase 9 (Total / Avg) | Reduction |
-|---|---:|---:|---:|
-| `exec.extractLocalsFromRawYAML` | 7.6s / 343µs | **6.3s / 282µs** | **−17% Total, 18% faster avg** |
-| `exec.extractAndAddLocalsToContext` | 8.9s / 401µs | **7.3s / 330µs** | **−18% Total, 18% faster avg** |
-
-**Wall-clock impact (local Mac):** 2.06s → 2.13s (within run-to-run
-noise on a many-core machine). Cumulative ~1.5s CPU saved →
-projected **~750ms wall-clock savings on a 2-core GHA runner**.
-
-**Race detector:**
-`go test -race -count=1 -run "TestExtractLocals|TestExtractAndAdd|TestHierarchicalImports" ./internal/exec/`
-green. Full `internal/exec` test suite passes.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -232,6 +232,60 @@ the same approach without addressing the underlying contract violation:
       than the perf.Track savings recovered (the inner-only walker
       had to allocate on every level). Documented in-code so future
       passes don't re-try.
+- [x] Phase 11: scope the remote-state-backend merge to the relevant
+      backend type. `processTerraformRemoteStateBackend` used to do
+      two `m.Merge` calls over the full remote-state-backend sections
+      (which can carry configs for multiple backend types — s3, gcs,
+      azurerm, etc.) and then extract one key from the merged result.
+      The Phase 11 helper `extractBackendTypeMap` pulls the chosen
+      backend-type's inner map from each of the four layered inputs
+      (backend section + global/base/component remote-state sections)
+      *before* the merge, so the only deep-copies are for entries
+      that actually end up in the result.
+      `processTerraformRemoteStateBackend` Total: 5.7s → 5.4s (−5%);
+      `processTerraformBackend` Total: 2.95s → 2.81s (−5%);
+      `merge.Merge` Total: 26.5s → 25.2s (−5%, smaller inputs
+      propagate). ~1s cumulative CPU saved; projected ~500ms wall-
+      clock on 2-core GHA.
+- [x] Phase 12 + 13: skip the deep-copy of nil fields in the
+      base-component cache. `deepCopyBaseComponentConfigMaps` used
+      to call `m.DeepCopyMap` unconditionally on 10 (later 15)
+      `BaseComponentConfig` map fields; in real workloads most
+      components leave several fields nil (notably
+      `BaseComponentProviders` / `Hooks` / `Generate` /
+      `Dependencies` for non-Terraform components). Each call is
+      now gated with `if src.Field != nil`, skipping the
+      function-call + perf.Track overhead for the nil case while
+      preserving `m.DeepCopyMap`'s exact semantics for empty-non-nil
+      input (empty-non-nil src → empty-non-nil dst, since collapsing
+      to nil would break the cache HIT/MISS shape contract and
+      could panic on later `result.BaseComponentX[k] = v`).
+      `cacheBaseComponentConfig` Total: 3.85s → 990ms (−74%, 3.9×
+      faster avg); `getCachedBaseComponentConfig` Total: 865ms →
+      360ms (−58%, 2.4× faster avg); `merge.DeepCopyMap` Calls:
+      223k → 175k (−22%, 48k calls eliminated).
+- [x] Coverage close-out: new tests cover the gaps the arc
+      introduced (public `Clear*Cache` wrappers,
+      `extractBackendTypeMap` type-mismatch path, Phase 12/13
+      empty-field contract). Final coverage on touched code is
+      85-100% on every function.
+- [x] Cache full BaseComponentConfig — follow-up correctness fix:
+      `deepCopyBaseComponentConfigMaps` and the surrounding struct
+      literals were missing **six** fields
+      (`BaseComponentLocals`, `BaseComponentGenerate`,
+      `BaseComponentSourceSection`, `BaseComponentProvisionSection`,
+      `BaseComponentRequiredProviders`, and the scalar
+      `BaseComponentRequiredVersion`) so cache HIT returned a
+      truncated config relative to cache MISS for the same
+      `(stack, component, baseComponent)` key. **Pre-existing
+      main-branch bug**, not introduced by this perf arc — same 10
+      of 21 fields covered on `main` HEAD before any commit on this
+      branch. Fixed alongside Phase 12/13 since the function was
+      already being modified.
+      `TestCacheBaseComponentConfig_RoundTripsAllFields` locks in
+      the contract that every field of `BaseComponentConfig`
+      populated by `processBaseComponentConfigInternal` round-trips
+      through the cache.
 - [~] Phase 9 (ATTEMPTED, REVERTED 2026-05-24, `b11f3cd9b`):
       asymmetric clone of `extractLocalsResult` — share
       `settings`/`vars`/`env` references with the cache, deep-copy
@@ -854,6 +908,181 @@ relative improvement plus the GC win compounded across cores.
 
 **Race detector:** `go test -race -count=1 ./pkg/utils/...` green.
 Full `pkg/utils` and `internal/exec` test suites pass.
+
+### Phase 10 (shipped 2026-05-24) — outer/inner perf.Track split for processYAMLNode
+
+**Root cause.** `processYAMLNode` is a recursive YAML walker invoked
+from `EvaluateYqExpression` (used by `atmos describe affected`'s yq
+filtering path). It adjusts the style of scalar string nodes that
+start with `#` so they round-trip without YAML re-interpreting them
+as comments. The body is trivial — a single tag/value comparison and
+an optional style assignment per node — but `perf.Track` was
+deferred on every recursive frame, adding ~3µs of mutex + counter
+overhead per call. The heatmap counted 34k recursive calls totaling
+5.5s for a function whose real work is microseconds.
+
+**Fix.** Same split as Phase 7 (`processCustomTags` /
+`processCustomTagsInner`):
+
+- `processYAMLNode` wraps the entry point with `perf.Track` and
+  delegates to the inner worker.
+- `processYAMLNodeInner` is the recursive walker, no `perf.Track`.
+  The metric now counts top-level invocations rather than every
+  node visited.
+
+**What was tried and not applied:** the same outer/inner pattern
+was tried for `WalkAndDeferYAMLFunctions` and reverted in-flight.
+That function uses `hasAnyYAMLFunction` as a per-recursion
+short-circuit to avoid allocating result maps for function-sparse
+subtrees. An outer/inner split made the inner walker allocate
+unconditionally on every recursion, regressing the common case
+(most subtrees have zero YAML functions) more than the `perf.Track`
+savings recovered. The current implementation documents this
+trade-off in-code so future passes don't re-try.
+
+**Confirmed impact (local Mac, mean of 3 runs):**
+
+| Function | Phase 9-reverted baseline | Phase 10 | Reduction |
+|---|---:|---:|---:|
+| `utils.processYAMLNode` | 5.5s / 34k calls / 160µs avg | **dropped out of top-25** | **>−90% Total** |
+| `utils.EvaluateYqExpression` | 2.5s / 82 calls | **180-206ms / 34-46 calls** | (call count varies; CPU dropped accordingly) |
+
+**Wall-clock (local Mac):** 2.2s → 2.03s (−7%). Cumulative CPU
+saved ~24s → projected ~6-12s wall-clock on 2-core GHA.
+
+### Phase 11 (shipped 2026-05-24) — scope remote-state-backend merge to the relevant backend type
+
+**Root cause.** `processTerraformRemoteStateBackend` used to do
+two `m.Merge` calls per component:
+
+1. Merge the three remote-state-backend sources (global / base
+   component / component) into a combined remote-state-backend
+   section, which can carry configs for *multiple* backend types
+   (`s3`, `gcs`, `azurerm`, ...).
+2. Merge that section with `finalComponentBackendSection` to layer
+   backend defaults under the remote-state overrides.
+
+Only the value at `merged[finalComponentRemoteStateBackendType]`
+was ever returned — but the merges deep-copied every backend type's
+config along the way. Most components carry s3 *and* gcs blocks
+in their backend section even when they're only ever provisioned
+into s3.
+
+**Fix.** Introduced `extractBackendTypeMap`, a small helper that
+returns the inner map at `section[backendType]` (or an empty map
+on miss). The function now extracts the chosen backend-type's
+inner map from **each** of the four layered inputs
+(`finalComponentBackendSection`, `globalRemoteStateBackendSection`,
+`baseComponentRemoteStateBackendSection`,
+`componentRemoteStateBackendSection`) *before* the merge, then
+runs a single `m.Merge` over those four scoped maps. The merge now
+operates on ~10x smaller inputs in the common case where multiple
+backend types coexist in the section maps.
+
+Precedence is preserved: backend section is the base, then the
+three remote-state layers stack global → base → component on top —
+matching the original two-stage merge semantics.
+
+**Confirmed impact (local Mac, mean of 3 runs):**
+
+| Function | Pre-Phase-11 | Phase 11 | Reduction |
+|---|---:|---:|---:|
+| `exec.processTerraformRemoteStateBackend` Total | 5.7s | **5.4s** | −5% |
+| `exec.processTerraformRemoteStateBackend` avg | 617µs | **582µs** | −5% |
+| `exec.processTerraformBackend` Total | 2.95s | **2.81s** | −5% |
+| `merge.Merge` Total | 26.5s | **25.2s** | −5% (smaller inputs propagate) |
+
+**Wall-clock:** unchanged on many-core Mac (parallelism absorbs the
+saved CPU). ~1s cumulative CPU saved → ~500ms wall-clock on 2-core
+GHA.
+
+### Phase 12 + 13 (shipped 2026-05-24) — skip deep-copy of empty BaseComponentConfig fields
+
+**Root cause.** `deepCopyBaseComponentConfigMaps` is invoked on
+every `cacheBaseComponentConfig` write and every
+`getCachedBaseComponentConfig` read. Pre-fix, it called
+`m.DeepCopyMap` unconditionally on **every** map field of
+`BaseComponentConfig` — even when the source field was empty or
+nil. `m.DeepCopyMap(nil)` is cheap (early-returns) but still pays
+the function-call + perf.Track overhead; `m.DeepCopyMap(emptyMap)`
+allocates an empty map for nothing.
+
+In the reference workload most components leave several fields
+empty: `BaseComponentProviders` / `Hooks` / `Generate` /
+`Dependencies` for non-Terraform components,
+`BaseComponentSourceSection` / `ProvisionSection` for components
+that don't use them, `BaseComponentRequiredProviders` /
+`RequiredVersion` for non-Terraform.
+
+**Fix.** Guard each `m.DeepCopyMap` call with
+`if len(src.Field) > 0`. The function-call overhead and the
+empty-map allocation are skipped when the source field is empty;
+the dst field defaults to `nil`, matching the previous
+`m.DeepCopyMap(nil) == nil` contract.
+
+This change applies to **both** cache paths (Phase 12 = write side,
+Phase 13 = read side), since they share the same
+`deepCopyBaseComponentConfigMaps` helper.
+
+**Confirmed impact (local Mac, mean of 3 runs):**
+
+| Function | Pre-Phase-11 | Phase 12+13 | Reduction |
+|---|---:|---:|---:|
+| `exec.cacheBaseComponentConfig` Total | 3.85s | **990ms** | **−74%, 3.9× faster avg** |
+| `exec.cacheBaseComponentConfig` avg | 598µs | **153µs** | |
+| `exec.getCachedBaseComponentConfig` Total | 865ms | **360ms** | **−58%, 2.4× faster avg** |
+| `exec.getCachedBaseComponentConfig` avg | 107µs | **44µs** | |
+| `merge.DeepCopyMap` Calls | 223,109 | **175,120** | **−22% (48k calls eliminated)** |
+| `merge.DeepCopyMap` Total | 5.0s | **3.8s** | **−24%** |
+
+**Wall-clock:** 2.05s → 2.02s (within noise on many-core Mac;
+parallelism absorbs the saved CPU). ~4.5s cumulative CPU saved →
+projected ~2.2s wall-clock on 2-core GHA.
+
+### Cache full BaseComponentConfig (correctness follow-up to Phase 12/13)
+
+**Root cause.** `deepCopyBaseComponentConfigMaps` and the
+surrounding `schema.BaseComponentConfig` struct literals on both
+the read and write sides covered only 10 of the 15
+`AtmosSectionMapType` fields in the struct, plus 4 of 5 string
+fields. Missing on **both** sides:
+
+- `BaseComponentLocals` (map)
+- `BaseComponentGenerate` (map)
+- `BaseComponentSourceSection` (map)
+- `BaseComponentProvisionSection` (map)
+- `BaseComponentRequiredProviders` (map)
+- `BaseComponentRequiredVersion` (string)
+
+`processBaseComponentConfigInternal` populates all of these.
+`applyBaseComponentConfig` (in the inheritance pipeline) reads
+every one of them off the cached config and assigns them into
+`result.BaseComponent*`. So the same
+`(stack, component, baseComponent)` cache key returned a **different
+config shape** on HIT (six fields nil) vs MISS (fields populated).
+Which path a given component took depended on goroutine scheduling
+order.
+
+**This was a pre-existing main-branch bug**, not a regression from
+this PR. Same 10-field coverage on `main` HEAD before any commit
+on this branch. The Phase 12+13 commit happened to land in this
+file, so it was the right place to also extend coverage to the
+missing fields.
+
+**Fix.** Added the five missing map fields to
+`deepCopyBaseComponentConfigMaps` (each behind the Phase 12/13
+`len(src.Field) > 0` guard so the empty-field optimization still
+applies) and the `BaseComponentRequiredVersion` string to both
+struct literals.
+
+**Test added.** `TestCacheBaseComponentConfig_RoundTripsAllFields`
+populates every `BaseComponentConfig` field with a distinguishable
+value and asserts each round-trips through the cache, plus a deep-
+copy isolation check on `BaseComponentLocals` (mutating a
+retrieved value must not affect subsequent retrievals).
+`TestCacheBaseComponentConfig_SkipsEmptyFields` was extended to
+also assert the previously-uncopied fields stay `nil` when the
+source is empty.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -227,6 +227,13 @@ open. Optimization plan:
       skip the per-call `yaml.Node.Decode` + `InternStringsInMap`
       walks (~500-700µs each). Wall-clock 2.4s → 2.06s (−14%
       locally).
+- [x] Phase 9: asymmetric clone in `cloneExtractLocalsResult` — only
+      `locals` is deep-copied (long-term stored in template context),
+      `settings`/`vars`/`env` are shared references (consumed only by
+      `processTemplatesInSection` which doesn't mutate inputs).
+      `extractLocalsFromRawYAML` Total dropped 17% (7.6s → 6.3s),
+      `extractAndAddLocalsToContext` Total dropped 18% (8.9s → 7.3s).
+      Local wall-clock within noise; ~750ms saved on 2-core GHA.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -809,6 +816,54 @@ relative improvement plus the GC win compounded across cores.
 
 **Race detector:** `go test -race -count=1 ./pkg/utils/...` green.
 Full `pkg/utils` and `internal/exec` test suites pass.
+
+### Phase 9 (shipped 2026-05-24) — asymmetric clone for extractLocalsResult
+
+**Root cause.** After Phase 4 cached the parsed locals result,
+`cloneExtractLocalsResult` deep-copied **all four** map fields
+(`locals`, `settings`, `vars`, `env`) on every retrieval to preserve
+the cache's immutability contract. This dominated the cache-hit
+path: 22,181 calls × ~343µs avg = 7.6s of cumulative CPU, with the
+deep-copy work being most of that.
+
+**The deep copy of settings/vars/env is overkill.** The only
+production consumer of those three fields is
+`processTemplatesInSection`, which:
+1. Marshals the section to YAML (read-only).
+2. Parses the YAML back into a *new* map.
+3. Returns the new map.
+
+The input section is never mutated. So sharing the cache's reference
+is safe — the per-caller deep copy was unnecessary overhead.
+
+**Fix.** Refactored `cloneExtractLocalsResult` to be asymmetric:
+
+- `locals` is still deep-copied. This field is stored long-term in
+  the template context (`context[cfg.LocalsSectionName] = ...`)
+  where downstream mutation surface is hard to bound, so the
+  defensive copy stays.
+- `settings`, `vars`, `env` are now shared references. The
+  contract is documented on the function: callers must treat them
+  as read-only.
+
+`TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies` was
+updated to reflect the new contract (only `locals` requires
+post-mutation isolation; settings/vars/env share with the cache).
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 8 (Total / Avg) | Phase 9 (Total / Avg) | Reduction |
+|---|---:|---:|---:|
+| `exec.extractLocalsFromRawYAML` | 7.6s / 343µs | **6.3s / 282µs** | **−17% Total, 18% faster avg** |
+| `exec.extractAndAddLocalsToContext` | 8.9s / 401µs | **7.3s / 330µs** | **−18% Total, 18% faster avg** |
+
+**Wall-clock impact (local Mac):** 2.06s → 2.13s (within run-to-run
+noise on a many-core machine). Cumulative ~1.5s CPU saved →
+projected **~750ms wall-clock savings on a 2-core GHA runner**.
+
+**Race detector:**
+`go test -race -count=1 -run "TestExtractLocals|TestExtractAndAdd|TestHierarchicalImports" ./internal/exec/`
+green. Full `internal/exec` test suite passes.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -203,9 +203,13 @@ open. Optimization plan:
       Merge calls eliminated, 215k walk calls eliminated. Wall-clock
       3.3s → 3.0s locally; cumulative ~75s saved on a 2-core GHA
       runner.
-- [ ] Phase 4: optimize `locals` extraction path.
+- [x] Phase 4: cache `extractLocalsFromRawYAML` by file path + content
+      hash; clone input context to fix pre-existing race. 22k+ calls
+      eliminated, wall-clock 3.0s → 2.3s (−23%, biggest single-phase
+      wall-clock win). Pre-existing race in
+      `extractAndAddLocalsToContext` (mergedContext mutation) fixed.
 - [ ] Phase 6 (new): investigate `ProcessYAMLConfigFileWithContext`
-      (1m05s post-Phase-5) — file loading hot path.
+      (~1m post-Phase-4) — file loading hot path.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -567,21 +571,72 @@ functions defers at the correct precedence, (d) two non-empty
 inputs take the full merge path, (e) the fast path does not mutate
 the input.
 
-### Phase 4 (open) — locals extraction
+### Phase 4 (shipped 2026-05-23) — cache locals extraction by file path + content hash
 
-`extractAndAddLocalsToContext` (22,181 calls, 14s) and
-`extractLocalsFromRawYAML` (22,181 calls, 13s) are the post-#1639
-additions for the `locals` feature. 22,181 = ~30 imports per
-stack × ~744 stacks processed — locals are extracted per imported
-file, not per component. Likely caching opportunity: extract once
-per file, cache by file path + mtime.
+**Root cause.** `extractLocalsFromRawYAML` was called 22,181 times for
+~836 unique files (~26 calls per file via transitive imports), at
+533µs avg. ~7s of the 13s total was `UnmarshalYAMLFromFile`
+re-parsing the same YAML content for the same file path. Within a
+single command execution, file content is immutable (and the file
+content itself was already cached via `getFileContentSyncMap`), so
+the parse + locals resolution is fully deterministic and trivially
+cacheable.
 
-Expected impact: -20s CPU on this workload. Small but easy.
+A pre-existing data race in `extractAndAddLocalsToContext`
+(surfaced under `-race` by some `TestHierarchicalImports_*` tests)
+mutated the parent `mergedContext` map directly via `delete(context,
+LocalsSectionName)` while multiple goroutines processed sibling
+imports concurrently. Phase 4 closes this race in the same fix.
 
-Pre-existing data race in `extractAndAddLocalsToContext` at
-`internal/exec/stack_processor_utils.go:260` should also be
-fixed in this phase — currently surfaces under `-race` for some
-`TestHierarchicalImports_*` tests.
+**Two changes:**
+
+1. **`localsExtractionCache` (sync.Map) keyed by `filePath + FNV-1a(yamlContent)`**
+   memoizes the parsed `*extractLocalsResult` for the duration of the
+   command. Cache reads deep-copy the cached value via
+   `cloneExtractLocalsResult` so downstream consumers can store the
+   maps into shared template contexts without corrupting the cache.
+   FNV-1a content fingerprinting prevents test pollution when the
+   same logical file path is reused with different content (a common
+   pattern in unit tests).
+2. **`extractAndAddLocalsToContext` clones its input context map** before
+   the file-scoped `delete` + assign, eliminating the pre-existing
+   race. The clone is shallow (values are shared references); the
+   only mutation surface inside the function is the map header, so
+   per-goroutine cloning is sufficient. Cost: O(N) over the context
+   entries, negligible compared to the function's overall work.
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 5 (Total / Avg / Calls) | Phase 4 (Total / Avg / Calls) | Reduction |
+|---|---:|---:|---:|
+| `exec.extractAndAddLocalsToContext` | 13s / 580µs / 22,181 | **6.7s / 300µs / 22,181** | **−48% Total, 2× faster avg** |
+| `exec.extractLocalsFromRawYAML` | 13s / 533µs / 22,181 | **5.9s / 264µs / 22,181** | **−55% Total, 2× faster avg** |
+| `utils.UnmarshalYAMLFromFile` Calls | 22,374 | **~1,900** | **−92% (20k+ calls eliminated)** |
+| `exec.ProcessStackLocals` | 1.5s / 22,167 | **170ms / ~1,800** | **−89% Total, −92% Calls** |
+
+**Wall-clock impact (local Mac, mean of 3 runs):** 3.0s → **2.3s
+(−23%)** — the biggest single-phase wall-clock win in this
+investigation. Unlike Phase 2 (lock-wait padding that doesn't show
+on Mac), the locals cache eliminates real CPU work (YAML parsing +
+locals resolution) that was contributing directly to wall-clock on
+every architecture.
+
+**Race detector:**
+`go test -race -count=1 -run TestHierarchicalImports ./internal/exec/`
+now green. Other pre-existing races elsewhere in the package
+(`processSettingsIntegrationsGithub` racing with `DeepCopyMap`,
+`MergeContext.WithFile` racing) are tracked separately — not
+introduced by Phase 4.
+
+**Cumulative trajectory (local Mac wall-clock, mean of 3 runs):**
+
+| Stage | Elapsed | Δ vs prior |
+|---|---:|---:|
+| Baseline (pre-Phase-2) | 4.1s | — |
+| Phase 3 (walk short-circuit) | 3.3s | −19% |
+| Phase 5 (skip trivial merges) | 3.0s | −10% |
+| Phase 4 (locals cache) | **2.3s** | **−23%** |
+| **Cumulative** | **2.3s** | **−44% vs baseline** |
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -221,6 +221,12 @@ open. Optimization plan:
       for the early-exit check); a split into outer/inner functions
       runs the check once per top-level call. ~24s cumulative CPU
       saved on this workload → ~6-12s wall-clock on 2-4 core GHA.
+- [x] Phase 8: cache the post-Decode + post-Intern result in a new
+      `decodedYAMLCache` (sync.Map keyed by file + content hash) so
+      repeat callers of `UnmarshalYAMLFromFileWithPositions[map[string]any]`
+      skip the per-call `yaml.Node.Decode` + `InternStringsInMap`
+      walks (~500-700µs each). Wall-clock 2.4s → 2.06s (−14%
+      locally).
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -746,6 +752,63 @@ core GHA runners** on top of Phases 1-6.
 **Race detector:**
 `go test -race -count=1 -run "ProcessCustomTags|UnmarshalYAML|TestHasCustomTags" ./pkg/utils/...`
 green. Full `pkg/utils` and `internal/exec` test suites pass.
+
+### Phase 8 (shipped 2026-05-23) — cache the decoded+interned YAML result
+
+**Root cause.** The `parsedYAMLCache` from Phase 6 already eliminates
+re-parsing of identical YAML content. But the inner Decode + Intern
+steps inside `UnmarshalYAMLFromFileWithPositions` run on **every**
+call — including cache hits:
+
+```go
+node, _, _ := getCachedParsedYAML(file, input)  // Phase 6 cache hit
+node.Decode(&data)                              // Always runs
+data = InternStringsInMap(data)                 // Always runs
+```
+
+Decode allocates a fresh map tree from the cached `yaml.Node`;
+InternStringsInMap recursively walks the decoded tree and allocates
+another tree with interned string keys/values. Combined they cost
+~500-700µs per call across the 22,181 invocations.
+
+**Fix.** Added a second sync.Map cache (`decodedYAMLCache`) keyed by
+the same (file, content hash) pair as `parsedYAMLCache`. The cache
+value is the post-Decode + post-Intern `map[string]any` plus the
+matching `PositionMap`. The hot-path call site checks this cache
+first; a hit returns a deep-copy of the cached result, skipping
+Decode and Intern entirely.
+
+The fast path activates only for `T == map[string]any` (the
+production hot path; `schema.AtmosSectionMapType` is exactly this
+type). Detection is done via a single `any(zeroValue).(map[string]any)`
+type assertion — no reflect, no per-call overhead. Other generic
+instantiations (used only in tests) fall through to the existing
+Decode path.
+
+A local `deepCopyDecodedMap` helper handles the deep copy on
+retrieval; we can't use `merge.DeepCopyMap` because `pkg/merge`
+imports `pkg/utils` (circular dependency).
+
+`ClearDecodedYAMLCache` added for test cleanup, mirroring the
+existing `ClearParsedYAMLCache` / `ClearLocalsExtractionCache` /
+`ClearBaseComponentConfigCache` pattern.
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 7 (Total / Avg) | Phase 8 (Total / Avg) | Reduction |
+|---|---:|---:|---:|
+| `utils.UnmarshalYAMLFromFileWithPositions` | 3.7s / 166µs | **3.2s / 144µs** | **−14% Total** |
+| **Wall-clock elapsed** | **2.4s** | **2.06s** | **−14% locally** |
+
+The cumulative CPU savings on `UnmarshalYAMLFromFileWithPositions`
+itself are modest (~500ms), but the wall-clock improvement is
+larger than the cumulative CPU delta would predict — likely from
+reduced allocation pressure (no fresh map allocations on cache hit)
+and resulting GC relief. On 2-4 core GHA runners, expect a similar
+relative improvement plus the GC win compounded across cores.
+
+**Race detector:** `go test -race -count=1 ./pkg/utils/...` green.
+Full `pkg/utils` and `internal/exec` test suites pass.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -227,6 +227,21 @@ open. Optimization plan:
       skip the per-call `yaml.Node.Decode` + `InternStringsInMap`
       walks (~500-700µs each). Wall-clock 2.4s → 2.06s (−14%
       locally).
+- [~] Phase 9 (ATTEMPTED, REVERTED 2026-05-24, `b11f3cd9b`):
+      asymmetric clone of `extractLocalsResult` — share
+      `settings`/`vars`/`env` references with the cache, deep-copy
+      only `locals`. Showed −17% on `extractLocalsFromRawYAML`
+      locally and passed `go test -race` on the targeted tests, but
+      crashed with `fatal error: concurrent map iteration and map
+      write` on the real customer workload (~9k parallel
+      goroutines). Root cause: `processTemplatesInSection` returns
+      its input map as-is when the section contains no `{{`, so the
+      cached settings *do* end up shared in the long-lived template
+      context where a sibling goroutine then mutates them via
+      `DeepCopyMap`. Lesson: the "consumed only by
+      `processTemplatesInSection`" claim was wrong — that function
+      has a fast-path pass-through. Re-attempting requires a clone
+      inside the pass-through, or a stronger immutability proof.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -197,11 +197,15 @@ open. Optimization plan:
       (−19% locally; ~18-35s on GHA projected). Original plan
       (component-level parallelization) abandoned because it's
       already in place.
+- [x] Phase 5: skip `MergeWithDeferred` when 0 or 1 input is
+      non-empty. `mergeComponentConfigurations` Total dropped 50%
+      (1m54s → 57s), `MergeWithDeferred` Total dropped 64%, 65k
+      Merge calls eliminated, 215k walk calls eliminated. Wall-clock
+      3.3s → 3.0s locally; cumulative ~75s saved on a 2-core GHA
+      runner.
 - [ ] Phase 4: optimize `locals` extraction path.
-- [ ] Phase 5 (new): skip `MergeWithDeferred` when only one input is
-      non-empty — newly visible after Phase 3.
 - [ ] Phase 6 (new): investigate `ProcessYAMLConfigFileWithContext`
-      (1m11s) — file loading hot path.
+      (1m05s post-Phase-5) — file loading hot path.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -500,6 +504,69 @@ present in main without Phase 3 changes. Tracked separately.
 - `ProcessYAMLConfigFileWithContext` (1m11s) — file loading. May be
   unrelated to inheritance; deferred to Phase 6.
 
+### Phase 5 (shipped 2026-05-23) — skip MergeWithDeferred for trivial input
+
+**Root cause.** `mergeComponentConfigurations` calls
+`MergeWithDeferred` 9 times per component instance — once per
+section (vars, settings, env, auth, providers, required_providers,
+hooks, generate) plus auth-merge fan-out. Each call passes 3-4
+candidate inputs: typically `GlobalX / BaseComponentX / ComponentX /
+ComponentOverridesX`. On the customer workload, most of those
+layers are empty: components that don't inherit have empty
+`BaseComponentX`, most components have no `ComponentOverridesX`, and
+some sections (`generate`, `required_providers`, `hooks`) are empty
+for most components.
+
+Despite the empty layers, every call ran the full pipeline:
+allocate a deferred merge context, walk each input (Phase 3
+short-circuit avoids the inner deep-copy but the walk function still
+runs and increments precedence), and call `Merge` to combine all
+processed inputs (which is a deep walk over all entries even when
+all but one are empty).
+
+**Fix.** Pre-scan the inputs in `MergeWithDeferred` and short-circuit
+when the merge degenerates:
+
+- **0 non-empty inputs:** return a fresh empty map and empty dctx.
+  No walk, no merge.
+- **1 non-empty input:** advance precedence to that input's
+  position, walk just that input (so YAML functions are deferred at
+  the correct precedence), and return the walked map directly. Skip
+  the `Merge` call entirely — a merge of one map degenerates to a
+  copy of that map, and the walk's result is already the result.
+
+The downstream `ApplyDeferredMerges` is dctx-driven: when dctx has
+no deferred values (the no-functions case), it's a no-op and does
+not touch the returned map. Combined with Phase 3's
+`WalkAndDeferYAMLFunctions` short-circuit, a single-input
+function-free section is now a zero-allocation pass-through end to
+end.
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 3 (Total / Avg / Calls) | Phase 5 (Total / Avg / Calls) | Reduction |
+|---|---:|---:|---:|
+| `mergeComponentConfigurations` | 1m54s / 12.5ms / 9,261 | **57s / 6.2ms / 9,261** | **−50% Total** |
+| `merge.MergeWithDeferred` | 1m10s / 851µs / 83,349 | **25s / 305µs / 83,349** | **−64% Total, 2.8× faster avg** |
+| `merge.Merge` Calls | 273,379 | **207,934** | **−65k calls eliminated (−24%)** |
+| `merge.WalkAndDeferYAMLFunctions` | 15.4s / 47µs / 328,218 | **6.0s / 53µs / 112,832** | **−61% Total, −215k calls (−66%)** |
+| `processComponent` | 34s / 3.7ms | **27s / 2.9ms** | **−21% Total** |
+
+**Wall-clock (local Mac, mean of 3 runs):** 3.3s → **3.0s** (−10%).
+Same caveat as Phase 3 — on many-core machines the parallelism
+absorbs much of the cumulative savings. Cumulative CPU saved
+across Phases 3+5 ≈ 150 seconds → projected **~37-75s wall-clock
+improvement on 2-4 core GHA runners** (on top of Phase 2's
+contention elimination).
+
+**Tests added (race-clean):** `TestMergeWithDeferred_TrivialInputShortCircuits`
+covers (a) zero non-empty inputs returns empty, (b) single
+non-empty function-free input returns same map header (composes with
+Phase 3 zero-alloc fast path), (c) single non-empty input with YAML
+functions defers at the correct precedence, (d) two non-empty
+inputs take the full merge path, (e) the fast path does not mutate
+the input.
+
 ### Phase 4 (open) — locals extraction
 
 `extractAndAddLocalsToContext` (22,181 calls, 14s) and
@@ -510,6 +577,11 @@ file, not per component. Likely caching opportunity: extract once
 per file, cache by file path + mtime.
 
 Expected impact: -20s CPU on this workload. Small but easy.
+
+Pre-existing data race in `extractAndAddLocalsToContext` at
+`internal/exec/stack_processor_utils.go:260` should also be
+fixed in this phase — currently surfaces under `-race` for some
+`TestHierarchicalImports_*` tests.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -208,8 +208,12 @@ open. Optimization plan:
       eliminated, wall-clock 3.0s → 2.3s (−23%, biggest single-phase
       wall-clock win). Pre-existing race in
       `extractAndAddLocalsToContext` (mergedContext mutation) fixed.
-- [ ] Phase 6 (new): investigate `ProcessYAMLConfigFileWithContext`
-      (~1m post-Phase-4) — file loading hot path.
+- [x] Phase 6: apply Phase 2's sync.Map + deep-copy-outside-lock
+      pattern to `parsedYAMLCache` in `pkg/utils/yaml_utils.go`.
+      `UnmarshalYAMLFromFileWithPositions` Total dropped 80%
+      (18.7s → 3.7s, 5× faster avg). Wall-clock unchanged on Mac
+      (parallelism already absorbed it); ~4-7s wall-clock saved on
+      2-4 core GHA runners.
 - [ ] Re-measure on GHA and confirm wall-clock improvement.
 
 ---
@@ -637,6 +641,55 @@ introduced by Phase 4.
 | Phase 5 (skip trivial merges) | 3.0s | −10% |
 | Phase 4 (locals cache) | **2.3s** | **−23%** |
 | **Cumulative** | **2.3s** | **−44% vs baseline** |
+
+### Phase 6 (shipped 2026-05-23) — sync.Map for parsedYAMLCache
+
+**Root cause.** After Phase 4 eliminated 92% of locals-extraction
+parses, the next bottleneck became `UnmarshalYAMLFromFileWithPositions`
+(22,181 calls, 18.7s Total, 844µs avg) — the position-tracking YAML
+parser used by `processYAMLConfigFileWithContextInternal` for the
+final stack-config parse. It already had a content-hash cache, but
+the cache structure was the same RWMutex-protected map pattern that
+Phase 2 fixed for `cacheBaseComponentConfig`:
+
+- `cacheParsedYAML` held `parsedYAMLCacheMu.Lock()` during the
+  recursive `deepCopyYAMLNode` work.
+- `getCachedParsedYAML` held `parsedYAMLCacheMu.RLock()` during the
+  read-side `deepCopyYAMLNode`.
+
+With ~22k concurrent calls, the global write lock serialized every
+cache write, padding apparent CPU time with lock-wait.
+
+**Fix.** Same as Phase 2:
+
+1. `parsedYAMLCache` is now a `sync.Map` (was `map + sync.RWMutex`).
+2. Deep-copy of `yaml.Node` + `PositionMap` happens *before* the
+   `sync.Map.Store` and *after* the `sync.Map.Load`, never inside any
+   critical section.
+
+Added `clearParsedYAMLCache()` plus the public `ClearParsedYAMLCache()`
+for tests, mirroring the `ClearBaseComponentConfigCache` /
+`ClearLocalsExtractionCache` pattern. Three existing tests that
+manually saved/restored the `map + mutex` state were updated to use
+the helper.
+
+**Confirmed impact (mean of 3 runs, customer workload):**
+
+| Function | Phase 4 (Total / Avg) | Phase 6 (Total / Avg) | Reduction |
+|---|---:|---:|---:|
+| `utils.UnmarshalYAMLFromFileWithPositions` | 18.7s / 844µs | **3.7s / 166µs** | **−80% Total, 5× faster avg** |
+| `exec.ProcessYAMLConfigFileWithContext` | 57.6s / 37ms | **54s / 35ms** | −6% Total (downstream beneficiary) |
+
+**Wall-clock impact (local Mac):** 2.3s → 2.3s (unchanged). Same
+caveat as Phase 2: lock-wait padding doesn't show on many-core
+machines because the waiters park rather than consume cores. On 2-4
+core GHA runners where the lock-wait IS wall-clock, projecting from
+the 15s of cumulative CPU eliminated → **~4-7 seconds wall-clock
+savings end-to-end**.
+
+**Race detector:**
+`go test -race -count=1 -run "UnmarshalYAMLFromFileWithPositions|HandleCacheMiss|CacheHit" ./pkg/utils/...`
+green. Full `pkg/utils` and `internal/exec` test suites pass.
 
 ### Verification
 

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -1015,10 +1015,17 @@ that don't use them, `BaseComponentRequiredProviders` /
 `RequiredVersion` for non-Terraform.
 
 **Fix.** Guard each `m.DeepCopyMap` call with
-`if len(src.Field) > 0`. The function-call overhead and the
-empty-map allocation are skipped when the source field is empty;
-the dst field defaults to `nil`, matching the previous
-`m.DeepCopyMap(nil) == nil` contract.
+`if src.Field != nil`. This skips the function-call + perf.Track
+overhead when the source field is nil (the dst field defaults to
+`nil`, matching `m.DeepCopyMap(nil) == nil`), while still routing
+empty-non-nil source fields through `m.DeepCopyMap` so they
+round-trip as empty-non-nil dst fields. Collapsing empty-non-nil to
+`nil` would break the cache HIT-shape == MISS-shape contract and
+turn a downstream `result.BaseComponentX[k] = v` write into an
+"assignment to entry in nil map" panic. The original `len(...) > 0`
+form was reverted for exactly this reason — see the
+`TestCacheBaseComponentConfig_EmptyNonNilFieldsStayNonNil`
+regression guard.
 
 This change applies to **both** cache paths (Phase 12 = write side,
 Phase 13 = read side), since they share the same
@@ -1071,9 +1078,10 @@ missing fields.
 
 **Fix.** Added the five missing map fields to
 `deepCopyBaseComponentConfigMaps` (each behind the Phase 12/13
-`len(src.Field) > 0` guard so the empty-field optimization still
-applies) and the `BaseComponentRequiredVersion` string to both
-struct literals.
+`src.Field != nil` guard so the nil-field optimization still
+applies while empty-non-nil maps continue to round-trip through
+`m.DeepCopyMap`) and the `BaseComponentRequiredVersion` string to
+both struct literals.
 
 **Test added.** `TestCacheBaseComponentConfig_RoundTripsAllFields`
 populates every `BaseComponentConfig` field with a distinguishable

--- a/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
+++ b/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md
@@ -1,0 +1,513 @@
+# Fix: `atmos describe affected` takes ~11 minutes on GitHub Actions
+
+**Date:** 2026-05-23
+
+**Issue:**
+
+Users running `atmos describe affected` in GitHub Actions on a
+large-scale Atmos configuration (≈836 stack YAML files, ~195 final
+stacks across three namespaces, ~9.3k component instances) reported
+**~11-minute** wall-clock times on the standard GHA runner on
+v1.219.0 and earlier. The same workload reproduced locally in
+**4m6s** with `--identity=false` and fake AWS credentials in env (no
+AWS API calls). Heatmap profiling pointed at two structural problems
+that grew since the `pkg/perf` instrumentation arc shipped in
+October 2025 (PRs #1576/#1611/#1622/#1639):
+
+1. **`--identity=false` was a lie (FIXED in v1.220.0-rc.1, PR #2471).**
+   In v1.219.0 and earlier, Atmos still constructed a credential
+   store per component instance even with `--identity=false`:
+   - `pkg/auth/credentials/store.go:67` — `NewCredentialStoreWithConfig`
+     called **12,124 times** (≈1.3× per component) — **2m36s** of
+     cumulative CPU time, 13ms avg, 23ms P95.
+   - `pkg/auth/credentials/keyring_system.go:187` —
+     `systemKeyringStore.Delete` called **6,062 times** — **1m15s** of
+     cumulative CPU time, 12ms avg, 22ms P95.
+   - Combined: **~3.5 minutes** of CPU time spent spinning up and
+     tearing down credential stores. PR #2471 (`fix(auth): honor
+     --identity=false in describe affected and dependents`) gated
+     credential-store creation behind the actual identity-resolution
+     decision. Confirmed in a local reproduction against
+     current `main`: **zero calls** to
+     `credentials.NewCredentialStoreWithConfig` and
+     `credentials.systemKeyringStore.Delete`. Users on v1.219.0
+     should upgrade to v1.220.0-rc.1 (or wait for v1.220.0) to
+     reclaim this 3.5 min of CPU time.
+
+2. **Component inheritance dominates the rest (REMAINING).** A
+   9,261-component workload hits the inheritance pipeline once per
+   instance, and each leg is ~38-46ms. **This is unchanged by
+   #2471** and is the remaining optimization target:
+   - `internal/exec/stack_processor_process_stacks_helpers.go:113` —
+     `processComponent`: **9,261 calls, 5m49s total, 38ms avg, 171ms P95**.
+   - `internal/exec/stack_processor_process_stacks_helpers_inheritance.go:15` —
+     `processComponentInheritance`: **9,261 calls, 5m47s total, 37ms
+     avg, 170ms P95**.
+   - `internal/exec/stack_processor_utils.go:1623` —
+     `ProcessBaseComponentConfig`: **8,017 calls, 5m45s total, 43ms
+     avg, 170ms P95**.
+   - `internal/exec/stack_processor_process_stacks_helpers_inheritance.go:157` —
+     `processInheritedComponent`: **4,845 calls, 5m43s total, 71ms
+     avg, 175ms P95**.
+   - `internal/exec/stack_processor_process_stacks_helpers_inheritance.go:91` —
+     `processMetadataInheritance`: **9,261 calls, 5m41s total, 37ms
+     avg, 170ms P95**.
+   - `internal/exec/stack_processor_cache.go:107` —
+     `cacheBaseComponentConfig`: **6,431 calls, 5m33s total, 52ms avg,
+     160ms P95**.
+   - `internal/exec/stack_processor_merge.go:40` —
+     `mergeComponentConfigurations`: **9,261 calls, 1m34s total, 10ms
+     avg, 38ms P95**.
+
+   That is **~5.7 minutes of CPU work** in the inheritance pipeline,
+   partially parallelized across cores. The high P95s (~170ms across
+   most legs) indicate the slow tail is not amortizing.
+
+YAML function evaluation is **not** the problem:
+
+- `merge.WalkAndDeferYAMLFunctions`: **685,202 calls, 1m13s total,
+  106µs avg, 326µs P95** — cheap per call despite the call count.
+- `utils.ProcessIncludeTag`: **1,085 calls, 3s total, 2.8ms avg, 24ms
+  P95** — negligible.
+
+Counter-intuitively, `--process-functions=false` made the run
+**slower** (5m35s vs 4m52s) — the flag short-circuits cheap work that
+was already amortized while leaving the expensive inheritance path
+untouched.
+
+### Post-#2471 fresh heatmap (2026-05-23, local Mac, current main)
+
+Reproducer below, `--identity=false --process-templates=false
+--process-functions=false`, comparing HEAD vs HEAD~1 via worktree.
+
+**Elapsed: 3.44 s wall-clock locally.** Cumulative CPU time across
+9,261 component instances ≈ 6m11s (parallelism ≈ 108× on this
+machine; on a 2-4 core GHA runner the wall-clock projects to
+**~1.5-3 minutes for the inheritance pipeline alone**).
+
+| Function | Calls | Total | Avg | P95 |
+|---|---:|---:|---:|---:|
+| `exec.processComponent` | 9,261 | 6m11s | 40ms | 192ms |
+| `exec.processComponentInheritance` | 9,261 | 6m02s | 39ms | 191ms |
+| `exec.ProcessBaseComponentConfig` | 8,017 | 6m02s | 45ms | 192ms |
+| `exec.processInheritedComponent` | 4,845 | 6m00s | 74ms | 198ms |
+| `exec.processMetadataInheritance` | 9,261 | 6m00s | 39ms | 189ms |
+| `exec.cacheBaseComponentConfig` | 6,431 | 5m50s | 55ms | 180ms |
+| `exec.mergeComponentConfigurations` | 9,261 | 1m35s | 10ms | 40ms |
+| `exec.ProcessStackConfig` | 744 | 1m11s | 96ms | 239ms |
+| `exec.ProcessYAMLConfigFileWithContext` | 1,518 | 1m07s | 44ms | 265ms |
+| `exec.processComponentsInParallel` | 719 | 1m06s | 92ms | 223ms |
+| `merge.MergeWithDeferred` | 83,349 | 1m02s | 752µs | 4ms |
+| `merge.WalkAndDeferYAMLFunctions` | 527,765 | 54s | 102µs | 311µs |
+| `utils.processCustomTags` | 55,156 | 38s | 680µs | 390µs |
+| `merge.Merge` | 273,379 | 27s | 98µs | 415µs |
+| `utils.UnmarshalYAMLFromFileWithPositions` | 22,181 | 16s | 716µs | 5ms |
+| `exec.extractAndAddLocalsToContext` | 22,181 | 14s | 617µs | 3ms |
+| `exec.extractLocalsFromRawYAML` | 22,181 | 13s | 572µs | 3ms |
+| `credentials.NewCredentialStoreWithConfig` | **0** | — | — | — |
+| `credentials.systemKeyringStore.Delete` | **0** | — | — | — |
+
+**Key observations:**
+
+- Credential store work is gone (0 calls) — #2471 confirmed.
+- Inheritance pipeline numbers are stable vs the v1.219.0 baseline:
+  `processComponent` 5m49s → 6m11s, `cacheBaseComponentConfig` 5m33s
+  → 5m50s. Within noise; nothing has improved.
+- New surface area visible at the bottom of the table:
+  `extractAndAddLocalsToContext` + `extractLocalsFromRawYAML` add
+  ~26s combined across 22,181 invocations each. The `locals` feature
+  added after #1639 is a small but real contributor.
+- `cacheBaseComponentConfig` remains a paradox: 6,431 calls × 55ms
+  avg = 5m50s, almost as expensive as the un-cached path. The cache
+  is doing work on insert that should be amortized.
+- `processComponentsInParallel` runs 719 times (one per stack)
+  fanning out into 9,261 component invocations — so parallelism
+  exists at the **stack** level but not at the **component-within-a-stack**
+  level. The 5.7-6 min of CPU work is bound by stack count, not
+  component count.
+
+### Affected detection note
+
+In the reproducer, the result set is empty (`[]`) even though a
+catalog file was modified. Atmos compares **resolved configs**, and
+the comment-only marker doesn't change the resolved output. The
+expensive part — the full stack processing on both refs — happens
+regardless: Atmos must compute both worktrees' resolved configs to
+diff them. **CI pain is the full processing pass, not the affected
+result size.**
+
+## Status
+
+**Phase 1 fixed in PR #2471 (v1.220.0-rc.1).** Phases 2 and 3 still
+open. Optimization plan:
+
+1. **~~Make `--identity=false` actually skip credential store
+   creation.~~ ✅ Shipped in PR #2471 (`fix(auth): honor
+   --identity=false in describe affected and dependents`), commit
+   `a0cd28671`, in `v1.220.0-rc.1`.** Reclaimed ~3.5 minutes of
+   credential-store CPU time. Confirmed zero credential calls in the
+   2026-05-23 reproduction.
+2. **Cache hit-rate audit of the inheritance pipeline (OPEN).**
+   `cacheBaseComponentConfig` is itself hot (6,431 calls, 5m50s),
+   which suggests either (a) the cache is being invalidated too
+   eagerly, (b) the cache key is too specific and missing equivalent
+   configurations, or (c) it is doing real work on first insertion
+   that should happen elsewhere. Companion: `getCachedBaseComponentConfig`
+   8,017 calls / 6.5s suggests reads are fast, so the cost is concentrated
+   on the insert path.
+3. **Parallelize the inheritance pipeline more aggressively (OPEN).**
+   `processComponentsInParallel` runs 719 times (one per stack)
+   fanning out into 9,261 component invocations. Stack-level
+   parallelism is in place (PR #1639 work); **component-level
+   parallelism within a stack is the next layer**. With ~13
+   components per stack on average and modern many-core runners,
+   pushing parallelism inside `processComponentsInParallel` should
+   yield 2-3× wall-clock improvement on the inheritance pipeline.
+4. **`locals` extraction (NEW, OPEN).**
+   `extractAndAddLocalsToContext` + `extractLocalsFromRawYAML` add
+   ~26s combined across 22,181 invocations each. The `locals`
+   feature shipped after #1639 and was never put through the
+   optimization taxonomy.
+5. **GHA container speed factor.** Even with #2471's win, the
+   remaining ~6m of CPU inheritance work projects to ~1.5-3 min on
+   a 2-4 core GHA runner. If users still see 5+ min on GHA after
+   upgrading to v1.220.0, Phase 2 + Phase 3 are required.
+
+### Progress checklist
+
+- [x] Reproduce locally with fake AWS credentials and `--identity=false`.
+- [x] Capture v1.219.0 baseline heatmap (4m6s elapsed, 9,261
+      components, 12,124 credential calls).
+- [x] Identify hot paths (component inheritance + credential store).
+- [x] Document repo scale (836 YAML files, 35k lines, 195 stacks,
+      2,114 imports).
+- [x] Run `atmos describe affected` against current main and capture
+      fresh heatmap — confirms #2471 eliminated credential calls and
+      isolates the inheritance pipeline as the remaining hot path.
+- [x] Phase 1: gate credential store creation on actual identity
+      resolution (shipped in PR #2471).
+- [x] Phase 2: eliminate cache-write lock contention (sync.Map +
+      deep-copy outside lock). `cacheBaseComponentConfig` Total
+      dropped 98.8% (5m50s → 4s), inheritance pipeline Total dropped
+      91-94%. Race-clean. Bottleneck shifted to
+      `mergeComponentConfigurations`.
+- [ ] Phase 3: parallelize component-level inheritance within
+      `processComponentsInParallel`.
+- [ ] Phase 4: optimize `locals` extraction path.
+- [ ] Phase 5 (new): optimize `mergeComponentConfigurations` —
+      newly visible 2m22s hot path post-Phase-2.
+- [ ] Re-measure on GHA and confirm wall-clock improvement.
+
+---
+
+## Problem
+
+### Repro environment
+
+Customer infrastructure repository, redacted scale:
+
+| Metric | Value |
+|---|---|
+| Stack YAML files | **836** |
+| Stack YAML lines | **35,335** |
+| Resolved stacks (final) | **~195** (~65 per namespace × 3) |
+| `import:` statements (transitive) | **2,114** |
+| Max imports in a single file | **203** |
+| Catalog component definitions | **65** (487 component instances) |
+| Terraform components in `components/terraform/` | **68** |
+| Component instances processed end-to-end | **9,261** |
+| Auth profiles | 9 (each with 13-14 identities) |
+
+`atmos.yaml` highlights:
+```yaml
+stacks:
+  base_path: "stacks"
+  included_paths: ["orgs/**/*"]
+  excluded_paths: ["**/_defaults.yaml"]
+  name_pattern: "{namespace}-{tenant}-{environment}-{stage}"
+
+templates:
+  settings:
+    enabled: true
+    sprig: { enabled: true }
+    gomplate: { enabled: true }
+```
+
+### Reproducer
+
+Modify a heavily-imported catalog file (e.g.,
+`stacks/catalog/aws-team-roles/defaults.yaml`) — anything not
+matched by the config's `excluded_paths` glob. **Note:**
+modifying `**/_defaults.yaml` files does *not* work for this
+purpose because the customer's `atmos.yaml` has them in
+`excluded_paths`. Commit the change locally, then run with a
+git worktree of the previous HEAD:
+
+```bash
+# In the customer repo:
+git worktree add /tmp/<repo>-base HEAD~1   # uses parent's remote URL
+export AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake
+atmos describe affected \
+  --repo-path /tmp/<repo>-base \
+  --process-templates=false \
+  --process-functions=false \
+  --identity=false \
+  --heatmap --heatmap-mode=table
+```
+
+`git clone --local` does *not* work here because the cloned remote's
+URL is a local path and Atmos's git URL parser rejects empty hosts
+(`repository host '' not supported`). Use `git worktree add`
+instead — it shares the parent repo's remote URL.
+
+Even with a comment-only catalog change producing **0 affected
+stacks** in the output, the full processing pass still happens on
+both refs to compute the diff. The heatmap captures the actual CI
+workload.
+
+### Baseline heatmap (collected 2026-05-21, local, no AWS calls)
+
+**Elapsed: 4m6s.** Top functions by cumulative CPU time:
+
+| Function | Calls | Total | Avg | P95 |
+|---|---:|---:|---:|---:|
+| `exec.processComponent` | 9,261 | 5m49s | 38ms | 171ms |
+| `exec.processComponentInheritance` | 9,261 | 5m47s | 37ms | 170ms |
+| `exec.ProcessBaseComponentConfig` | 8,017 | 5m45s | 43ms | 170ms |
+| `exec.processInheritedComponent` | 4,845 | 5m43s | 71ms | 175ms |
+| `exec.processMetadataInheritance` | 9,261 | 5m41s | 37ms | 170ms |
+| `exec.cacheBaseComponentConfig` | 6,431 | 5m33s | 52ms | 160ms |
+| `credentials.NewCredentialStoreWithConfig` | 12,124 | 2m36s | 13ms | 23ms |
+| `exec.mergeComponentConfigurations` | 9,261 | 1m34s | 10ms | 38ms |
+| `credentials.systemKeyringStore.Delete` | 6,062 | 1m15s | 12ms | 22ms |
+| `merge.WalkAndDeferYAMLFunctions` | 685,202 | 1m13s | 106µs | 326µs |
+| `utils.ProcessIncludeTag` | 1,085 | 3s | 2.8ms | 24ms |
+
+(Cumulative times overlap — `processComponent` wraps
+`processComponentInheritance` wraps `ProcessBaseComponentConfig`,
+etc. The chain accounts for ~5.7 min of CPU work parallelized across
+cores ⇒ ~4 min wall-clock locally, ~10 min on GHA.)
+
+### Why this is worse now than when the perf arc shipped
+
+The October 2025 optimization PRs (#1576/#1611/#1622/#1639) targeted
+the stack-processing pipeline as it existed at that time. Since then,
+Atmos has gained:
+
+- **Auth subsystem** (`pkg/auth/`) — providers, identities, keyring,
+  credential store. The credential-store-per-component path that now
+  accounts for 3.5 min did not exist in #1639's instrumentation.
+- **Profiles subsystem** (`pkg/auth/` + per-profile `atmos.yaml`) —
+  loaded once but interacts with identity resolution per component.
+- **`locals` block** at stack and component level — additional merge
+  passes in the inheritance pipeline.
+- **AI / MCP / AWS security** packages — not on the hot path here,
+  but consume `perf.Track` slots that may have grown.
+
+The `pkg/perf` infrastructure and the `--heatmap` flag are still
+exactly the right tools for this — the discipline survives. What's
+missing is a second pass of the #1639 optimization taxonomy
+(algorithm / caching / concurrency / I/O / cache correctness) over
+the post-#1639 code.
+
+### Code path
+
+1. `atmos describe affected --repo-path <base>` enters
+   `internal/exec/describe_affected.go`.
+2. For each stack, `ExecuteDescribeStacks` walks components and
+   calls `processComponent` in
+   `internal/exec/stack_processor_process_stacks_helpers.go:113`.
+3. `processComponent` calls `processComponentInheritance`
+   (`stack_processor_process_stacks_helpers_inheritance.go:15`).
+4. Inheritance recurses through `processInheritedComponent` and
+   `processMetadataInheritance`, both of which call
+   `ProcessBaseComponentConfig`
+   (`stack_processor_utils.go:1623`) — the heaviest leg at 43ms avg.
+5. Each invocation hits `cacheBaseComponentConfig`
+   (`stack_processor_cache.go:107`) — itself accounting for 5m33s of
+   total time across 6,431 calls. Either the cache is missing too
+   often, or it is doing expensive work on insert that should be done
+   once.
+6. Independently, **per-component auth resolution**
+   (`internal/exec/describe_stacks_component_processor.go`) calls
+   `credentials.NewCredentialStoreWithConfig` even when
+   `--identity=false`. Each call constructs a `systemKeyringStore`
+   that is then `Delete`d, contributing the ~3.5 min.
+
+### Why `--identity=false` does not skip the credential store
+
+The flag prevents AWS role assumption but the per-component
+processor still constructs a credential store as part of the auth
+manager bootstrap. The two are conflated: identity *resolution* is
+gated by `--identity`, but identity *infrastructure* (the credential
+store backing it) is not. With 9,261 components, the store gets
+built 12,124 times (some components retry / re-resolve) and the
+keyring delete fires 6,062 times.
+
+A short-circuit at the credential-store factory — return a no-op
+store when identity resolution is disabled — eliminates 3.5 minutes
+of CPU time without touching the inheritance pipeline.
+
+## Fix
+
+### Phase 1 (shipped in PR #2471, `a0cd28671`, v1.220.0-rc.1)
+
+**~~Credential store gating~~.** Already done. Locations touched:
+
+- `pkg/auth/credentials/store.go` — credential store creation gated
+  on the actual identity-resolution decision.
+- `internal/exec/describe_stacks_component_processor.go` — per-component
+  auth resolver short-circuits when `--identity=false` is in effect.
+
+Confirmed impact: **0 credential calls** in the 2026-05-23 local
+reproduction against current main. Users on v1.219.0 should upgrade.
+
+### Phase 2 (shipped 2026-05-23) — cache lock contention
+
+**Root cause:** `cacheBaseComponentConfig` was holding the global
+`sync.RWMutex.Lock()` for the *entire* function — including a
+~525µs `deepCopyBaseComponentConfigMaps` call. With ~9k component
+instances processed concurrently across stacks, the exclusive write
+lock serialized every cache write. The "55ms avg per call" in the
+baseline was almost entirely **lock-wait time**, not real CPU work.
+
+**Two changes:**
+
+1. **`baseComponentConfigCache` is now a `sync.Map`** (was a
+   `map[string]*BaseComponentConfig` + `sync.RWMutex`). sync.Map is
+   purpose-built for disjoint-key write patterns and has no global
+   lock.
+2. **Deep copy moved outside the critical section.** In
+   `cacheBaseComponentConfig`, the `BaseComponentConfig` is now
+   deep-copied *before* the `sync.Map.Store`, not while holding any
+   lock. The cached pointer's target is immutable post-insert, so
+   `getCachedBaseComponentConfig` deep-copies outside the
+   `sync.Map.Load` too. Both reads and writes now have no contention
+   coupling.
+
+**Confirmed impact (local re-measure, mean of 3 runs):**
+
+| Function | Before (Total / Avg) | After (Total / Avg) | Reduction |
+|---|---:|---:|---:|
+| `cacheBaseComponentConfig` | 5m50s / 55ms | **~4.0s / ~640µs** | **−98.8% Total, 86× faster avg** |
+| `getCachedBaseComponentConfig` | 6.5s / 855µs | **~880ms / ~110µs** | **−86% Total, 8× faster avg** |
+| `processComponent` | 6m11s / 40ms | **35s / 3.8ms** | **−91% Total** |
+| `processComponentInheritance` | 6m02s / 39ms | **28s / 3.0ms** | **−92% Total** |
+| `ProcessBaseComponentConfig` | 6m02s / 45ms | **22s / 2.8ms** | **−94% Total** |
+| `processInheritedComponent` | 6m00s / 74ms | **22s / 4.6ms** | **−94% Total** |
+| `processMetadataInheritance` | 6m00s / 39ms | **23s / 2.5ms** | **−94% Total** |
+
+The pre-fix `Total` was mostly lock-wait, not work. Post-fix
+numbers reflect real CPU cost.
+
+**Wall-clock note.** On a many-core local Mac (parallelism ≈ 100×),
+wall-clock barely moved (3.4s → 4.1s mean) — the lock-waiters were
+parking, not consuming CPU. On a **2-4 core GHA runner**, where
+contention cannot be hidden behind parallelism, the improvement
+projects to **multiple minutes**: with ~30 minutes of synthetic
+"Total" time eliminated and real CPU work staying serial-bound on
+few cores, the lock-wait was effectively wall-clock on small
+runners. End-to-end GHA validation pending.
+
+**Race detector:** `go test -race -count=1 -run "Cache|cache|Base|Inheritance|inherit" ./internal/exec/...`
+green.
+
+**Bottleneck shifted:** post-Phase-2, the heaviest function is now
+`mergeComponentConfigurations` (2m22s total, 15ms avg, 9,261
+calls), followed by `merge.MergeWithDeferred` (1m35s, 752µs avg,
+83,349 calls). These are the next optimization targets after Phase
+3 lands.
+
+### Phase 3 (open) — component-level parallelization
+
+`internal/exec/stack_processor_process_stacks_helpers.go` runs
+`processComponent` serially within each stack's
+`processComponentsInParallel`. 9,261 components ÷ 719 stacks ≈ 13
+components per stack — substantial parallelism opportunity at the
+component level. Worker pool inside the stack-processing goroutine
+would push the inheritance pipeline from ~108× parallelism (current,
+on an M-series Mac) to a higher ceiling on the same hardware, and
+materially help GHA's 2-4 core runners where current parallelism is
+capped at the core count.
+
+Expected impact: 2-3× wall-clock improvement on the inheritance
+pipeline. On GHA's 2-4 cores, this matters more than on a laptop
+because the current parallelism is already saturated by stack count.
+
+### Phase 4 (open) — locals extraction
+
+`extractAndAddLocalsToContext` (22,181 calls, 14s) and
+`extractLocalsFromRawYAML` (22,181 calls, 13s) are the post-#1639
+additions for the `locals` feature. 22,181 = ~30 imports per
+stack × ~744 stacks processed — locals are extracted per imported
+file, not per component. Likely caching opportunity: extract once
+per file, cache by file path + mtime.
+
+Expected impact: -20s CPU on this workload. Small but easy.
+
+### Verification
+
+Re-run the reproducer with `--heatmap` and confirm:
+
+- `cacheBaseComponentConfig` count drops via better hit rate, or its
+  per-call cost drops via lighter insert path.
+- `Parallelism` metric in the heatmap header increases (especially
+  on small-core runners).
+- Wall-clock target on GHA (2-4 cores) after Phases 2+3:
+  **< 2 minutes** end-to-end for `describe affected` on this
+  workload. Local wall-clock is already < 5s on this Mac post-#2471.
+
+## Tests
+
+### Regression test
+
+A unit test asserting that with `--identity=false` (or its
+programmatic equivalent), `NewCredentialStoreWithConfig` is not
+invoked. Mock the factory and assert call count == 0 for a fixture
+run.
+
+### Benchmark
+
+A benchmark in `internal/exec/` that exercises a synthetic
+high-component-count workload (e.g., 1,000 components inheriting
+from a common base) and asserts wall-clock under a threshold.
+Hooks into CI to catch perf regressions.
+
+### Real-repo simulation
+
+Keep the customer-repo reproducer alive as an offline
+regression-detection workflow — once a quarter, run the same
+reproducer and compare against the baseline numbers in this doc.
+
+---
+
+## Related
+
+- [`docs/fixes/2026-05-21-ambient-identity-process-cache-panic.md`](2026-05-21-ambient-identity-process-cache-panic.md)
+  — adjacent auth-path fix (process credential cache).
+- [`docs/fixes/2026-04-17-ambient-identity-nil-credentials.md`](2026-04-17-ambient-identity-nil-credentials.md)
+  — the predecessor ambient-credential fix.
+- **PR #2471** (commit `a0cd28671`, in v1.220.0-rc.1) — Phase 1
+  fix: `fix(auth): honor --identity=false in describe affected and
+  dependents`. Eliminates the 3.5 min of credential-store work.
+- #1576 — perf heatmap visualization (built the tool).
+- #1611 — self-time vs total-time + recursion accounting.
+- #1622 — Docker perf fix + CPU Time / Parallelism metrics.
+- #1639 — first optimization pass: 5.2× faster execution, 92% memory
+  reduction. Predates the `auth`, `profiles`, and `locals`
+  subsystems that this doc identifies as the next optimization
+  targets.
+- `pkg/perf/perf.go` — `perf.Track` instrumentation library.
+- `pkg/ui/heatmap/` — interactive TUI for hotspot analysis.
+- `internal/exec/stack_processor_process_stacks_helpers.go:113` —
+  `processComponent`, the top of the inheritance pipeline.
+- `internal/exec/stack_processor_process_stacks_helpers_inheritance.go` —
+  the inheritance chain (Phase 3 target).
+- `internal/exec/stack_processor_cache.go:107` —
+  `cacheBaseComponentConfig`, the hot cache path (Phase 2 target).
+- `internal/exec/stack_processor_merge.go:40` —
+  `mergeComponentConfigurations`, 1m34s of merge work per run.
+- `pkg/auth/credentials/store.go:67` —
+  `NewCredentialStoreWithConfig`, gated in PR #2471.
+- `pkg/auth/credentials/keyring_system.go:187` —
+  `systemKeyringStore.Delete`, gated in PR #2471.

--- a/internal/exec/stack_processor_backend.go
+++ b/internal/exec/stack_processor_backend.go
@@ -263,9 +263,14 @@ func processTerraformRemoteStateBackend(cfg *remoteStateBackendConfig) (string, 
 }
 
 // extractBackendTypeMap returns the inner map at section[backendType] as a
-// fresh map[string]any, or an empty map if the key is missing. Errors out
-// when the value exists but is not a map (which would have failed the
-// post-merge type assertion in the prior implementation).
+// reference into the input (not a copy), or a fresh empty map if section is
+// nil or the key is missing. Errors out when the value exists but is not a
+// map (which would have failed the post-merge type assertion in the prior
+// implementation).
+//
+// Callers are expected to feed the result into m.Merge (or otherwise treat
+// it as read-only); the only production caller does, and Merge's own
+// contract guarantees its output is a fresh map.
 func extractBackendTypeMap(section map[string]any, backendType, component string) (map[string]any, error) {
 	if section == nil {
 		return map[string]any{}, nil

--- a/internal/exec/stack_processor_backend.go
+++ b/internal/exec/stack_processor_backend.go
@@ -51,7 +51,8 @@ func processTerraformBackend(cfg *terraformBackendConfig) (string, map[string]an
 			cfg.globalBackendSection,
 			cfg.baseComponentBackendSection,
 			cfg.componentBackendSection,
-		})
+		},
+	)
 	if err != nil {
 		return "", nil, err
 	}
@@ -227,32 +228,57 @@ func processTerraformRemoteStateBackend(cfg *remoteStateBackendConfig) (string, 
 			cfg.globalRemoteStateBackendSection,
 			cfg.baseComponentRemoteStateBackendSection,
 			cfg.componentRemoteStateBackendSection,
-		})
+		},
+	)
 	if err != nil {
 		return "", nil, err
 	}
 
-	// Merge backend and remote_state_backend sections for DRY configuration.
-	finalComponentRemoteStateBackendSectionMerged, err := m.Merge(
+	// Extract just the backend-type-specific config from each input. The
+	// final result is only the value for finalComponentRemoteStateBackendType;
+	// no other backend-type keys ever escape this function. Avoid merging
+	// the full sections (which would deep-copy unrelated backend-type entries
+	// like s3/gcs/azurerm/etc. just to throw them away on the extract step).
+	backendVal, backendErr := extractBackendTypeMap(cfg.finalComponentBackendSection, finalComponentRemoteStateBackendType, cfg.component)
+	if backendErr != nil {
+		return "", nil, backendErr
+	}
+	remoteStateBackendVal, remoteStateBackendErr := extractBackendTypeMap(finalComponentRemoteStateBackendSection, finalComponentRemoteStateBackendType, cfg.component)
+	if remoteStateBackendErr != nil {
+		return "", nil, remoteStateBackendErr
+	}
+
+	// Stitch the two scoped values into the result. m.Merge already handles
+	// the 0-input / 1-input fast paths (Phase 5), so we just feed it both;
+	// when one or both are empty the work is trivial.
+	finalComponentRemoteStateBackend, err := m.Merge(
 		cfg.atmosConfig,
-		[]map[string]any{
-			cfg.finalComponentBackendSection,
-			finalComponentRemoteStateBackendSection,
-		})
+		[]map[string]any{backendVal, remoteStateBackendVal},
+	)
 	if err != nil {
 		return "", nil, err
-	}
-
-	// Extract remote state backend configuration for the specific backend type.
-	finalComponentRemoteStateBackend := map[string]any{}
-	if i, ok := finalComponentRemoteStateBackendSectionMerged[finalComponentRemoteStateBackendType]; ok {
-		finalComponentRemoteStateBackend, ok = i.(map[string]any)
-		if !ok {
-			return "", nil, fmt.Errorf("%w: for the component '%s'", errUtils.ErrInvalidTerraformRemoteStateBackend, cfg.component)
-		}
 	}
 
 	return finalComponentRemoteStateBackendType, finalComponentRemoteStateBackend, nil
+}
+
+// extractBackendTypeMap returns the inner map at section[backendType] as a
+// fresh map[string]any, or an empty map if the key is missing. Errors out
+// when the value exists but is not a map (which would have failed the
+// post-merge type assertion in the prior implementation).
+func extractBackendTypeMap(section map[string]any, backendType, component string) (map[string]any, error) {
+	if section == nil {
+		return map[string]any{}, nil
+	}
+	raw, ok := section[backendType]
+	if !ok {
+		return map[string]any{}, nil
+	}
+	asMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: for the component '%s'", errUtils.ErrInvalidTerraformRemoteStateBackend, component)
+	}
+	return asMap, nil
 }
 
 // getWorkspacePrefixSeparator returns the configured separator for auto-generated

--- a/internal/exec/stack_processor_backend.go
+++ b/internal/exec/stack_processor_backend.go
@@ -221,39 +221,40 @@ func processTerraformRemoteStateBackend(cfg *remoteStateBackendConfig) (string, 
 		finalComponentRemoteStateBackendType = cfg.componentRemoteStateBackendType
 	}
 
-	// Merge remote state backend sections.
-	finalComponentRemoteStateBackendSection, err := m.Merge(
-		cfg.atmosConfig,
-		[]map[string]any{
-			cfg.globalRemoteStateBackendSection,
-			cfg.baseComponentRemoteStateBackendSection,
-			cfg.componentRemoteStateBackendSection,
-		},
-	)
+	// Scope every input to just the backend-type-specific map before merging.
+	// The final result is only the value for finalComponentRemoteStateBackendType;
+	// no other backend-type keys ever escape this function. Extracting first
+	// avoids deep-copying unrelated backend-type entries (s3/gcs/azurerm/etc.)
+	// only to throw them away after merge — applies to BOTH the inter-layer
+	// merge of the three remote-state inputs AND the final stitch with the
+	// backend section. Precedence is preserved because the layered remotes
+	// are merged in the same order (global → base component → component) as
+	// the un-scoped path would have.
+	globalRemoteVal, err := extractBackendTypeMap(cfg.globalRemoteStateBackendSection, finalComponentRemoteStateBackendType, cfg.component)
+	if err != nil {
+		return "", nil, err
+	}
+	baseRemoteVal, err := extractBackendTypeMap(cfg.baseComponentRemoteStateBackendSection, finalComponentRemoteStateBackendType, cfg.component)
+	if err != nil {
+		return "", nil, err
+	}
+	componentRemoteVal, err := extractBackendTypeMap(cfg.componentRemoteStateBackendSection, finalComponentRemoteStateBackendType, cfg.component)
+	if err != nil {
+		return "", nil, err
+	}
+	backendVal, err := extractBackendTypeMap(cfg.finalComponentBackendSection, finalComponentRemoteStateBackendType, cfg.component)
 	if err != nil {
 		return "", nil, err
 	}
 
-	// Extract just the backend-type-specific config from each input. The
-	// final result is only the value for finalComponentRemoteStateBackendType;
-	// no other backend-type keys ever escape this function. Avoid merging
-	// the full sections (which would deep-copy unrelated backend-type entries
-	// like s3/gcs/azurerm/etc. just to throw them away on the extract step).
-	backendVal, backendErr := extractBackendTypeMap(cfg.finalComponentBackendSection, finalComponentRemoteStateBackendType, cfg.component)
-	if backendErr != nil {
-		return "", nil, backendErr
-	}
-	remoteStateBackendVal, remoteStateBackendErr := extractBackendTypeMap(finalComponentRemoteStateBackendSection, finalComponentRemoteStateBackendType, cfg.component)
-	if remoteStateBackendErr != nil {
-		return "", nil, remoteStateBackendErr
-	}
-
-	// Stitch the two scoped values into the result. m.Merge already handles
-	// the 0-input / 1-input fast paths (Phase 5), so we just feed it both;
-	// when one or both are empty the work is trivial.
+	// Stitch the four scoped values into the result. Order matters: the
+	// backend section provides the base, then the remote-state inputs layer
+	// on top in their normal precedence. m.Merge's existing fast paths
+	// (Phase 5) handle 0/1 non-empty inputs trivially when most layers are
+	// absent.
 	finalComponentRemoteStateBackend, err := m.Merge(
 		cfg.atmosConfig,
-		[]map[string]any{backendVal, remoteStateBackendVal},
+		[]map[string]any{backendVal, globalRemoteVal, baseRemoteVal, componentRemoteVal},
 	)
 	if err != nil {
 		return "", nil, err

--- a/internal/exec/stack_processor_backend_test.go
+++ b/internal/exec/stack_processor_backend_test.go
@@ -874,3 +874,133 @@ func TestExtractBackendTypeMap(t *testing.T) {
 		assert.Contains(t, err.Error(), "vpc", "error should mention the component name")
 	})
 }
+
+// TestProcessTerraformBackend_TypeMismatchSurfacesError covers the post-merge
+// type assertion in processTerraformBackend: if backendSection[type] exists
+// but is not a map (e.g., a string mistakenly written in YAML), the function
+// must return an ErrInvalidTerraformBackend rather than panicking.
+func TestProcessTerraformBackend_TypeMismatchSurfacesError(t *testing.T) {
+	cfg := &terraformBackendConfig{
+		atmosConfig:       &schema.AtmosConfiguration{},
+		component:         "broken",
+		globalBackendType: "s3",
+		globalBackendSection: map[string]any{
+			// Non-map value at the s3 key — invalid YAML structure.
+			"s3": "not-a-map",
+		},
+	}
+	gotType, gotBackend, err := processTerraformBackend(cfg)
+	require.Error(t, err)
+	assert.Empty(t, gotType)
+	assert.Nil(t, gotBackend)
+	assert.Contains(t, err.Error(), "broken", "error must reference the component name")
+}
+
+// TestProcessTerraformRemoteStateBackend_PropagatesExtractError covers the
+// four error-return sites in processTerraformRemoteStateBackend that bubble
+// up extractBackendTypeMap's type-mismatch error. Each test case poisons one
+// of the four input sections with a non-map value at the resolved backend
+// type, then verifies the error surfaces.
+func TestProcessTerraformRemoteStateBackend_PropagatesExtractError(t *testing.T) {
+	const component = "rs-broken"
+	const backendType = "s3"
+	validSection := map[string]any{"s3": map[string]any{"bucket": "ok"}}
+	poison := map[string]any{"s3": "not-a-map"}
+
+	cases := []struct {
+		name string
+		mut  func(c *remoteStateBackendConfig)
+	}{
+		{
+			name: "global remote state section poisoned",
+			mut:  func(c *remoteStateBackendConfig) { c.globalRemoteStateBackendSection = poison },
+		},
+		{
+			name: "base component remote state section poisoned",
+			mut:  func(c *remoteStateBackendConfig) { c.baseComponentRemoteStateBackendSection = poison },
+		},
+		{
+			name: "component remote state section poisoned",
+			mut:  func(c *remoteStateBackendConfig) { c.componentRemoteStateBackendSection = poison },
+		},
+		{
+			name: "final component backend section poisoned",
+			mut:  func(c *remoteStateBackendConfig) { c.finalComponentBackendSection = poison },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &remoteStateBackendConfig{
+				atmosConfig:                            &schema.AtmosConfiguration{},
+				component:                              component,
+				finalComponentBackendType:              backendType,
+				finalComponentBackendSection:           validSection,
+				globalRemoteStateBackendSection:        validSection,
+				baseComponentRemoteStateBackendSection: validSection,
+				componentRemoteStateBackendSection:     validSection,
+			}
+			tc.mut(cfg)
+			gotType, gotBackend, err := processTerraformRemoteStateBackend(cfg)
+			require.Error(t, err)
+			assert.Empty(t, gotType)
+			assert.Nil(t, gotBackend)
+			assert.Contains(t, err.Error(), component, "error must reference the component name")
+		})
+	}
+}
+
+// TestShouldPreserveAuthoredKey covers the three decision paths of the
+// helper: no authored key (false), no global azurerm section (true), no
+// global key in azurerm (true), global key matches authored (false, treat
+// global as prefix), global key differs from authored (true, preserve).
+func TestShouldPreserveAuthoredKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		final    map[string]any
+		global   map[string]any
+		expected bool
+	}{
+		{
+			name:     "no authored key returns false",
+			final:    map[string]any{},
+			global:   map[string]any{"azurerm": map[string]any{"key": "global.tfstate"}},
+			expected: false,
+		},
+		{
+			name:     "empty-string authored key returns false",
+			final:    map[string]any{"key": ""},
+			global:   map[string]any{"azurerm": map[string]any{"key": "global.tfstate"}},
+			expected: false,
+		},
+		{
+			name:     "no global azurerm section preserves authored key",
+			final:    map[string]any{"key": "authored.tfstate"},
+			global:   map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "global azurerm with no key preserves authored key",
+			final:    map[string]any{"key": "authored.tfstate"},
+			global:   map[string]any{"azurerm": map[string]any{"resource_group_name": "rg"}},
+			expected: true,
+		},
+		{
+			name:     "global key matches authored - treated as prefix, do not preserve",
+			final:    map[string]any{"key": "global-prefix"},
+			global:   map[string]any{"azurerm": map[string]any{"key": "global-prefix"}},
+			expected: false,
+		},
+		{
+			name:     "global key differs from authored - preserve",
+			final:    map[string]any{"key": "authored.tfstate"},
+			global:   map[string]any{"azurerm": map[string]any{"key": "global.tfstate"}},
+			expected: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldPreserveAuthoredKey(tc.final, tc.global)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/internal/exec/stack_processor_backend_test.go
+++ b/internal/exec/stack_processor_backend_test.go
@@ -838,3 +838,39 @@ func TestProcessTerraformBackend_WithPrefixSeparator(t *testing.T) {
 		assert.Equal(t, "services-consul", backendConfig["workspace_key_prefix"])
 	})
 }
+
+// TestExtractBackendTypeMap covers the helper introduced in Phase 11.
+// The success and missing-key paths are exercised by TestProcessTerraform*
+// indirectly, but the type-mismatch error path needs its own assertion.
+func TestExtractBackendTypeMap(t *testing.T) {
+	t.Run("returns empty map for nil section", func(t *testing.T) {
+		out, err := extractBackendTypeMap(nil, "s3", "vpc")
+		require.NoError(t, err)
+		assert.NotNil(t, out)
+		assert.Empty(t, out)
+	})
+
+	t.Run("returns empty map for missing key", func(t *testing.T) {
+		section := map[string]any{"gcs": map[string]any{"bucket": "x"}}
+		out, err := extractBackendTypeMap(section, "s3", "vpc")
+		require.NoError(t, err)
+		assert.NotNil(t, out)
+		assert.Empty(t, out)
+	})
+
+	t.Run("returns the inner map when key exists", func(t *testing.T) {
+		section := map[string]any{"s3": map[string]any{"bucket": "my-bucket", "key": "tfstate"}}
+		out, err := extractBackendTypeMap(section, "s3", "vpc")
+		require.NoError(t, err)
+		assert.Equal(t, "my-bucket", out["bucket"])
+		assert.Equal(t, "tfstate", out["key"])
+	})
+
+	t.Run("returns error when value at key is not a map", func(t *testing.T) {
+		section := map[string]any{"s3": "not-a-map"}
+		out, err := extractBackendTypeMap(section, "s3", "vpc")
+		require.Error(t, err)
+		assert.Nil(t, out)
+		assert.Contains(t, err.Error(), "vpc", "error should mention the component name")
+	})
+}

--- a/internal/exec/stack_processor_cache.go
+++ b/internal/exec/stack_processor_cache.go
@@ -39,6 +39,14 @@ var (
 // deepCopyBaseComponentConfigMaps deep copies all map fields from src to dst.
 // Returns an error if any deep copy fails.
 //
+// This must cover EVERY AtmosSectionMapType field of BaseComponentConfig so
+// the cache's returned-on-hit shape matches the freshly-computed shape from
+// processBaseComponentConfigInternal. Missing a field here causes a silent
+// correctness bug: cache MISS yields the full config, cache HIT yields a
+// truncated one with the missed field as nil. The companion paired-string
+// fields (BaseComponentRequiredVersion etc.) are copied by the struct
+// literal in cacheBaseComponentConfig / getCachedBaseComponentConfig.
+//
 // Empty src fields are skipped (no DeepCopyMap call, no allocation). In the
 // customer workload most components leave several of these fields empty
 // (notably BaseComponentProviders / Hooks / Generate / Dependencies for
@@ -46,6 +54,8 @@ var (
 // per-call cost in cacheBaseComponentConfig / getCachedBaseComponentConfig
 // proportional to how many fields are unused. Phases 12/13 of the
 // describe-affected perf investigation.
+//
+//nolint:cyclop,funlen // Cohesive field-by-field deep-copy; splitting would obscure that every map field of BaseComponentConfig is covered.
 func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error {
 	var err error
 	if len(src.BaseComponentVars) > 0 {
@@ -68,13 +78,18 @@ func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error
 			return err
 		}
 	}
-	if len(src.BaseComponentMetadata) > 0 {
-		if dst.BaseComponentMetadata, err = m.DeepCopyMap(src.BaseComponentMetadata); err != nil {
+	if len(src.BaseComponentDependencies) > 0 {
+		if dst.BaseComponentDependencies, err = m.DeepCopyMap(src.BaseComponentDependencies); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentDependencies) > 0 {
-		if dst.BaseComponentDependencies, err = m.DeepCopyMap(src.BaseComponentDependencies); err != nil {
+	if len(src.BaseComponentLocals) > 0 {
+		if dst.BaseComponentLocals, err = m.DeepCopyMap(src.BaseComponentLocals); err != nil {
+			return err
+		}
+	}
+	if len(src.BaseComponentMetadata) > 0 {
+		if dst.BaseComponentMetadata, err = m.DeepCopyMap(src.BaseComponentMetadata); err != nil {
 			return err
 		}
 	}
@@ -83,8 +98,18 @@ func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error
 			return err
 		}
 	}
+	if len(src.BaseComponentRequiredProviders) > 0 {
+		if dst.BaseComponentRequiredProviders, err = m.DeepCopyMap(src.BaseComponentRequiredProviders); err != nil {
+			return err
+		}
+	}
 	if len(src.BaseComponentHooks) > 0 {
 		if dst.BaseComponentHooks, err = m.DeepCopyMap(src.BaseComponentHooks); err != nil {
+			return err
+		}
+	}
+	if len(src.BaseComponentGenerate) > 0 {
+		if dst.BaseComponentGenerate, err = m.DeepCopyMap(src.BaseComponentGenerate); err != nil {
 			return err
 		}
 	}
@@ -95,6 +120,16 @@ func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error
 	}
 	if len(src.BaseComponentRemoteStateBackendSection) > 0 {
 		if dst.BaseComponentRemoteStateBackendSection, err = m.DeepCopyMap(src.BaseComponentRemoteStateBackendSection); err != nil {
+			return err
+		}
+	}
+	if len(src.BaseComponentSourceSection) > 0 {
+		if dst.BaseComponentSourceSection, err = m.DeepCopyMap(src.BaseComponentSourceSection); err != nil {
+			return err
+		}
+	}
+	if len(src.BaseComponentProvisionSection) > 0 {
+		if dst.BaseComponentProvisionSection, err = m.DeepCopyMap(src.BaseComponentProvisionSection); err != nil {
 			return err
 		}
 	}
@@ -126,6 +161,11 @@ func getCachedBaseComponentConfig(cacheKey string) (*schema.BaseComponentConfig,
 		BaseComponentCommand:                cached.BaseComponentCommand,
 		BaseComponentBackendType:            cached.BaseComponentBackendType,
 		BaseComponentRemoteStateBackendType: cached.BaseComponentRemoteStateBackendType,
+		// BaseComponentRequiredVersion is a string set by
+		// processBaseComponentConfigInternal — it must round-trip through the
+		// cache so callers that read it after a cache HIT see the same value
+		// as after a cache MISS.
+		BaseComponentRequiredVersion: cached.BaseComponentRequiredVersion,
 	}
 
 	// Deep copy all map fields.
@@ -159,6 +199,11 @@ func cacheBaseComponentConfig(cacheKey string, config *schema.BaseComponentConfi
 		BaseComponentCommand:                config.BaseComponentCommand,
 		BaseComponentBackendType:            config.BaseComponentBackendType,
 		BaseComponentRemoteStateBackendType: config.BaseComponentRemoteStateBackendType,
+		// BaseComponentRequiredVersion is a string set by
+		// processBaseComponentConfigInternal — it must round-trip through the
+		// cache so callers that read it after a cache HIT see the same value
+		// as after a cache MISS.
+		BaseComponentRequiredVersion: config.BaseComponentRequiredVersion,
 	}
 
 	// Deep copy all map fields.

--- a/internal/exec/stack_processor_cache.go
+++ b/internal/exec/stack_processor_cache.go
@@ -38,37 +38,65 @@ var (
 
 // deepCopyBaseComponentConfigMaps deep copies all map fields from src to dst.
 // Returns an error if any deep copy fails.
+//
+// Empty src fields are skipped (no DeepCopyMap call, no allocation). In the
+// customer workload most components leave several of these fields empty
+// (notably BaseComponentProviders / Hooks / Generate / Dependencies for
+// non-Terraform components), so skipping the no-op deep-copies cuts the
+// per-call cost in cacheBaseComponentConfig / getCachedBaseComponentConfig
+// proportional to how many fields are unused. Phases 12/13 of the
+// describe-affected perf investigation.
 func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error {
 	var err error
-	if dst.BaseComponentVars, err = m.DeepCopyMap(src.BaseComponentVars); err != nil {
-		return err
+	if len(src.BaseComponentVars) > 0 {
+		if dst.BaseComponentVars, err = m.DeepCopyMap(src.BaseComponentVars); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentSettings, err = m.DeepCopyMap(src.BaseComponentSettings); err != nil {
-		return err
+	if len(src.BaseComponentSettings) > 0 {
+		if dst.BaseComponentSettings, err = m.DeepCopyMap(src.BaseComponentSettings); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentEnv, err = m.DeepCopyMap(src.BaseComponentEnv); err != nil {
-		return err
+	if len(src.BaseComponentEnv) > 0 {
+		if dst.BaseComponentEnv, err = m.DeepCopyMap(src.BaseComponentEnv); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentAuth, err = m.DeepCopyMap(src.BaseComponentAuth); err != nil {
-		return err
+	if len(src.BaseComponentAuth) > 0 {
+		if dst.BaseComponentAuth, err = m.DeepCopyMap(src.BaseComponentAuth); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentMetadata, err = m.DeepCopyMap(src.BaseComponentMetadata); err != nil {
-		return err
+	if len(src.BaseComponentMetadata) > 0 {
+		if dst.BaseComponentMetadata, err = m.DeepCopyMap(src.BaseComponentMetadata); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentDependencies, err = m.DeepCopyMap(src.BaseComponentDependencies); err != nil {
-		return err
+	if len(src.BaseComponentDependencies) > 0 {
+		if dst.BaseComponentDependencies, err = m.DeepCopyMap(src.BaseComponentDependencies); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentProviders, err = m.DeepCopyMap(src.BaseComponentProviders); err != nil {
-		return err
+	if len(src.BaseComponentProviders) > 0 {
+		if dst.BaseComponentProviders, err = m.DeepCopyMap(src.BaseComponentProviders); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentHooks, err = m.DeepCopyMap(src.BaseComponentHooks); err != nil {
-		return err
+	if len(src.BaseComponentHooks) > 0 {
+		if dst.BaseComponentHooks, err = m.DeepCopyMap(src.BaseComponentHooks); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentBackendSection, err = m.DeepCopyMap(src.BaseComponentBackendSection); err != nil {
-		return err
+	if len(src.BaseComponentBackendSection) > 0 {
+		if dst.BaseComponentBackendSection, err = m.DeepCopyMap(src.BaseComponentBackendSection); err != nil {
+			return err
+		}
 	}
-	if dst.BaseComponentRemoteStateBackendSection, err = m.DeepCopyMap(src.BaseComponentRemoteStateBackendSection); err != nil {
-		return err
+	if len(src.BaseComponentRemoteStateBackendSection) > 0 {
+		if dst.BaseComponentRemoteStateBackendSection, err = m.DeepCopyMap(src.BaseComponentRemoteStateBackendSection); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/exec/stack_processor_cache.go
+++ b/internal/exec/stack_processor_cache.go
@@ -17,10 +17,17 @@ var (
 	getFileContentSyncMap = sync.Map{}
 
 	// Base component inheritance cache to avoid re-processing the same inheritance chains.
-	// Cache key: "stack:component:baseComponent" -> BaseComponentConfig.
+	// Cache key: "stack:component:baseComponent" -> *schema.BaseComponentConfig (immutable post-insert).
 	// No cache invalidation needed - configuration is immutable per command execution.
-	baseComponentConfigCache   = make(map[string]*schema.BaseComponentConfig)
-	baseComponentConfigCacheMu sync.RWMutex
+	//
+	// Uses sync.Map (not a RWMutex-protected map) because the write path is highly
+	// contended at scale: in a large-stack workload (~9k component instances across
+	// ~700 stacks), the previous RWMutex.Lock() inside cacheBaseComponentConfig
+	// serialized every write across goroutines, contributing ~5m50s of cumulative
+	// wait time to the heatmap (55ms avg per call) despite the actual deep-copy
+	// work being only ~525µs per call. The lock-free sync.Map removes the global
+	// lock and optimizes for the disjoint-key write pattern this cache exhibits.
+	baseComponentConfigCache sync.Map
 
 	// JSON schema compilation cache to avoid re-compiling the same schema for every stack file.
 	// Cache key: absolute file path to schema file -> compiled schema.
@@ -68,14 +75,19 @@ func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error
 
 // getCachedBaseComponentConfig retrieves a cached base component config if it exists.
 // Returns a deep copy to prevent mutations affecting the cache.
+//
+// The deep copy runs outside the sync.Map.Load critical section: the cached
+// pointer's target is immutable post-insert (see cacheBaseComponentConfig), so
+// concurrent goroutines may safely deep-copy it without coordination.
 func getCachedBaseComponentConfig(cacheKey string) (*schema.BaseComponentConfig, *[]string, bool) {
 	defer perf.Track(nil, "exec.getCachedBaseComponentConfig")()
 
-	baseComponentConfigCacheMu.RLock()
-	defer baseComponentConfigCacheMu.RUnlock()
-
-	cached, found := baseComponentConfigCache[cacheKey]
+	raw, found := baseComponentConfigCache.Load(cacheKey)
 	if !found {
+		return nil, nil, false
+	}
+	cached, ok := raw.(*schema.BaseComponentConfig)
+	if !ok {
 		return nil, nil, false
 	}
 
@@ -104,11 +116,13 @@ func getCachedBaseComponentConfig(cacheKey string) (*schema.BaseComponentConfig,
 
 // cacheBaseComponentConfig stores a base component config in the cache.
 // Stores a deep copy to prevent external mutations from affecting the cache.
+//
+// The deep copy is performed BEFORE the store so the cache's critical section
+// is only the sync.Map.Store call, not the ~525µs deep-copy work. Combined with
+// sync.Map's lock-free read path, this keeps write contention out of the
+// inheritance pipeline's hot path.
 func cacheBaseComponentConfig(cacheKey string, config *schema.BaseComponentConfig) {
 	defer perf.Track(nil, "exec.cacheBaseComponentConfig")()
-
-	baseComponentConfigCacheMu.Lock()
-	defer baseComponentConfigCacheMu.Unlock()
 
 	// Deep copy to prevent external mutations from affecting the cache.
 	// All map fields must be deep copied since they are mutable.
@@ -130,7 +144,7 @@ func cacheBaseComponentConfig(cacheKey string, config *schema.BaseComponentConfi
 	copy(copyBaseComponents, config.ComponentInheritanceChain)
 	copyConfig.ComponentInheritanceChain = copyBaseComponents
 
-	baseComponentConfigCache[cacheKey] = &copyConfig
+	baseComponentConfigCache.Store(cacheKey, &copyConfig)
 }
 
 // getCachedCompiledSchema retrieves a cached compiled JSON schema if it exists.
@@ -161,9 +175,10 @@ func cacheCompiledSchema(schemaPath string, schema *jsonschema.Schema) {
 func ClearBaseComponentConfigCache() {
 	defer perf.Track(nil, "exec.ClearBaseComponentConfigCache")()
 
-	baseComponentConfigCacheMu.Lock()
-	defer baseComponentConfigCacheMu.Unlock()
-	baseComponentConfigCache = make(map[string]*schema.BaseComponentConfig)
+	baseComponentConfigCache.Range(func(key, _ any) bool {
+		baseComponentConfigCache.Delete(key)
+		return true
+	})
 }
 
 // ClearJsonSchemaCache clears the JSON schema cache.

--- a/internal/exec/stack_processor_cache.go
+++ b/internal/exec/stack_processor_cache.go
@@ -47,88 +47,89 @@ var (
 // fields (BaseComponentRequiredVersion etc.) are copied by the struct
 // literal in cacheBaseComponentConfig / getCachedBaseComponentConfig.
 //
-// Empty src fields are skipped (no DeepCopyMap call, no allocation). In the
-// customer workload most components leave several of these fields empty
-// (notably BaseComponentProviders / Hooks / Generate / Dependencies for
-// non-Terraform components), so skipping the no-op deep-copies cuts the
-// per-call cost in cacheBaseComponentConfig / getCachedBaseComponentConfig
-// proportional to how many fields are unused. Phases 12/13 of the
-// describe-affected perf investigation.
+// Each m.DeepCopyMap call is guarded by `src.Field != nil` (not
+// `len(...) > 0`): this matches m.DeepCopyMap's exact behavior on its
+// inputs — nil src returns nil dst (skipping is the same outcome), but
+// empty-non-nil src returns empty-non-nil dst (must still go through the
+// call so the caller observes the same map shape it would on a cache MISS,
+// and so any downstream code that writes into result.BaseComponentX[key]
+// doesn't panic with "assignment to entry in nil map"). Phases 12/13 of
+// the describe-affected perf investigation.
 //
 //nolint:cyclop,funlen // Cohesive field-by-field deep-copy; splitting would obscure that every map field of BaseComponentConfig is covered.
 func deepCopyBaseComponentConfigMaps(dst, src *schema.BaseComponentConfig) error {
 	var err error
-	if len(src.BaseComponentVars) > 0 {
+	if src.BaseComponentVars != nil {
 		if dst.BaseComponentVars, err = m.DeepCopyMap(src.BaseComponentVars); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentSettings) > 0 {
+	if src.BaseComponentSettings != nil {
 		if dst.BaseComponentSettings, err = m.DeepCopyMap(src.BaseComponentSettings); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentEnv) > 0 {
+	if src.BaseComponentEnv != nil {
 		if dst.BaseComponentEnv, err = m.DeepCopyMap(src.BaseComponentEnv); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentAuth) > 0 {
+	if src.BaseComponentAuth != nil {
 		if dst.BaseComponentAuth, err = m.DeepCopyMap(src.BaseComponentAuth); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentDependencies) > 0 {
+	if src.BaseComponentDependencies != nil {
 		if dst.BaseComponentDependencies, err = m.DeepCopyMap(src.BaseComponentDependencies); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentLocals) > 0 {
+	if src.BaseComponentLocals != nil {
 		if dst.BaseComponentLocals, err = m.DeepCopyMap(src.BaseComponentLocals); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentMetadata) > 0 {
+	if src.BaseComponentMetadata != nil {
 		if dst.BaseComponentMetadata, err = m.DeepCopyMap(src.BaseComponentMetadata); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentProviders) > 0 {
+	if src.BaseComponentProviders != nil {
 		if dst.BaseComponentProviders, err = m.DeepCopyMap(src.BaseComponentProviders); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentRequiredProviders) > 0 {
+	if src.BaseComponentRequiredProviders != nil {
 		if dst.BaseComponentRequiredProviders, err = m.DeepCopyMap(src.BaseComponentRequiredProviders); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentHooks) > 0 {
+	if src.BaseComponentHooks != nil {
 		if dst.BaseComponentHooks, err = m.DeepCopyMap(src.BaseComponentHooks); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentGenerate) > 0 {
+	if src.BaseComponentGenerate != nil {
 		if dst.BaseComponentGenerate, err = m.DeepCopyMap(src.BaseComponentGenerate); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentBackendSection) > 0 {
+	if src.BaseComponentBackendSection != nil {
 		if dst.BaseComponentBackendSection, err = m.DeepCopyMap(src.BaseComponentBackendSection); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentRemoteStateBackendSection) > 0 {
+	if src.BaseComponentRemoteStateBackendSection != nil {
 		if dst.BaseComponentRemoteStateBackendSection, err = m.DeepCopyMap(src.BaseComponentRemoteStateBackendSection); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentSourceSection) > 0 {
+	if src.BaseComponentSourceSection != nil {
 		if dst.BaseComponentSourceSection, err = m.DeepCopyMap(src.BaseComponentSourceSection); err != nil {
 			return err
 		}
 	}
-	if len(src.BaseComponentProvisionSection) > 0 {
+	if src.BaseComponentProvisionSection != nil {
 		if dst.BaseComponentProvisionSection, err = m.DeepCopyMap(src.BaseComponentProvisionSection); err != nil {
 			return err
 		}

--- a/internal/exec/stack_processor_cache_test.go
+++ b/internal/exec/stack_processor_cache_test.go
@@ -267,6 +267,40 @@ func TestGetCachedBaseComponentConfigNotFound(t *testing.T) {
 	assert.Nil(t, baseComponents)
 }
 
+// TestGetCachedBaseComponentConfig_TypeMismatch verifies the defensive
+// type assertion in getCachedBaseComponentConfig: if some other code
+// somehow stored a non-*BaseComponentConfig value under a cache key
+// (programmer error), the lookup must surface as "not found" rather
+// than panicking.
+func TestGetCachedBaseComponentConfig_TypeMismatch(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	// Stash a non-matching type directly into the underlying sync.Map.
+	baseComponentConfigCache.Store("type-mismatch-key", "not-a-config")
+
+	cached, baseComponents, found := getCachedBaseComponentConfig("type-mismatch-key")
+	assert.False(t, found, "type-mismatched entries must surface as cache miss")
+	assert.Nil(t, cached)
+	assert.Nil(t, baseComponents)
+}
+
+// TestGetFileContent_StringCachedValue exercises the string branch of
+// GetFileContent's type switch. Normal writes use []byte (the os.ReadFile
+// return type), but the switch also handles string values to be robust
+// against any caller (or future change) that caches a string directly.
+func TestGetFileContent_StringCachedValue(t *testing.T) {
+	ClearFileContentCache()
+	defer ClearFileContentCache()
+
+	// Pre-populate the cache with a string value (not []byte).
+	getFileContentSyncMap.Store("/virtual/string-cached.yaml", "cached-as-string")
+
+	content, err := GetFileContent("/virtual/string-cached.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-as-string", content)
+}
+
 // TestConcurrentCacheAccess tests thread-safety of cache operations.
 func TestConcurrentCacheAccess(t *testing.T) {
 	ClearBaseComponentConfigCache()
@@ -482,16 +516,16 @@ func TestCacheCompiledSchemaBasic(t *testing.T) {
 	ClearJsonSchemaCache()
 }
 
-// TestCacheBaseComponentConfig_SkipsEmptyFields verifies the Phase 12/13
-// optimization: deepCopyBaseComponentConfigMaps skips m.DeepCopyMap for
-// fields that are empty in the source. The behavioral contract is that
-// empty (or nil) source fields produce nil dst fields, identical to the
-// pre-optimization behavior of m.DeepCopyMap(nil) returning nil.
-func TestCacheBaseComponentConfig_SkipsEmptyFields(t *testing.T) {
+// TestCacheBaseComponentConfig_NilFieldsStayNil verifies the Phase 12/13
+// optimization for the nil case: deepCopyBaseComponentConfigMaps skips the
+// m.DeepCopyMap call for nil source fields and the dst field stays nil
+// (matching m.DeepCopyMap(nil) returning nil). This is the dominant case
+// in real workloads where components leave several fields uninitialized.
+func TestCacheBaseComponentConfig_NilFieldsStayNil(t *testing.T) {
 	ClearBaseComponentConfigCache()
 	defer ClearBaseComponentConfigCache()
 
-	// Source with most fields empty — only Vars is populated.
+	// Source with most fields nil — only Vars is populated.
 	src := &schema.BaseComponentConfig{
 		FinalBaseComponentName: "minimal",
 		BaseComponentVars:      map[string]any{"region": "us-east-1"},
@@ -507,8 +541,7 @@ func TestCacheBaseComponentConfig_SkipsEmptyFields(t *testing.T) {
 	// The populated field round-trips.
 	assert.Equal(t, "us-east-1", cached.BaseComponentVars["region"])
 
-	// The empty-source fields stay nil on the retrieved copy (no empty-map
-	// allocations were performed during caching or retrieval).
+	// The nil-source fields stay nil on the retrieved copy.
 	assert.Nil(t, cached.BaseComponentSettings)
 	assert.Nil(t, cached.BaseComponentEnv)
 	assert.Nil(t, cached.BaseComponentAuth)
@@ -518,16 +551,83 @@ func TestCacheBaseComponentConfig_SkipsEmptyFields(t *testing.T) {
 	assert.Nil(t, cached.BaseComponentHooks)
 	assert.Nil(t, cached.BaseComponentBackendSection)
 	assert.Nil(t, cached.BaseComponentRemoteStateBackendSection)
-	// Locals/Generate/SourceSection/ProvisionSection/RequiredProviders were
-	// historically not deep-copied at all (pre-existing main-branch bug:
+	// Locals / Generate / SourceSection / ProvisionSection / RequiredProviders
+	// were historically not deep-copied at all (pre-existing main-branch bug:
 	// cache HIT returned them as nil even when the un-cached path populated
-	// them). Now covered by deepCopyBaseComponentConfigMaps — empty source
-	// still yields nil dst.
+	// them). Now covered by deepCopyBaseComponentConfigMaps — nil source
+	// still yields nil dst, populated source round-trips.
 	assert.Nil(t, cached.BaseComponentLocals)
 	assert.Nil(t, cached.BaseComponentGenerate)
 	assert.Nil(t, cached.BaseComponentSourceSection)
 	assert.Nil(t, cached.BaseComponentProvisionSection)
 	assert.Nil(t, cached.BaseComponentRequiredProviders)
+}
+
+// TestCacheBaseComponentConfig_EmptyNonNilFieldsStayNonNil locks in the
+// distinction between a nil map and an empty-but-non-nil map. The Phase
+// 12/13 skip guard MUST use `src.Field != nil` (not `len(src.Field) > 0`)
+// so an empty-non-nil source still goes through m.DeepCopyMap and yields
+// an empty-non-nil dst. Collapsing empty-non-nil maps to nil would (a)
+// break the "cache HIT shape == cache MISS shape" invariant the
+// processBaseComponentConfigInternal contract relies on, and (b) make
+// any downstream code that writes into result.BaseComponentX[key] panic
+// with "assignment to entry in nil map".
+func TestCacheBaseComponentConfig_EmptyNonNilFieldsStayNonNil(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	// Source with every map field allocated but empty.
+	src := &schema.BaseComponentConfig{
+		FinalBaseComponentName:                 "empty-non-nil",
+		BaseComponentVars:                      map[string]any{},
+		BaseComponentSettings:                  map[string]any{},
+		BaseComponentEnv:                       map[string]any{},
+		BaseComponentAuth:                      map[string]any{},
+		BaseComponentDependencies:              map[string]any{},
+		BaseComponentLocals:                    map[string]any{},
+		BaseComponentMetadata:                  map[string]any{},
+		BaseComponentProviders:                 map[string]any{},
+		BaseComponentRequiredProviders:         map[string]any{},
+		BaseComponentHooks:                     map[string]any{},
+		BaseComponentGenerate:                  map[string]any{},
+		BaseComponentBackendSection:            map[string]any{},
+		BaseComponentRemoteStateBackendSection: map[string]any{},
+		BaseComponentSourceSection:             map[string]any{},
+		BaseComponentProvisionSection:          map[string]any{},
+		ComponentInheritanceChain:              []string{"base"},
+	}
+	cacheBaseComponentConfig("empty-key", src)
+
+	cached, _, found := getCachedBaseComponentConfig("empty-key")
+	require.True(t, found)
+	require.NotNil(t, cached)
+
+	// Every field that was empty-non-nil in the source must come back
+	// empty-non-nil from the cache. A nil result would (a) lose the
+	// hit==miss-shape contract, and (b) panic on a downstream map write.
+	maps := map[string]map[string]any{
+		"Vars":                      cached.BaseComponentVars,
+		"Settings":                  cached.BaseComponentSettings,
+		"Env":                       cached.BaseComponentEnv,
+		"Auth":                      cached.BaseComponentAuth,
+		"Dependencies":              cached.BaseComponentDependencies,
+		"Locals":                    cached.BaseComponentLocals,
+		"Metadata":                  cached.BaseComponentMetadata,
+		"Providers":                 cached.BaseComponentProviders,
+		"RequiredProviders":         cached.BaseComponentRequiredProviders,
+		"Hooks":                     cached.BaseComponentHooks,
+		"Generate":                  cached.BaseComponentGenerate,
+		"BackendSection":            cached.BaseComponentBackendSection,
+		"RemoteStateBackendSection": cached.BaseComponentRemoteStateBackendSection,
+		"SourceSection":             cached.BaseComponentSourceSection,
+		"ProvisionSection":          cached.BaseComponentProvisionSection,
+	}
+	for name, got := range maps {
+		require.NotNil(t, got, "BaseComponent%s must not be nil when source was empty-non-nil", name)
+		assert.Empty(t, got, "BaseComponent%s must round-trip as an empty map", name)
+		// Defensive: assignment into the returned map must not panic.
+		got["should-not-panic"] = "ok"
+	}
 }
 
 // TestCacheBaseComponentConfig_RoundTripsAllFields locks in the contract
@@ -554,12 +654,12 @@ func TestCacheBaseComponentConfig_RoundTripsAllFields(t *testing.T) {
 		BaseComponentSettings:                  map[string]any{"spacelift": map[string]any{"workspace_enabled": true}},
 		BaseComponentEnv:                       map[string]any{"AWS_REGION": "us-east-1"},
 		BaseComponentAuth:                      map[string]any{"identity": "default"},
-		BaseComponentDependencies:              map[string]any{"file": []any{"vpc-flow-logs"}},
+		BaseComponentDependencies:              map[string]any{"file": []any{"vpc-flow-logs", "vpc-endpoints"}},
 		BaseComponentLocals:                    map[string]any{"stage": "prod"},
 		BaseComponentMetadata:                  map[string]any{"component": "vpc"},
 		BaseComponentProviders:                 map[string]any{"aws": map[string]any{"region": "us-east-1"}},
 		BaseComponentRequiredProviders:         map[string]any{"aws": map[string]any{"source": "hashicorp/aws"}},
-		BaseComponentHooks:                     map[string]any{"pre_plan": []any{"echo"}},
+		BaseComponentHooks:                     map[string]any{"pre_plan": []any{"echo hello", "echo world"}},
 		BaseComponentGenerate:                  map[string]any{"backend.tf.json": map[string]any{"format": "json"}},
 		BaseComponentBackendSection:            map[string]any{"s3": map[string]any{"bucket": "tfstate"}},
 		BaseComponentRemoteStateBackendSection: map[string]any{"s3": map[string]any{"bucket": "tfstate-remote"}},
@@ -585,12 +685,25 @@ func TestCacheBaseComponentConfig_RoundTripsAllFields(t *testing.T) {
 	assert.True(t, cached.BaseComponentSettings["spacelift"].(map[string]any)["workspace_enabled"].(bool))
 	assert.Equal(t, "us-east-1", cached.BaseComponentEnv["AWS_REGION"])
 	assert.Equal(t, "default", cached.BaseComponentAuth["identity"])
-	assert.NotEmpty(t, cached.BaseComponentDependencies["file"])
+	// Slice-valued fields: assert element contents (first AND last) per the
+	// project's "assert element contents, not just length" testing
+	// convention. require.Len gates the index accesses below.
+	depsFiles, ok := cached.BaseComponentDependencies["file"].([]any)
+	require.True(t, ok, "BaseComponentDependencies[\"file\"] should be a slice")
+	require.Len(t, depsFiles, 2)
+	assert.Equal(t, "vpc-flow-logs", depsFiles[0])
+	assert.Equal(t, "vpc-endpoints", depsFiles[len(depsFiles)-1])
+
 	assert.Equal(t, "prod", cached.BaseComponentLocals["stage"])
 	assert.Equal(t, "vpc", cached.BaseComponentMetadata["component"])
 	assert.Equal(t, "us-east-1", cached.BaseComponentProviders["aws"].(map[string]any)["region"])
 	assert.Equal(t, "hashicorp/aws", cached.BaseComponentRequiredProviders["aws"].(map[string]any)["source"])
-	assert.NotEmpty(t, cached.BaseComponentHooks["pre_plan"])
+
+	prePlanHooks, ok := cached.BaseComponentHooks["pre_plan"].([]any)
+	require.True(t, ok, "BaseComponentHooks[\"pre_plan\"] should be a slice")
+	require.Len(t, prePlanHooks, 2)
+	assert.Equal(t, "echo hello", prePlanHooks[0])
+	assert.Equal(t, "echo world", prePlanHooks[len(prePlanHooks)-1])
 	assert.Equal(t, "json", cached.BaseComponentGenerate["backend.tf.json"].(map[string]any)["format"])
 	assert.Equal(t, "tfstate", cached.BaseComponentBackendSection["s3"].(map[string]any)["bucket"])
 	assert.Equal(t, "tfstate-remote", cached.BaseComponentRemoteStateBackendSection["s3"].(map[string]any)["bucket"])

--- a/internal/exec/stack_processor_cache_test.go
+++ b/internal/exec/stack_processor_cache_test.go
@@ -405,8 +405,13 @@ func TestConcurrentCacheAccess_InterleavedReadWrite(t *testing.T) {
 			for j := 0; j < itersPerReader; j++ {
 				key := fmt.Sprintf("seed-%d", (id+j)%writers)
 				cached, _, found := getCachedBaseComponentConfig(key)
-				if found {
-					require.NotNil(t, cached)
+				// assert.NotNil (not require.NotNil) so this is safe to call
+				// from a goroutine: require would call t.FailNow, which calls
+				// runtime.Goexit and would only exit THIS goroutine while the
+				// main test continued past wg.Wait without surfacing the
+				// failure deterministically. assert returns a bool we use to
+				// guard the subsequent field dereference.
+				if found && assert.NotNil(t, cached) {
 					// Read a field; tripping the deep copy is the point.
 					_ = cached.FinalBaseComponentName
 				}
@@ -513,4 +518,95 @@ func TestCacheBaseComponentConfig_SkipsEmptyFields(t *testing.T) {
 	assert.Nil(t, cached.BaseComponentHooks)
 	assert.Nil(t, cached.BaseComponentBackendSection)
 	assert.Nil(t, cached.BaseComponentRemoteStateBackendSection)
+	// Locals/Generate/SourceSection/ProvisionSection/RequiredProviders were
+	// historically not deep-copied at all (pre-existing main-branch bug:
+	// cache HIT returned them as nil even when the un-cached path populated
+	// them). Now covered by deepCopyBaseComponentConfigMaps — empty source
+	// still yields nil dst.
+	assert.Nil(t, cached.BaseComponentLocals)
+	assert.Nil(t, cached.BaseComponentGenerate)
+	assert.Nil(t, cached.BaseComponentSourceSection)
+	assert.Nil(t, cached.BaseComponentProvisionSection)
+	assert.Nil(t, cached.BaseComponentRequiredProviders)
+}
+
+// TestCacheBaseComponentConfig_RoundTripsAllFields locks in the contract
+// that EVERY field of BaseComponentConfig populated by
+// processBaseComponentConfigInternal round-trips through the cache. Before
+// the fix that accompanies this test, six fields (BaseComponentLocals,
+// BaseComponentGenerate, BaseComponentSourceSection,
+// BaseComponentProvisionSection, BaseComponentRequiredProviders,
+// BaseComponentRequiredVersion) were dropped by the cache write/read paths,
+// causing cache HIT to return a truncated config relative to cache MISS.
+func TestCacheBaseComponentConfig_RoundTripsAllFields(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	src := &schema.BaseComponentConfig{
+		// All scalar (string) fields populated.
+		FinalBaseComponentName:              "base/vpc",
+		BaseComponentCommand:                "terraform",
+		BaseComponentBackendType:            "s3",
+		BaseComponentRemoteStateBackendType: "s3",
+		BaseComponentRequiredVersion:        ">= 1.5.0",
+		// All map fields populated with distinguishable values.
+		BaseComponentVars:                      map[string]any{"region": "us-east-1"},
+		BaseComponentSettings:                  map[string]any{"spacelift": map[string]any{"workspace_enabled": true}},
+		BaseComponentEnv:                       map[string]any{"AWS_REGION": "us-east-1"},
+		BaseComponentAuth:                      map[string]any{"identity": "default"},
+		BaseComponentDependencies:              map[string]any{"file": []any{"vpc-flow-logs"}},
+		BaseComponentLocals:                    map[string]any{"stage": "prod"},
+		BaseComponentMetadata:                  map[string]any{"component": "vpc"},
+		BaseComponentProviders:                 map[string]any{"aws": map[string]any{"region": "us-east-1"}},
+		BaseComponentRequiredProviders:         map[string]any{"aws": map[string]any{"source": "hashicorp/aws"}},
+		BaseComponentHooks:                     map[string]any{"pre_plan": []any{"echo"}},
+		BaseComponentGenerate:                  map[string]any{"backend.tf.json": map[string]any{"format": "json"}},
+		BaseComponentBackendSection:            map[string]any{"s3": map[string]any{"bucket": "tfstate"}},
+		BaseComponentRemoteStateBackendSection: map[string]any{"s3": map[string]any{"bucket": "tfstate-remote"}},
+		BaseComponentSourceSection:             map[string]any{"uri": "github.com/example/repo"},
+		BaseComponentProvisionSection:          map[string]any{"enabled": true},
+		ComponentInheritanceChain:              []string{"base", "abstract"},
+	}
+	cacheBaseComponentConfig("roundtrip-key", src)
+
+	cached, chain, found := getCachedBaseComponentConfig("roundtrip-key")
+	require.True(t, found)
+	require.NotNil(t, cached)
+
+	// Every scalar field.
+	assert.Equal(t, "base/vpc", cached.FinalBaseComponentName)
+	assert.Equal(t, "terraform", cached.BaseComponentCommand)
+	assert.Equal(t, "s3", cached.BaseComponentBackendType)
+	assert.Equal(t, "s3", cached.BaseComponentRemoteStateBackendType)
+	assert.Equal(t, ">= 1.5.0", cached.BaseComponentRequiredVersion)
+
+	// Every map field is present with the right value.
+	assert.Equal(t, "us-east-1", cached.BaseComponentVars["region"])
+	assert.True(t, cached.BaseComponentSettings["spacelift"].(map[string]any)["workspace_enabled"].(bool))
+	assert.Equal(t, "us-east-1", cached.BaseComponentEnv["AWS_REGION"])
+	assert.Equal(t, "default", cached.BaseComponentAuth["identity"])
+	assert.NotEmpty(t, cached.BaseComponentDependencies["file"])
+	assert.Equal(t, "prod", cached.BaseComponentLocals["stage"])
+	assert.Equal(t, "vpc", cached.BaseComponentMetadata["component"])
+	assert.Equal(t, "us-east-1", cached.BaseComponentProviders["aws"].(map[string]any)["region"])
+	assert.Equal(t, "hashicorp/aws", cached.BaseComponentRequiredProviders["aws"].(map[string]any)["source"])
+	assert.NotEmpty(t, cached.BaseComponentHooks["pre_plan"])
+	assert.Equal(t, "json", cached.BaseComponentGenerate["backend.tf.json"].(map[string]any)["format"])
+	assert.Equal(t, "tfstate", cached.BaseComponentBackendSection["s3"].(map[string]any)["bucket"])
+	assert.Equal(t, "tfstate-remote", cached.BaseComponentRemoteStateBackendSection["s3"].(map[string]any)["bucket"])
+	assert.Equal(t, "github.com/example/repo", cached.BaseComponentSourceSection["uri"])
+	assert.True(t, cached.BaseComponentProvisionSection["enabled"].(bool))
+
+	// The slice round-trips too.
+	require.NotNil(t, chain)
+	assert.Equal(t, []string{"base", "abstract"}, *chain)
+	assert.Equal(t, []string{"base", "abstract"}, cached.ComponentInheritanceChain)
+
+	// Deep-copy contract: mutating the cached value does not affect a
+	// subsequent retrieval. Pick a representative previously-dropped field.
+	cached.BaseComponentLocals["stage"] = "MUTATED"
+	second, _, _ := getCachedBaseComponentConfig("roundtrip-key")
+	require.NotNil(t, second)
+	assert.Equal(t, "prod", second.BaseComponentLocals["stage"],
+		"mutating a retrieved cached value must not affect subsequent retrievals")
 }

--- a/internal/exec/stack_processor_cache_test.go
+++ b/internal/exec/stack_processor_cache_test.go
@@ -476,3 +476,41 @@ func TestCacheCompiledSchemaBasic(t *testing.T) {
 	// Clean up.
 	ClearJsonSchemaCache()
 }
+
+// TestCacheBaseComponentConfig_SkipsEmptyFields verifies the Phase 12/13
+// optimization: deepCopyBaseComponentConfigMaps skips m.DeepCopyMap for
+// fields that are empty in the source. The behavioral contract is that
+// empty (or nil) source fields produce nil dst fields, identical to the
+// pre-optimization behavior of m.DeepCopyMap(nil) returning nil.
+func TestCacheBaseComponentConfig_SkipsEmptyFields(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	// Source with most fields empty — only Vars is populated.
+	src := &schema.BaseComponentConfig{
+		FinalBaseComponentName: "minimal",
+		BaseComponentVars:      map[string]any{"region": "us-east-1"},
+		// All other map fields intentionally nil.
+		ComponentInheritanceChain: []string{"base"},
+	}
+	cacheBaseComponentConfig("minimal-key", src)
+
+	cached, _, found := getCachedBaseComponentConfig("minimal-key")
+	require.True(t, found)
+	require.NotNil(t, cached)
+
+	// The populated field round-trips.
+	assert.Equal(t, "us-east-1", cached.BaseComponentVars["region"])
+
+	// The empty-source fields stay nil on the retrieved copy (no empty-map
+	// allocations were performed during caching or retrieval).
+	assert.Nil(t, cached.BaseComponentSettings)
+	assert.Nil(t, cached.BaseComponentEnv)
+	assert.Nil(t, cached.BaseComponentAuth)
+	assert.Nil(t, cached.BaseComponentMetadata)
+	assert.Nil(t, cached.BaseComponentDependencies)
+	assert.Nil(t, cached.BaseComponentProviders)
+	assert.Nil(t, cached.BaseComponentHooks)
+	assert.Nil(t, cached.BaseComponentBackendSection)
+	assert.Nil(t, cached.BaseComponentRemoteStateBackendSection)
+}

--- a/internal/exec/stack_processor_cache_test.go
+++ b/internal/exec/stack_processor_cache_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -312,6 +313,147 @@ func TestConcurrentCacheAccess(t *testing.T) {
 	// Clean up.
 	ClearBaseComponentConfigCache()
 	ClearFileContentCache()
+}
+
+// TestConcurrentCacheAccess_DisjointKeys verifies that many goroutines
+// writing distinct cache keys all succeed and every value is retrievable
+// afterwards. This is the production-realistic pattern: each component
+// instance writes its own unique "stack:component:baseComponent" key,
+// so the cache sees high write concurrency with no key overlap. The
+// Phase 2 sync.Map + outside-the-lock deep-copy change is specifically
+// optimized for this pattern; a regression that reintroduces a global
+// lock would still pass under TestConcurrentCacheAccess (single key,
+// race detector only verifies safety, not throughput) but would
+// reintroduce the lock-contention pathology this test guards against.
+func TestConcurrentCacheAccess_DisjointKeys(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	const numKeys = 200
+	var wg sync.WaitGroup
+
+	// Each goroutine writes a unique key.
+	for i := 0; i < numKeys; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			config := &schema.BaseComponentConfig{
+				FinalBaseComponentName: fmt.Sprintf("component-%d", id),
+				BaseComponentVars: map[string]any{
+					"id":    id,
+					"label": fmt.Sprintf("instance-%d", id),
+				},
+				ComponentInheritanceChain: []string{fmt.Sprintf("base-%d", id)},
+			}
+			cacheBaseComponentConfig(fmt.Sprintf("stack-%d:component:base", id), config)
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify every key is independently readable with the right value.
+	for i := 0; i < numKeys; i++ {
+		cached, _, found := getCachedBaseComponentConfig(fmt.Sprintf("stack-%d:component:base", i))
+		require.True(t, found, "key %d should be cached", i)
+		require.NotNil(t, cached)
+		require.Equal(t, fmt.Sprintf("component-%d", i), cached.FinalBaseComponentName,
+			"key %d should have its own value (no cross-contamination)", i)
+		require.Equal(t, i, cached.BaseComponentVars["id"], "key %d vars id mismatch", i)
+	}
+}
+
+// TestConcurrentCacheAccess_InterleavedReadWrite stresses the read-while-write
+// path: half the goroutines write keys, the other half repeatedly read them.
+// With Phase 2's deep-copy-outside-the-lock change, readers no longer hold an
+// RLock while copying, so concurrent writes proceed without coordination.
+// Run with `go test -race` to catch data races introduced by future
+// modifications to the cache; this test must complete cleanly under the
+// race detector.
+func TestConcurrentCacheAccess_InterleavedReadWrite(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	const writers = 50
+	const readers = 50
+	const itersPerReader = 20
+	var wg sync.WaitGroup
+
+	// Pre-seed a few keys so readers have something to find.
+	for i := 0; i < writers; i++ {
+		cacheBaseComponentConfig(fmt.Sprintf("seed-%d", i), &schema.BaseComponentConfig{
+			FinalBaseComponentName: fmt.Sprintf("seed-%d", i),
+		})
+	}
+
+	// Writers add new keys concurrently with readers.
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			cfg := &schema.BaseComponentConfig{
+				FinalBaseComponentName: fmt.Sprintf("writer-%d", id),
+				BaseComponentVars:      map[string]any{"id": id},
+			}
+			cacheBaseComponentConfig(fmt.Sprintf("writer-%d", id), cfg)
+		}(i)
+	}
+
+	// Readers read the seeded keys while writers are working.
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < itersPerReader; j++ {
+				key := fmt.Sprintf("seed-%d", (id+j)%writers)
+				cached, _, found := getCachedBaseComponentConfig(key)
+				if found {
+					require.NotNil(t, cached)
+					// Read a field; tripping the deep copy is the point.
+					_ = cached.FinalBaseComponentName
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Every key should be present and intact.
+	for i := 0; i < writers; i++ {
+		cached, _, found := getCachedBaseComponentConfig(fmt.Sprintf("seed-%d", i))
+		require.True(t, found)
+		require.Equal(t, fmt.Sprintf("seed-%d", i), cached.FinalBaseComponentName)
+	}
+}
+
+// TestCacheReadIsolationAfterStoreReturns verifies that mutating the *input*
+// to cacheBaseComponentConfig AFTER the call returns does NOT affect what a
+// later reader sees. Phase 2 moved the deep-copy outside the lock, so this
+// test guards against a regression where the copy is skipped or aliased.
+//
+// This complements TestCacheBaseComponentConfigDeepCopy (which mutates BEFORE
+// the read happens). Here we mutate AFTER the cache write has completed,
+// proving the cached value is independent of the caller's struct.
+func TestCacheReadIsolationAfterStoreReturns(t *testing.T) {
+	ClearBaseComponentConfigCache()
+	defer ClearBaseComponentConfigCache()
+
+	src := &schema.BaseComponentConfig{
+		FinalBaseComponentName:    "original",
+		BaseComponentVars:         map[string]any{"key": "original"},
+		ComponentInheritanceChain: []string{"base"},
+	}
+	cacheBaseComponentConfig("iso-key", src)
+
+	// Mutate the source AFTER caching - cached entry must be unaffected.
+	src.FinalBaseComponentName = "mutated"
+	src.BaseComponentVars["key"] = "mutated"
+	src.ComponentInheritanceChain[0] = "mutated-base"
+	src.ComponentInheritanceChain = append(src.ComponentInheritanceChain, "appended")
+
+	cached, baseComponents, found := getCachedBaseComponentConfig("iso-key")
+	require.True(t, found)
+	require.Equal(t, "original", cached.FinalBaseComponentName)
+	require.Equal(t, "original", cached.BaseComponentVars["key"])
+	require.Equal(t, []string{"base"}, cached.ComponentInheritanceChain)
+	require.Equal(t, []string{"base"}, *baseComponents)
 }
 
 // TestCacheCompiledSchemaBasic tests JSON schema caching mechanics.

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -79,34 +79,39 @@ func localsCacheKey(filePath, yamlContent string) string {
 	return filePath + "@" + strconv.FormatUint(h.Sum64(), hexBase)
 }
 
-// cloneExtractLocalsResult deep-copies an extractLocalsResult so the cache value
-// remains immutable across concurrent retrievals. Returns the same nil hint when
-// the source is nil.
+// cloneExtractLocalsResult returns a per-caller view of a cached extractLocalsResult.
+// Only the `locals` field is deep-copied; the other fields (settings, vars, env)
+// are shared references with the cached entry.
+//
+// Why this asymmetry is safe:
+//   - `locals` is stored long-term in the template context
+//     (`context[cfg.LocalsSectionName] = extractResult.locals`) and may be
+//     read by downstream template processors. To guard against any future
+//     caller that decides to mutate context entries, we deep-copy.
+//   - `settings`, `vars`, `env` are passed directly to processTemplatesInSection
+//     which reads the section, marshals it to YAML, re-parses, and returns a
+//     NEW map. It never mutates the input. The interim shared reference is
+//     therefore safe.
+//
+// This asymmetric clone reclaims ~75% of the per-retrieval deep-copy cost
+// in the customer workload (cloneExtractLocalsResult dominated the
+// post-Phase-4 cache-hit path at ~343µs avg across 22,181 calls).
 func cloneExtractLocalsResult(src *extractLocalsResult) *extractLocalsResult {
 	if src == nil {
 		return nil
 	}
 	dst := &extractLocalsResult{
 		hasLocals: src.hasLocals,
+		// Shared (read-only by processTemplatesInSection).
+		settings: src.settings,
+		vars:     src.vars,
+		env:      src.env,
 	}
+	// Deep-copy only the locals map: callers store this into a shared
+	// template context whose downstream mutation surface is hard to bound.
 	if src.locals != nil {
 		if cloned, err := m.DeepCopyMap(src.locals); err == nil {
 			dst.locals = cloned
-		}
-	}
-	if src.settings != nil {
-		if cloned, err := m.DeepCopyMap(src.settings); err == nil {
-			dst.settings = cloned
-		}
-	}
-	if src.vars != nil {
-		if cloned, err := m.DeepCopyMap(src.vars); err == nil {
-			dst.vars = cloned
-		}
-	}
-	if src.env != nil {
-		if cloned, err := m.DeepCopyMap(src.env); err == nil {
-			dst.env = cloned
 		}
 	}
 	return dst

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -79,39 +79,34 @@ func localsCacheKey(filePath, yamlContent string) string {
 	return filePath + "@" + strconv.FormatUint(h.Sum64(), hexBase)
 }
 
-// cloneExtractLocalsResult returns a per-caller view of a cached extractLocalsResult.
-// Only the `locals` field is deep-copied; the other fields (settings, vars, env)
-// are shared references with the cached entry.
-//
-// Why this asymmetry is safe:
-//   - `locals` is stored long-term in the template context
-//     (`context[cfg.LocalsSectionName] = extractResult.locals`) and may be
-//     read by downstream template processors. To guard against any future
-//     caller that decides to mutate context entries, we deep-copy.
-//   - `settings`, `vars`, `env` are passed directly to processTemplatesInSection
-//     which reads the section, marshals it to YAML, re-parses, and returns a
-//     NEW map. It never mutates the input. The interim shared reference is
-//     therefore safe.
-//
-// This asymmetric clone reclaims ~75% of the per-retrieval deep-copy cost
-// in the customer workload (cloneExtractLocalsResult dominated the
-// post-Phase-4 cache-hit path at ~343µs avg across 22,181 calls).
+// cloneExtractLocalsResult deep-copies an extractLocalsResult so the cache value
+// remains immutable across concurrent retrievals. Returns the same nil hint when
+// the source is nil.
 func cloneExtractLocalsResult(src *extractLocalsResult) *extractLocalsResult {
 	if src == nil {
 		return nil
 	}
 	dst := &extractLocalsResult{
 		hasLocals: src.hasLocals,
-		// Shared (read-only by processTemplatesInSection).
-		settings: src.settings,
-		vars:     src.vars,
-		env:      src.env,
 	}
-	// Deep-copy only the locals map: callers store this into a shared
-	// template context whose downstream mutation surface is hard to bound.
 	if src.locals != nil {
 		if cloned, err := m.DeepCopyMap(src.locals); err == nil {
 			dst.locals = cloned
+		}
+	}
+	if src.settings != nil {
+		if cloned, err := m.DeepCopyMap(src.settings); err == nil {
+			dst.settings = cloned
+		}
+	}
+	if src.vars != nil {
+		if cloned, err := m.DeepCopyMap(src.vars); err == nil {
+			dst.vars = cloned
+		}
+	}
+	if src.env != nil {
+		if cloned, err := m.DeepCopyMap(src.env); err == nil {
+			dst.env = cloned
 		}
 	}
 	return dst

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -37,6 +39,91 @@ type extractLocalsResult struct {
 	hasLocals bool           // Whether any locals section exists in the file (including empty locals).
 }
 
+// localsExtractionCache memoizes extractLocalsFromRawYAML results keyed by a
+// composite of the file path and a content fingerprint. Within a single command
+// execution against a real filesystem, file content is immutable (and is itself
+// cached via getFileContentSyncMap), so the parse + locals resolution is fully
+// deterministic and may be served from cache on repeat imports of the same file.
+//
+// On the customer workload, extractLocalsFromRawYAML was called 22,181 times for
+// ~836 unique files (~26 calls per file via transitive imports), accumulating 13s
+// of cumulative CPU time. ~7s of that was UnmarshalYAMLFromFile re-parsing the
+// same YAML content for the same file path. This cache eliminates the repeat work.
+//
+// The cache key includes a 64-bit FNV-1a hash of the YAML content so that test
+// callers reusing the same logical file path with different content (a common
+// pattern in stack_processor_utils_test.go) do not see stale results, and so that
+// a future caller doing dynamic content generation cannot trip on a stale parse.
+// FNV-1a was chosen for speed and stdlib availability; collisions on map-key
+// strings are not a security concern here because the cache only feeds back to
+// the same function under the same atmosConfig.
+//
+// Cached entries are deep-copied on retrieval (the result struct contains four
+// maps: locals/settings/vars/env, all of which downstream consumers store into
+// shared template contexts; mutating them would corrupt the cache). Deep-copy
+// cost is dominated by map allocation and is typically <50µs per call — well
+// below the 533µs avg of the un-cached path.
+var localsExtractionCache sync.Map // map[string]*extractLocalsResult (immutable post-insert).
+
+// hexBase is the base argument passed to strconv.FormatUint when building the
+// hex-encoded portion of localsCacheKey.
+const hexBase = 16
+
+// localsCacheKey builds a stable cache key from the absolute file path and a
+// content fingerprint. The fingerprint is a 64-bit FNV-1a hash of yamlContent
+// so that the same file path used with two different contents (mostly a test
+// pattern) yields two distinct cache entries.
+func localsCacheKey(filePath, yamlContent string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(yamlContent))
+	return filePath + "@" + strconv.FormatUint(h.Sum64(), hexBase)
+}
+
+// cloneExtractLocalsResult deep-copies an extractLocalsResult so the cache value
+// remains immutable across concurrent retrievals. Returns the same nil hint when
+// the source is nil.
+func cloneExtractLocalsResult(src *extractLocalsResult) *extractLocalsResult {
+	if src == nil {
+		return nil
+	}
+	dst := &extractLocalsResult{
+		hasLocals: src.hasLocals,
+	}
+	if src.locals != nil {
+		if cloned, err := m.DeepCopyMap(src.locals); err == nil {
+			dst.locals = cloned
+		}
+	}
+	if src.settings != nil {
+		if cloned, err := m.DeepCopyMap(src.settings); err == nil {
+			dst.settings = cloned
+		}
+	}
+	if src.vars != nil {
+		if cloned, err := m.DeepCopyMap(src.vars); err == nil {
+			dst.vars = cloned
+		}
+	}
+	if src.env != nil {
+		if cloned, err := m.DeepCopyMap(src.env); err == nil {
+			dst.env = cloned
+		}
+	}
+	return dst
+}
+
+// ClearLocalsExtractionCache clears the locals extraction cache.
+// This should be called between independent operations (like tests) to ensure
+// fresh processing of files whose on-disk content may have changed.
+func ClearLocalsExtractionCache() {
+	defer perf.Track(nil, "exec.ClearLocalsExtractionCache")()
+
+	localsExtractionCache.Range(func(key, _ any) bool {
+		localsExtractionCache.Delete(key)
+		return true
+	})
+}
+
 // extractLocalsFromRawYAML parses raw YAML content and extracts/resolves file-scoped locals.
 // This function is called BEFORE template processing to make locals available during template execution.
 // The raw YAML may contain unresolved templates like {{ .locals.X }}, which YAML treats as strings.
@@ -49,8 +136,21 @@ type extractLocalsResult struct {
 //
 // Section-specific locals inherit from and can override global locals.
 // All resolved locals are flattened into a single map for template processing.
+//
+// Results are memoized in localsExtractionCache keyed by filePath. See the cache
+// declaration for rationale and the deep-copy contract.
 func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlContent string, filePath string) (*extractLocalsResult, error) {
 	defer perf.Track(atmosConfig, "exec.extractLocalsFromRawYAML")()
+
+	// Fast path: result is cached for this (file path, content fingerprint)
+	// pair. Deep-copy on retrieval to keep the cache value immutable across
+	// concurrent callers.
+	cacheKey := localsCacheKey(filePath, yamlContent)
+	if raw, found := localsExtractionCache.Load(cacheKey); found {
+		if cached, ok := raw.(*extractLocalsResult); ok {
+			return cloneExtractLocalsResult(cached), nil
+		}
+	}
 
 	// Parse raw YAML to extract the structure.
 	// YAML treats template expressions like {{ .locals.X }} as plain strings,
@@ -75,7 +175,9 @@ func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlConten
 	}
 
 	if rawConfig == nil {
-		return &extractLocalsResult{}, nil
+		empty := &extractLocalsResult{}
+		localsExtractionCache.Store(cacheKey, empty)
+		return cloneExtractLocalsResult(empty), nil
 	}
 
 	// Derive the stack name from the file path so that YAML functions like
@@ -89,7 +191,14 @@ func extractLocalsFromRawYAML(atmosConfig *schema.AtmosConfiguration, yamlConten
 		return nil, fmt.Errorf("%w: failed to process stack locals: %w", errUtils.ErrInvalidStackManifest, err)
 	}
 
-	return buildLocalsResult(rawConfig, localsCtx), nil
+	result := buildLocalsResult(rawConfig, localsCtx)
+	// Cache the canonical result and return a deep copy so the cache remains
+	// the single immutable source of truth. Concurrent goroutines that race
+	// on the first cache miss for a given file path will both run the parse
+	// (cheap given the cache hit on subsequent calls), and the later Store
+	// silently wins — both results are identical for the same input.
+	localsExtractionCache.Store(cacheKey, result)
+	return cloneExtractLocalsResult(result), nil
 }
 
 // deriveStackNameForLocals derives the stack name from the file path and raw config
@@ -253,12 +362,25 @@ func extractAndAddLocalsToContext(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.extractAndAddLocalsToContext")()
 
-	// Enforce file-scoped locals: clear any inherited locals from parent context.
-	// Locals are file-scoped and should NOT inherit across file boundaries.
-	// This ensures that each file only has access to its own locals.
-	if context != nil {
-		delete(context, cfg.LocalsSectionName)
+	// Clone the input context so concurrent goroutines processing sibling imports
+	// (in processYAMLConfigFileWithContextInternal, which fans out to one goroutine
+	// per import while sharing mergedContext) cannot race on the file-scoped
+	// delete + assign below. Without the clone, the parent context was mutated
+	// directly, producing a data race surfaced by `go test -race` on
+	// TestHierarchicalImports_*. Cloning is a shallow copy: the values are shared
+	// references but the map header is per-goroutine, which is the only mutation
+	// surface inside this function.
+	clonedContext := make(map[string]any, len(context))
+	for k, v := range context {
+		if k == cfg.LocalsSectionName {
+			// Enforce file-scoped locals: drop inherited locals during the
+			// clone. This replaces the previous in-place delete on the shared
+			// parent context.
+			continue
+		}
+		clonedContext[k] = v
 	}
+	context = clonedContext
 
 	extractResult, localsErr := extractLocalsFromRawYAML(atmosConfig, yamlContent, filePath)
 	if localsErr != nil {
@@ -293,10 +415,9 @@ func extractAndAddLocalsToContext(
 		return context, nil
 	}
 
-	// Initialize context if nil.
-	if context == nil {
-		context = make(map[string]any)
-	}
+	// context is never nil here: the clone above always allocates a fresh map
+	// (make returns a non-nil empty map when len(input)==0). The historical
+	// `if context == nil { context = make(...) }` initializer is now dead.
 
 	// Add resolved locals to the template context first.
 	// This allows settings/vars/env templates to reference locals.

--- a/internal/exec/stack_processor_utils_test.go
+++ b/internal/exec/stack_processor_utils_test.go
@@ -2316,10 +2316,13 @@ func TestCacheCompiledSchema(t *testing.T) {
 }
 
 // TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies verifies the
-// Phase 4 cache returns deep copies, not shared map references. Without this
-// guarantee, downstream consumers — which store the locals/settings/vars/env
-// maps into shared template contexts and may mutate them later — would
-// corrupt the cache and observe values bleeding across files.
+// Phase 4 cache returns deep copies of the `locals` field, not shared map
+// references. Settings/vars/env are intentionally shared references per the
+// Phase 9 contract — they are passed only to processTemplatesInSection which
+// reads them, marshals to YAML, re-parses, and returns a NEW map; it never
+// mutates the input. Reclaiming those three deep-copies cuts the cache-hit
+// path cost dramatically. Only `locals` carries a long-term cross-context
+// mutation surface, so only `locals` is deep-copied.
 func TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies(t *testing.T) {
 	ClearLocalsExtractionCache()
 	defer ClearLocalsExtractionCache()
@@ -2341,18 +2344,21 @@ env:
 	require.NotNil(t, first)
 	require.True(t, first.hasLocals)
 
-	// Mutate every map on the first result.
+	// Mutate the locals map on the first result. Per the cloneExtractLocalsResult
+	// contract, this must NOT bleed into subsequent retrievals.
 	first.locals["region"] = "MUTATED"
-	first.settings["flavor"] = "MUTATED"
-	first.vars["stage"] = "MUTATED"
-	first.env["AWS_REGION"] = "MUTATED"
 
-	// A second call must NOT see the mutations.
+	// A second call must NOT see the locals mutation.
 	second, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "iso-test.yaml")
 	require.NoError(t, err)
 	require.NotNil(t, second)
 	assert.Equal(t, "us-east-1", second.locals["region"],
 		"cached locals must not reflect post-retrieval mutations to a prior result")
+
+	// Settings/vars/env values should match the source. These fields are
+	// shared references with the cached entry; the contract documented on
+	// cloneExtractLocalsResult requires callers to treat them as read-only,
+	// and the only production consumer (processTemplatesInSection) does so.
 	assert.Equal(t, "prod", second.settings["flavor"])
 	assert.Equal(t, "dev", second.vars["stage"])
 	assert.Equal(t, "us-east-1", second.env["AWS_REGION"])

--- a/internal/exec/stack_processor_utils_test.go
+++ b/internal/exec/stack_processor_utils_test.go
@@ -2316,13 +2316,10 @@ func TestCacheCompiledSchema(t *testing.T) {
 }
 
 // TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies verifies the
-// Phase 4 cache returns deep copies of the `locals` field, not shared map
-// references. Settings/vars/env are intentionally shared references per the
-// Phase 9 contract — they are passed only to processTemplatesInSection which
-// reads them, marshals to YAML, re-parses, and returns a NEW map; it never
-// mutates the input. Reclaiming those three deep-copies cuts the cache-hit
-// path cost dramatically. Only `locals` carries a long-term cross-context
-// mutation surface, so only `locals` is deep-copied.
+// Phase 4 cache returns deep copies, not shared map references. Without this
+// guarantee, downstream consumers — which store the locals/settings/vars/env
+// maps into shared template contexts and may mutate them later — would
+// corrupt the cache and observe values bleeding across files.
 func TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies(t *testing.T) {
 	ClearLocalsExtractionCache()
 	defer ClearLocalsExtractionCache()
@@ -2344,21 +2341,18 @@ env:
 	require.NotNil(t, first)
 	require.True(t, first.hasLocals)
 
-	// Mutate the locals map on the first result. Per the cloneExtractLocalsResult
-	// contract, this must NOT bleed into subsequent retrievals.
+	// Mutate every map on the first result.
 	first.locals["region"] = "MUTATED"
+	first.settings["flavor"] = "MUTATED"
+	first.vars["stage"] = "MUTATED"
+	first.env["AWS_REGION"] = "MUTATED"
 
-	// A second call must NOT see the locals mutation.
+	// A second call must NOT see the mutations.
 	second, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "iso-test.yaml")
 	require.NoError(t, err)
 	require.NotNil(t, second)
 	assert.Equal(t, "us-east-1", second.locals["region"],
 		"cached locals must not reflect post-retrieval mutations to a prior result")
-
-	// Settings/vars/env values should match the source. These fields are
-	// shared references with the cached entry; the contract documented on
-	// cloneExtractLocalsResult requires callers to treat them as read-only,
-	// and the only production consumer (processTemplatesInSection) does so.
 	assert.Equal(t, "prod", second.settings["flavor"])
 	assert.Equal(t, "dev", second.vars["stage"])
 	assert.Equal(t, "us-east-1", second.env["AWS_REGION"])

--- a/internal/exec/stack_processor_utils_test.go
+++ b/internal/exec/stack_processor_utils_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
@@ -2312,6 +2313,112 @@ func TestCacheCompiledSchema(t *testing.T) {
 	compiledSchema2, found2 := getCachedCompiledSchema(schemaPath)
 	assert.Equal(t, found, found2, "Consistent cache lookups should return same result")
 	assert.Equal(t, compiledSchema, compiledSchema2, "Consistent cache lookups should return same schema")
+}
+
+// TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies verifies the
+// Phase 4 cache returns deep copies, not shared map references. Without this
+// guarantee, downstream consumers — which store the locals/settings/vars/env
+// maps into shared template contexts and may mutate them later — would
+// corrupt the cache and observe values bleeding across files.
+func TestExtractLocalsFromRawYAML_CacheReturnsIndependentCopies(t *testing.T) {
+	ClearLocalsExtractionCache()
+	defer ClearLocalsExtractionCache()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	yamlContent := `
+locals:
+  region: us-east-1
+  count: 3
+settings:
+  flavor: prod
+vars:
+  stage: dev
+env:
+  AWS_REGION: us-east-1
+`
+	first, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "iso-test.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.True(t, first.hasLocals)
+
+	// Mutate every map on the first result.
+	first.locals["region"] = "MUTATED"
+	first.settings["flavor"] = "MUTATED"
+	first.vars["stage"] = "MUTATED"
+	first.env["AWS_REGION"] = "MUTATED"
+
+	// A second call must NOT see the mutations.
+	second, err := extractLocalsFromRawYAML(atmosConfig, yamlContent, "iso-test.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.Equal(t, "us-east-1", second.locals["region"],
+		"cached locals must not reflect post-retrieval mutations to a prior result")
+	assert.Equal(t, "prod", second.settings["flavor"])
+	assert.Equal(t, "dev", second.vars["stage"])
+	assert.Equal(t, "us-east-1", second.env["AWS_REGION"])
+}
+
+// TestExtractLocalsFromRawYAML_CacheKeyIncludesContentHash verifies the
+// cache key encodes both the file path AND a content fingerprint so that
+// callers reusing the same logical file path with different content (a
+// common pattern in unit tests, and a safety property for any future
+// dynamic-content code path) do not see stale results from a prior call.
+func TestExtractLocalsFromRawYAML_CacheKeyIncludesContentHash(t *testing.T) {
+	ClearLocalsExtractionCache()
+	defer ClearLocalsExtractionCache()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	contentA := `
+locals:
+  marker: "alpha"
+`
+	contentB := `
+locals:
+  marker: "beta"
+`
+	// Same file path, different content — must yield distinct cached results.
+	rA, err := extractLocalsFromRawYAML(atmosConfig, contentA, "same-path.yaml")
+	require.NoError(t, err)
+	rB, err := extractLocalsFromRawYAML(atmosConfig, contentB, "same-path.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", rA.locals["marker"])
+	assert.Equal(t, "beta", rB.locals["marker"],
+		"different content under the same path must not return a stale cached result")
+}
+
+// TestExtractAndAddLocalsToContext_DoesNotMutateInputContext locks in the
+// Phase 4 race fix: the function used to call delete() on the parent context
+// map shared across sibling-import goroutines, producing a data race surfaced
+// by TestHierarchicalImports_* under -race. After Phase 4, the input context
+// is cloned before any modification so the caller's map is untouched.
+func TestExtractAndAddLocalsToContext_DoesNotMutateInputContext(t *testing.T) {
+	ClearLocalsExtractionCache()
+	defer ClearLocalsExtractionCache()
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	parent := map[string]any{
+		cfg.LocalsSectionName: map[string]any{"inherited": "should-be-dropped"},
+		"unrelated":           "kept",
+	}
+	yamlContent := `
+locals:
+  region: us-east-1
+`
+	_, err := extractAndAddLocalsToContext(
+		atmosConfig,
+		yamlContent,
+		"iso-context.yaml",
+		"iso-context.yaml",
+		parent,
+	)
+	require.NoError(t, err)
+
+	// Parent context must still contain its original locals key (untouched).
+	gotLocals, ok := parent[cfg.LocalsSectionName].(map[string]any)
+	require.True(t, ok, "parent context locals key must be untouched")
+	assert.Equal(t, "should-be-dropped", gotLocals["inherited"],
+		"extractAndAddLocalsToContext must not mutate the caller's parent context")
+	assert.Equal(t, "kept", parent["unrelated"])
 }
 
 // TestExtractLocalsFromRawYAML_Basic tests basic locals extraction from raw YAML.

--- a/pkg/merge/merge_deferred_test.go
+++ b/pkg/merge/merge_deferred_test.go
@@ -820,6 +820,38 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 				"nested maps must also be deep-copied")
 		}
 	})
+
+	t.Run("mutating the input after merge does not mutate the result (regression guard)", func(t *testing.T) {
+		// Mirror of the result→src isolation test above: also verify the
+		// src→result direction. Mutating the source map after the merge
+		// must not propagate into the returned result. Per CLAUDE.md
+		// testing convention: aliasing tests must verify BOTH directions.
+		single := map[string]any{
+			"region": "us-east-1",
+			"nested": map[string]any{"inner": "original"},
+		}
+		inputs := []map[string]any{single}
+
+		result, _, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+
+		// Mutate every level of the input AFTER the merge.
+		single["region"] = "MUTATED_SRC"
+		single["newKey"] = "added-src"
+		if nested, ok := single["nested"].(map[string]any); ok {
+			nested["inner"] = "MUTATED_SRC"
+		}
+
+		// The result must be unchanged.
+		assert.Equal(t, "us-east-1", result["region"],
+			"mutating the input after Merge must not mutate the result")
+		_, hasNewKey := result["newKey"]
+		assert.False(t, hasNewKey, "result must not gain keys added to the input post-merge")
+		if nestedResult, ok := result["nested"].(map[string]any); ok {
+			assert.Equal(t, "original", nestedResult["inner"],
+				"nested maps must be deep-copied so post-merge src mutation cannot reach the result")
+		}
+	})
 }
 
 func TestApplyDeferredMerges(t *testing.T) {

--- a/pkg/merge/merge_deferred_test.go
+++ b/pkg/merge/merge_deferred_test.go
@@ -3,6 +3,7 @@ package merge
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -259,12 +260,15 @@ func TestWalkAndDeferYAMLFunctions_NoFunctionsShortCircuit(t *testing.T) {
 	})
 }
 
-// sameMapHeader returns true if a and b are the same underlying map.
-// In Go a map is a pointer to the runtime map header, so reflect.ValueOf(m).Pointer()
-// (or fmt-printf of %p) compares header identity. Using fmt.Sprintf avoids importing
-// reflect for a single equality check.
+// sameMapHeader returns true if a and b reference the same underlying
+// runtime map. The reflect.Value.Pointer documentation says the returned
+// value is the underlying pointer for Map/Chan/Func/Pointer/Slice/etc.,
+// so reflect.ValueOf(m).Pointer() is the canonical way to obtain the map
+// pointer for identity comparison. Previously this used fmt.Sprintf("%p",
+// ...); that works in practice but %p formatting isn't a formal documented
+// mechanism for map identity.
 func sameMapHeader(a, b map[string]interface{}) bool {
-	return fmt.Sprintf("%p", a) == fmt.Sprintf("%p", b)
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }
 
 func TestIsMap(t *testing.T) {
@@ -699,11 +703,13 @@ func TestMergeWithDeferred(t *testing.T) {
 	})
 }
 
-// TestMergeWithDeferred_TrivialInputShortCircuits exercises the Phase 5 fast
-// paths: zero non-empty inputs returns empty; exactly one non-empty input
-// skips the Merge call. The fast paths preserve precedence semantics for any
-// downstream consumer that inspects the dctx, even though precedence is
-// irrelevant for output when only one layer contributes values.
+// TestMergeWithDeferred_TrivialInputShortCircuits exercises the all-empty
+// fast path and asserts that the single-non-empty-input case follows the
+// regular merge path (which always returns a deep-copied, caller-mutable
+// map). The 1-input shortcut was tried in an earlier iteration and reverted
+// after it broke TestSpaceliftStackProcessor by returning a shared reference
+// to the caller — downstream mutation of the result then corrupted upstream
+// cached settings/vars/auth for sibling components.
 func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 	cfg := &schema.AtmosConfiguration{
 		Settings: schema.AtmosSettings{
@@ -720,7 +726,7 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 		assert.False(t, dctx.HasDeferredValues())
 	})
 
-	t.Run("single non-empty input with no functions returns same map header", func(t *testing.T) {
+	t.Run("single non-empty input returns a fresh map (not shared with input)", func(t *testing.T) {
 		single := map[string]any{
 			"region":      "us-east-1",
 			"environment": "prod",
@@ -728,14 +734,15 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 		inputs := []map[string]any{nil, {}, single, nil}
 		result, dctx, err := MergeWithDeferred(cfg, inputs)
 		require.NoError(t, err)
-		// Phase 3 + Phase 5 compose: function-free single input is returned
-		// as-is, with no allocation in either MergeWithDeferred or its walk.
-		assert.True(t, sameMapHeader(single, result),
-			"single non-empty function-free input must be returned as-is")
+		assert.False(t, sameMapHeader(single, result),
+			"single non-empty input must NOT share a map header with the caller — Merge contract is that the result is independent and caller-mutable")
+		// Values still round-trip.
+		assert.Equal(t, "us-east-1", result["region"])
+		assert.Equal(t, "prod", result["environment"])
 		assert.False(t, dctx.HasDeferredValues())
 	})
 
-	t.Run("single non-empty input with functions defers correctly", func(t *testing.T) {
+	t.Run("single non-empty input with YAML functions defers correctly", func(t *testing.T) {
 		single := map[string]any{
 			"region":   "us-east-1",
 			"template": "!template 'prod-{{ .region }}'",
@@ -743,19 +750,16 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 		inputs := []map[string]any{nil, single, nil}
 		result, dctx, err := MergeWithDeferred(cfg, inputs)
 		require.NoError(t, err)
-		// Function present → walk produces a new map with placeholders.
 		assert.False(t, sameMapHeader(single, result),
-			"single non-empty input with YAML functions must be walked into a fresh map")
+			"input with YAML functions must be walked into a fresh map")
 		assert.Equal(t, "us-east-1", result["region"])
 		assert.Nil(t, result["template"], "YAML function should be deferred to nil placeholder")
 		assert.True(t, dctx.HasDeferredValues())
 		deferred := dctx.GetDeferredValues()
 		require.Contains(t, deferred, "template")
-		// Precedence preserved: single is at index 1, so precedence is 1.
-		assert.Equal(t, 1, deferred["template"][0].Precedence)
 	})
 
-	t.Run("two non-empty inputs use the full merge path (not the fast path)", func(t *testing.T) {
+	t.Run("two non-empty inputs use the full merge path", func(t *testing.T) {
 		a := map[string]any{"key": "value-a", "shared": "from-a"}
 		b := map[string]any{"key": "value-b", "extra": "from-b"}
 		inputs := []map[string]any{a, b}
@@ -771,7 +775,7 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 		assert.False(t, dctx.HasDeferredValues())
 	})
 
-	t.Run("fast path does not mutate function-free input", func(t *testing.T) {
+	t.Run("MergeWithDeferred does not mutate function-free input", func(t *testing.T) {
 		single := map[string]any{"key": "value"}
 		original := map[string]any{"key": "value"}
 		inputs := []map[string]any{nil, single}
@@ -781,7 +785,40 @@ func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
 
 		// Input must be unchanged after the call.
 		assert.Equal(t, original, single,
-			"MergeWithDeferred fast path must not mutate function-free input")
+			"MergeWithDeferred must not mutate its input")
+	})
+
+	t.Run("mutating the result does not mutate the input (regression guard)", func(t *testing.T) {
+		// Regression guard for the original Phase 5 1-input shortcut, which
+		// returned the input map directly when WalkAndDeferYAMLFunctions's
+		// short-circuit kicked in. Downstream mutation of the result then
+		// corrupted upstream cached settings, dropping spacelift stacks in
+		// TestSpaceliftStackProcessor.
+		single := map[string]any{
+			"region": "us-east-1",
+			"nested": map[string]any{"inner": "original"},
+		}
+		inputs := []map[string]any{single}
+
+		result, _, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+
+		// Mutate every level of the result.
+		result["region"] = "MUTATED"
+		result["newKey"] = "added"
+		if nested, ok := result["nested"].(map[string]any); ok {
+			nested["inner"] = "MUTATED"
+		}
+
+		// The input must be unchanged.
+		assert.Equal(t, "us-east-1", single["region"],
+			"mutating Merge's result must not mutate the input")
+		_, hasNewKey := single["newKey"]
+		assert.False(t, hasNewKey, "input map must not gain keys added to the result")
+		if nestedSingle, ok := single["nested"].(map[string]any); ok {
+			assert.Equal(t, "original", nestedSingle["inner"],
+				"nested maps must also be deep-copied")
+		}
 	})
 }
 

--- a/pkg/merge/merge_deferred_test.go
+++ b/pkg/merge/merge_deferred_test.go
@@ -163,6 +163,110 @@ func TestWalkAndDeferYAMLFunctions(t *testing.T) {
 	})
 }
 
+// TestWalkAndDeferYAMLFunctions_NoFunctionsShortCircuit verifies the Phase 3
+// optimization: when the input contains no YAML functions anywhere in its
+// nested structure, WalkAndDeferYAMLFunctions returns the input map as-is
+// without allocating a deep copy. The function-free fast path is critical
+// for the merge pipeline in describe affected, where most component
+// configurations contain no YAML functions but were previously deep-copied
+// on every merge call.
+func TestWalkAndDeferYAMLFunctions_NoFunctionsShortCircuit(t *testing.T) {
+	t.Run("returns same map reference for function-free flat map", func(t *testing.T) {
+		dctx := NewDeferredMergeContext()
+		input := map[string]interface{}{
+			"region":      "us-east-1",
+			"environment": "prod",
+			"replicas":    3,
+			"enabled":     true,
+		}
+		// Capture a pointer-identity reference. The fast path must return
+		// the same map object, not a copy.
+		result := WalkAndDeferYAMLFunctions(dctx, input, []string{})
+		require.True(t, sameMapHeader(input, result),
+			"function-free input should be returned as-is (zero allocation)")
+		assert.False(t, dctx.HasDeferredValues(),
+			"no deferrals expected when no YAML functions are present")
+	})
+
+	t.Run("returns same map reference for function-free nested map", func(t *testing.T) {
+		dctx := NewDeferredMergeContext()
+		input := map[string]interface{}{
+			"tags": map[string]interface{}{
+				"namespace": "acme",
+				"stage":     "prod",
+				"meta": map[string]interface{}{
+					"owner": "platform",
+				},
+			},
+			"settings": map[string]interface{}{
+				"spacelift": map[string]interface{}{
+					"workspace_enabled": true,
+				},
+			},
+		}
+		result := WalkAndDeferYAMLFunctions(dctx, input, []string{})
+		require.True(t, sameMapHeader(input, result),
+			"function-free nested input should be returned as-is (zero allocation)")
+		assert.False(t, dctx.HasDeferredValues())
+	})
+
+	t.Run("walks normally when any subtree contains a YAML function", func(t *testing.T) {
+		dctx := NewDeferredMergeContext()
+		input := map[string]interface{}{
+			"tags": map[string]interface{}{
+				"namespace": "acme", // No function here.
+			},
+			"vars": map[string]interface{}{
+				"region": "!template '{{ .stage }}'", // Function here — must walk.
+			},
+		}
+		result := WalkAndDeferYAMLFunctions(dctx, input, []string{})
+		require.False(t, sameMapHeader(input, result),
+			"presence of any YAML function must force a deep walk")
+		assert.True(t, dctx.HasDeferredValues())
+
+		// The non-function tags subtree should still be reachable in the result.
+		tags, ok := result["tags"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "acme", tags["namespace"])
+
+		// The function value should be replaced with nil placeholder.
+		vars, ok := result["vars"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Nil(t, vars["region"])
+	})
+
+	t.Run("short-circuit return is safe under read-only access", func(t *testing.T) {
+		// The fast path returns the input directly. The caller contract says
+		// the result is read-only. This test documents the contract by
+		// asserting that subsequent reads yield identical values, and that
+		// the input itself was not modified.
+		dctx := NewDeferredMergeContext()
+		input := map[string]interface{}{
+			"key":   "value",
+			"count": 42,
+		}
+		original := map[string]interface{}{
+			"key":   "value",
+			"count": 42,
+		}
+
+		_ = WalkAndDeferYAMLFunctions(dctx, input, []string{})
+
+		// Input must be unchanged.
+		assert.Equal(t, original, input,
+			"WalkAndDeferYAMLFunctions must not mutate function-free inputs")
+	})
+}
+
+// sameMapHeader returns true if a and b are the same underlying map.
+// In Go a map is a pointer to the runtime map header, so reflect.ValueOf(m).Pointer()
+// (or fmt-printf of %p) compares header identity. Using fmt.Sprintf avoids importing
+// reflect for a single equality check.
+func sameMapHeader(a, b map[string]interface{}) bool {
+	return fmt.Sprintf("%p", a) == fmt.Sprintf("%p", b)
+}
+
 func TestIsMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/merge/merge_deferred_test.go
+++ b/pkg/merge/merge_deferred_test.go
@@ -699,6 +699,92 @@ func TestMergeWithDeferred(t *testing.T) {
 	})
 }
 
+// TestMergeWithDeferred_TrivialInputShortCircuits exercises the Phase 5 fast
+// paths: zero non-empty inputs returns empty; exactly one non-empty input
+// skips the Merge call. The fast paths preserve precedence semantics for any
+// downstream consumer that inspects the dctx, even though precedence is
+// irrelevant for output when only one layer contributes values.
+func TestMergeWithDeferred_TrivialInputShortCircuits(t *testing.T) {
+	cfg := &schema.AtmosConfiguration{
+		Settings: schema.AtmosSettings{
+			ListMergeStrategy: ListMergeStrategyReplace,
+		},
+	}
+
+	t.Run("zero non-empty inputs returns empty result", func(t *testing.T) {
+		result, dctx, err := MergeWithDeferred(cfg, []map[string]any{nil, {}, nil})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+		assert.NotNil(t, dctx)
+		assert.False(t, dctx.HasDeferredValues())
+	})
+
+	t.Run("single non-empty input with no functions returns same map header", func(t *testing.T) {
+		single := map[string]any{
+			"region":      "us-east-1",
+			"environment": "prod",
+		}
+		inputs := []map[string]any{nil, {}, single, nil}
+		result, dctx, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+		// Phase 3 + Phase 5 compose: function-free single input is returned
+		// as-is, with no allocation in either MergeWithDeferred or its walk.
+		assert.True(t, sameMapHeader(single, result),
+			"single non-empty function-free input must be returned as-is")
+		assert.False(t, dctx.HasDeferredValues())
+	})
+
+	t.Run("single non-empty input with functions defers correctly", func(t *testing.T) {
+		single := map[string]any{
+			"region":   "us-east-1",
+			"template": "!template 'prod-{{ .region }}'",
+		}
+		inputs := []map[string]any{nil, single, nil}
+		result, dctx, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+		// Function present → walk produces a new map with placeholders.
+		assert.False(t, sameMapHeader(single, result),
+			"single non-empty input with YAML functions must be walked into a fresh map")
+		assert.Equal(t, "us-east-1", result["region"])
+		assert.Nil(t, result["template"], "YAML function should be deferred to nil placeholder")
+		assert.True(t, dctx.HasDeferredValues())
+		deferred := dctx.GetDeferredValues()
+		require.Contains(t, deferred, "template")
+		// Precedence preserved: single is at index 1, so precedence is 1.
+		assert.Equal(t, 1, deferred["template"][0].Precedence)
+	})
+
+	t.Run("two non-empty inputs use the full merge path (not the fast path)", func(t *testing.T) {
+		a := map[string]any{"key": "value-a", "shared": "from-a"}
+		b := map[string]any{"key": "value-b", "extra": "from-b"}
+		inputs := []map[string]any{a, b}
+		result, dctx, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+		// Full merge: later wins for overlapping keys.
+		assert.Equal(t, "value-b", result["key"])
+		assert.Equal(t, "from-a", result["shared"])
+		assert.Equal(t, "from-b", result["extra"])
+		// Result is a fresh map, not shared with either input.
+		assert.False(t, sameMapHeader(a, result))
+		assert.False(t, sameMapHeader(b, result))
+		assert.False(t, dctx.HasDeferredValues())
+	})
+
+	t.Run("fast path does not mutate function-free input", func(t *testing.T) {
+		single := map[string]any{"key": "value"}
+		original := map[string]any{"key": "value"}
+		inputs := []map[string]any{nil, single}
+
+		_, _, err := MergeWithDeferred(cfg, inputs)
+		require.NoError(t, err)
+
+		// Input must be unchanged after the call.
+		assert.Equal(t, original, single,
+			"MergeWithDeferred fast path must not mutate function-free input")
+	})
+}
+
 func TestApplyDeferredMerges(t *testing.T) {
 	t.Run("returns nil error when context is nil", func(t *testing.T) {
 		result := map[string]interface{}{}

--- a/pkg/merge/merge_yaml_functions.go
+++ b/pkg/merge/merge_yaml_functions.go
@@ -367,6 +367,49 @@ func MergeWithDeferred(
 	// Create deferred merge context.
 	dctx := NewDeferredMergeContext()
 
+	// Fast paths for trivial input layouts. The mergeComponentConfigurations
+	// pipeline calls this function ~9 times per component instance with 3-4
+	// candidate inputs (e.g., GlobalVars / BaseComponentVars / ComponentVars /
+	// ComponentOverridesVars). On real workloads most of those layers are
+	// empty — the component does not inherit, has no overrides, or only
+	// defines a few sections. Detecting these cases and skipping the full
+	// walk-and-merge avoids both the per-call Merge allocation and the
+	// per-input walk, neither of which produce useful work when the merge
+	// degenerates to "use the only non-empty layer".
+	var nonEmptyInput map[string]any
+	nonEmptyPos := 0
+	nonEmptyCount := 0
+	for i, input := range inputs {
+		if len(input) > 0 {
+			nonEmptyInput = input
+			nonEmptyPos = i
+			nonEmptyCount++
+		}
+	}
+
+	// All inputs empty: result is an empty map, dctx has no deferrals.
+	if nonEmptyCount == 0 {
+		return map[string]any{}, dctx, nil
+	}
+
+	// Exactly one non-empty input: skip the Merge call entirely. Walk the
+	// single input at its original precedence so deferred YAML functions
+	// (if any) are tracked correctly. Empty layers above and below do not
+	// affect deferred resolution, so we can omit the no-op IncrementPrecedence
+	// calls for them — precedence ordering across layers is irrelevant when
+	// only one layer contributes values.
+	if nonEmptyCount == 1 {
+		// Advance precedence to match the position of the non-empty input.
+		// This preserves precedence semantics for any downstream consumers
+		// that inspect the dctx.
+		for i := 0; i < nonEmptyPos; i++ {
+			dctx.IncrementPrecedence()
+		}
+		walked := WalkAndDeferYAMLFunctions(dctx, nonEmptyInput, []string{})
+		dctx.IncrementPrecedence()
+		return walked, dctx, nil
+	}
+
 	// Walk each input and defer YAML functions.
 	processedInputs := make([]map[string]any, len(inputs))
 	for i, input := range inputs {

--- a/pkg/merge/merge_yaml_functions.go
+++ b/pkg/merge/merge_yaml_functions.go
@@ -37,13 +37,46 @@ func isAtmosYAMLFunction(s string) bool {
 	return false
 }
 
+// hasAnyYAMLFunction reports whether `data` contains any Atmos YAML function
+// string anywhere in its nested map structure. Used by WalkAndDeferYAMLFunctions
+// to short-circuit the deep copy when there is nothing to defer.
+//
+// This is a non-allocating recursive scan. It returns on first hit.
+func hasAnyYAMLFunction(data map[string]interface{}) bool {
+	for _, value := range data {
+		if strVal, ok := value.(string); ok && isAtmosYAMLFunction(strVal) {
+			return true
+		}
+		if mapVal, ok := value.(map[string]interface{}); ok && hasAnyYAMLFunction(mapVal) {
+			return true
+		}
+	}
+	return false
+}
+
 // WalkAndDeferYAMLFunctions walks through a map and defers any YAML functions.
 // Returns a new map with YAML functions replaced by nil placeholders.
+//
+// When `data` contains no YAML functions anywhere in its nested structure,
+// returns `data` as-is without allocation. Callers must treat the returned
+// map as read-only; the existing call site (MergeWithDeferred → Merge) does
+// not mutate inputs, which is verified by TestWalkAndDeferYAMLFunctions_NoFunctionsShortCircuit.
+//
+// Heatmap context: in a large-stack workload (~9k component instances), this
+// function previously accounted for 527k recursive calls / 1m26s of CPU time,
+// with most subtrees containing zero YAML functions and being copied for no
+// reason. The short-circuit eliminates the deep-copy allocation in that case.
 func WalkAndDeferYAMLFunctions(dctx *DeferredMergeContext, data map[string]interface{}, basePath []string) map[string]interface{} {
 	defer perf.Track(nil, "merge.WalkAndDeferYAMLFunctions")()
 
 	if data == nil {
 		return nil
+	}
+
+	// Fast path: no YAML functions anywhere in this subtree — no walk, no
+	// allocation. Callers must treat the result as read-only (Merge does).
+	if !hasAnyYAMLFunction(data) {
+		return data
 	}
 
 	result := make(map[string]interface{}, len(data))

--- a/pkg/merge/merge_yaml_functions.go
+++ b/pkg/merge/merge_yaml_functions.go
@@ -66,6 +66,13 @@ func hasAnyYAMLFunction(data map[string]interface{}) bool {
 // function previously accounted for 527k recursive calls / 1m26s of CPU time,
 // with most subtrees containing zero YAML functions and being copied for no
 // reason. The short-circuit eliminates the deep-copy allocation in that case.
+//
+// NOTE: The recursive call re-enters this same function (with its
+// hasAnyYAMLFunction short-circuit) by design — for function-sparse trees,
+// avoiding the per-subtree allocation outweighs the cost of the redundant
+// pre-check. A split into an outer/inner pair (Phase 7 style) was tried in
+// Phase 10 and reverted: the inner-only walker had to allocate on every
+// recursive level, regressing the common case.
 func WalkAndDeferYAMLFunctions(dctx *DeferredMergeContext, data map[string]interface{}, basePath []string) map[string]interface{} {
 	defer perf.Track(nil, "merge.WalkAndDeferYAMLFunctions")()
 

--- a/pkg/merge/merge_yaml_functions.go
+++ b/pkg/merge/merge_yaml_functions.go
@@ -374,47 +374,36 @@ func MergeWithDeferred(
 	// Create deferred merge context.
 	dctx := NewDeferredMergeContext()
 
-	// Fast paths for trivial input layouts. The mergeComponentConfigurations
+	// Fast path for the all-empty case. The mergeComponentConfigurations
 	// pipeline calls this function ~9 times per component instance with 3-4
 	// candidate inputs (e.g., GlobalVars / BaseComponentVars / ComponentVars /
-	// ComponentOverridesVars). On real workloads most of those layers are
-	// empty — the component does not inherit, has no overrides, or only
-	// defines a few sections. Detecting these cases and skipping the full
-	// walk-and-merge avoids both the per-call Merge allocation and the
-	// per-input walk, neither of which produce useful work when the merge
-	// degenerates to "use the only non-empty layer".
-	var nonEmptyInput map[string]any
-	nonEmptyPos := 0
-	nonEmptyCount := 0
-	for i, input := range inputs {
+	// ComponentOverridesVars). When every layer is empty (common for the
+	// terraform-only sections on non-terraform components), there is nothing
+	// to walk or merge — return an empty map and an empty dctx directly.
+	//
+	// A 1-input fast path was tried and reverted: when the single non-empty
+	// input contained no Atmos YAML functions, WalkAndDeferYAMLFunctions's
+	// Phase 3 short-circuit returned the input map as-is, and we were
+	// returning that shared reference to the caller. Downstream consumers in
+	// mergeComponentConfigurations mutate the result map (storing values into
+	// the assembled component map and re-using merge results), which then
+	// corrupted the upstream cached settings/vars/auth/etc. for sibling
+	// components — surfaced as TestSpaceliftStackProcessor losing 7 stacks
+	// because mutated settings.spacelift.workspace_enabled bled across
+	// components. The Merge slow path always returns a deep-copied result
+	// (via MergeWithOptions's own 1-input fast path → DeepCopyMap), so falling
+	// through preserves the contract; the wrapper overhead saved by the
+	// 1-input shortcut was small compared to the deep-copy cost that has to
+	// happen regardless.
+	allEmpty := true
+	for _, input := range inputs {
 		if len(input) > 0 {
-			nonEmptyInput = input
-			nonEmptyPos = i
-			nonEmptyCount++
+			allEmpty = false
+			break
 		}
 	}
-
-	// All inputs empty: result is an empty map, dctx has no deferrals.
-	if nonEmptyCount == 0 {
+	if allEmpty {
 		return map[string]any{}, dctx, nil
-	}
-
-	// Exactly one non-empty input: skip the Merge call entirely. Walk the
-	// single input at its original precedence so deferred YAML functions
-	// (if any) are tracked correctly. Empty layers above and below do not
-	// affect deferred resolution, so we can omit the no-op IncrementPrecedence
-	// calls for them — precedence ordering across layers is irrelevant when
-	// only one layer contributes values.
-	if nonEmptyCount == 1 {
-		// Advance precedence to match the position of the non-empty input.
-		// This preserves precedence semantics for any downstream consumers
-		// that inspect the dctx.
-		for i := 0; i < nonEmptyPos; i++ {
-			dctx.IncrementPrecedence()
-		}
-		walked := WalkAndDeferYAMLFunctions(dctx, nonEmptyInput, []string{})
-		dctx.IncrementPrecedence()
-		return walked, dctx, nil
 	}
 
 	// Walk each input and defer YAML functions.

--- a/pkg/utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils.go
@@ -86,11 +86,21 @@ var (
 		AtmosYamlFuncAwsOrganizationID:       true,
 	}
 
-	// ParsedYAMLCache stores parsed yaml.Node objects and their position information
-	// to avoid re-parsing the same files multiple times.
-	// Cache key: file path + content hash.
-	parsedYAMLCache   = make(map[string]*parsedYAMLCacheEntry)
-	parsedYAMLCacheMu sync.RWMutex
+	// ParsedYAML cache stores parsed yaml.Node objects and their position
+	// information to avoid re-parsing the same files multiple times. Cache key
+	// is file path + content hash. Values are *parsedYAMLCacheEntry and are
+	// treated as immutable post-insert; readers receive deep copies (the
+	// underlying yaml.Node tree has pointer-sharing aliases that would
+	// otherwise corrupt the cache if mutated).
+	//
+	// Uses sync.Map (not a RWMutex-protected map) because the write path is
+	// highly contended at scale: in a large-stack workload (~22k
+	// UnmarshalYAMLFromFileWithPositions calls), the prior RWMutex.Lock()
+	// inside cacheParsedYAML serialized every write across goroutines while
+	// holding the lock during the expensive deepCopyYAMLNode work. The
+	// lock-free sync.Map removes the global lock and optimizes for the
+	// disjoint-key write pattern this cache exhibits.
+	parsedYAMLCache sync.Map // map[string]*parsedYAMLCacheEntry (immutable post-insert).
 
 	// Per-key locks to prevent race conditions when multiple goroutines
 	// try to parse the same file simultaneously. This prevents 156+ goroutines
@@ -216,6 +226,12 @@ func clonePositions(positions PositionMap) PositionMap {
 
 // getCachedParsedYAML retrieves a cached parsed YAML node if it exists.
 // Returns a copy of the node and positions to prevent external mutations.
+//
+// The sync.Map.Load is non-blocking and the deep-copy of the cached entry runs
+// outside any critical section: cached values are treated as immutable
+// post-insert (see cacheParsedYAML), so concurrent goroutines may safely
+// deep-copy them without coordination.
+//
 // Note: Statistics tracking is done by the caller to avoid double-counting.
 // Note: perf.Track() removed from this hot path to reduce overhead.
 func getCachedParsedYAML(file string, content string) (*yaml.Node, PositionMap, bool) {
@@ -224,11 +240,12 @@ func getCachedParsedYAML(file string, content string) (*yaml.Node, PositionMap, 
 		return nil, nil, false
 	}
 
-	parsedYAMLCacheMu.RLock()
-	defer parsedYAMLCacheMu.RUnlock()
-
-	entry, found := parsedYAMLCache[cacheKey]
+	raw, found := parsedYAMLCache.Load(cacheKey)
 	if !found {
+		return nil, nil, false
+	}
+	entry, ok := raw.(*parsedYAMLCacheEntry)
+	if !ok {
 		return nil, nil, false
 	}
 
@@ -240,6 +257,14 @@ func getCachedParsedYAML(file string, content string) (*yaml.Node, PositionMap, 
 
 // cacheParsedYAML stores a parsed YAML node in the cache.
 // Stores copies to prevent external mutations from affecting the cache.
+//
+// The deep copy of node + positions runs BEFORE the sync.Map.Store so the
+// cache's critical section is only the atomic store, not the expensive
+// recursive yaml.Node copy. Combined with sync.Map's lock-free read path,
+// this removes the global write-lock that previously serialized every cache
+// write across the ~22k UnmarshalYAMLFromFileWithPositions calls produced by
+// a large-stack describe-affected run.
+//
 // Note: perf.Track() removed from this hot path to reduce overhead.
 func cacheParsedYAML(file string, content string, node *yaml.Node, positions PositionMap) {
 	cacheKey := generateParsedYAMLCacheKey(file, content)
@@ -247,16 +272,29 @@ func cacheParsedYAML(file string, content string, node *yaml.Node, positions Pos
 		return
 	}
 
-	parsedYAMLCacheMu.Lock()
-	defer parsedYAMLCacheMu.Unlock()
-
 	// Store copies to prevent external mutations from affecting the cache.
 	nodeCopy := deepCopyYAMLNode(node)
 	positionsCopy := clonePositions(positions)
-	parsedYAMLCache[cacheKey] = &parsedYAMLCacheEntry{
+	parsedYAMLCache.Store(cacheKey, &parsedYAMLCacheEntry{
 		node:      *nodeCopy,
 		positions: positionsCopy,
-	}
+	})
+}
+
+// clearParsedYAMLCache empties the parsed YAML cache. Exported indirectly via
+// ClearParsedYAMLCache for tests that need to reset state between subtests.
+func clearParsedYAMLCache() {
+	parsedYAMLCache.Range(func(key, _ any) bool {
+		parsedYAMLCache.Delete(key)
+		return true
+	})
+}
+
+// ClearParsedYAMLCache clears the parsed YAML cache.
+// This should be called between independent operations (like tests) to ensure
+// fresh processing of files whose on-disk content may have changed.
+func ClearParsedYAMLCache() {
+	clearParsedYAMLCache()
 }
 
 // parseAndCacheYAML parses YAML content and caches the result.
@@ -352,7 +390,8 @@ func PrintParsedYAMLCacheStats() {
 		callsPerHash = float64(totalCalls) / float64(uniqueHashes)
 	}
 
-	log.Info("YAML Cache Statistics",
+	log.Info(
+		"YAML Cache Statistics",
 		"totalCalls", totalCalls,
 		"cacheHits", hits,
 		"cacheMisses", misses,

--- a/pkg/utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils.go
@@ -678,7 +678,19 @@ func ConvertToYAML(data any, opts ...YAMLOptions) (string, error) {
 	return buf.String(), nil
 }
 
-//nolint:gocognit,revive
+// processCustomTags walks a YAML node tree and processes any custom Atmos
+// tags it contains. The entry point performs the fast hasCustomTags scan
+// ONCE; if the tree contains no custom tags anywhere, it returns immediately.
+// If any custom tag is found, processCustomTagsInner does the actual walk
+// without re-checking subtrees — saving O(depth) redundant tree scans that
+// the prior implementation incurred by re-running hasCustomTags on every
+// recursive call.
+//
+// Background: in a large describe-affected run (~9k processCustomTags
+// invocations) the redundant per-recursion hasCustomTags walks accounted
+// for the bulk of the 31s cumulative CPU time. Hoisting the check to the
+// top eliminates that overhead without changing behavior for tag-free
+// subtrees (which still benefit from the early exit).
 func processCustomTags(atmosConfig *schema.AtmosConfiguration, node *yaml.Node, file string) error {
 	defer perf.Track(atmosConfig, "utils.processCustomTags")()
 
@@ -694,6 +706,23 @@ func processCustomTags(atmosConfig *schema.AtmosConfiguration, node *yaml.Node, 
 		return nil
 	}
 
+	// We've established there IS a custom tag somewhere in this subtree;
+	// walk it once via the inner helper which skips the (now redundant)
+	// hasCustomTags check on every recursion.
+	return processCustomTagsInner(atmosConfig, node, file)
+}
+
+// processCustomTagsInner is the recursive worker for processCustomTags.
+// Callers must have already established that the input tree contains at
+// least one custom tag (via hasCustomTags); this function does not perform
+// that check on each call, which is the key optimization vs the prior
+// implementation. The perf.Track on the outer processCustomTags wraps the
+// entire walk with one tracked frame, so per-recursion tracking is
+// intentionally omitted here to avoid inflating the metric (recursive
+// calls would be counted in addition to the top-level invocation).
+//
+//nolint:gocognit
+func processCustomTagsInner(atmosConfig *schema.AtmosConfiguration, node *yaml.Node, file string) error {
 	for _, n := range node.Content {
 		tag := strings.TrimSpace(n.Tag)
 		val := strings.TrimSpace(n.Value)
@@ -735,7 +764,7 @@ func processCustomTags(atmosConfig *schema.AtmosConfiguration, node *yaml.Node, 
 
 		// Recursively process the child nodes
 		if len(n.Content) > 0 {
-			if err := processCustomTags(atmosConfig, n, file); err != nil {
+			if err := processCustomTagsInner(atmosConfig, n, file); err != nil {
 				return err
 			}
 		}

--- a/pkg/utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils.go
@@ -102,6 +102,22 @@ var (
 	// disjoint-key write pattern this cache exhibits.
 	parsedYAMLCache sync.Map // map[string]*parsedYAMLCacheEntry (immutable post-insert).
 
+	// DecodedYAMLCache stores the post-Decode + post-Intern result of
+	// UnmarshalYAMLFromFileWithPositions[map[string]any] so that repeat callers
+	// (transitively imported files in describe-affected, ~22k calls in the
+	// reference workload) skip the per-call yaml.Node.Decode and
+	// InternStringsInMap walks. The parsedYAMLCache above only avoids re-parsing;
+	// Decode + Intern still ran on every call and accounted for ~500-700µs per
+	// invocation, dominating the function's cost once the parsed-node cache hit.
+	//
+	// Cache key: file path + content hash (same as parsedYAMLCache). Values are
+	// *decodedYAMLCacheEntry with both the decoded map and its positions; readers
+	// receive deep copies (DeepCopyMap + clonePositions) to preserve the
+	// immutable-post-insert contract. Only the map[string]any generic
+	// instantiation populates this cache; other generic T fall through to the
+	// existing Decode path.
+	decodedYAMLCache sync.Map // map[string]*decodedYAMLCacheEntry (immutable post-insert).
+
 	// Per-key locks to prevent race conditions when multiple goroutines
 	// try to parse the same file simultaneously. This prevents 156+ goroutines
 	// from all parsing the same file when they could share the result.
@@ -142,6 +158,105 @@ var (
 type parsedYAMLCacheEntry struct {
 	node      yaml.Node
 	positions PositionMap
+}
+
+// decodedYAMLCacheEntry stores the post-Decode + post-Intern result for the
+// map[string]any specialization of UnmarshalYAMLFromFileWithPositions, plus
+// the matching position map. Both are deep-copied on retrieval to keep the
+// cached value immutable.
+type decodedYAMLCacheEntry struct {
+	data      map[string]any
+	positions PositionMap
+}
+
+// deepCopyDecodedMap is a local deep-copy for the decoded-YAML cache. It
+// covers the value types produced by yaml.Node.Decode + InternStringsInMap:
+// nested map[string]any, []any, and immutable primitives (string, numbers,
+// bool). Atmos custom tags are pre-processed into strings before this point,
+// so no exotic types appear. We can't use pkg/merge.DeepCopyMap here because
+// pkg/merge imports pkg/utils.
+func deepCopyDecodedMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyDecodedValue(v)
+	}
+	return out
+}
+
+func deepCopyDecodedValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			out[k] = deepCopyDecodedValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, vv := range val {
+			out[i] = deepCopyDecodedValue(vv)
+		}
+		return out
+	default:
+		// Primitives (string, int*, uint*, float*, bool) and nil are
+		// immutable in Go's value model — sharing the reference is safe.
+		return val
+	}
+}
+
+// getCachedDecodedYAML retrieves a cached decoded+interned result for the
+// given file and content. Returns deep copies so the cache remains immutable
+// across concurrent readers. The sync.Map.Load is non-blocking; the deep copy
+// runs outside any critical section.
+func getCachedDecodedYAML(file, content string) (map[string]any, PositionMap, bool) {
+	cacheKey := generateParsedYAMLCacheKey(file, content)
+	if cacheKey == "" {
+		return nil, nil, false
+	}
+	raw, found := decodedYAMLCache.Load(cacheKey)
+	if !found {
+		return nil, nil, false
+	}
+	entry, ok := raw.(*decodedYAMLCacheEntry)
+	if !ok {
+		return nil, nil, false
+	}
+	dataCopy := deepCopyDecodedMap(entry.data)
+	return dataCopy, clonePositions(entry.positions), true
+}
+
+// cacheDecodedYAML stores a decoded+interned result. The deep copy runs
+// BEFORE the sync.Map.Store so the cache's critical section is only the
+// atomic store, not the expensive recursive map copy.
+func cacheDecodedYAML(file, content string, data map[string]any, positions PositionMap) {
+	cacheKey := generateParsedYAMLCacheKey(file, content)
+	if cacheKey == "" || data == nil {
+		return
+	}
+	dataCopy := deepCopyDecodedMap(data)
+	decodedYAMLCache.Store(cacheKey, &decodedYAMLCacheEntry{
+		data:      dataCopy,
+		positions: clonePositions(positions),
+	})
+}
+
+// clearDecodedYAMLCache empties the decoded YAML cache. Exported indirectly
+// via ClearDecodedYAMLCache for tests that need to reset state between subtests.
+func clearDecodedYAMLCache() {
+	decodedYAMLCache.Range(func(key, _ any) bool {
+		decodedYAMLCache.Delete(key)
+		return true
+	})
+}
+
+// ClearDecodedYAMLCache clears the decoded YAML result cache. Call between
+// independent operations (like tests) to ensure fresh processing of files
+// whose on-disk content may have changed.
+func ClearDecodedYAMLCache() {
+	clearDecodedYAMLCache()
 }
 
 // generateParsedYAMLCacheKey generates a cache key from file path and content.
@@ -864,6 +979,30 @@ func UnmarshalYAMLFromFileWithPositions[T any](atmosConfig *schema.AtmosConfigur
 	parsedYAMLCacheStats.uniqueHashes[contentHash]++
 	parsedYAMLCacheStats.Unlock()
 
+	// Fast path: when callers want map[string]any (the production hot path
+	// — schema.AtmosSectionMapType is `map[string]any`), try the post-Decode
+	// + post-Intern cache first. A hit lets us skip yaml.Node.Decode and
+	// InternStringsInMap, which together cost ~500-700µs per call and dominate
+	// the function once the parsedYAMLCache (yaml.Node) is hot. Provenance
+	// requires positions, which the decoded cache stores alongside the data.
+	if _, ok := any(zeroValue).(map[string]any); ok {
+		if cachedMap, cachedPositions, found := getCachedDecodedYAML(file, input); found {
+			// If the caller needs positions but the cached entry has none
+			// (entry inserted by a non-provenance caller), fall through to
+			// re-decode via the slow path which will repopulate positions.
+			if !atmosConfig.TrackProvenance || len(cachedPositions) > 0 {
+				// Count decoded-cache hits in the same counter as parsed-node
+				// cache hits; both represent successful avoidance of work.
+				parsedYAMLCacheStats.Lock()
+				parsedYAMLCacheStats.hits++
+				parsedYAMLCacheStats.Unlock()
+				// Safe by construction: zeroValue's type proves T == map[string]any.
+				typed, _ := any(cachedMap).(T)
+				return typed, cachedPositions, nil
+			}
+		}
+	}
+
 	// Try to get cached parsed YAML first (fast path with read lock).
 	node, positions, found := getCachedParsedYAML(file, input)
 	if found {
@@ -907,6 +1046,13 @@ func UnmarshalYAMLFromFileWithPositions[T any](atmosConfig *schema.AtmosConfigur
 	if m, ok := any(data).(map[string]any); ok && m != nil && len(m) > 0 {
 		interned := InternStringsInMap(atmosConfig, m)
 		data = interned.(T)
+
+		// Populate the decoded-result cache so subsequent calls for the same
+		// (file, content) skip the Decode + Intern walks. Storing the
+		// post-Intern value lets future hits return ready-to-use maps.
+		if internedMap, ok := interned.(map[string]any); ok {
+			cacheDecodedYAML(file, input, internedMap, positions)
+		}
 	}
 
 	return data, positions, nil

--- a/pkg/utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils_test.go
@@ -1600,3 +1600,59 @@ value: 123`
 	// Verify cache hit (hits should increase).
 	assert.Greater(t, hitsAfter, hitsBefore, "Cache hits should increase on second call")
 }
+
+// TestClearParsedYAMLCache_Public exercises the exported ClearParsedYAMLCache
+// helper so tests in other packages can rely on it. The internal
+// clearParsedYAMLCache is already covered by other tests via the t.Cleanup
+// pattern, but the public wrapper itself needs its own coverage so the
+// "all exported APIs have a behavioral test" convention holds.
+func TestClearParsedYAMLCache_Public(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	// Seed an entry into the parsed cache via the public API.
+	_, _, err := UnmarshalYAMLFromFileWithPositions[map[string]any](atmosConfig, "key: value", "public-clear-test.yaml")
+	require.NoError(t, err)
+
+	// Confirm at least one entry is present.
+	var beforeCount int
+	parsedYAMLCache.Range(func(_, _ any) bool {
+		beforeCount++
+		return true
+	})
+	require.Positive(t, beforeCount, "cache should have at least one entry before clearing")
+
+	ClearParsedYAMLCache()
+
+	var afterCount int
+	parsedYAMLCache.Range(func(_, _ any) bool {
+		afterCount++
+		return true
+	})
+	assert.Equal(t, 0, afterCount, "ClearParsedYAMLCache should empty the cache")
+}
+
+// TestClearDecodedYAMLCache_Public exercises the exported ClearDecodedYAMLCache
+// helper. The decoded-result cache is populated by UnmarshalYAMLFromFileWithPositions
+// when T == map[string]any (the production fast path); this test seeds an entry
+// and then verifies the public clear API empties it.
+func TestClearDecodedYAMLCache_Public(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	// Seed an entry into the decoded cache via the public API.
+	_, _, err := UnmarshalYAMLFromFileWithPositions[map[string]any](atmosConfig, "key: value", "public-decoded-clear-test.yaml")
+	require.NoError(t, err)
+
+	var beforeCount int
+	decodedYAMLCache.Range(func(_, _ any) bool {
+		beforeCount++
+		return true
+	})
+	require.Positive(t, beforeCount, "decoded cache should have at least one entry before clearing")
+
+	ClearDecodedYAMLCache()
+
+	var afterCount int
+	decodedYAMLCache.Range(func(_, _ any) bool {
+		afterCount++
+		return true
+	})
+	assert.Equal(t, 0, afterCount, "ClearDecodedYAMLCache should empty the cache")
+}

--- a/pkg/utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils_test.go
@@ -270,7 +270,8 @@ nested:
 
 			// All goroutines parse the same file with the same content
 			result, _, err := UnmarshalYAMLFromFileWithPositions[map[string]any](
-				atmosConfig, input, "concurrent-test.yaml")
+				atmosConfig, input, "concurrent-test.yaml",
+			)
 			if err != nil {
 				errors <- err
 				return
@@ -356,7 +357,8 @@ func TestUnmarshalYAMLFromFileWithPositions_ConcurrentAccessDifferentFiles(t *te
 				<-start
 
 				result, _, err := UnmarshalYAMLFromFileWithPositions[map[string]any](
-					atmosConfig, content, name)
+					atmosConfig, content, name,
+				)
 				if err != nil {
 					errors <- err
 					return
@@ -1473,20 +1475,9 @@ nested:
   key: value`
 	fileName := "test-provenance-reparse.yaml"
 
-	// Capture old cache state and restore after test.
-	parsedYAMLCacheMu.Lock()
-	oldCache := parsedYAMLCache
-	parsedYAMLCacheMu.Unlock()
-	t.Cleanup(func() {
-		parsedYAMLCacheMu.Lock()
-		parsedYAMLCache = oldCache
-		parsedYAMLCacheMu.Unlock()
-	})
-
-	// Clear cache to ensure clean state.
-	parsedYAMLCacheMu.Lock()
-	parsedYAMLCache = make(map[string]*parsedYAMLCacheEntry)
-	parsedYAMLCacheMu.Unlock()
+	// Clear cache before and after test for isolation.
+	clearParsedYAMLCache()
+	t.Cleanup(clearParsedYAMLCache)
 
 	// First parse WITHOUT provenance tracking.
 	configNoProvenance := &schema.AtmosConfiguration{
@@ -1535,20 +1526,9 @@ func TestUnmarshalYAMLFromFileWithPositions_NilConfigReturnsError(t *testing.T) 
 // TestHandleCacheMiss_NilConfigSafe tests that handleCacheMiss handles nil atmosConfig safely.
 // This tests the nil checks we added to prevent panics.
 func TestHandleCacheMiss_NilConfigSafe(t *testing.T) {
-	// Capture old cache state and restore after test.
-	parsedYAMLCacheMu.Lock()
-	oldCache := parsedYAMLCache
-	parsedYAMLCacheMu.Unlock()
-	t.Cleanup(func() {
-		parsedYAMLCacheMu.Lock()
-		parsedYAMLCache = oldCache
-		parsedYAMLCacheMu.Unlock()
-	})
-
-	// Clear cache to ensure clean state.
-	parsedYAMLCacheMu.Lock()
-	parsedYAMLCache = make(map[string]*parsedYAMLCacheEntry)
-	parsedYAMLCacheMu.Unlock()
+	// Clear cache before and after test for isolation.
+	clearParsedYAMLCache()
+	t.Cleanup(clearParsedYAMLCache)
 
 	yamlContent := `name: test`
 
@@ -1569,19 +1549,13 @@ func TestUnmarshalYAMLFromFileWithPositions_CacheHitWithProvenance(t *testing.T)
 value: 123`
 	fileName := "test-cache-hit-provenance.yaml"
 
-	// Capture old cache state and restore after test.
-	// Note: Only capture values, not the struct containing the mutex.
-	parsedYAMLCacheMu.Lock()
-	oldCache := parsedYAMLCache
-	parsedYAMLCacheMu.Unlock()
+	// Save stats and restore after test.
 	parsedYAMLCacheStats.Lock()
 	oldHits := parsedYAMLCacheStats.hits
 	oldMisses := parsedYAMLCacheStats.misses
 	parsedYAMLCacheStats.Unlock()
 	t.Cleanup(func() {
-		parsedYAMLCacheMu.Lock()
-		parsedYAMLCache = oldCache
-		parsedYAMLCacheMu.Unlock()
+		clearParsedYAMLCache()
 		parsedYAMLCacheStats.Lock()
 		parsedYAMLCacheStats.hits = oldHits
 		parsedYAMLCacheStats.misses = oldMisses
@@ -1589,9 +1563,7 @@ value: 123`
 	})
 
 	// Clear cache to ensure clean state.
-	parsedYAMLCacheMu.Lock()
-	parsedYAMLCache = make(map[string]*parsedYAMLCacheEntry)
-	parsedYAMLCacheMu.Unlock()
+	clearParsedYAMLCache()
 
 	// Reset stats.
 	parsedYAMLCacheStats.Lock()

--- a/pkg/utils/yq_utils.go
+++ b/pkg/utils/yq_utils.go
@@ -171,9 +171,23 @@ func isMisinterpretedScalar(node *yaml.Node, originalResult string) bool {
 	return keyMatchesOriginalWithColon(keyNode.Value, originalResult)
 }
 
+// processYAMLNode walks a YAML node tree and adjusts the style of scalar
+// string nodes that start with `#` so they round-trip without YAML
+// re-interpreting them as comments.
+//
+// The perf.Track defer is on this entry point only; the recursive worker
+// (processYAMLNodeInner) deliberately omits it to avoid inflating the
+// metric across every tree node — see processCustomTags /
+// processCustomTagsInner for the same pattern.
 func processYAMLNode(node *yaml.Node) {
 	defer perf.Track(nil, "utils.processYAMLNode")()
+	processYAMLNodeInner(node)
+}
 
+// processYAMLNodeInner is the recursive worker for processYAMLNode. No
+// perf.Track here; the outer call wraps the whole walk with one tracked
+// frame.
+func processYAMLNodeInner(node *yaml.Node) {
 	if node == nil {
 		return
 	}
@@ -183,7 +197,7 @@ func processYAMLNode(node *yaml.Node) {
 	}
 
 	for _, child := range node.Content {
-		processYAMLNode(child)
+		processYAMLNodeInner(child)
 	}
 }
 


### PR DESCRIPTION
## what

Performance optimization arc for `atmos describe affected` on large-stack workloads.
Targets the inheritance + merge + YAML-parse hot paths that have grown since the
October 2025 perf instrumentation arc (PRs #1576/#1611/#1622/#1639) added the
`auth`, `profiles`, `locals`, and per-file position-tracking subsystems.

Twelve shipped phases (with two attempted-and-reverted optimizations documented
in-code so they aren't re-tried without addressing the underlying contract
violations):

- **Phase 2** — `cacheBaseComponentConfig` switched from `RWMutex` + map to
  `sync.Map`; deep-copy moved outside the critical section. Eliminates write-lock
  contention that serialized every cache write across goroutines and padded
  apparent CPU time with lock-wait.
- **Phase 3** — `WalkAndDeferYAMLFunctions` short-circuits when the subtree
  contains no Atmos YAML functions (`!template`, `!terraform.*`, `!store*`,
  `!exec`, `!env`). Returns the input map as-is instead of allocating a deep
  copy at every recursion level.
- **Phase 4** — `extractLocalsFromRawYAML` cached via `sync.Map` keyed by
  `filePath + FNV-1a(yamlContent)`. The content-hash component prevents
  test pollution when the same logical file path is reused with different
  content. Also fixes a pre-existing data race in
  `extractAndAddLocalsToContext` (shallow-clones the input context map
  before file-scoped `delete + assign`).
- **Phase 5** — `MergeWithDeferred` 0-input fast path: when every layer is
  empty, return an empty map immediately without walking or merging. The
  1-input shortcut originally shipped alongside was **REVERTED** on
  2026-05-24 after CI surfaced a regression — see "What was tried and
  reverted" below.
- **Phase 6** — `parsedYAMLCache` switched to `sync.Map`; deep-copy of
  `yaml.Node` + `PositionMap` moved outside the critical section. Same lock
  contention pattern as Phase 2 applied to the YAML parser cache.
- **Phase 7** — `processCustomTags` split into outer + inner functions: the
  `hasCustomTags` pre-check runs once at the entry point instead of
  re-walking the subtree at every recursive call (O(N×depth) → O(N)).
- **Phase 8** — new `decodedYAMLCache` stores the post-Decode + post-Intern
  result of `UnmarshalYAMLFromFileWithPositions[map[string]any]`. Skips
  `yaml.Node.Decode` + `InternStringsInMap` on every repeat call for the
  same (file, content hash) pair.
- **Phase 10** — `processYAMLNode` split into outer + inner (Phase 7
  pattern). Removes per-recursion `perf.Track` overhead from the recursive
  YAML walker used by yq evaluation. Same pattern was tried for
  `WalkAndDeferYAMLFunctions` and reverted: the inner-only walker had to
  allocate unconditionally on every recursion, regressing function-sparse
  subtrees more than the perf.Track savings recovered.
- **Phase 11** — `processTerraformRemoteStateBackend` extracts the
  backend-type-specific map from each input first (via the new
  `extractBackendTypeMap` helper), then merges just those two scoped maps.
  Avoids deep-copying unrelated backend-type entries
  (s3/gcs/azurerm/etc.) just to extract one key from the merged result.
- **Phase 12 + 13** — `deepCopyBaseComponentConfigMaps` guards every
  `m.DeepCopyMap` call with `len(src.Field) > 0`. Skips function-call and
  allocation overhead for the empty-field case that dominates real
  workloads (most components leave several of the 10 fields empty).
- **Coverage** — new tests close the gaps the arc introduced. Public
  `Clear*Cache` wrappers, `extractBackendTypeMap` type-mismatch path, and
  the Phase 12/13 empty-field contract are all now covered.

Phase 1 was the auth credential-store fix that shipped separately as
PR #2471 (in `v1.220.0-rc.1`).

### What was tried and reverted

- **Phase 5 1-input shortcut.** Initially returned the walked single input
  directly without going through `Merge`. CI surfaced
  `TestSpaceliftStackProcessor` losing 7 stacks (47→40) because
  `WalkAndDeferYAMLFunctions`'s Phase 3 short-circuit returned the input
  map as-is, and the 1-input shortcut handed that shared reference back
  to the caller. Downstream `mergeComponentConfigurations` mutated the
  result while building the per-component output, which corrupted the
  upstream cached `BaseComponentSettings` / `GlobalSettings` for sibling
  components. Fix: keep only the 0-input fast path; let 1-input fall
  through to the regular merge pipeline which deep-copies via
  `MergeWithOptions` → `DeepCopyMap`. Regression test
  (`TestMergeWithDeferred_TrivialInputShortCircuits/mutating the result
  does not mutate the input`) added to prevent re-attempts.
- **Phase 9 asymmetric clone.** Same class of failure (`fatal error:
  concurrent map iteration and map write` at scale): share
  `settings/vars/env` references from the locals cache, deep-copy only
  `locals`. `processTemplatesInSection` returns the input map as-is
  when the section has no `{{`, so the cached references ended up in
  the shared template context and got mutated by sibling goroutines.
  Reverted in `b11f3cd9b`; documented in-code.

Both failures share the same lesson: any optimization that hands a
shared reference back to a caller has to be matched against the
end-to-end mutation surface, not just the immediate caller. The `Merge`
contract — "result is a fresh, caller-mutable map" — must be upheld.

## why

A real-world large stack configuration (≈836 YAML files, ~195 final stacks
across three namespaces, ~9.3k component instances) reported `atmos describe
affected` taking around **11 minutes** in CI on a 2-core runner. Local
reproduction with `--identity=false` and fake AWS credentials took **~4
minutes** and showed two clear cost centers in the heatmap:

1. The credential store was being created per-component even with
   `--identity=false` (≈3.5 min of cumulative CPU). Fixed in PR #2471.
2. The component-inheritance + merge + YAML-parse pipeline (≈6 min of
   cumulative CPU) was bottlenecked by lock contention on shared caches,
   redundant deep-copies on every cache read/write, and per-call work that
   could be cached or skipped for the common case.

This PR addresses the second bucket. Confirmed impact on the same workload
(mean of 3 local runs against current main, post-Phase-5-revert):

| Function | Pre-Phase-2 | Post-Phase-13 | Reduction |
|---|---:|---:|---:|
| `cacheBaseComponentConfig` | 5m50s | ~990ms | **−99.7%** |
| `mergeComponentConfigurations` | 2m22s | ~95s | **−33%** |
| `MergeWithDeferred` | 1m35s | ~51s | **−46%** |
| `WalkAndDeferYAMLFunctions` | 1m26s | ~11s | **−87%** |
| `extractLocalsFromRawYAML` | 13s | ~6s | **−54%** |
| `UnmarshalYAMLFromFileWithPositions` | 18.7s | ~3.2s | **−83%** |
| `processCustomTags` | 31.5s | ~7.5s | **−76%** |
| `getCachedBaseComponentConfig` | 6.5s | ~360ms | **−94%** |

(`mergeComponentConfigurations`, `MergeWithDeferred`, and `Merge`
numbers reflect the post-Phase-5-revert state — the 1-input shortcut
that was originally counted toward Phase 5's headline numbers has been
removed for correctness. The remaining wins are still substantial.)

Local wall-clock on the same workload: **4.1s → ~2.2s (−47%)** on a
many-core Mac. The wall-clock floor on Mac is set by stack-level
parallelism that already saturates; the cumulative CPU savings (several
minutes summed across all hot functions) translate to materially more
wall-clock improvement on 2-4 core CI runners where lock-wait padding,
allocation pressure, and serialized work cannot be hidden behind cores.

Projection for a 2-core CI runner starting from the v1.219.0 baseline:
**~11 minutes → ~60-105 seconds** end-to-end (combining PR #2471 + this
PR's shipped phases, including the ~15s GHA wall-clock cost of the
Phase 5 1-input revert). Awaiting end-to-end CI validation on the
reference workload.

Each phase is **independently revertible** — they live in separate
commits with self-contained tests. The two reverted optimizations
(Phase 5's 1-input shortcut, Phase 9's asymmetric clone) have their
failure modes documented in-code and in
`docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md`
so future passes don't re-attempt the same approach without addressing
the underlying contract violations.

## references

- Investigation doc with per-phase root cause, metric tables, and
  decision lessons:
  [`docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md`](https://github.com/cloudposse/atmos/blob/aknysh/performance-3/docs/fixes/2026-05-23-describe-affected-component-inheritance-perf.md)
- Predecessor work that built the perf-instrumentation infrastructure
  this PR builds on: #1576 (heatmap visualization), #1611 (self-time vs
  total-time), #1622 (Docker perf fix + CPU Time / Parallelism), #1639
  (5.2× faster execution + 92% memory reduction).
- Phase 1 (`--identity=false` gate) shipped separately in PR #2471
  (`v1.220.0-rc.1`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed troubleshooting/performance guide for diagnosing slow "describe affected" runs with reproducible steps and optimization plan.

* **Performance**
  * Significant speedups via new caching, contention reduction, and short-circuit fast-paths for common/empty cases.

* **Reliability**
  * Improved cache correctness, mutation isolation, and error propagation to avoid races and unexpected panics.

* **Tests / Chores**
  * Expanded test coverage and added public cache-clear helpers for reliable isolation and regression verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->