### PR TITLE
fix(ci): restore security-events: write for Dockerfile lint SARIF upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,16 @@ jobs:
     name: "[lint] Dockerfile"
     needs: build
     runs-on: ubuntu-latest
+    # The workflow-level `permissions:` block above (added in #2487 for
+    # `packages: read` on ghcr.io pulls) REPLACES — not extends — the default
+    # token scope for every job. That stripped the implicit
+    # `security-events: write` this job relied on for SARIF upload, breaking
+    # the post-merge run on main. Job-level `permissions:` also fully
+    # overrides the workflow-level set, so `contents: read` is re-listed here
+    # for actions/checkout.
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## what

Restores `security-events: write` permission for the `[lint] Dockerfile`
job in `.github/workflows/test.yml` so its hadolint SARIF results can
be uploaded to GitHub Code Scanning.

- Adds a job-level `permissions:` block to the `docker` job:
  ```yaml
  permissions:
    contents: read           # actions/checkout
    security-events: write   # github/codeql-action/upload-sarif
  ```
- `contents: read` is re-listed because a job-level `permissions:` block
  **fully overrides** the workflow-level set (rather than merging).

## why

PR #2487 (`2437e13bf`) added a top-level `permissions:` block to the
workflow to grant `packages: read` for ghcr.io pulls:

```yaml
permissions:
  contents: read
  packages: read
```

In GitHub Actions, a workflow-level `permissions:` block **replaces**
(not extends) the default `GITHUB_TOKEN` scope for every job in the
file. That replacement inadvertently stripped the implicit
`security-events: write` that the `[lint] Dockerfile` job relied on to
upload hadolint SARIF results via `github/codeql-action/upload-sarif@v4`.

Every post-merge run on `main` has been failing the **Upload SARIF
file** step since #2487:

```
##[warning]This run of the CodeQL Action does not have permission to
access the CodeQL Action API endpoints. ... please ensure the workflow
has at least the 'security-events: read' permission.
##[error]Resource not accessible by integration -
https://docs.github.com/rest
```

Failing run for reference:
<https://github.com/cloudposse/atmos/actions/runs/26339160817/job/77562841194>

Note: hadolint itself ran successfully in the failing run — the SARIF
output contained zero findings. Only the **upload** step failed.

A job-level fix (this PR) is preferred over expanding the workflow-level
permissions block, because it follows least-privilege: only the one job
that actually needs to write security events gets the elevated scope.

## references

- Failing CI run: <https://github.com/cloudposse/atmos/actions/runs/26339160817/job/77562841194>
- Regressing PR: #2487
- GitHub Actions permissions docs:
  <https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token>
- `github/codeql-action/upload-sarif` permission requirement:
  <https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-the-sarif-file-to-github>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed permissions configuration in the CI/CD pipeline to restore security scanning capabilities in automated testing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->