### PR TITLE
fix(toolchain): retry cosign on transient Sigstore Rekor failures

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -229,6 +229,7 @@ var (
 	ErrToolAlreadyInstalled         = errors.New("tool already installed")
 	ErrDownloadFailed               = errors.New("download failed")
 	ErrDownloadRetryable            = errors.New("retryable download error")
+	ErrSignatureRetryable           = errors.New("retryable signature verification error")
 	ErrExtractionFailed             = errors.New("extraction failed")
 	ErrChecksumMismatch             = errors.New("checksum mismatch")
 	ErrNoVersionsInstalled          = errors.New("no versions installed")

--- a/pkg/toolchain/verification/signature.go
+++ b/pkg/toolchain/verification/signature.go
@@ -88,7 +88,10 @@ func runCosignWithRetry(ctx context.Context, req *Request, args []string) error 
 	return retry.WithPredicate(ctx, cosignRetryConfig(), func() error {
 		attempt++
 		runErr := classifyCosignError(runner(req).Run(ctx, "cosign", args...))
-		if runErr != nil && isRetryableCosignError(runErr) {
+		// Only log the "retrying" warning when a retry will actually happen
+		// — suppress on the terminal attempt where the retry budget is
+		// exhausted and the error is about to surface unchanged.
+		if runErr != nil && isRetryableCosignError(runErr) && attempt < cosignRetryMaxAttempts {
 			log.Warn(
 				"cosign verification hit transient Sigstore Rekor error; retrying",
 				"attempt", attempt,

--- a/pkg/toolchain/verification/signature.go
+++ b/pkg/toolchain/verification/signature.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	log "github.com/charmbracelet/log"
+
+	"github.com/cloudposse/atmos/pkg/retry"
 	"github.com/cloudposse/atmos/pkg/toolchain/registry"
 )
 
@@ -69,11 +72,32 @@ func (v *Verifier) verifyCosign(ctx context.Context, req *Request, cfg *registry
 		defer cleanup()
 	}
 	args = append(args, req.AssetPath)
-	if err := runner(req).Run(ctx, "cosign", args...); err != nil {
+	if err := runCosignWithRetry(ctx, req, args); err != nil {
 		return err
 	}
 	result.SignatureMethods = append(result.SignatureMethods, "cosign")
 	return nil
+}
+
+// runCosignWithRetry invokes cosign with bounded exponential backoff,
+// retrying only on transient Sigstore Rekor failures. All other cosign
+// failures (tampering, expired cert, identity mismatch, missing signature)
+// surface immediately on the first attempt.
+func runCosignWithRetry(ctx context.Context, req *Request, args []string) error {
+	attempt := 0
+	return retry.WithPredicate(ctx, cosignRetryConfig(), func() error {
+		attempt++
+		runErr := classifyCosignError(runner(req).Run(ctx, "cosign", args...))
+		if runErr != nil && isRetryableCosignError(runErr) {
+			log.Warn(
+				"cosign verification hit transient Sigstore Rekor error; retrying",
+				"attempt", attempt,
+				"max_attempts", cosignRetryMaxAttempts,
+				"error", runErr.Error(),
+			)
+		}
+		return runErr
+	}, isRetryableCosignError)
 }
 
 func (v *Verifier) cosignArgs(ctx context.Context, req *Request, cfg *registry.CosignConfig, result *Result) ([]string, func(), error) {

--- a/pkg/toolchain/verification/signature_rekor.go
+++ b/pkg/toolchain/verification/signature_rekor.go
@@ -1,0 +1,97 @@
+package verification
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// Cosign retry tuning. Mirrors the toolchain downloader retry budget
+// (downloadRetryMaxAttempts/InitialDelay/MaxDelay) so transient cosign
+// failures get the same treatment as transient HTTP failures.
+const (
+	cosignRetryMaxAttempts  = 5
+	cosignRetryInitialDelay = 1 * time.Second
+	cosignRetryMaxDelay     = 10 * time.Second
+)
+
+// rekorFlakeMarkers are substrings in cosign's combined stderr+stdout that
+// indicate a transient Sigstore Rekor transparency-log error (i.e. an
+// upstream-service problem, not a real signature failure). Match must stay
+// narrow: anything not in this allowlist surfaces immediately so that real
+// tampering, expired certs, or identity mismatches are never silently
+// retried away.
+var rekorFlakeMarkers = []string{
+	// Observed: Rekor /api/v1/log/entries/retrieve sometimes returns HTTP 400
+	// with a bogus signature-decode message even for valid signatures. The
+	// generated go-openapi client surfaces this as "searchLogQueryBadRequest".
+	"searchLogQueryBadRequest",
+	// The specific Rekor backend decode error that accompanies the 400 above.
+	// Including this as a secondary marker so a related Rekor regression that
+	// surfaces the same decode message under a different operation name is
+	// still classified as transient.
+	"Invalid IEEE_P1363 encoded bytes",
+}
+
+// rekorTlogEndpointMarker plus a 5xx status code is also treated as
+// transient. We do not match arbitrary 5xx anywhere in the cosign output —
+// only those scoped to Rekor's transparency-log retrieve endpoint, which is
+// the endpoint historically prone to short-window outages.
+const rekorTlogEndpointMarker = "/api/v1/log/entries/retrieve]["
+
+var rekorTlog5xxStatuses = []string{"500", "502", "503", "504"}
+
+// classifyCosignError joins ErrSignatureRetryable into err when the cosign
+// output contains a known transient Sigstore Rekor failure marker.
+// Otherwise returns err unchanged.
+//
+// Never broaden what counts as retryable beyond known upstream-service
+// flakes — real signature failures (tampering, expired cert, identity
+// mismatch, missing signature) must surface immediately on the first
+// attempt.
+func classifyCosignError(err error) error {
+	defer perf.Track(nil, "verification.classifyCosignError")()
+
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	for _, marker := range rekorFlakeMarkers {
+		if strings.Contains(msg, marker) {
+			return errors.Join(errUtils.ErrSignatureRetryable, err)
+		}
+	}
+	if strings.Contains(msg, rekorTlogEndpointMarker) {
+		for _, status := range rekorTlog5xxStatuses {
+			if strings.Contains(msg, rekorTlogEndpointMarker+status+"]") {
+				return errors.Join(errUtils.ErrSignatureRetryable, err)
+			}
+		}
+	}
+	return err
+}
+
+// isRetryableCosignError is the predicate handed to retry.WithPredicate.
+func isRetryableCosignError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, errUtils.ErrSignatureRetryable)
+}
+
+// cosignRetryConfig returns the retry budget used when invoking cosign.
+func cosignRetryConfig() *schema.RetryConfig {
+	maxAttempts := cosignRetryMaxAttempts
+	initialDelay := cosignRetryInitialDelay
+	maxDelay := cosignRetryMaxDelay
+	return &schema.RetryConfig{
+		MaxAttempts:     &maxAttempts,
+		BackoffStrategy: schema.BackoffExponential,
+		InitialDelay:    &initialDelay,
+		MaxDelay:        &maxDelay,
+	}
+}

--- a/pkg/toolchain/verification/signature_rekor_test.go
+++ b/pkg/toolchain/verification/signature_rekor_test.go
@@ -21,15 +21,23 @@ func TestClassifyCosignError(t *testing.T) {
 		"Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest " +
 		`{"code":400,"message":"verifying signature: ecdsa: Invalid IEEE_P1363 encoded bytes"}`
 
-	rekor503 := "cosign [verify-blob ...]: exit status 1\n" +
-		"Error: searching log query: [POST /api/v1/log/entries/retrieve][503] retrieveLogEntryDefault " +
-		`{"code":503,"message":"service unavailable"}`
+	rekorStatusErr := func(status string) error {
+		return errors.New("cosign [verify-blob ...]: exit status 1\n" +
+			"Error: searching log query: [POST /api/v1/log/entries/retrieve][" + status + "] retrieveLogEntryDefault " +
+			`{"code":` + status + `,"message":"service unavailable"}`)
+	}
 
 	tampered := "cosign [verify-blob ...]: exit status 1\n" +
 		"Error: invalid signature when validating ASN.1 encoded signature"
 
 	identityMismatch := "cosign [verify-blob ...]: exit status 1\n" +
 		"Error: none of the expected identities matched what was in the certificate"
+
+	// Rekor /retrieve with a non-5xx status that is also not in the explicit
+	// 400-marker allowlist (e.g. 401) must surface immediately — only
+	// allowlisted 5xx codes are retried on that endpoint.
+	rekor401 := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][401] retrieveLogEntryUnauthorized"
 
 	cases := []struct {
 		name        string
@@ -38,7 +46,11 @@ func TestClassifyCosignError(t *testing.T) {
 	}{
 		{name: "nil error stays nil", err: nil, wantWrapped: false},
 		{name: "rekor 400 searchLogQueryBadRequest is retryable", err: errors.New(rekor400), wantWrapped: true},
-		{name: "rekor 503 on tlog retrieve endpoint is retryable", err: errors.New(rekor503), wantWrapped: true},
+		{name: "rekor 500 on tlog retrieve endpoint is retryable", err: rekorStatusErr("500"), wantWrapped: true},
+		{name: "rekor 502 on tlog retrieve endpoint is retryable", err: rekorStatusErr("502"), wantWrapped: true},
+		{name: "rekor 503 on tlog retrieve endpoint is retryable", err: rekorStatusErr("503"), wantWrapped: true},
+		{name: "rekor 504 on tlog retrieve endpoint is retryable", err: rekorStatusErr("504"), wantWrapped: true},
+		{name: "rekor 401 on tlog retrieve endpoint is NOT retryable", err: errors.New(rekor401), wantWrapped: false},
 		{name: "tampered artifact is NOT retryable", err: errors.New(tampered), wantWrapped: false},
 		{name: "identity mismatch is NOT retryable", err: errors.New(identityMismatch), wantWrapped: false},
 		{name: "generic cosign failure is NOT retryable", err: errors.New("cosign: exit status 1"), wantWrapped: false},

--- a/pkg/toolchain/verification/signature_rekor_test.go
+++ b/pkg/toolchain/verification/signature_rekor_test.go
@@ -1,0 +1,189 @@
+package verification
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/toolchain/registry"
+)
+
+func TestClassifyCosignError(t *testing.T) {
+	t.Parallel()
+
+	// Realistic cosign stderr captured from a Sigstore Rekor flake in CI.
+	rekor400 := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest " +
+		`{"code":400,"message":"verifying signature: ecdsa: Invalid IEEE_P1363 encoded bytes"}`
+
+	rekor503 := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][503] retrieveLogEntryDefault " +
+		`{"code":503,"message":"service unavailable"}`
+
+	tampered := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: invalid signature when validating ASN.1 encoded signature"
+
+	identityMismatch := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: none of the expected identities matched what was in the certificate"
+
+	cases := []struct {
+		name        string
+		err         error
+		wantWrapped bool
+	}{
+		{name: "nil error stays nil", err: nil, wantWrapped: false},
+		{name: "rekor 400 searchLogQueryBadRequest is retryable", err: errors.New(rekor400), wantWrapped: true},
+		{name: "rekor 503 on tlog retrieve endpoint is retryable", err: errors.New(rekor503), wantWrapped: true},
+		{name: "tampered artifact is NOT retryable", err: errors.New(tampered), wantWrapped: false},
+		{name: "identity mismatch is NOT retryable", err: errors.New(identityMismatch), wantWrapped: false},
+		{name: "generic cosign failure is NOT retryable", err: errors.New("cosign: exit status 1"), wantWrapped: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			classified := classifyCosignError(tc.err)
+			if tc.err == nil {
+				assert.NoError(t, classified)
+				return
+			}
+			require.Error(t, classified)
+			assert.Equal(t, tc.wantWrapped, errors.Is(classified, errUtils.ErrSignatureRetryable),
+				"expected ErrSignatureRetryable wrap=%v, got err=%q", tc.wantWrapped, classified.Error())
+			// Underlying cosign output must always be preserved in the chain.
+			assert.ErrorContains(t, classified, tc.err.Error())
+		})
+	}
+}
+
+// flakyRunner returns retryableErr for the first failAttempts calls, then
+// succeeds (returns nil) on the next call. After it succeeds, further calls
+// also succeed. Tracks the total number of calls.
+type flakyRunner struct {
+	retryableErr  error
+	failAttempts  int
+	calls         int
+	finalCallArgs []string
+}
+
+func (r *flakyRunner) Run(_ context.Context, _ string, args ...string) error {
+	r.calls++
+	r.finalCallArgs = append([]string(nil), args...)
+	if r.calls <= r.failAttempts {
+		return r.retryableErr
+	}
+	return nil
+}
+
+// fatalRunner always returns the supplied non-retryable error.
+type fatalRunner struct {
+	err   error
+	calls int
+}
+
+func (r *fatalRunner) Run(_ context.Context, _ string, _ ...string) error {
+	r.calls++
+	return r.err
+}
+
+func TestRunCosignWithRetry_RecoversFromRekorFlake(t *testing.T) {
+	t.Parallel()
+
+	// Build an error that simulates the runner's wrapping. Need
+	// classifyCosignError to detect the Rekor marker in the message.
+	rekorErr := fmt.Errorf("%w: cosign [verify-blob ...]: exit status 1\n"+
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest",
+		ErrSignatureFailed)
+
+	runner := &flakyRunner{retryableErr: rekorErr, failAttempts: 2}
+	req := &Request{Runner: runner}
+
+	err := runCosignWithRetry(context.Background(), req, []string{"verify-blob", "asset.tar.gz"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, runner.calls, "expected 2 retried failures + 1 success")
+	assert.Equal(t, []string{"verify-blob", "asset.tar.gz"}, runner.finalCallArgs)
+}
+
+func TestRunCosignWithRetry_DoesNotRetryRealFailures(t *testing.T) {
+	t.Parallel()
+
+	// A real "tampered artifact" failure must surface immediately, never
+	// retried. Otherwise we'd mask tampering events.
+	tamperErr := fmt.Errorf("%w: cosign [verify-blob ...]: exit status 1\n"+
+		"Error: invalid signature when validating ASN.1 encoded signature",
+		ErrSignatureFailed)
+
+	runner := &fatalRunner{err: tamperErr}
+	req := &Request{Runner: runner}
+
+	err := runCosignWithRetry(context.Background(), req, []string{"verify-blob", "asset.tar.gz"})
+	require.Error(t, err)
+	assert.Equal(t, 1, runner.calls, "tampering must not be retried")
+	assert.False(t, errors.Is(err, errUtils.ErrSignatureRetryable),
+		"real signature failures must not be classified as retryable")
+	assert.ErrorIs(t, err, ErrSignatureFailed)
+}
+
+func TestRunCosignWithRetry_ExhaustsRetriesOnPersistentRekorOutage(t *testing.T) {
+	t.Parallel()
+
+	rekorErr := fmt.Errorf("%w: cosign [verify-blob ...]: exit status 1\n"+
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest",
+		ErrSignatureFailed)
+
+	runner := &fatalRunner{err: rekorErr}
+	req := &Request{Runner: runner}
+
+	err := runCosignWithRetry(context.Background(), req, []string{"verify-blob", "asset.tar.gz"})
+	require.Error(t, err)
+	assert.Equal(t, cosignRetryMaxAttempts, runner.calls,
+		"should retry exactly cosignRetryMaxAttempts times before giving up")
+	assert.ErrorIs(t, err, ErrSignatureFailed,
+		"underlying signature failure must be preserved when retries exhaust")
+	assert.Contains(t, err.Error(), "max attempts",
+		"retry exhaustion message should call out the attempt budget")
+}
+
+// TestVerifyCosignRetriesViaPublicAPI ensures the retry path is actually
+// wired into the public Verify entrypoint, not just into runCosignWithRetry.
+func TestVerifyCosignRetriesViaPublicAPI(t *testing.T) {
+	t.Parallel()
+
+	rekorErr := fmt.Errorf("%w: cosign [verify-blob ...]: exit status 1\n"+
+		"Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest",
+		ErrSignatureFailed)
+
+	runner := &flakyRunner{retryableErr: rekorErr, failAttempts: 1}
+
+	result, err := (&Verifier{}).Verify(context.Background(), Request{
+		Tool: &registry.Tool{
+			RepoOwner: "owner",
+			RepoName:  "tool",
+			Cosign: registry.CosignConfig{
+				Opts: []string{
+					"--signature", "https://example.com/{{.Asset}}.sig",
+					"--certificate-identity",
+					"https://github.com/owner/tool/.github/workflows/release.yaml@refs/tags/{{.Version}}",
+				},
+			},
+		},
+		Version:   "1.0.0",
+		AssetURL:  "https://example.com/tool.tar.gz",
+		AssetPath: writeAsset(t, []byte("hello")),
+		Policy: Policy{
+			Checksums:  PolicyDisabled,
+			Signatures: PolicyWhenAvailable,
+		},
+		Runner: runner,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, runner.calls, "expected 1 retried failure + 1 success")
+	assert.Contains(t, result.SignatureMethods, "cosign")
+}


### PR DESCRIPTION
## what

- Wrap the `cosign verify-blob` exec in `pkg/toolchain/verification/signature.go` with bounded exponential backoff, retrying **only** on a narrow allowlist of transient Sigstore Rekor failures.
- Add a new `errUtils.ErrSignatureRetryable` sentinel next to the existing `ErrDownloadRetryable`, and a `classifyCosignError` helper that joins the sentinel into cosign errors when the combined output matches a Rekor-flake marker.
- New `runCosignWithRetry` uses the same retry budget as the existing downloader (`5 attempts, 1s → 10s exponential`). Logs a `WARN` before each retry so CI logs surface the upstream-service context.

## why

- `cosign verify-blob` sometimes fails not because of a real signature problem but because Sigstore's Rekor transparency-log API returns a short-window upstream error. The most common signature is:
  ```
  Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest
    {"code":400,"message":"verifying signature: ecdsa: Invalid IEEE_P1363 encoded bytes"}
  ```
  The same artifact verifies cleanly seconds later. Without retry, this turns a transient Sigstore outage into a hard `tool not found` install failure for every Atmos user pulling toolchain assets during the outage window. We hit this twice in 48h on the Windows mock jobs alone.
- The retry allowlist is intentionally narrow — `searchLogQueryBadRequest`, `Invalid IEEE_P1363 encoded bytes`, and Rekor's `/api/v1/log/entries/retrieve` endpoint paired with a 5xx status. Anything outside the allowlist (tampering, expired cert, identity mismatch, missing signature) surfaces immediately on the first attempt. **Blanket-retrying signature verification would mask real tampering events and is the canonical anti-pattern; we do not do that here.**
- Mirrors the existing pattern in `pkg/toolchain/installer/download.go` (sentinel + `retry.WithPredicate` + classifier) so the toolchain's resilience story stays consistent across download and verification.

## references

- Failing run that prompted this: https://github.com/cloudposse/atmos/actions/runs/26368136271/job/77615786736 (Windows `[mock-windows] demo-component-versions`, Rekor returned 400 on a valid OpenTofu 1.9.1 release signature).
- Same flake also hit `[mock-windows] demo-vendoring` in the same run.
- Companion CI permissions fix: #2499 (merged) and #2500 (open).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Signature verification now automatically retries on transient Sigstore Rekor service issues with bounded exponential backoff for greater resilience.
  * Error handling improved to distinguish retryable transient failures from permanent signature verification errors, reducing false failures.
* **Tests**
  * Added unit tests covering classification of transient Rekor failures and retry behavior through the public verification path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->