### PR TITLE
fix(ci): repair Docker build and Homebrew formula bump in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
     needs: release
     environment: release
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      # mislav/bump-homebrew-formula-action is broken: GitHub now returns HTTP 303
+      # instead of 302 for tarball redirects and the action only accepts 302.
+      # See https://github.com/mislav/bump-homebrew-formula-action/issues/340
+      - uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
         with:
-          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
-          formula-name: atmos
-          formula-path: Formula/a/atmos.rb
-        env:
-          COMMITTER_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          token: ${{ secrets.GH_BOT_TOKEN }}
+          formula: atmos
 
   docker:
     name: "Build and push Docker image for Atmos CLI"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,15 @@ RUN set -ex; \
     curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/bash.deb.sh' | bash -x; \
     # Install OpenTofu
     curl -1sSLf 'https://get.opentofu.org/install-opentofu.sh' | bash -s -- --root-method none --install-method deb; \
-    # Install Kustomize binary (required by Helmfile)
-    curl -1sSLf "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- /usr/local/bin; \
+    # Install Kustomize binary (required by Helmfile).
+    # Direct download instead of install_kustomize.sh which has known bugs (kubernetes-sigs/kustomize#5562).
+    KUSTOMIZE_VERSION=5.8.1; \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") KUSTOMIZE_ARCH=amd64 ;; \
+        "linux/arm64") KUSTOMIZE_ARCH=arm64 ;; \
+        *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac; \
+    curl -1sSLf "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${KUSTOMIZE_ARCH}.tar.gz" | tar xz -C /usr/local/bin; \
     # Install toolchain used with Atmos \
     apt-get -y install --no-install-recommends terraform kubectl helmfile helm; \
     # Install the helm-diff plugin required by Helmfile.


### PR DESCRIPTION
## what

- Replace the flaky upstream `install_kustomize.sh` script in the Dockerfile with a direct download from GitHub Releases, pinned to kustomize v5.8.1
- Replace `mislav/bump-homebrew-formula-action@v3` with `dawidd6/action-homebrew-bump-formula@v7` (SHA-pinned) for the Homebrew formula bump step

## why

- The kustomize install script has known bugs ([kubernetes-sigs/kustomize#5562](https://github.com/kubernetes-sigs/kustomize/issues/5562)) causing tar extraction failures (`tar: ./kustomize_v*_linux_amd64.tar.gz: Cannot open`) during Docker image builds
- The `mislav/bump-homebrew-formula-action` is broken because GitHub now returns HTTP 303 instead of 302 for tarball redirects, and the action hardcodes `statusCode == 302` ([mislav/bump-homebrew-formula-action#340](https://github.com/mislav/bump-homebrew-formula-action/issues/340), open/unfixed)
- Both failures blocked the v1.219.0 release workflow ([run #26131090357](https://github.com/cloudposse/atmos/actions/runs/26131090357))

## references

- https://github.com/cloudposse/atmos/actions/runs/26131090357/job/77908154273
- https://github.com/mislav/bump-homebrew-formula-action/issues/340
- https://github.com/kubernetes-sigs/kustomize/issues/5562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure, including CI/CD workflow configuration and Docker build process improvements for enhanced reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->