### PR TITLE
Add component type aliases

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -39,11 +39,17 @@ Every new or changed `atmos.yaml` section needs configuration docs.
 
 ## Command Docs
 
-When command behavior is configured by `atmos.yaml`, link command docs back to configuration docs.
+When command behavior is materially configured by `atmos.yaml`, link command docs back to the command-level
+configuration page. For example, `atmos terraform` should link to Terraform configuration, not to every nested
+Terraform configuration subsection.
 
-- Import `ActionCard` and `PrimaryCTA`.
-- Place the card near the top, after `Intro` and any status badges.
-- Link to the relevant configuration page, not just the root docs section.
+- Use action cards sparingly. Before adding one, ask whether that configuration is one of the main things readers should
+  take away from the page.
+- Avoid placing emphasized React components back-to-back, such as a screengrab immediately followed by an action card or
+  an admonition immediately followed by another callout.
+- Import `ActionCard` and `PrimaryCTA` only when a command-level configuration link deserves callout treatment.
+- Place the card near the top, after `Intro` and any status badges, only when it is part of the primary page path.
+- Link to the relevant command-level configuration page, not to every nested option or feature-specific child page.
 - Use definition lists for flags and positional arguments.
 - Use `DocCardList` for command families and subcommands.
 

--- a/agent-skills/skills/atmos-components/SKILL.md
+++ b/agent-skills/skills/atmos-components/SKILL.md
@@ -21,13 +21,14 @@ This separation is fundamental: you write the Terraform module once, then config
 
 ## Component Types
 
-Atmos natively supports three component types:
+Atmos natively supports four component types:
 
 | Type | Implementation Location | Purpose |
 |------|------------------------|---------|
 | Terraform / OpenTofu | `components/terraform/<name>/` | Provision cloud infrastructure resources |
 | Helmfile | `components/helmfile/<name>/` | Deploy Helm charts to Kubernetes clusters |
 | Packer | `components/packer/<name>/` | Build machine images (AMIs, VM images) |
+| Ansible | `components/ansible/<name>/` | Run Ansible playbooks and automation |
 
 Terraform is by far the most common type. Custom commands can extend Atmos to support any tooling.
 
@@ -73,6 +74,30 @@ components:
   terraform:
     base_path: "components/terraform"
 ```
+
+Canonical component types can also declare aliases:
+
+```yaml
+components:
+  terraform:
+    aliases: opentofu
+    base_path: "components/terraform"
+    command: tofu
+```
+
+Stack manifests may then use the alias envelope:
+
+```yaml
+components:
+  opentofu:
+    vpc:
+      vars: {}
+```
+
+Atmos resolves `opentofu` to Terraform semantics internally for provider lookup, execution, dependencies, validation,
+and path resolution. Describe output preserves the authored envelope (`components.opentofu`) and exposes the canonical
+type in `component_info.component_type`. The alias does not change the executable; set `components.terraform.command:
+tofu` to run OpenTofu.
 
 Nested directories are supported. A component at `components/terraform/eks/cluster/` is referenced as `eks/cluster` in stack configurations.
 

--- a/agent-skills/skills/atmos-config/SKILL.md
+++ b/agent-skills/skills/atmos-config/SKILL.md
@@ -59,7 +59,14 @@ stacks:
 components:
   terraform:
     base_path: "components/terraform"
+    aliases: opentofu
 ```
+
+`components.<type>.aliases` may be a string or list of strings. Aliases are declared under the canonical component type
+in `atmos.yaml`; stack manifests may use the alias as the component envelope. For example, `components.terraform.aliases:
+opentofu` allows `components.opentofu` in stacks and `atmos opentofu ...` commands, while Atmos resolves the component
+to canonical Terraform behavior internally. Use `components.terraform.command: tofu` separately when OpenTofu should be
+the executable.
 
 ## Complete Section Overview
 

--- a/agent-skills/skills/atmos-config/SKILL.md
+++ b/agent-skills/skills/atmos-config/SKILL.md
@@ -59,7 +59,6 @@ stacks:
 components:
   terraform:
     base_path: "components/terraform"
-    aliases: opentofu
 ```
 
 `components.<type>.aliases` may be a string or list of strings. Aliases are declared under the canonical component type

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -18,12 +18,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/cloudposse/atmos/cmd/internal"
 	errUtils "github.com/cloudposse/atmos/errors"
 	e "github.com/cloudposse/atmos/internal/exec"
 	tuiUtils "github.com/cloudposse/atmos/internal/tui/utils"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/auth/credentials"
 	"github.com/cloudposse/atmos/pkg/auth/validation"
+	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
@@ -117,6 +119,30 @@ func processCustomCommands(
 		}
 	}
 
+	return nil
+}
+
+var ErrComponentCommandAliasConflict = errors.New("component command alias conflict")
+
+func processComponentCommandAliases(atmosConfig *schema.AtmosConfiguration) error {
+	aliases, err := component.AliasMap(atmosConfig)
+	if err != nil {
+		return err
+	}
+	existingTopLevelCommands := getTopLevelCommands()
+	for alias, canonical := range aliases {
+		if _, exists := existingTopLevelCommands[alias]; exists {
+			return fmt.Errorf("%w: component alias %q conflicts with an existing top-level command",
+				ErrComponentCommandAliasConflict, alias)
+		}
+		if _, exists := atmosConfig.CommandAliases[alias]; exists {
+			return fmt.Errorf("%w: component alias %q conflicts with configured command alias",
+				ErrComponentCommandAliasConflict, alias)
+		}
+		if err := internal.AddTopLevelAlias(canonical, alias); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -249,7 +275,8 @@ func preCustomCommand(
 	if len(args) < requiredNoDefaultCount {
 		sb.WriteString(
 			fmt.Sprintf("Command requires at least %d argument(s) (no defaults provided for them):\n",
-				requiredNoDefaultCount))
+				requiredNoDefaultCount),
+		)
 
 		// List out which arguments are missing
 		missingIndex := 1
@@ -531,6 +558,9 @@ func getTopLevelCommands() map[string]*cobra.Command {
 
 	for _, c := range RootCmd.Commands() {
 		existingTopLevelCommands[c.Name()] = c
+		for _, alias := range c.Aliases {
+			existingTopLevelCommands[alias] = c
+		}
 	}
 
 	return existingTopLevelCommands
@@ -1128,7 +1158,8 @@ func resolveComponentPath(info *schema.ConfigAndStacksInfo, commandName string) 
 		return handlePathResolutionError(err)
 	}
 
-	log.Debug("Resolved component from path",
+	log.Debug(
+		"Resolved component from path",
 		"original_path", info.ComponentFromArg,
 		"resolved_component", resolvedComponent,
 		"stack", info.Stack,
@@ -1272,7 +1303,8 @@ func StackFlagCompletion(cmd *cobra.Command, args []string, toComplete string) (
 				)
 				if err != nil {
 					// If resolution fails, fall through to list all stacks (graceful degradation)
-					log.Trace("Could not resolve path for stack completion, listing all stacks",
+					log.Trace(
+						"Could not resolve path for stack completion, listing all stacks",
 						"path", component,
 						"error", err,
 					)
@@ -1283,7 +1315,8 @@ func StackFlagCompletion(cmd *cobra.Command, args []string, toComplete string) (
 					return output, cobra.ShellCompDirectiveNoFileComp
 				}
 				component = resolvedComponent
-				log.Trace("Resolved path for stack completion",
+				log.Trace(
+					"Resolved path for stack completion",
 					"original", args[0],
 					"resolved", component,
 				)

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmdregistry "github.com/cloudposse/atmos/cmd/internal"
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/reexec"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -1548,6 +1549,45 @@ func TestProcessCommandAliases_DoesNotOverrideExistingCommands(t *testing.T) {
 		}
 	}
 	assert.True(t, newAliasFound, "test-alias-new2 should be added")
+}
+
+func TestProcessComponentCommandAliasesAddsTopLevelCommandAlias(t *testing.T) {
+	_ = NewTestKit(t)
+
+	provider, ok := cmdregistry.GetProvider("terraform")
+	require.True(t, ok)
+	terraformCmd := provider.GetCommand()
+	originalAliases := append([]string(nil), terraformCmd.Aliases...)
+	t.Cleanup(func() {
+		terraformCmd.Aliases = originalAliases
+	})
+
+	alias := "opentofu-test-alias"
+	err := processComponentCommandAliases(&schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{alias}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, terraformCmd.Aliases, alias)
+
+	found, _, err := RootCmd.Find([]string{alias, "plan"})
+	require.NoError(t, err)
+	assert.Equal(t, "plan", found.Name())
+}
+
+func TestProcessComponentCommandAliasesRejectsConfiguredCommandAliasConflict(t *testing.T) {
+	alias := "opentofu-config-alias-conflict"
+	err := processComponentCommandAliases(&schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{alias}},
+		},
+		CommandAliases: schema.CommandAliases{
+			alias: "terraform plan",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with configured command alias")
 }
 
 // TestProcessCommandAliases_NonTopLevel tests that non-top-level aliases are NOT added.

--- a/cmd/internal/registry.go
+++ b/cmd/internal/registry.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -23,6 +24,8 @@ const IoContextKey contextKey = "ioContext"
 var registry = &CommandRegistry{
 	providers: make(map[string]CommandProvider),
 }
+
+var ErrCommandProviderNotFound = errors.New("command provider not found")
 
 // CommandRegistry manages built-in command registration.
 //
@@ -221,6 +224,25 @@ func GetProvider(name string) (CommandProvider, bool) {
 
 	provider, ok := registry.providers[name]
 	return provider, ok
+}
+
+// AddTopLevelAlias adds a Cobra top-level alias to a registered command provider.
+func AddTopLevelAlias(providerName, alias string) error {
+	provider, ok := GetProvider(providerName)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrCommandProviderNotFound, providerName)
+	}
+	cmd := provider.GetCommand()
+	if cmd == nil {
+		return fmt.Errorf("%w: provider %s", errUtils.ErrCommandNil, providerName)
+	}
+	for _, existing := range cmd.Aliases {
+		if existing == alias {
+			return nil
+		}
+	}
+	cmd.Aliases = append(cmd.Aliases, alias)
+	return nil
 }
 
 // IsCommandExperimental returns true if the named command is experimental.

--- a/cmd/internal/registry_test.go
+++ b/cmd/internal/registry_test.go
@@ -184,12 +184,53 @@ func TestRegisterAllNilCommand(t *testing.T) {
 	assert.Contains(t, err.Error(), "test", "error message should include provider name")
 }
 
+func TestAddTopLevelAlias(t *testing.T) {
+	Reset()
+
+	provider := &mockCommandProvider{
+		name:  "terraform",
+		group: "Test",
+		cmd: &cobra.Command{
+			Use:     "terraform",
+			Aliases: []string{"tf"},
+		},
+	}
+	Register(provider)
+
+	err := AddTopLevelAlias("terraform", "opentofu")
+	require.NoError(t, err)
+	err = AddTopLevelAlias("terraform", "opentofu")
+	require.NoError(t, err)
+
+	assert.Contains(t, provider.cmd.Aliases, "tf")
+	assert.Contains(t, provider.cmd.Aliases, "opentofu")
+	assert.Equal(t, 1, countString(provider.cmd.Aliases, "opentofu"))
+}
+
+func TestAddTopLevelAliasUnknownProvider(t *testing.T) {
+	Reset()
+
+	err := AddTopLevelAlias("terraform", "opentofu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `command provider not found: "terraform"`)
+}
+
 func TestGetProviderNotFound(t *testing.T) {
 	Reset()
 
 	provider, ok := GetProvider("nonexistent")
 	assert.False(t, ok)
 	assert.Nil(t, provider)
+}
+
+func countString(values []string, target string) int {
+	var count int
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
 }
 
 func TestListProviders(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1517,6 +1517,11 @@ func Execute() error {
 		if err != nil {
 			return err
 		}
+
+		err = processComponentCommandAliases(&atmosConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Boa styling is already applied via RootCmd.SetHelpFunc() which is inherited by all subcommands.

--- a/examples/component-aliases/README.md
+++ b/examples/component-aliases/README.md
@@ -1,0 +1,45 @@
+# Component Type Aliases Example
+
+This example shows how to expose Terraform semantics through another component type name.
+
+`atmos.yaml` declares `opentofu` as an alias for the canonical `terraform` component type:
+
+```yaml
+components:
+  terraform:
+    aliases: opentofu
+    base_path: components/terraform
+    command: tofu
+```
+
+Stack manifests can then use the alias envelope:
+
+```yaml
+components:
+  opentofu:
+    vpc:
+      vars:
+        cidr_block: 10.10.0.0/16
+```
+
+Atmos resolves `opentofu` to Terraform internally for provider lookup, path resolution,
+validation, dependencies, and command execution. Describe output preserves the original
+stack envelope, so `atmos describe stacks -s dev` renders the component under
+`components.opentofu`.
+
+## Usage
+
+```bash
+# Run through the alias command
+atmos opentofu plan vpc -s dev
+
+# The canonical command still works against the same aliased stack component
+atmos terraform plan vpc -s dev
+
+# Describe output preserves components.opentofu
+atmos describe stacks -s dev
+atmos describe component vpc -s dev
+```
+
+The alias does not change the executable. Use `components.terraform.command: tofu`
+when you want the Terraform provider integration to run OpenTofu.

--- a/examples/component-aliases/atmos.yaml
+++ b/examples/component-aliases/atmos.yaml
@@ -1,0 +1,20 @@
+base_path: "./"
+
+components:
+  terraform:
+    aliases: opentofu
+    base_path: "components/terraform"
+    command: tofu
+    apply_auto_approve: false
+    deploy_run_init: true
+    init_run_reconfigure: true
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "**/*"
+
+logs:
+  file: "/dev/stderr"
+  level: Info

--- a/examples/component-aliases/components/terraform/vpc/main.tf
+++ b/examples/component-aliases/components/terraform/vpc/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+locals {
+  tags = merge(
+    {
+      Component = "vpc"
+      ManagedBy = "atmos"
+    },
+    var.tags,
+  )
+}
+
+output "cidr_block" {
+  value = var.cidr_block
+}
+
+output "tags" {
+  value = local.tags
+}

--- a/examples/component-aliases/components/terraform/vpc/variables.tf
+++ b/examples/component-aliases/components/terraform/vpc/variables.tf
@@ -1,0 +1,10 @@
+variable "cidr_block" {
+  type        = string
+  description = "CIDR block for the example VPC."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to attach to the example outputs."
+  default     = {}
+}

--- a/examples/component-aliases/stacks/dev.yaml
+++ b/examples/component-aliases/stacks/dev.yaml
@@ -1,0 +1,7 @@
+components:
+  opentofu:
+    vpc:
+      vars:
+        cidr_block: 10.10.0.0/16
+        tags:
+          Environment: dev

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudposse/atmos/internal/tui/templates/term"
 	"github.com/cloudposse/atmos/pkg/auth"
+	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/pager"
 	"github.com/cloudposse/atmos/pkg/perf"
@@ -14,7 +15,7 @@ import (
 )
 
 // componentInfoKey is the key used for component info in stack sections.
-const componentInfoKey = "component_info"
+const componentInfoKey = component.ComponentInfoKey
 
 // logFieldStack is the log field key for stack names.
 const logFieldStack = "stack"
@@ -210,6 +211,7 @@ func executeDescribeStacks(
 
 // getComponentBasePath returns the base path for a component kind from atmos config.
 func getComponentBasePath(atmosConfig *schema.AtmosConfiguration, componentKind string) string {
+	componentKind = component.CanonicalType(atmosConfig, componentKind)
 	switch componentKind {
 	case cfg.TerraformSectionName:
 		return atmosConfig.Components.Terraform.BasePath
@@ -231,8 +233,14 @@ func getComponentBasePath(atmosConfig *schema.AtmosConfiguration, componentKind 
 func buildComponentInfo(atmosConfig *schema.AtmosConfiguration, componentSection map[string]any, componentKind string) map[string]any {
 	defer perf.Track(atmosConfig, "exec.buildComponentInfo")()
 
+	canonicalKind := component.CanonicalType(atmosConfig, componentKind)
 	componentInfo := map[string]any{
-		"component_type": componentKind,
+		component.ComponentTypeInfoKey: canonicalKind,
+	}
+	if existing, ok := componentSection[componentInfoKey].(map[string]any); ok {
+		if envelope, ok := existing[component.ComponentEnvelopeKey].(string); ok && envelope != "" && envelope != canonicalKind {
+			componentInfo[component.ComponentEnvelopeKey] = envelope
+		}
 	}
 
 	// Get the actual component name to use for path resolution.
@@ -257,7 +265,7 @@ func buildComponentInfo(atmosConfig *schema.AtmosConfiguration, componentSection
 
 	// Build the relative component path directly from config.
 	// This avoids returning absolute paths which are environment-specific.
-	basePath := getComponentBasePath(atmosConfig, componentKind)
+	basePath := getComponentBasePath(atmosConfig, canonicalKind)
 	if basePath == "" {
 		return componentInfo
 	}

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -4,12 +4,14 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
+	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	m "github.com/cloudposse/atmos/pkg/merge"
@@ -42,6 +44,12 @@ type processComponentTypeOpts struct {
 	applyMetadataInheritance bool
 	// checkIncludeEmpty instructs the processor to filter out empty sections according to AtmosConfiguration.Describe.Settings.IncludeEmpty.
 	checkIncludeEmpty bool
+}
+
+type describeComponentTypeEntry struct {
+	displayName   string
+	canonicalName string
+	opts          processComponentTypeOpts
 }
 
 // componentAuthManagerResolver builds a per-component AuthManager for the given
@@ -215,30 +223,43 @@ func (p *describeStacksProcessor) processStackFile(stackFileName string, stackMa
 		return nil
 	}
 
-	type typeEntry struct {
-		name string
-		opts processComponentTypeOpts
-	}
-	typeEntries := []typeEntry{
-		{cfg.TerraformSectionName, processComponentTypeOpts{
+	typeOpts := map[string]processComponentTypeOpts{
+		cfg.TerraformSectionName: {
 			buildWorkspace:           true,
 			applyMetadataInheritance: true,
 			checkIncludeEmpty:        true,
-		}},
-		{cfg.HelmfileSectionName, processComponentTypeOpts{}},
-		{cfg.PackerSectionName, processComponentTypeOpts{}},
-		{cfg.AnsibleSectionName, processComponentTypeOpts{}},
+		},
+		cfg.HelmfileSectionName: {},
+		cfg.PackerSectionName:   {},
+		cfg.AnsibleSectionName:  {},
 	}
-
-	for _, te := range typeEntries {
-		if len(p.componentTypes) > 0 && !u.SliceContainsString(p.componentTypes, te.name) {
-			continue
-		}
-		typeSection, ok := componentsSection[te.name].(map[string]any)
+	typeEntries := make([]describeComponentTypeEntry, 0, len(componentsSection))
+	for displayName := range componentsSection {
+		canonicalName := component.CanonicalType(p.atmosConfig, displayName)
+		opts, ok := typeOpts[canonicalName]
 		if !ok {
 			continue
 		}
-		if err := p.processComponentTypeSection(stackFileName, stackManifestName, te.name, typeSection, te.opts); err != nil {
+		typeEntries = append(typeEntries, describeComponentTypeEntry{displayName: displayName, canonicalName: canonicalName, opts: opts})
+	}
+	sort.Slice(typeEntries, func(i, j int) bool {
+		return typeEntries[i].displayName < typeEntries[j].displayName
+	})
+	if err := validateComponentTypeEnvelopeDuplicates(componentsSection, typeEntries); err != nil {
+		return err
+	}
+
+	for _, te := range typeEntries {
+		if len(p.componentTypes) > 0 &&
+			!u.SliceContainsString(p.componentTypes, te.displayName) &&
+			!u.SliceContainsString(p.componentTypes, te.canonicalName) {
+			continue
+		}
+		typeSection, ok := componentsSection[te.displayName].(map[string]any)
+		if !ok {
+			continue
+		}
+		if err := p.processComponentTypeSection(stackFileName, stackManifestName, te.displayName, typeSection, te.opts); err != nil {
 			return err
 		}
 	}
@@ -246,10 +267,30 @@ func (p *describeStacksProcessor) processStackFile(stackFileName string, stackMa
 	return nil
 }
 
+func validateComponentTypeEnvelopeDuplicates(componentsSection map[string]any, typeEntries []describeComponentTypeEntry) error {
+	seenByCanonical := make(map[string]map[string]string)
+	for _, te := range typeEntries {
+		typeSection, ok := componentsSection[te.displayName].(map[string]any)
+		if !ok {
+			continue
+		}
+		if seenByCanonical[te.canonicalName] == nil {
+			seenByCanonical[te.canonicalName] = make(map[string]string)
+		}
+		for componentName := range typeSection {
+			if previousEnvelope, exists := seenByCanonical[te.canonicalName][componentName]; exists && previousEnvelope != te.displayName {
+				return fmt.Errorf("component %q is defined under both components.%s and components.%s", componentName, previousEnvelope, te.displayName) //nolint:err113 // Dynamic context for debugging.
+			}
+			seenByCanonical[te.canonicalName][componentName] = te.displayName
+		}
+	}
+	return nil
+}
+
 // processComponentTypeSection iterates over every component within a component type section
 // (e.g., all Terraform components in a stack file) and processes each one.
 func (p *describeStacksProcessor) processComponentTypeSection(
-	stackFileName, stackManifestName, typeName string,
+	stackFileName, stackManifestName, displayTypeName string,
 	typeSection map[string]any,
 	opts processComponentTypeOpts,
 ) error {
@@ -259,7 +300,7 @@ func (p *describeStacksProcessor) processComponentTypeSection(
 		origSection, ok := compSection.(map[string]any)
 		if !ok {
 			return fmt.Errorf("invalid 'components.%s.%s' section in the file '%s'", //nolint:err113 // Dynamic context needed for debugging.
-				typeName, componentName, stackFileName)
+				displayTypeName, componentName, stackFileName)
 		}
 
 		// Shallow-clone the component section so mutations (setting defaults,
@@ -275,7 +316,7 @@ func (p *describeStacksProcessor) processComponentTypeSection(
 		}
 
 		if err := p.processComponentEntry(
-			stackFileName, stackManifestName, typeName,
+			stackFileName, stackManifestName, displayTypeName,
 			componentName, componentSection, typeSection, opts,
 		); err != nil {
 			return err
@@ -287,12 +328,13 @@ func (p *describeStacksProcessor) processComponentTypeSection(
 // processComponentEntry processes a single component: resolves the stack name,
 // filters, builds the ConfigAndStacksInfo, processes templates, and writes to the result map.
 func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,revive,cyclop,funlen // Orchestrator function with unavoidable branching.
-	stackFileName, stackManifestName, typeName,
+	stackFileName, stackManifestName, displayTypeName,
 	componentName string,
 	componentSection, allTypeComponents map[string]any,
 	opts processComponentTypeOpts,
 ) error {
 	defer perf.Track(p.atmosConfig, "exec.describeStacksProcessor.processComponentEntry")()
+	canonicalTypeName := component.CanonicalType(p.atmosConfig, displayTypeName)
 
 	// Find derived components to include even when the component filter is active.
 	derivedComponents, err := FindComponentsDerivedFromBaseComponents(stackFileName, allTypeComponents, p.components)
@@ -314,6 +356,7 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	}
 
 	info := buildConfigAndStacksInfo(componentName, stackFileName, stackManifestName, secs)
+	info.ComponentType = canonicalTypeName
 
 	// Ensure the component key is present in the info's ComponentSection.
 	if comp, ok := info.ComponentSection[cfg.ComponentSectionName].(string); !ok || comp == "" {
@@ -365,7 +408,7 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	setAtmosComponentMetadata(componentSection, componentName, stackName, stackFileName)
 	setAtmosComponentMetadata(info.ComponentSection, componentName, stackName, stackFileName)
 
-	ensureComponentEntryInMap(p.finalStacksMap, stackName, typeName, componentName)
+	ensureComponentEntryInMap(p.finalStacksMap, stackName, displayTypeName, componentName)
 
 	// Terraform-only: build and attach the Terraform workspace.
 	if opts.buildWorkspace {
@@ -378,7 +421,15 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	}
 
 	// Add component_info with component_path.
-	componentInfo := buildComponentInfo(p.atmosConfig, componentSection, typeName)
+	if displayTypeName != canonicalTypeName {
+		existingInfo, _ := componentSection[componentInfoKey].(map[string]any)
+		if existingInfo == nil {
+			existingInfo = make(map[string]any)
+			componentSection[componentInfoKey] = existingInfo
+		}
+		existingInfo[component.ComponentEnvelopeKey] = displayTypeName
+	}
+	componentInfo := buildComponentInfo(p.atmosConfig, componentSection, canonicalTypeName)
 	componentSection[componentInfoKey] = componentInfo
 	info.ComponentSection[componentInfoKey] = componentInfo
 
@@ -403,9 +454,9 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 
 	// Write the (optionally filtered) sections into the result map.
 	includeEmpty := resolveIncludeEmpty(p.atmosConfig, opts.checkIncludeEmpty)
-	destMap, ok := getComponentDestMap(p.finalStacksMap, stackName, typeName, componentName)
+	destMap, ok := getComponentDestMap(p.finalStacksMap, stackName, displayTypeName, componentName)
 	if !ok {
-		return fmt.Errorf("internal error: component entry not found for %s/%s/%s", stackName, typeName, componentName) //nolint:err113 // Dynamic context for debugging.
+		return fmt.Errorf("internal error: component entry not found for %s/%s/%s", stackName, displayTypeName, componentName) //nolint:err113 // Dynamic context for debugging.
 	}
 	addSectionsToComponentEntry(destMap, componentSection, p.sections, includeEmpty)
 

--- a/internal/exec/describe_stacks_component_processor_test.go
+++ b/internal/exec/describe_stacks_component_processor_test.go
@@ -848,6 +848,69 @@ func TestProcessStackFile_ProcessComponentTypeSectionError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid")
 }
 
+func TestProcessStackFile_ComponentAliasPreservesEnvelope(t *testing.T) {
+	p := newDescribeStacksProcessor(
+		&schema.AtmosConfiguration{
+			Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+			},
+		},
+		"",
+		nil, nil, nil,
+		false, false, false, nil, nil,
+	)
+	stackMap := map[string]any{
+		"name": "dev",
+		cfg.ComponentsSectionName: map[string]any{
+			"opentofu": map[string]any{
+				"vpc": map[string]any{
+					"vars": map[string]any{"name": "vpc"},
+				},
+			},
+		},
+	}
+
+	err := p.processStackFile("stacks/dev.yaml", stackMap)
+	require.NoError(t, err)
+
+	dev, ok := p.finalStacksMap["dev"].(map[string]any)
+	require.True(t, ok)
+	components, ok := dev[cfg.ComponentsSectionName].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, components, cfg.TerraformSectionName)
+	opentofu, ok := components["opentofu"].(map[string]any)
+	require.True(t, ok)
+	vpc, ok := opentofu["vpc"].(map[string]any)
+	require.True(t, ok)
+	componentInfo, ok := vpc["component_info"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "terraform", componentInfo["component_type"])
+	assert.Equal(t, "opentofu", componentInfo["component_envelope"])
+}
+
+func TestProcessStackFile_ComponentAliasRejectsDuplicateCanonicalComponent(t *testing.T) {
+	p := newDescribeStacksProcessor(
+		&schema.AtmosConfiguration{
+			Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+			},
+		},
+		"",
+		nil, nil, nil,
+		false, false, false, nil, nil,
+	)
+	stackMap := map[string]any{
+		cfg.ComponentsSectionName: map[string]any{
+			"terraform": map[string]any{"vpc": map[string]any{}},
+			"opentofu":  map[string]any{"vpc": map[string]any{}},
+		},
+	}
+
+	err := p.processStackFile("stacks/dev.yaml", stackMap)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `component "vpc" is defined under both`)
+}
+
 func TestProcessComponentTypeSection_ComponentSectionNotMap(t *testing.T) {
 	// When a component entry in the type section is not a map, an error is returned.
 	p := newMinimalProcessor()

--- a/internal/exec/stack_processor_process_stacks.go
+++ b/internal/exec/stack_processor_process_stacks.go
@@ -1,3 +1,4 @@
+//nolint:revive // file-length-limit: existing stack processor is intentionally large.
 package exec
 
 import (
@@ -9,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
 	m "github.com/cloudposse/atmos/pkg/merge"
@@ -42,11 +44,13 @@ func ProcessStackConfig(
 	checkBaseComponentExists bool,
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ProcessStackConfig")()
+	componentTypeFilter = component.CanonicalType(atmosConfig, componentTypeFilter)
 
 	stackName := strings.TrimSuffix(
 		strings.TrimSuffix(
 			u.TrimBasePathFromPath(stacksBasePath+"/", stack),
-			u.DefaultStackConfigFileExtension),
+			u.DefaultStackConfigFileExtension,
+		),
 		".yml",
 	)
 
@@ -175,6 +179,14 @@ func ProcessStackConfig(
 		globalComponentsSection, ok = i.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(errFormatWithFile, errUtils.ErrInvalidComponentsSection, stackName)
+		}
+	}
+	componentEnvelopes := map[string]map[string]string{}
+	if len(globalComponentsSection) > 0 {
+		var err error
+		globalComponentsSection, componentEnvelopes, err = component.NormalizeComponentSections(atmosConfig, globalComponentsSection)
+		if err != nil {
+			return nil, fmt.Errorf(errFormatWithFile, err, stackName)
 		}
 	}
 
@@ -623,6 +635,7 @@ func ProcessStackConfig(
 			if err != nil {
 				return nil, err
 			}
+			annotateComponentEnvelopes(terraformComponents, cfg.TerraformComponentType, componentEnvelopes[cfg.TerraformComponentType])
 		}
 	}
 
@@ -661,6 +674,7 @@ func ProcessStackConfig(
 			if err != nil {
 				return nil, err
 			}
+			annotateComponentEnvelopes(helmfileComponents, cfg.HelmfileComponentType, componentEnvelopes[cfg.HelmfileComponentType])
 		}
 	}
 
@@ -699,6 +713,7 @@ func ProcessStackConfig(
 			if err != nil {
 				return nil, err
 			}
+			annotateComponentEnvelopes(packerComponents, cfg.PackerComponentType, componentEnvelopes[cfg.PackerComponentType])
 		}
 	}
 
@@ -737,6 +752,7 @@ func ProcessStackConfig(
 			if err != nil {
 				return nil, err
 			}
+			annotateComponentEnvelopes(ansibleComponents, cfg.AnsibleComponentType, componentEnvelopes[cfg.AnsibleComponentType])
 		}
 	}
 
@@ -859,4 +875,23 @@ func processComponentsInParallel(
 	}
 
 	return processedComponents, nil
+}
+
+func annotateComponentEnvelopes(components map[string]any, canonicalType string, envelopes map[string]string) {
+	if len(envelopes) == 0 {
+		return
+	}
+	for componentName, envelope := range envelopes {
+		componentSection, ok := components[componentName].(map[string]any)
+		if !ok {
+			continue
+		}
+		info, ok := componentSection[component.ComponentInfoKey].(map[string]any)
+		if !ok {
+			info = make(map[string]any)
+			componentSection[component.ComponentInfoKey] = info
+		}
+		info[component.ComponentTypeInfoKey] = canonicalType
+		info[component.ComponentEnvelopeKey] = envelope
+	}
 }

--- a/internal/exec/stack_processor_process_stacks_test.go
+++ b/internal/exec/stack_processor_process_stacks_test.go
@@ -383,3 +383,83 @@ func TestProcessStackConfig_ErrorPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessStackConfigComponentAliasResolvesToCanonicalAndTracksEnvelope(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+		},
+	}
+	config := map[string]any{
+		cfg.ComponentsSectionName: map[string]any{
+			"opentofu": map[string]any{
+				"vpc": map[string]any{
+					cfg.VarsSectionName: map[string]any{"name": "vpc"},
+				},
+			},
+		},
+	}
+
+	result, err := ProcessStackConfig(
+		atmosConfig,
+		"/test/stacks",
+		"/test/components/terraform",
+		"/test/components/helmfile",
+		"/test/components/packer",
+		"/test/components/ansible",
+		"dev.yaml",
+		config,
+		false,
+		false,
+		"opentofu",
+		map[string]map[string][]string{},
+		map[string]map[string]any{},
+		false,
+	)
+	require.NoError(t, err)
+
+	components, ok := result[cfg.ComponentsSectionName].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, components, "opentofu")
+	tf, ok := components[cfg.TerraformComponentType].(map[string]any)
+	require.True(t, ok)
+	vpc, ok := tf["vpc"].(map[string]any)
+	require.True(t, ok)
+	componentInfo, ok := vpc["component_info"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "terraform", componentInfo["component_type"])
+	assert.Equal(t, "opentofu", componentInfo["component_envelope"])
+}
+
+func TestProcessStackConfigComponentAliasRejectsDuplicateCanonicalComponent(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+		},
+	}
+	config := map[string]any{
+		cfg.ComponentsSectionName: map[string]any{
+			"terraform": map[string]any{"vpc": map[string]any{}},
+			"opentofu":  map[string]any{"vpc": map[string]any{}},
+		},
+	}
+
+	_, err := ProcessStackConfig(
+		atmosConfig,
+		"/test/stacks",
+		"/test/components/terraform",
+		"/test/components/helmfile",
+		"/test/components/packer",
+		"/test/components/ansible",
+		"dev.yaml",
+		config,
+		false,
+		false,
+		"",
+		map[string]map[string][]string{},
+		map[string]map[string]any{},
+		false,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `component "vpc" is defined under both`)
+}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -17,6 +17,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	auth "github.com/cloudposse/atmos/pkg/auth"
+	componentreg "github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/env"
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -109,6 +110,7 @@ func ProcessComponentConfig(
 	if len(componentType) == 0 {
 		return errors.New("component type must be provided and must not be empty")
 	}
+	componentType = componentreg.CanonicalType(atmosConfig, componentType)
 
 	if stackSection, ok = stacksMap[stack].(map[string]any); !ok {
 		return fmt.Errorf("could not find the stack '%s'", stack)

--- a/pkg/component/aliases.go
+++ b/pkg/component/aliases.go
@@ -1,0 +1,268 @@
+package component
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+const (
+	ComponentInfoKey       = "component_info"
+	ComponentEnvelopeKey   = "component_envelope"
+	ComponentTypeInfoKey   = "component_type"
+	componentAliasesKey    = "aliases"
+	componentTypeTerraform = "terraform"
+	componentTypeHelmfile  = "helmfile"
+	componentTypePacker    = "packer"
+	componentTypeAnsible   = "ansible"
+)
+
+var builtInComponentTypes = map[string]struct{}{
+	componentTypeTerraform: {},
+	componentTypeHelmfile:  {},
+	componentTypePacker:    {},
+	componentTypeAnsible:   {},
+}
+
+var (
+	ErrInvalidComponentAlias   = errors.New("invalid component alias")
+	ErrInvalidComponentSection = errors.New("invalid component section")
+)
+
+type componentAliasSource struct {
+	canonical string
+	aliases   []string
+}
+
+// AliasMap returns a normalized alias -> canonical component type map.
+func AliasMap(atmosConfig *schema.AtmosConfiguration) (map[string]string, error) {
+	defer perf.Track(atmosConfig, "component.AliasMap")()
+
+	aliases := make(map[string]string)
+	if atmosConfig == nil {
+		return aliases, nil
+	}
+
+	canonicalTypes := knownComponentTypes(atmosConfig)
+	for _, source := range componentAliasSources(atmosConfig) {
+		if err := registerComponentAliases(aliases, canonicalTypes, source); err != nil {
+			return nil, err
+		}
+	}
+
+	return aliases, nil
+}
+
+// CanonicalType resolves an input or display component type to its canonical type.
+func CanonicalType(atmosConfig *schema.AtmosConfiguration, componentType string) string {
+	defer perf.Track(atmosConfig, "component.CanonicalType")()
+
+	normalized := normalizeComponentType(componentType)
+	aliases, err := AliasMap(atmosConfig)
+	if err != nil {
+		return normalized
+	}
+	if canonical, ok := aliases[normalized]; ok {
+		return canonical
+	}
+	return normalized
+}
+
+// AliasesByCanonical returns normalized aliases grouped by canonical component type.
+func AliasesByCanonical(atmosConfig *schema.AtmosConfiguration) (map[string][]string, error) {
+	defer perf.Track(atmosConfig, "component.AliasesByCanonical")()
+
+	aliasMap, err := AliasMap(atmosConfig)
+	if err != nil {
+		return nil, err
+	}
+	grouped := make(map[string][]string)
+	for alias, canonical := range aliasMap {
+		grouped[canonical] = append(grouped[canonical], alias)
+	}
+	for canonical := range grouped {
+		sort.Strings(grouped[canonical])
+	}
+	return grouped, nil
+}
+
+// NormalizeComponentSections merges alias component sections into canonical sections.
+// It returns an envelope map keyed by canonical type and component name.
+func NormalizeComponentSections(
+	atmosConfig *schema.AtmosConfiguration,
+	components map[string]any,
+) (map[string]any, map[string]map[string]string, error) {
+	defer perf.Track(atmosConfig, "component.NormalizeComponentSections")()
+
+	normalized := make(map[string]any, len(components))
+	for k, v := range components {
+		normalized[k] = v
+	}
+
+	envelopes := make(map[string]map[string]string)
+	aliases, err := AliasMap(atmosConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	for alias, canonical := range aliases {
+		if _, ok := normalized[alias]; !ok {
+			continue
+		}
+		if err := mergeAliasComponentSection(normalized, envelopes, alias, canonical); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return normalized, envelopes, nil
+}
+
+func componentAliasSources(atmosConfig *schema.AtmosConfiguration) []componentAliasSource {
+	sources := []componentAliasSource{
+		{canonical: componentTypeTerraform, aliases: atmosConfig.Components.Terraform.Aliases},
+		{canonical: componentTypeHelmfile, aliases: atmosConfig.Components.Helmfile.Aliases},
+		{canonical: componentTypePacker, aliases: atmosConfig.Components.Packer.Aliases},
+		{canonical: componentTypeAnsible, aliases: atmosConfig.Components.Ansible.Aliases},
+	}
+	for componentType, raw := range atmosConfig.Components.Plugins {
+		sources = append(sources, componentAliasSource{
+			canonical: componentType,
+			aliases:   extractPluginAliases(raw),
+		})
+	}
+	return sources
+}
+
+func registerComponentAliases(
+	aliases map[string]string,
+	canonicalTypes map[string]struct{},
+	source componentAliasSource,
+) error {
+	canonical := normalizeComponentType(source.canonical)
+	seenForCanonical := make(map[string]struct{}, len(source.aliases))
+	for _, value := range source.aliases {
+		alias := normalizeComponentType(value)
+		if err := validateComponentAlias(alias, canonical, seenForCanonical, canonicalTypes, aliases); err != nil {
+			return err
+		}
+		seenForCanonical[alias] = struct{}{}
+		aliases[alias] = canonical
+	}
+	return nil
+}
+
+func validateComponentAlias(
+	alias string,
+	canonical string,
+	seenForCanonical map[string]struct{},
+	canonicalTypes map[string]struct{},
+	aliases map[string]string,
+) error {
+	if alias == "" {
+		return fmt.Errorf("%w: alias for %q cannot be empty", ErrInvalidComponentAlias, canonical)
+	}
+	if alias == canonical {
+		return fmt.Errorf("%w: alias %q cannot alias itself", ErrInvalidComponentAlias, alias)
+	}
+	if _, exists := seenForCanonical[alias]; exists {
+		return fmt.Errorf("%w: alias %q is declared more than once for %q", ErrInvalidComponentAlias, alias, canonical)
+	}
+	if _, exists := canonicalTypes[alias]; exists {
+		return fmt.Errorf("%w: alias %q conflicts with registered component type", ErrInvalidComponentAlias, alias)
+	}
+	if existing, exists := aliases[alias]; exists && existing != canonical {
+		return fmt.Errorf("%w: alias %q maps to both %q and %q", ErrInvalidComponentAlias, alias, existing, canonical)
+	}
+	return nil
+}
+
+func mergeAliasComponentSection(
+	normalized map[string]any,
+	envelopes map[string]map[string]string,
+	alias string,
+	canonical string,
+) error {
+	aliasSection, err := componentSectionMap(normalized, alias)
+	if err != nil {
+		return err
+	}
+	canonicalSection := map[string]any{}
+	if _, ok := normalized[canonical]; ok {
+		canonicalSection, err = componentSectionMap(normalized, canonical)
+		if err != nil {
+			return err
+		}
+	}
+
+	for componentName, componentConfig := range aliasSection {
+		if _, exists := canonicalSection[componentName]; exists {
+			return fmt.Errorf("%w: component %q is defined under both components.%s and components.%s",
+				ErrInvalidComponentSection, componentName, canonical, alias)
+		}
+		canonicalSection[componentName] = componentConfig
+		if envelopes[canonical] == nil {
+			envelopes[canonical] = make(map[string]string)
+		}
+		envelopes[canonical][componentName] = alias
+	}
+
+	normalized[canonical] = canonicalSection
+	delete(normalized, alias)
+	return nil
+}
+
+func componentSectionMap(components map[string]any, componentType string) (map[string]any, error) {
+	section, ok := components[componentType].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: components.%s must be a map", ErrInvalidComponentSection, componentType)
+	}
+	return section, nil
+}
+
+func normalizeComponentType(componentType string) string {
+	return strings.ToLower(strings.TrimSpace(componentType))
+}
+
+func knownComponentTypes(atmosConfig *schema.AtmosConfiguration) map[string]struct{} {
+	types := make(map[string]struct{}, len(builtInComponentTypes)+len(atmosConfig.Components.Plugins)+len(ListTypes()))
+	for t := range builtInComponentTypes {
+		types[t] = struct{}{}
+	}
+	for t := range atmosConfig.Components.Plugins {
+		types[normalizeComponentType(t)] = struct{}{}
+	}
+	for _, t := range ListTypes() {
+		types[normalizeComponentType(t)] = struct{}{}
+	}
+	return types
+}
+
+func extractPluginAliases(raw any) []string {
+	config, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	value, ok := config[componentAliasesKey]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case string:
+		return []string{typed}
+	case []string:
+		return typed
+	case []any:
+		aliases := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if alias, ok := item.(string); ok {
+				aliases = append(aliases, alias)
+			}
+		}
+		return aliases
+	default:
+		return nil
+	}
+}

--- a/pkg/component/aliases_test.go
+++ b/pkg/component/aliases_test.go
@@ -1,0 +1,137 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+func TestAliasMapBuiltInAndPluginAliases(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+			Helmfile:  schema.Helmfile{Aliases: []string{"helm"}},
+			Plugins: map[string]any{
+				"cloudformation": map[string]any{
+					"aliases": []any{"rain", "cft"},
+				},
+			},
+		},
+	}
+
+	aliases, err := AliasMap(atmosConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"opentofu": "terraform",
+		"helm":     "helmfile",
+		"rain":     "cloudformation",
+		"cft":      "cloudformation",
+	}, aliases)
+	assert.Equal(t, "terraform", CanonicalType(atmosConfig, " OpenTofu "))
+}
+
+func TestAliasMapValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      schema.AtmosConfiguration
+		errContains string
+	}{
+		{
+			name: "empty alias",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{""}},
+			}},
+			errContains: "cannot be empty",
+		},
+		{
+			name: "self alias",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"terraform"}},
+			}},
+			errContains: "cannot alias itself",
+		},
+		{
+			name: "duplicate alias for same type",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"opentofu", "opentofu"}},
+			}},
+			errContains: "declared more than once",
+		},
+		{
+			name: "duplicate alias across types",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+				Helmfile:  schema.Helmfile{Aliases: []string{"opentofu"}},
+			}},
+			errContains: "maps to both",
+		},
+		{
+			name: "alias conflicts with registered type",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Terraform: schema.Terraform{Aliases: []string{"helmfile"}},
+			}},
+			errContains: "conflicts with registered component type",
+		},
+		{
+			name: "empty plugin alias",
+			config: schema.AtmosConfiguration{Components: schema.Components{
+				Plugins: map[string]any{"cloudformation": map[string]any{"aliases": ""}},
+			}},
+			errContains: "cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := AliasMap(&tt.config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
+func TestNormalizeComponentSectionsMergesAliasesAndTracksEnvelope(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+		},
+	}
+	components := map[string]any{
+		"terraform": map[string]any{
+			"eks": map[string]any{"vars": map[string]any{"name": "eks"}},
+		},
+		"opentofu": map[string]any{
+			"vpc": map[string]any{"vars": map[string]any{"name": "vpc"}},
+		},
+	}
+
+	normalized, envelopes, err := NormalizeComponentSections(atmosConfig, components)
+	require.NoError(t, err)
+
+	assert.NotContains(t, normalized, "opentofu")
+	tf, ok := normalized["terraform"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, tf, "eks")
+	assert.Contains(t, tf, "vpc")
+	assert.Equal(t, "opentofu", envelopes["terraform"]["vpc"])
+}
+
+func TestNormalizeComponentSectionsRejectsDuplicateComponentsAcrossEnvelopes(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+		},
+	}
+	components := map[string]any{
+		"terraform": map[string]any{"vpc": map[string]any{}},
+		"opentofu":  map[string]any{"vpc": map[string]any{}},
+	}
+
+	_, _, err := NormalizeComponentSections(atmosConfig, components)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `component "vpc" is defined under both`)
+}

--- a/pkg/component/resolver.go
+++ b/pkg/component/resolver.go
@@ -72,7 +72,8 @@ func (r *Resolver) ResolveComponentFromPath(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPath")()
 
-	log.Debug("Resolving component from path",
+	log.Debug(
+		"Resolving component from path",
 		"path", path,
 		"stack", stack,
 		"expected_type", expectedComponentType,
@@ -113,7 +114,8 @@ func (r *Resolver) ResolveComponentFromPath(
 		resolvedComponent = componentInfo.FullComponent
 	}
 
-	log.Debug("Successfully resolved component from path",
+	log.Debug(
+		"Successfully resolved component from path",
 		"path", path,
 		"component", resolvedComponent,
 		"type", componentInfo.ComponentType,
@@ -131,7 +133,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutTypeCheck(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPathWithoutTypeCheck")()
 
-	log.Debug("Resolving component from path (without type check)",
+	log.Debug(
+		"Resolving component from path (without type check)",
 		"path", path,
 		"stack", stack,
 	)
@@ -156,7 +159,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutTypeCheck(
 		resolvedComponent = componentInfo.FullComponent
 	}
 
-	log.Debug("Successfully resolved component from path (without type check)",
+	log.Debug(
+		"Successfully resolved component from path (without type check)",
 		"path", path,
 		ComponentKey, resolvedComponent,
 		"detected_type", componentInfo.ComponentType,
@@ -187,7 +191,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutValidation(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPathWithoutValidation")()
 
-	log.Debug("Resolving component from path (without validation)",
+	log.Debug(
+		"Resolving component from path (without validation)",
 		"path", path,
 		"expected_type", expectedComponentType,
 	)
@@ -215,7 +220,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutValidation(
 		return "", err
 	}
 
-	log.Debug("Successfully resolved component from path (without validation)",
+	log.Debug(
+		"Successfully resolved component from path (without validation)",
 		"path", path,
 		"component", componentInfo.FullComponent,
 		"type", componentInfo.ComponentType,
@@ -275,6 +281,15 @@ func extractComponentsSection(
 	componentType string,
 	stack string,
 ) (map[string]any, error) {
+	return extractComponentsSectionWithConfig(nil, stackConfigMap, componentType, stack)
+}
+
+func extractComponentsSectionWithConfig(
+	atmosConfig *schema.AtmosConfiguration,
+	stackConfigMap map[string]any,
+	componentType string,
+	stack string,
+) (map[string]any, error) {
 	// Extract components section.
 	components, ok := stackConfigMap["components"]
 	if !ok {
@@ -285,15 +300,23 @@ func extractComponentsSection(
 	if !ok {
 		return nil, fmt.Errorf("%w: invalid components section in stack '%s'", errUtils.ErrComponentNotInStack, stack)
 	}
+	if atmosConfig != nil {
+		normalizedComponentsMap, _, err := NormalizeComponentSections(atmosConfig, componentsMap)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errUtils.ErrComponentNotInStack, err)
+		}
+		componentsMap = normalizedComponentsMap
+	}
 
+	canonicalType := CanonicalType(atmosConfig, componentType)
 	// Extract component type section (terraform/helmfile/packer).
-	typeComponents, ok := componentsMap[componentType]
+	typeComponents, ok := componentsMap[canonicalType]
 	if !ok {
 		return nil, fmt.Errorf(
 			"%w: stack '%s' has no %s components",
 			errUtils.ErrComponentNotInStack,
 			stack,
-			componentType,
+			canonicalType,
 		)
 	}
 
@@ -302,7 +325,7 @@ func extractComponentsSection(
 		return nil, fmt.Errorf(
 			"%w: invalid %s components section in stack '%s'",
 			errUtils.ErrComponentNotInStack,
-			componentType,
+			canonicalType,
 			stack,
 		)
 	}
@@ -402,7 +425,8 @@ func handleMultipleMatches(matches []string, componentName, stack, componentType
 	}
 
 	// Interactive terminal - prompt user to select.
-	log.Debug("Multiple component matches found, prompting user for selection",
+	log.Debug(
+		"Multiple component matches found, prompting user for selection",
 		"matches", matches,
 		"component", componentName,
 		StackKey, stack,
@@ -415,14 +439,16 @@ func handleMultipleMatches(matches []string, componentName, stack, componentType
 			return "", errUtils.ErrUserAborted
 		}
 		// Other error - fall back to ambiguous path error.
-		log.Debug("Component selection failed, falling back to error",
+		log.Debug(
+			"Component selection failed, falling back to error",
 			"error", err.Error(),
 		)
 		return "", buildAmbiguousComponentError(matches, componentName, stack, componentType)
 	}
 
 	// User made a selection - return it.
-	log.Info("User selected component from interactive prompt",
+	log.Info(
+		"User selected component from interactive prompt",
 		"selected", selected,
 		"matches", matches,
 		StackKey, stack,
@@ -497,7 +523,8 @@ func promptForComponentSelection(
 		return "", fmt.Errorf("component selection failed: %w", err)
 	}
 
-	log.Debug("User selected component",
+	log.Debug(
+		"User selected component",
 		"selected", selected,
 		"from_matches", matches,
 		StackKey, stack,
@@ -514,7 +541,8 @@ func (r *Resolver) validateComponentInStack(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.validateComponentInStack")()
 
-	log.Debug("Validating component exists in stack",
+	log.Debug(
+		"Validating component exists in stack",
 		ComponentKey, componentName,
 		StackKey, stack,
 		TypeKey, componentType,
@@ -527,7 +555,7 @@ func (r *Resolver) validateComponentInStack(
 	}
 
 	// Extract the component type section.
-	typeComponentsMap, err := extractComponentsSection(stackConfigMap, componentType, stack)
+	typeComponentsMap, err := extractComponentsSectionWithConfig(atmosConfig, stackConfigMap, componentType, stack)
 	if err != nil {
 		return "", err
 	}
@@ -543,13 +571,15 @@ func (r *Resolver) validateComponentInStack(
 
 	// Log success.
 	if resolvedComponent == componentName {
-		log.Debug("Component validated successfully in stack (direct match)",
+		log.Debug(
+			"Component validated successfully in stack (direct match)",
 			ComponentKey, componentName,
 			StackKey, stack,
 			TypeKey, componentType,
 		)
 	} else {
-		log.Debug("Component validated successfully in stack (alias match)",
+		log.Debug(
+			"Component validated successfully in stack (alias match)",
 			"path_component", componentName,
 			"stack_key", resolvedComponent,
 			StackKey, stack,

--- a/pkg/component/resolver_test.go
+++ b/pkg/component/resolver_test.go
@@ -296,6 +296,25 @@ func TestExtractComponentsSection_ComponentTypeNotMap(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestExtractComponentsSectionWithConfig_ResolvesAliasEnvelope(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{
+		Components: schema.Components{
+			Terraform: schema.Terraform{Aliases: []string{"opentofu"}},
+		},
+	}
+	stackConfig := map[string]any{
+		"components": map[string]any{
+			"opentofu": map[string]any{
+				"vpc": map[string]any{"vars": map[string]any{"name": "vpc"}},
+			},
+		},
+	}
+
+	result, err := extractComponentsSectionWithConfig(atmosConfig, stackConfig, "opentofu", "dev")
+	require.NoError(t, err)
+	assert.Contains(t, result, "vpc")
+}
+
 // TestHandleNoMatches_DifferentComponentTypes tests error messages for different component types.
 func TestHandleNoMatches_DifferentComponentTypes(t *testing.T) {
 	tests := []struct {

--- a/pkg/config/atmos_decode_hook_test.go
+++ b/pkg/config/atmos_decode_hook_test.go
@@ -54,6 +54,28 @@ func TestAtmosDecodeHook_StringToSlice(t *testing.T) {
 	assert.Equal(t, []string{"tag1", "tag2", "tag3"}, result.Tags)
 }
 
+func TestAtmosDecodeHook_ComponentAliases(t *testing.T) {
+	yamlContent := `
+components:
+  terraform:
+    aliases: opentofu
+  helmfile:
+    aliases: [helm, releases]
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(bytes.NewReader([]byte(yamlContent)))
+	require.NoError(t, err)
+
+	var result schema.AtmosConfiguration
+	err = v.Unmarshal(&result, atmosDecodeHook())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"opentofu"}, result.Components.Terraform.Aliases)
+	assert.Equal(t, []string{"helm", "releases"}, result.Components.Helmfile.Aliases)
+}
+
 // TestAtmosDecodeHook_TasksDecodeHook tests that the decode hook
 // correctly handles Tasks (flexible command steps) conversion.
 func TestAtmosDecodeHook_TasksDecodeHook(t *testing.T) {

--- a/pkg/datafetcher/schema/atmos/manifest/1.0.json
+++ b/pkg/datafetcher/schema/atmos/manifest/1.0.json
@@ -250,12 +250,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/terraform_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/terraform_component_manifest"
+          }
         }
       ]
     },
@@ -363,12 +365,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/helmfile_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/helmfile_component_manifest"
+          }
         }
       ]
     },
@@ -455,12 +459,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/packer_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/packer_component_manifest"
+          }
         }
       ]
     },
@@ -1575,6 +1581,21 @@
               "type": "string",
               "description": "Console session duration (e.g., '12h'). Max: 12h for AWS."
             }
+          }
+        }
+      ]
+    },
+    "component_type_aliases": {
+      "title": "aliases",
+      "description": "Component type aliases. May be a single alias or a list of aliases.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]

--- a/pkg/datafetcher/schema/config/global/1.0.json
+++ b/pkg/datafetcher/schema/config/global/1.0.json
@@ -240,12 +240,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/terraform_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/terraform_component_manifest"
+          }
         }
       ]
     },
@@ -344,12 +346,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/helmfile_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/helmfile_component_manifest"
+          }
         }
       ]
     },
@@ -430,12 +434,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/packer_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/packer_component_manifest"
+          }
         }
       ]
     },
@@ -1180,6 +1186,21 @@
         {
           "type": "object",
           "additionalProperties": true
+        }
+      ]
+    },
+    "component_type_aliases": {
+      "title": "aliases",
+      "description": "Component type aliases. May be a single alias or a list of aliases.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       ]
     }

--- a/pkg/datafetcher/schema/stacks/stack-config/1.0.json
+++ b/pkg/datafetcher/schema/stacks/stack-config/1.0.json
@@ -261,12 +261,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/terraform_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/terraform_component_manifest"
+          }
         }
       ]
     },
@@ -377,12 +379,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/helmfile_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/helmfile_component_manifest"
+          }
         }
       ]
     },
@@ -463,12 +467,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/packer_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/packer_component_manifest"
+          }
         }
       ]
     },
@@ -951,7 +957,11 @@
             },
             "backoff_strategy": {
               "type": "string",
-              "enum": ["constant", "linear", "exponential"],
+              "enum": [
+                "constant",
+                "linear",
+                "exponential"
+              ],
               "description": "How delays grow between attempts. Defaults to exponential when initial_delay is set."
             },
             "initial_delay": {
@@ -1348,8 +1358,25 @@
                   "description": "List of provider configuration aliases"
                 }
               },
-              "required": ["source"]
+              "required": [
+                "source"
+              ]
             }
+          }
+        }
+      ]
+    },
+    "component_type_aliases": {
+      "title": "aliases",
+      "description": "Component type aliases. May be a single alias or a list of aliases.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -470,12 +470,13 @@ type SourceSettings struct {
 }
 
 type Terraform struct {
-	BasePath                string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
-	ApplyAutoApprove        bool   `yaml:"apply_auto_approve" json:"apply_auto_approve" mapstructure:"apply_auto_approve"`
-	AppendUserAgent         string `yaml:"append_user_agent" json:"append_user_agent" mapstructure:"append_user_agent"`
-	DeployRunInit           bool   `yaml:"deploy_run_init" json:"deploy_run_init" mapstructure:"deploy_run_init"`
-	InitRunReconfigure      bool   `yaml:"init_run_reconfigure" json:"init_run_reconfigure" mapstructure:"init_run_reconfigure"`
-	AutoGenerateBackendFile bool   `yaml:"auto_generate_backend_file" json:"auto_generate_backend_file" mapstructure:"auto_generate_backend_file"`
+	Aliases                 []string `yaml:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases"`
+	BasePath                string   `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
+	ApplyAutoApprove        bool     `yaml:"apply_auto_approve" json:"apply_auto_approve" mapstructure:"apply_auto_approve"`
+	AppendUserAgent         string   `yaml:"append_user_agent" json:"append_user_agent" mapstructure:"append_user_agent"`
+	DeployRunInit           bool     `yaml:"deploy_run_init" json:"deploy_run_init" mapstructure:"deploy_run_init"`
+	InitRunReconfigure      bool     `yaml:"init_run_reconfigure" json:"init_run_reconfigure" mapstructure:"init_run_reconfigure"`
+	AutoGenerateBackendFile bool     `yaml:"auto_generate_backend_file" json:"auto_generate_backend_file" mapstructure:"auto_generate_backend_file"`
 	// AutoGenerateFiles enables automatic generation of auxiliary configuration files
 	// (e.g., .tf, .json, .yaml) during Terraform operations when set to true.
 	// Generated files are defined in the component's generate section.
@@ -640,14 +641,15 @@ type CITemplatesConfig struct {
 }
 
 type Helmfile struct {
-	BasePath              string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
-	UseEKS                bool   `yaml:"use_eks" json:"use_eks" mapstructure:"use_eks"`
-	KubeconfigPath        string `yaml:"kubeconfig_path" json:"kubeconfig_path" mapstructure:"kubeconfig_path"`
-	HelmAwsProfilePattern string `yaml:"helm_aws_profile_pattern" json:"helm_aws_profile_pattern" mapstructure:"helm_aws_profile_pattern"` // Deprecated: use --identity flag instead.
-	ClusterNamePattern    string `yaml:"cluster_name_pattern" json:"cluster_name_pattern" mapstructure:"cluster_name_pattern"`             // Deprecated: use ClusterNameTemplate with Go template syntax.
-	ClusterNameTemplate   string `yaml:"cluster_name_template" json:"cluster_name_template" mapstructure:"cluster_name_template"`
-	ClusterName           string `yaml:"cluster_name" json:"cluster_name" mapstructure:"cluster_name"`
-	Command               string `yaml:"command" json:"command" mapstructure:"command"`
+	Aliases               []string `yaml:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases"`
+	BasePath              string   `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
+	UseEKS                bool     `yaml:"use_eks" json:"use_eks" mapstructure:"use_eks"`
+	KubeconfigPath        string   `yaml:"kubeconfig_path" json:"kubeconfig_path" mapstructure:"kubeconfig_path"`
+	HelmAwsProfilePattern string   `yaml:"helm_aws_profile_pattern" json:"helm_aws_profile_pattern" mapstructure:"helm_aws_profile_pattern"` // Deprecated: use --identity flag instead.
+	ClusterNamePattern    string   `yaml:"cluster_name_pattern" json:"cluster_name_pattern" mapstructure:"cluster_name_pattern"`             // Deprecated: use ClusterNameTemplate with Go template syntax.
+	ClusterNameTemplate   string   `yaml:"cluster_name_template" json:"cluster_name_template" mapstructure:"cluster_name_template"`
+	ClusterName           string   `yaml:"cluster_name" json:"cluster_name" mapstructure:"cluster_name"`
+	Command               string   `yaml:"command" json:"command" mapstructure:"command"`
 	// AutoGenerateFiles enables automatic generation of auxiliary configuration files
 	// during Helmfile operations when set to true.
 	// Generated files are defined in the component's generate section.
@@ -657,8 +659,9 @@ type Helmfile struct {
 }
 
 type Packer struct {
-	BasePath string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
-	Command  string `yaml:"command" json:"command" mapstructure:"command"`
+	Aliases  []string `yaml:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases"`
+	BasePath string   `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
+	Command  string   `yaml:"command" json:"command" mapstructure:"command"`
 	// AutoGenerateFiles enables automatic generation of auxiliary configuration files
 	// during Packer operations when set to true.
 	// Generated files are defined in the component's generate section.
@@ -669,8 +672,9 @@ type Packer struct {
 
 // Ansible defines configuration for Ansible components.
 type Ansible struct {
-	BasePath string `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
-	Command  string `yaml:"command" json:"command" mapstructure:"command"`
+	Aliases  []string `yaml:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases"`
+	BasePath string   `yaml:"base_path" json:"base_path" mapstructure:"base_path"`
+	Command  string   `yaml:"command" json:"command" mapstructure:"command"`
 	// AutoGenerateFiles enables automatic generation of auxiliary configuration files
 	// during Ansible operations when set to true.
 	// Generated files are defined in the component's generate section.

--- a/pkg/validator/schema_validator_test.go
+++ b/pkg/validator/schema_validator_test.go
@@ -2,6 +2,8 @@ package validator
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -115,6 +117,63 @@ key: value
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedErrors, len(resultErrors))
 			}
+		})
+	}
+}
+
+func TestValidateYAMLSchema_ComponentTypeAliases(t *testing.T) {
+	schemaData, err := os.ReadFile(filepath.Join("..", "datafetcher", "schema", "atmos", "manifest", "1.0.json"))
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		yamlData []byte
+	}{
+		{
+			name: "canonical section aliases scalar",
+			yamlData: []byte(`
+components:
+  terraform:
+    aliases: opentofu
+`),
+		},
+		{
+			name: "canonical section aliases list",
+			yamlData: []byte(`
+components:
+  terraform:
+    aliases: [opentofu, tofu]
+`),
+		},
+		{
+			name: "alias envelope remains schema-compatible",
+			yamlData: []byte(`
+components:
+  opentofu:
+    vpc:
+      vars:
+        name: vpc
+`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockFetcher := datafetcher.NewMockDataFetcher(ctrl)
+			mockFetcher.EXPECT().GetData("data.yaml").Return(tt.yamlData, nil)
+			mockFetcher.EXPECT().GetData("schema.json").Return(schemaData, nil)
+
+			v := &yamlSchemaValidator{
+				atmosConfig: &schema.AtmosConfiguration{},
+				dataFetcher: mockFetcher,
+			}
+
+			resultErrors, err := v.ValidateYAMLSchema("schema.json", "data.yaml")
+			assert.NoError(t, err)
+			assert.Empty(t, resultErrors)
 		})
 	}
 }

--- a/tests/fixtures/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+++ b/tests/fixtures/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
@@ -258,12 +258,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/terraform_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/terraform_component_manifest"
+          }
         }
       ]
     },
@@ -386,12 +388,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/helmfile_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/helmfile_component_manifest"
+          }
         }
       ]
     },
@@ -493,12 +497,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/packer_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/packer_component_manifest"
+          }
         }
       ]
     },
@@ -1630,15 +1636,27 @@
       },
       "anyOf": [
         {
-          "required": ["name"]
+          "required": [
+            "name"
+          ]
         },
         {
-          "required": ["component"]
+          "required": [
+            "component"
+          ]
         },
         {
-          "required": ["kind", "path"],
+          "required": [
+            "kind",
+            "path"
+          ],
           "properties": {
-            "kind": { "enum": ["file", "folder"] }
+            "kind": {
+              "enum": [
+                "file",
+                "folder"
+              ]
+            }
           }
         }
       ],
@@ -1942,6 +1960,21 @@
               "type": "string",
               "description": "Console session duration (e.g., '12h'). Max: 12h for AWS."
             }
+          }
+        }
+      ]
+    },
+    "component_type_aliases": {
+      "title": "aliases",
+      "description": "Component type aliases. May be a single alias or a list of aliases.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]

--- a/website/docs/cli/commands/describe/describe-component.mdx
+++ b/website/docs/cli/commands/describe/describe-component.mdx
@@ -24,6 +24,8 @@ Execute the `atmos describe component` command like this:
 atmos describe component <component> -s <stack>
 ```
 
+When the component was declared under a [component type alias](/cli/configuration/components/aliases), describe output preserves that stack envelope. For example, `components.opentofu.vpc` remains under `components.opentofu`, while `component_info.component_type` identifies the canonical type as `terraform`.
+
 ### Path-Based Component Resolution
 
 Atmos supports using filesystem paths instead of component names for convenience. This allows you to navigate to a component directory and use `.` to reference it:

--- a/website/docs/cli/commands/describe/describe-stacks.mdx
+++ b/website/docs/cli/commands/describe/describe-stacks.mdx
@@ -24,6 +24,8 @@ atmos describe stacks [options]
 
 This command shows configuration for stacks and components in the stacks.
 
+When a stack manifest uses a [component type alias](/cli/configuration/components/aliases), `describe stacks` preserves the authored envelope. For example, a component declared under `components.opentofu` renders under `components.opentofu`, while `component_info.component_type` exposes the canonical type, such as `terraform`.
+
 :::info YAML Functions and Authentication
 By default, `atmos describe stacks` executes YAML template functions (e.g., `!terraform.state`, `!terraform.output`) and Go templates during stack processing. When these functions access remote resources requiring authentication, use the `--identity` flag to authenticate before execution. You can disable function/template processing with `--process-functions=false` or `--process-templates=false` flags.
 :::

--- a/website/docs/cli/commands/terraform/usage.mdx
+++ b/website/docs/cli/commands/terraform/usage.mdx
@@ -9,20 +9,12 @@ import Terminal from '@site/src/components/Terminal'
 import Intro from '@site/src/components/Intro'
 import ActionCard from '@site/src/components/ActionCard'
 import File from '@site/src/components/File'
-import PrimaryCTA from '@site/src/components/PrimaryCTA'
 
 <Intro>
 Use these subcommands to interact with Terraform and OpenTofu.
 </Intro>
 
 <Screengrab title="atmos terraform --help" slug="atmos-terraform--help" />
-
-<ActionCard title="Configure Component Type Aliases">
-  Use aliases such as `opentofu` for Terraform semantics while keeping canonical Terraform behavior inside Atmos.
-  <div>
-    <PrimaryCTA to="/cli/configuration/components/aliases">Component Type Aliases</PrimaryCTA>
-  </div>
-</ActionCard>
 
 Atmos supports all Terraform and OpenTofu commands and options described in
 [Terraform CLI Overview](https://developer.hashicorp.com/terraform/cli/commands)

--- a/website/docs/cli/commands/terraform/usage.mdx
+++ b/website/docs/cli/commands/terraform/usage.mdx
@@ -9,12 +9,20 @@ import Terminal from '@site/src/components/Terminal'
 import Intro from '@site/src/components/Intro'
 import ActionCard from '@site/src/components/ActionCard'
 import File from '@site/src/components/File'
+import PrimaryCTA from '@site/src/components/PrimaryCTA'
 
 <Intro>
 Use these subcommands to interact with Terraform and OpenTofu.
 </Intro>
 
 <Screengrab title="atmos terraform --help" slug="atmos-terraform--help" />
+
+<ActionCard title="Configure Component Type Aliases">
+  Use aliases such as `opentofu` for Terraform semantics while keeping canonical Terraform behavior inside Atmos.
+  <div>
+    <PrimaryCTA to="/cli/configuration/components/aliases">Component Type Aliases</PrimaryCTA>
+  </div>
+</ActionCard>
 
 Atmos supports all Terraform and OpenTofu commands and options described in
 [Terraform CLI Overview](https://developer.hashicorp.com/terraform/cli/commands)
@@ -45,6 +53,19 @@ atmos terraform <command> <component> -s <stack> [options]
 The `component` argument and `--stack` flag are required to generate variables and backend config for the component in the stack.
 
 See individual command pages for detailed options: [plan](/cli/commands/terraform/plan), [apply](/cli/commands/terraform/apply), [deploy](/cli/commands/terraform/deploy), [destroy](/cli/commands/terraform/destroy).
+
+### Component Type Aliases
+
+If `components.terraform.aliases` is configured in `atmos.yaml`, the alias becomes a top-level command that dispatches through Terraform behavior. For example, with `aliases: opentofu`, these commands are equivalent:
+
+<Terminal>
+```shell
+atmos opentofu plan vpc -s dev
+atmos terraform plan vpc -s dev
+```
+</Terminal>
+
+The alias reuses the Terraform command's flags, completions, help, compatibility flags, and execution behavior. The alias does not change the executable; set `components.terraform.command: tofu` when you want Atmos to run OpenTofu.
 
 ### Path-Based Component Resolution
 

--- a/website/docs/cli/configuration/components/aliases.mdx
+++ b/website/docs/cli/configuration/components/aliases.mdx
@@ -1,0 +1,152 @@
+---
+title: Component Type Aliases
+sidebar_position: 6
+sidebar_label: aliases
+sidebar_class_name: command
+id: aliases
+description: Configure aliases for canonical Atmos component types in atmos.yaml.
+---
+import File from '@site/src/components/File'
+import Intro from '@site/src/components/Intro'
+
+<Intro>
+Component type aliases let stack manifests use an alternate envelope, such as `opentofu`, while Atmos continues to use the canonical component type implementation, such as `terraform`.
+</Intro>
+
+## Configuration
+
+Declare aliases under the canonical component type in `atmos.yaml`.
+
+<File title="atmos.yaml">
+```yaml
+components:
+  terraform:
+    aliases: opentofu
+    base_path: components/terraform
+    command: tofu
+```
+</File>
+
+The `aliases` value can be a single string or a list.
+
+<File title="atmos.yaml">
+```yaml
+components:
+  terraform:
+    aliases:
+      - opentofu
+      - tofu
+    base_path: components/terraform
+    command: tofu
+```
+</File>
+
+## Stack Manifests
+
+After an alias is configured, stack manifests may use the alias as a component envelope.
+
+<File title="stacks/dev.yaml">
+```yaml
+components:
+  opentofu:
+    vpc:
+      vars:
+        cidr_block: 10.10.0.0/16
+```
+</File>
+
+Atmos resolves `opentofu` to the canonical `terraform` component type for:
+
+- provider lookup
+- command execution
+- dependency processing
+- component path resolution
+- validation
+- generated backend and varfile behavior
+
+Describe output preserves the authored envelope. If a stack uses `components.opentofu`, commands such as `atmos describe stacks` and `atmos describe component` render that component under `components.opentofu`, with `component_info.component_type: terraform` available for canonical type context.
+
+## Alias Commands
+
+Component type aliases also register top-level command aliases. For example, with `aliases: opentofu` under `components.terraform`, these commands are equivalent:
+
+```shell
+atmos opentofu plan vpc -s dev
+atmos terraform plan vpc -s dev
+```
+
+The alias command reuses the canonical command's flags, completions, help, compatibility flags, and execution behavior.
+
+## OpenTofu
+
+An alias does not change the executable. To run OpenTofu, set the canonical Terraform command to `tofu`.
+
+<File title="atmos.yaml">
+```yaml
+components:
+  terraform:
+    aliases: opentofu
+    command: tofu
+    base_path: components/terraform
+```
+</File>
+
+With that configuration, `atmos opentofu plan vpc -s dev` uses Terraform semantics in Atmos and runs the `tofu` executable.
+
+## Configuration Reference
+
+<dl>
+  <dt>`components.<component-type>.aliases`</dt>
+  <dd>
+    Optional component type alias or list of aliases for a canonical component type. Supported forms are a string or a list of strings. Defaults to unset.
+  </dd>
+
+  <dt>`components.terraform.aliases`</dt>
+  <dd>
+    Aliases for Terraform semantics. Common use: `opentofu` or `tofu`.
+  </dd>
+
+  <dt>`components.helmfile.aliases`</dt>
+  <dd>
+    Aliases for Helmfile semantics.
+  </dd>
+
+  <dt>`components.packer.aliases`</dt>
+  <dd>
+    Aliases for Packer semantics.
+  </dd>
+
+  <dt>`components.ansible.aliases`</dt>
+  <dd>
+    Aliases for Ansible semantics.
+  </dd>
+</dl>
+
+## Validation
+
+Aliases must be unambiguous:
+
+- An alias cannot be empty.
+- An alias cannot be the same as its canonical component type.
+- The same alias cannot be declared more than once.
+- An alias cannot conflict with another registered component type or top-level command.
+- A component name cannot be defined under both canonical and alias envelopes in the same stack.
+
+For example, this is rejected because `vpc` appears under both `terraform` and `opentofu`:
+
+<File title="stacks/dev.yaml">
+```yaml
+components:
+  terraform:
+    vpc: {}
+  opentofu:
+    vpc: {}
+```
+</File>
+
+## Related
+
+- [Component Configuration Overview](/cli/configuration/components)
+- [Terraform Configuration](/cli/configuration/components/terraform)
+- [Terraform Commands](/cli/commands/terraform/usage)
+- [Stack Components](/stacks/components)

--- a/website/docs/cli/configuration/components/index.mdx
+++ b/website/docs/cli/configuration/components/index.mdx
@@ -45,6 +45,7 @@ components:
   terraform:
     base_path: components/terraform
     command: terraform
+    aliases: opentofu
     # ... terraform-specific settings
 
   helmfile:
@@ -74,10 +75,14 @@ All component types share these common configuration options:
 
   <dt>`command`</dt>
   <dd>Executable to run for this component type. Can be a command name (resolved via PATH) or an absolute path to a binary.</dd>
+
+  <dt>`aliases`</dt>
+  <dd>Optional component type alias or list of aliases for the canonical component type. Stack manifests can use the alias envelope, while Atmos resolves it to the canonical type internally. See [Component Type Aliases](/cli/configuration/components/aliases).</dd>
 </dl>
 
 ## Related
 
+- [Component Type Aliases](/cli/configuration/components/aliases)
 - [Terraform Configuration](/cli/configuration/components/terraform)
 - [Helmfile Configuration](/cli/configuration/components/helmfile)
 - [Packer Configuration](/cli/configuration/components/packer)

--- a/website/docs/cli/configuration/components/index.mdx
+++ b/website/docs/cli/configuration/components/index.mdx
@@ -45,7 +45,6 @@ components:
   terraform:
     base_path: components/terraform
     command: terraform
-    aliases: opentofu
     # ... terraform-specific settings
 
   helmfile:

--- a/website/docs/cli/configuration/components/terraform.mdx
+++ b/website/docs/cli/configuration/components/terraform.mdx
@@ -24,6 +24,9 @@ The term "Terraform" is used in this documentation to refer to generic concepts 
 ```yaml
 components:
   terraform:
+    # Optional aliases for the Terraform component type
+    aliases: opentofu
+
     # Executable to run (terraform, tofu, or absolute path)
     command: terraform
 
@@ -78,6 +81,19 @@ components:
     - `tofu` - Use OpenTofu from PATH
     - `/usr/local/bin/terraform-1.8` - Use specific version
     - `/usr/local/bin/tofu-1.7.1` - Use specific OpenTofu version
+  </dd>
+
+  <dt>`aliases`</dt>
+  <dd>
+    Optional alias or list of aliases for the Terraform component type. Aliases let stack manifests use an alternate envelope, such as `components.opentofu`, while Atmos resolves the component to Terraform semantics internally.
+
+    **Default:** unset
+
+    Examples:
+    - `opentofu` - Use `components.opentofu` in stack manifests and `atmos opentofu ...` as a command alias.
+    - `[opentofu, tofu]` - Register multiple aliases for Terraform semantics.
+
+    See [Component Type Aliases](/cli/configuration/components/aliases).
   </dd>
 
   <dt>`base_path`</dt>
@@ -208,6 +224,35 @@ components:
 ```
 </File>
 
+You can also add a component type alias so stack manifests and commands use `opentofu` while Atmos keeps Terraform semantics internally:
+
+<File title="atmos.yaml">
+```yaml
+components:
+  terraform:
+    aliases: opentofu
+    command: tofu
+    base_path: components/terraform
+```
+</File>
+
+Then define components under the alias envelope:
+
+<File title="stacks/dev.yaml">
+```yaml
+components:
+  opentofu:
+    vpc:
+      vars: {}
+```
+</File>
+
+Run the aliased command:
+
+```shell
+atmos opentofu plan vpc -s dev
+```
+
 OpenTofu supports additional features like passing variables to `init` for dynamic backend configuration:
 
 <File title="atmos.yaml">
@@ -245,6 +290,7 @@ backend.tf.json
 ## Related
 
 - [Component Configuration Overview](/cli/configuration/components)
+- [Component Type Aliases](/cli/configuration/components/aliases)
 - [Stack Configuration](/cli/configuration/stacks)
 - [Terraform Components](/components/terraform)
 - [Terraform Backend](/stacks/backend)

--- a/website/docs/cli/configuration/components/terraform.mdx
+++ b/website/docs/cli/configuration/components/terraform.mdx
@@ -24,9 +24,6 @@ The term "Terraform" is used in this documentation to refer to generic concepts 
 ```yaml
 components:
   terraform:
-    # Optional aliases for the Terraform component type
-    aliases: opentofu
-
     # Executable to run (terraform, tofu, or absolute path)
     command: terraform
 

--- a/website/static/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+++ b/website/static/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
@@ -258,12 +258,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/terraform_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/terraform_component_manifest"
+          }
         }
       ]
     },
@@ -386,12 +388,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/helmfile_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/helmfile_component_manifest"
+          }
         }
       ]
     },
@@ -493,12 +497,14 @@
         },
         {
           "type": "object",
-          "patternProperties": {
-            "^[/a-zA-Z0-9-_{}. ]+$": {
-              "$ref": "#/definitions/packer_component_manifest"
+          "properties": {
+            "aliases": {
+              "$ref": "#/definitions/component_type_aliases"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/definitions/packer_component_manifest"
+          }
         }
       ]
     },
@@ -1630,15 +1636,27 @@
       },
       "anyOf": [
         {
-          "required": ["name"]
+          "required": [
+            "name"
+          ]
         },
         {
-          "required": ["component"]
+          "required": [
+            "component"
+          ]
         },
         {
-          "required": ["kind", "path"],
+          "required": [
+            "kind",
+            "path"
+          ],
           "properties": {
-            "kind": { "enum": ["file", "folder"] }
+            "kind": {
+              "enum": [
+                "file",
+                "folder"
+              ]
+            }
           }
         }
       ],
@@ -1942,6 +1960,21 @@
               "type": "string",
               "description": "Console session duration (e.g., '12h'). Max: 12h for AWS."
             }
+          }
+        }
+      ]
+    },
+    "component_type_aliases": {
+      "title": "aliases",
+      "description": "Component type aliases. May be a single alias or a list of aliases.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]


### PR DESCRIPTION
## what
- Add component type aliases declared under canonical component types, including scalar and list alias forms.
- Normalize alias envelopes to canonical component types for stack processing, component resolution, execution, dependencies, and validation while preserving the original envelope in describe output.
- Register top-level alias commands so commands like `atmos opentofu plan vpc -s dev` dispatch through the canonical Terraform command behavior.
- Update bundled Atmos manifest schemas to accept `aliases` in canonical component sections and add `examples/component-aliases`.
- Document component aliases across configuration docs, Terraform command docs, describe docs, and Atmos agent skills.
- Refine docs-skill guidance for command/config linking and sparse use of action cards.

## why
- Allows users to model tools such as OpenTofu as Terraform semantics without duplicating provider behavior.
- Keeps user-facing describe output faithful to the stack manifest envelope that was authored.
- Ensures schema validation, command dispatch, documentation, and registry lookups all understand aliases consistently.
- Keeps command docs focused on command-level configuration instead of over-promoting every nested config feature.

## references
- N/A