### PR TITLE
fix(auth): normalize override keys to uppercase in filterAtmosOverrides (#2349)

### DIFF
--- a/pkg/auth/manager_env_overrides.go
+++ b/pkg/auth/manager_env_overrides.go
@@ -110,14 +110,25 @@ func CreateAndAuthenticateManagerWithEnvOverrides(envOverrides map[string]string
 // filterAtmosOverrides returns a new map containing only the entries whose
 // key has the canonical Atmos env-var prefix (cfg.AtmosEnvVarPrefix). Nil
 // or empty input yields nil.
+//
+// Keys are normalized to uppercase before the prefix check and in the output.
+// This matters because the main caller path (MCP server `env:` blocks in
+// atmos.yaml / .atmos.d/mcp.yaml) loads the map via Viper, which lowercases
+// all YAML map keys — so an authored `ATMOS_PROFILE: managers` reaches this
+// function as `atmos_profile: managers` and would otherwise be silently
+// dropped. See cloudposse/atmos#2349. The same Viper-lowercasing pitfall is
+// handled separately on the CLI-provider pass-through path by
+// pkg/mcp/client/mcpconfig.go:copyEnv; this function applies the equivalent
+// fix to the auth code path.
 func filterAtmosOverrides(overrides map[string]string) map[string]string {
 	if len(overrides) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(overrides))
 	for k, v := range overrides {
-		if strings.HasPrefix(k, cfg.AtmosEnvVarPrefix) {
-			out[k] = v
+		normalized := strings.ToUpper(k)
+		if strings.HasPrefix(normalized, cfg.AtmosEnvVarPrefix) {
+			out[normalized] = v
 		}
 	}
 	return out

--- a/pkg/auth/manager_env_overrides_test.go
+++ b/pkg/auth/manager_env_overrides_test.go
@@ -488,6 +488,53 @@ func TestFilterAtmosOverrides(t *testing.T) {
 				"ATMOS_PROFILE": "",
 			},
 		},
+		// Regression tests for cloudposse/atmos#2349.
+		// Viper lowercases YAML map keys, so MCP servers that author
+		// `ATMOS_PROFILE: managers` under `env:` hand this function
+		// `atmos_profile: managers`. Without case-folding, the entry was
+		// silently dropped and auth manager construction fell back to the
+		// default profile, surfacing as "identity not found".
+		{
+			name: "viper-lowercased atmos key is normalized to uppercase",
+			in: map[string]string{
+				"atmos_profile": "managers",
+			},
+			want: map[string]string{
+				"ATMOS_PROFILE": "managers",
+			},
+		},
+		{
+			name: "mixed-case atmos key is normalized to uppercase",
+			in: map[string]string{
+				"Atmos_Profile": "managers",
+			},
+			want: map[string]string{
+				"ATMOS_PROFILE": "managers",
+			},
+		},
+		{
+			name: "viper-lowercased non-atmos key is dropped",
+			in: map[string]string{
+				"aws_profile": "p",
+				"foo":         "bar",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "mixed casings across atmos and non-atmos keys",
+			in: map[string]string{
+				"atmos_profile":         "managers",
+				"ATMOS_CLI_CONFIG_PATH": "/e",
+				"Atmos_Base_Path":       "/s",
+				"aws_profile":           "p",
+				"FOO":                   "bar",
+			},
+			want: map[string]string{
+				"ATMOS_PROFILE":         "managers",
+				"ATMOS_CLI_CONFIG_PATH": "/e",
+				"ATMOS_BASE_PATH":       "/s",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## what

* Uppercase the override key before the prefix check (and in the returned map) inside `pkg/auth/manager_env_overrides.go:filterAtmosOverrides`.
* Add regression test cases in `TestFilterAtmosOverrides` covering Viper-lowercased keys, mixed-case keys, and mixed atmos/non-atmos casings.

## why

`filterAtmosOverrides` did a case-sensitive `strings.HasPrefix(k, \"ATMOS_\")`. The function's documented contract was \"only keys with the `ATMOS_*` prefix\" — but in production the only realistic source of its input map is an MCP server `env:` block in `atmos.yaml` / `.atmos.d/mcp.yaml`, which Viper loads with **all map keys lowercased**.

This is the same Viper-lowercasing pitfall already documented and handled on a sibling code path by `pkg/mcp/client/mcpconfig.go:copyEnv` (the CLI-provider pass-through that writes config files for Claude Code / Codex / Gemini). That fix wasn't applied to the auth code path, so an authored:

```yaml
mcp:
  servers:
    atmos:
      command: atmos
      args: [\"mcp\", \"start\"]
      env:
        ATMOS_PROFILE: managers
      identity: core-root/terraform
```

reached `filterAtmosOverrides` as `{\"atmos_profile\": \"managers\"}`, was silently dropped, and the auth manager was rebuilt against the default profile. Identity resolution then surfaced as:

```
✗ Server failed to start
   Error: MCP server failed to start: atmos: auth setup failed for \"atmos\": identity not found: core-root/terraform
```

I confirmed Viper's lowercasing end-to-end against the actual `schema.MCPServerConfig` shape (`Env map[string]string`):

```
env key=\"atmos_profile\" value=\"managers\"
env key=\"aws_region\"    value=\"us-east-1\"
```

— so the authored `ATMOS_PROFILE` is gone by the time the filter runs.

## scope of behavior change

* Already-uppercase callers (`ATMOS_PROFILE`): unchanged.
* Previously-dropped lowercase/mixed-case callers (`atmos_profile`, `Atmos_Profile`): now honored — and those are exactly the users hitting the documented bug.
* Non-`ATMOS_*` keys: still dropped, regardless of case (`aws_profile`, `FOO`, `foo`).
* Existing `TestFilterAtmosOverrides` cases still pass unchanged.
* Existing `TestCreateAndAuthenticateManagerWithEnvOverrides_*` tests still pass unchanged.

## alternatives considered

I weighed three fix locations on the original issue:

1. **Uppercase inside `filterAtmosOverrides`** (this PR). Smallest possible surface, single source of truth for the auth path, doesn't touch the MCP layer.
2. **`copyEnv` (or equivalent) inside `ScopedAuthProvider.ForServer`.** Localizes to the MCP adapter; downside is a future non-MCP consumer of `CreateAndAuthenticateManagerWithEnvOverrides` that loads its env map from YAML would hit the same trap.
3. **Uppercase at `ParseConfig` time.** Widest reach — would also affect subprocess env propagation. A real (if narrow) behavior change for users who deliberately set unconventionally-cased env vars in `env:` and expected those passed to the spawned MCP server verbatim.

Option 1 fixes the documented case without altering any other code path's behavior or risking the subprocess-env corner case in Option 3.

## references

* Closes #2349
* Related context: `pkg/mcp/client/mcpconfig.go:128` (`copyEnv`) — the parallel fix on the CLI-provider pass-through path that documents the Viper-lowercasing trap.

## test plan

```
go test ./pkg/auth -run 'TestFilterAtmosOverrides|TestCreateAndAuthenticateManagerWithEnvOverrides' -v
go test ./pkg/auth ./pkg/mcp/client/...
```

Both pass. New regression subtests:
- `viper-lowercased atmos key is normalized to uppercase`
- `mixed-case atmos key is normalized to uppercase`
- `viper-lowercased non-atmos key is dropped`
- `mixed casings across atmos and non-atmos keys`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where environment configuration overrides specified in lowercase format (from YAML configuration files) were incorrectly dropped during processing. Environment override keys are now properly normalized to ensure consistent handling regardless of the input format used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse/atmos/pull/2541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->