### PR TITLE
fix(pro): respect metadata.enabled when uploading instances for drift

### DIFF
--- a/docs/fixes/2026-06-03-drift-dispatch-ignores-metadata-enabled.md
+++ b/docs/fixes/2026-06-03-drift-dispatch-ignores-metadata-enabled.md
@@ -20,8 +20,7 @@ design live here alongside the other regression/fix write-ups.
 
 ## Symptom
 
-Datadog `datadog-configuration` / `datadog-integration` instances in the Cloud Posse demos
-workspace (repo `cloudposse/infra-live`) kept failing scheduled drift detection with
+Components disabled via `metadata.enabled: false` kept failing scheduled drift detection with
 `dispatchError: "missing_plan_result"` and `drift_status: error`, even though multiple upstream PRs
 had "disabled" those components:
 
@@ -58,10 +57,10 @@ crossed the wire to Atmos Pro.
    arriving, a component carrying `settings.pro: {enabled: true, drift_detection: {enabled: true}}`
    was persisted as enabled + drift-enabled and dispatched, regardless of `metadata.enabled: false`.
 
-Neon prod data (project `super-paper-60425112`, table `instances`) confirmed the split was driven
-entirely by the one signal Atmos Pro stored: rows with `enabled:true, drift_enabled:true` were
-dispatched and went to `error`; rows with `drift_enabled:false` were correctly `disabled`. All of
-them carried `metadata.enabled:false` — it moved neither column.
+Inspecting Atmos Pro's persisted instance state confirmed the split was driven entirely by the one
+signal Atmos Pro stored: rows with `enabled:true, drift_enabled:true` were dispatched and went to
+`error`; rows with `drift_enabled:false` were correctly `disabled`. All of them carried
+`metadata.enabled:false` — it moved neither column.
 
 ## Fix
 
@@ -105,10 +104,9 @@ data migration.
 ## Verification
 
 - `go test ./pkg/list/...` — new `TestExtractProSettings*` cases plus the updated toast tests pass.
-- End-to-end against `cloudposse/infra-live`: after this change ships, run
-  `atmos list instances --upload` and confirm in Neon (`super-paper-60425112`, table `instances`)
-  that the `core-gbl-*` / `e98d-*` `datadog-configuration` + `datadog-integration` rows flip to
-  `enabled=false`, `drift_enabled=false`, `drift_status=disabled`, `disabled_at` set.
+- End-to-end: after this change ships, run `atmos list instances --upload` and confirm in Atmos Pro
+  that the previously-stuck disabled instances flip to `enabled=false`, `drift_enabled=false`,
+  `drift_status=disabled`, with `disabled_at` set.
 - Confirm the next scheduled drift cycle no longer dispatches them (no new `missing_plan_result`
   runs for those stack/component pairs).
 
@@ -117,6 +115,6 @@ data migration.
 - **Atmos Pro could also accept `metadata.enabled` defensively.** This fix closes the gap at the
   source (the CLI), but the ingestion contract still has no `metadata` field. Persisting it would
   make the platform robust against older CLIs that predate this fix.
-- **Duplicate-repository rows are a separate issue.** Several `core-gbl-*` stacks have two
-  `datadog-configuration` rows (distinct `repository_id`, both `deleted_at IS NULL`). That is a
-  distinct duplicate-repository question, not addressed here.
+- **Duplicate-repository rows are a separate issue.** A stack can end up with two rows for the same
+  component (distinct `repository_id`, both `deleted_at IS NULL`). That is a distinct
+  duplicate-repository question, not addressed here.

--- a/docs/fixes/2026-06-03-drift-dispatch-ignores-metadata-enabled.md
+++ b/docs/fixes/2026-06-03-drift-dispatch-ignores-metadata-enabled.md
@@ -1,0 +1,122 @@
+# Drift Detection Dispatched for Components Disabled via `metadata.enabled`
+
+**Date:** 2026-06-03
+**Severity:** High — disabled components keep failing scheduled drift detection forever (`dispatchError: "missing_plan_result"`, `drift_status: error`), and the noise never clears because every upload re-asserts the wrong state
+**Reproducer:** `pkg/list/list_instances_pro_test.go` (`TestExtractProSettings` — "metadata disabled forces pro and drift off")
+
+---
+
+## Why this is a fix doc (and not a blog post / changelog entry)
+
+This is a `patch` bugfix: it makes `atmos list instances --upload` report the state Atmos already
+resolves at plan time. There is no new command, flag, or feature to announce — only a correction so
+the upload payload stops contradicting the CLI's own enabled determination. Per the repo's label
+decision tree that makes it a `patch`, which does not require a `website/blog/` post or a roadmap
+milestone. The user-facing reference docs (`settings/pro.mdx`, `list/list-instances.mdx`) are
+updated in the same PR because they documented the old (now-incorrect) behavior; the rationale and
+design live here alongside the other regression/fix write-ups.
+
+---
+
+## Symptom
+
+Datadog `datadog-configuration` / `datadog-integration` instances in the Cloud Posse demos
+workspace (repo `cloudposse/infra-live`) kept failing scheduled drift detection with
+`dispatchError: "missing_plan_result"` and `drift_status: error`, even though multiple upstream PRs
+had "disabled" those components:
+
+```yaml
+metadata:
+  enabled: false
+vars:
+  enabled: false
+```
+
+The Atmos CLI clearly knows not to produce a plan — at plan time it skips the disabled component —
+yet Atmos Pro kept dispatching drift on a schedule and recording errors because no plan result ever
+arrived.
+
+## Root Cause
+
+The "don't run this component" determination lived **only in the Atmos CLI at plan time** and never
+crossed the wire to Atmos Pro.
+
+1. **The CLI's enabled signal is `metadata.enabled`.** `isComponentEnabled`
+   (`internal/exec/component_utils.go:8`) treats a component as enabled by default and skips it only
+   when `metadata.enabled` is the boolean `false`. That is what made the CLI skip planning.
+
+2. **The Atmos Pro upload contract has no `metadata` field.** `atmos list instances --upload`
+   serialized only the raw `settings.pro` block (`extractProSettings` in
+   `pkg/list/list_instances.go`). Atmos Pro's ingestion schema accepts `component`, `stack`,
+   `component_type`, and `settings.pro` — `metadata.enabled` could not influence ingestion even if
+   it had been sent.
+
+3. **Atmos Pro derives its persisted state purely from `settings.pro`.** It stores
+   `instances.enabled ← settings.pro.enabled` (default **true**) and
+   `instances.drift_enabled ← settings.pro.drift_detection.enabled` (default false), and the drift
+   scheduler dispatches on `drift_enabled = true AND enabled = true`. With `metadata.enabled` never
+   arriving, a component carrying `settings.pro: {enabled: true, drift_detection: {enabled: true}}`
+   was persisted as enabled + drift-enabled and dispatched, regardless of `metadata.enabled: false`.
+
+Neon prod data (project `super-paper-60425112`, table `instances`) confirmed the split was driven
+entirely by the one signal Atmos Pro stored: rows with `enabled:true, drift_enabled:true` were
+dispatched and went to `error`; rows with `drift_enabled:false` were correctly `disabled`. All of
+them carried `metadata.enabled:false` — it moved neither column.
+
+## Fix
+
+Collapse the enabled hierarchy in the Atmos CLI **before upload**, so the single signal Atmos Pro
+persists already reflects any outer disable. Precedence (an outer disable forces all inner levels
+off):
+
+```
+metadata.enabled  >  settings.pro.enabled  >  settings.pro.drift_detection.enabled
+
+effectiveProEnabled   = metadata.enabled && settings.pro.enabled                    // both default true
+effectiveDriftEnabled = effectiveProEnabled && settings.pro.drift_detection.enabled // drift defaults false
+```
+
+Implementation (`pkg/list/list_instances.go`):
+
+- A single `effectiveEnabledState(settings, metadata)` helper is the source of truth, used by both
+  the upload payload (`extractProSettings`) and the success-toast counts (`isProEnabled` /
+  `isDriftEnabled` / `countEnabledDisabled`), so the toast can never report a state different from
+  what was uploaded.
+- `extractProSettings` now writes `settings.pro.enabled = effectiveProEnabled` and, when a
+  `drift_detection` block exists, `settings.pro.drift_detection.enabled = effectiveDriftEnabled`.
+  The collapse runs on the JSON-sanitized copy, so the source instance is never mutated.
+
+**Why `settings.pro.enabled` defaults to true (not the CLI's previous strict-bool default-false):**
+Atmos Pro already defaults a missing/non-bool `pro.enabled` to enabled. If the CLI wrote `false` for
+a component that has a `pro` block but omits `enabled` (e.g. `pro: {drift_detection: {enabled:
+true}}`), it would regress default-enabled components by disabling their drift. Default-true aligns
+the CLI with the Pro side; the new gating only ever turns things **off** when an outer level is
+explicitly disabled.
+
+**Disabled components are still uploaded (not omitted).** Omitting them would make Atmos Pro's
+`markMissingAsOrphaned` reconciler mark them `orphaned`, which is wrong. Uploading them as
+`pro.enabled: false` makes Atmos Pro show them `disabled`.
+
+**No Atmos Pro code change is required.** `settings.pro.enabled` already maps to `instances.enabled`,
+and the upsert transitions automatically on the next upload: `enabled true→false` sets `disabled_at`,
+`drift_enabled true→false` sets `drift_status = "disabled"`. The stuck `error` rows self-heal — no
+data migration.
+
+## Verification
+
+- `go test ./pkg/list/...` — new `TestExtractProSettings*` cases plus the updated toast tests pass.
+- End-to-end against `cloudposse/infra-live`: after this change ships, run
+  `atmos list instances --upload` and confirm in Neon (`super-paper-60425112`, table `instances`)
+  that the `core-gbl-*` / `e98d-*` `datadog-configuration` + `datadog-integration` rows flip to
+  `enabled=false`, `drift_enabled=false`, `drift_status=disabled`, `disabled_at` set.
+- Confirm the next scheduled drift cycle no longer dispatches them (no new `missing_plan_result`
+  runs for those stack/component pairs).
+
+## Recommendations
+
+- **Atmos Pro could also accept `metadata.enabled` defensively.** This fix closes the gap at the
+  source (the CLI), but the ingestion contract still has no `metadata` field. Persisting it would
+  make the platform robust against older CLIs that predate this fix.
+- **Duplicate-repository rows are a separate issue.** Several `core-gbl-*` stacks have two
+  `datadog-configuration` rows (distinct `repository_id`, both `deleted_at IS NULL`). That is a
+  distinct duplicate-repository question, not addressed here.

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -313,8 +313,11 @@ func proSettingEnabled(pro map[string]any) bool {
 
 // driftSettingEnabled reads settings.pro.drift_detection.enabled, defaulting to
 // false. Only an explicit boolean true enables drift detection.
+// The drift block is normalized with sanitizeForJSON first: nested YAML maps can
+// arrive as map[interface{}]interface{}, which would otherwise fail the
+// map[string]any assertion and read as "no drift block".
 func driftSettingEnabled(pro map[string]any) bool {
-	drift, ok := pro[driftDetectionKey].(map[string]any)
+	drift, ok := sanitizeForJSON(pro[driftDetectionKey]).(map[string]any)
 	if !ok {
 		return false
 	}
@@ -335,7 +338,10 @@ func driftSettingEnabled(pro map[string]any) bool {
 // payload (extractProSettings) and the success-toast counts, so the two can
 // never diverge.
 func effectiveEnabledState(settings, metadata map[string]any) (proEnabled, driftEnabled bool) {
-	pro, ok := settings[proSettingsKey].(map[string]any)
+	// Normalize with sanitizeForJSON first: the pro subtree parsed from YAML can
+	// be map[interface{}]interface{}, which would otherwise fail the
+	// map[string]any assertion and incorrectly read as "no pro block".
+	pro, ok := sanitizeForJSON(settings[proSettingsKey]).(map[string]any)
 	if !ok {
 		return false, false
 	}

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -351,11 +351,11 @@ func effectiveEnabledState(settings, metadata map[string]any) (proEnabled, drift
 }
 
 // metadataDisabledPro reports whether metadata.enabled: false is the reason an
-// otherwise Pro-enabled instance collapses to disabled. It is true only when the
-// pro block itself would be enabled (pro.enabled true or defaulted) but
-// metadata.enabled is explicitly false, i.e. the outer metadata disable is what
-// squashes pro.enabled to false in the upload payload. Used only for a debug log
-// so operators can trace why a component is uploaded as disabled.
+// otherwise Pro-enabled instance is uploaded as disabled. It is true only when
+// the pro block itself would be enabled (pro.enabled true or defaulted) but
+// metadata.enabled is explicitly false, i.e. the higher-precedence metadata
+// disable overrides pro.enabled to false in the upload payload. Used only for a
+// debug log so operators can trace why a component is uploaded as disabled.
 func metadataDisabledPro(settings, metadata map[string]any) bool {
 	pro, ok := sanitizeForJSON(settings[proSettingsKey]).(map[string]any)
 	if !ok {
@@ -500,7 +500,7 @@ func uploadInstancesWithDeps(
 	uploadInstances := make([]dtos.UploadInstance, len(instances))
 	for i, inst := range instances {
 		if metadataDisabledPro(inst.Settings, inst.Metadata) {
-			log.Debug("Collapsing pro.enabled to false for upload: metadata.enabled is false",
+			log.Debug("Overriding pro.enabled to false for upload: metadata.enabled is false",
 				KeyComponent, inst.Component, KeyStack, inst.Stack)
 		}
 		uploadInstances[i] = dtos.UploadInstance{

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -350,6 +350,20 @@ func effectiveEnabledState(settings, metadata map[string]any) (proEnabled, drift
 	return proEnabled, driftEnabled
 }
 
+// metadataDisabledPro reports whether metadata.enabled: false is the reason an
+// otherwise Pro-enabled instance collapses to disabled. It is true only when the
+// pro block itself would be enabled (pro.enabled true or defaulted) but
+// metadata.enabled is explicitly false, i.e. the outer metadata disable is what
+// squashes pro.enabled to false in the upload payload. Used only for a debug log
+// so operators can trace why a component is uploaded as disabled.
+func metadataDisabledPro(settings, metadata map[string]any) bool {
+	pro, ok := sanitizeForJSON(settings[proSettingsKey]).(map[string]any)
+	if !ok {
+		return false
+	}
+	return proSettingEnabled(pro) && !metadataEnabled(metadata)
+}
+
 // isProEnabled reports whether an instance is effectively Atmos Pro enabled,
 // honoring the metadata.enabled > pro.enabled precedence.
 func isProEnabled(instance *schema.Instance) bool {
@@ -485,6 +499,10 @@ func uploadInstancesWithDeps(
 	// Sensitive data (vars, env, backend) never leaves this boundary.
 	uploadInstances := make([]dtos.UploadInstance, len(instances))
 	for i, inst := range instances {
+		if metadataDisabledPro(inst.Settings, inst.Metadata) {
+			log.Debug("Collapsing pro.enabled to false for upload: metadata.enabled is false",
+				KeyComponent, inst.Component, KeyStack, inst.Stack)
+		}
 		uploadInstances[i] = dtos.UploadInstance{
 			Component:     inst.Component,
 			Stack:         inst.Stack,

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -283,38 +283,90 @@ func createInstance(stackName, componentName, componentType string, componentCon
 	return instance
 }
 
-// isProEnabled checks if an instance has Atmos Pro enabled.
-// Returns true only if settings.pro.enabled is the boolean true.
-// Non-boolean values (e.g., the string "true") and missing values return false.
-func isProEnabled(instance *schema.Instance) bool {
-	proSettings, ok := instance.Settings["pro"].(map[string]any)
+// Stack-section keys used when collapsing the Atmos Pro enabled hierarchy.
+const (
+	proSettingsKey    = "pro"
+	enabledKey        = "enabled"
+	driftDetectionKey = "drift_detection"
+)
+
+// metadataEnabled reports whether a component's metadata marks it enabled.
+// Mirrors isComponentEnabled (internal/exec/component_utils.go): a component is
+// enabled by default; only an explicit metadata.enabled: false disables it.
+func metadataEnabled(metadata map[string]any) bool {
+	if enabled, ok := metadata[enabledKey].(bool); ok {
+		return enabled
+	}
+	return true
+}
+
+// proSettingEnabled reads settings.pro.enabled, defaulting to true.
+// Only an explicit boolean false disables; a missing or non-boolean value
+// (e.g. the string "true") defaults to true, matching the Atmos Pro server-side
+// default. The caller is responsible for confirming a pro block exists.
+func proSettingEnabled(pro map[string]any) bool {
+	if enabled, ok := pro[enabledKey].(bool); ok {
+		return enabled
+	}
+	return true
+}
+
+// driftSettingEnabled reads settings.pro.drift_detection.enabled, defaulting to
+// false. Only an explicit boolean true enables drift detection.
+func driftSettingEnabled(pro map[string]any) bool {
+	drift, ok := pro[driftDetectionKey].(map[string]any)
 	if !ok {
 		return false
 	}
-
-	enabled, ok := proSettings["enabled"].(bool)
+	enabled, ok := drift[enabledKey].(bool)
 	return ok && enabled
 }
 
-// isDriftEnabled checks if an instance has drift detection enabled.
-// Returns true only if settings.pro.drift_detection.enabled is the boolean true.
+// effectiveEnabledState collapses the enabled hierarchy
+// metadata.enabled > settings.pro.enabled > settings.pro.drift_detection.enabled.
+// An outer disable forces all inner levels off, so the single signal Atmos Pro
+// persists already reflects the component's resolved state:
+//
+//	proEnabled   = metadata.enabled && pro.enabled                     (both default true)
+//	driftEnabled = proEnabled       && pro.drift_detection.enabled     (drift defaults false)
+//
+// A missing pro block means the instance is not Pro-enabled (and therefore not
+// drift-enabled). This is the single source of truth shared by both the upload
+// payload (extractProSettings) and the success-toast counts, so the two can
+// never diverge.
+func effectiveEnabledState(settings, metadata map[string]any) (proEnabled, driftEnabled bool) {
+	pro, ok := settings[proSettingsKey].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	proEnabled = metadataEnabled(metadata) && proSettingEnabled(pro)
+	driftEnabled = proEnabled && driftSettingEnabled(pro)
+	return proEnabled, driftEnabled
+}
+
+// isProEnabled reports whether an instance is effectively Atmos Pro enabled,
+// honoring the metadata.enabled > pro.enabled precedence.
+func isProEnabled(instance *schema.Instance) bool {
+	proEnabled, _ := effectiveEnabledState(instance.Settings, instance.Metadata)
+	return proEnabled
+}
+
+// isDriftEnabled reports whether an instance is effectively drift-enabled.
+// Drift requires the instance to be effectively Pro-enabled, so an outer
+// metadata.enabled: false or pro.enabled: false disables drift regardless of
+// settings.pro.drift_detection.enabled.
 func isDriftEnabled(instance *schema.Instance) bool {
-	proSettings, ok := instance.Settings["pro"].(map[string]any)
-	if !ok {
-		return false
-	}
-	drift, ok := proSettings["drift_detection"].(map[string]any)
-	if !ok {
-		return false
-	}
-	enabled, ok := drift["enabled"].(bool)
-	return ok && enabled
+	_, driftEnabled := effectiveEnabledState(instance.Settings, instance.Metadata)
+	return driftEnabled
 }
 
 // countEnabledDisabled returns counts of pro-enabled and non-enabled instances,
-// plus the number with drift detection enabled.
-// "Disabled" covers both explicit `settings.pro.enabled: false` and instances
-// with no `pro` config at all.
+// plus the number with drift detection enabled. Counts use the effective state
+// (metadata.enabled > pro.enabled > drift_detection.enabled), so they match
+// exactly what is uploaded to Atmos Pro.
+// "Disabled" covers explicit `settings.pro.enabled: false`, instances disabled
+// via `metadata.enabled: false`, and instances with no `pro` config at all.
+// Drift is counted only when the instance is effectively pro-enabled.
 func countEnabledDisabled(instances []schema.Instance) (enabled, disabled, drift int) {
 	for i := range instances {
 		if isProEnabled(&instances[i]) {
@@ -431,7 +483,7 @@ func uploadInstancesWithDeps(
 			Component:     inst.Component,
 			Stack:         inst.Stack,
 			ComponentType: inst.ComponentType,
-			Settings:      extractProSettings(inst.Settings),
+			Settings:      extractProSettings(inst.Settings, inst.Metadata),
 		}
 	}
 
@@ -788,19 +840,42 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 // Returns nil if settings is nil or has no "pro" key.
 // Sanitizes nested maps to ensure JSON compatibility (converting
 // map[interface{}]interface{} from YAML to map[string]interface{}).
-func extractProSettings(settings map[string]any) map[string]any {
+//
+// Before upload it collapses the enabled hierarchy
+// (metadata.enabled > pro.enabled > drift_detection.enabled) so the values
+// Atmos Pro persists already reflect any outer disable. Atmos Pro's ingestion
+// contract has no `metadata` field, so a component disabled via
+// `metadata.enabled: false` would otherwise be uploaded as enabled and keep
+// getting dispatched for drift detection. The collapse runs on the sanitized
+// copy, so the source instance (used by the toast counts) is never mutated.
+func extractProSettings(settings, metadata map[string]any) map[string]any {
 	if settings == nil {
 		return nil
 	}
 
-	pro, hasPro := settings["pro"]
+	pro, hasPro := settings[proSettingsKey]
 	if !hasPro {
 		return nil
 	}
 
-	return map[string]any{
-		"pro": sanitizeForJSON(pro),
+	sanitized := sanitizeForJSON(pro)
+
+	// When pro is not a map (malformed config, e.g. a stray string), there is
+	// nothing to collapse; pass it through unchanged.
+	proMap, ok := sanitized.(map[string]any)
+	if !ok {
+		return map[string]any{proSettingsKey: sanitized}
 	}
+
+	proEnabled, driftEnabled := effectiveEnabledState(settings, metadata)
+	proMap[enabledKey] = proEnabled
+	// Only override an existing drift_detection block. When none exists, Atmos
+	// Pro already defaults drift to false, so synthesizing one adds noise.
+	if drift, ok := proMap[driftDetectionKey].(map[string]any); ok {
+		drift[enabledKey] = driftEnabled
+	}
+
+	return map[string]any{proSettingsKey: proMap}
 }
 
 // sanitizeForJSON recursively converts map[interface{}]interface{} to

--- a/pkg/list/list_instances_cmd_test.go
+++ b/pkg/list/list_instances_cmd_test.go
@@ -129,7 +129,7 @@ func TestListInstancesCommandLogic(t *testing.T) {
 						Component:     inst.Component,
 						Stack:         inst.Stack,
 						ComponentType: inst.ComponentType,
-						Settings:      extractProSettings(inst.Settings),
+						Settings:      extractProSettings(inst.Settings, inst.Metadata),
 					}
 				}
 				dto := dtos.InstancesUploadRequest{Instances: uploadDeps}

--- a/pkg/list/list_instances_pro_test.go
+++ b/pkg/list/list_instances_pro_test.go
@@ -509,3 +509,65 @@ func TestExtractProSettingsIsolation(t *testing.T) {
 	srcDrift["enabled"] = "changed-after"
 	assert.Equal(t, "mutated", resultDrift["enabled"], "result drift_detection must be independent of later source mutation")
 }
+
+// TestMetadataDisabledPro verifies detection of the metadata-caused collapse used
+// for the upload debug log: it is true only when the pro block would be enabled
+// but metadata.enabled is explicitly false.
+func TestMetadataDisabledPro(t *testing.T) {
+	testCases := []struct {
+		name     string
+		settings map[string]any
+		metadata map[string]any
+		expected bool
+	}{
+		{
+			name:     "metadata false squashes enabled pro",
+			settings: map[string]any{"pro": map[string]any{"enabled": true}},
+			metadata: map[string]any{"enabled": false},
+			expected: true,
+		},
+		{
+			name:     "metadata false squashes defaulted pro (drift_detection only)",
+			settings: map[string]any{"pro": map[string]any{"drift_detection": map[string]any{"enabled": true}}},
+			metadata: map[string]any{"enabled": false},
+			expected: true,
+		},
+		{
+			name:     "YAML-shaped pro block still detected",
+			settings: map[string]any{"pro": map[interface{}]interface{}{"enabled": true}},
+			metadata: map[string]any{"enabled": false},
+			expected: true,
+		},
+		{
+			name:     "metadata enabled is not a squash",
+			settings: map[string]any{"pro": map[string]any{"enabled": true}},
+			metadata: map[string]any{"enabled": true},
+			expected: false,
+		},
+		{
+			name:     "no metadata is not a squash",
+			settings: map[string]any{"pro": map[string]any{"enabled": true}},
+			metadata: nil,
+			expected: false,
+		},
+		{
+			// pro.enabled is already false, so metadata is not the cause.
+			name:     "pro already disabled is not a metadata squash",
+			settings: map[string]any{"pro": map[string]any{"enabled": false}},
+			metadata: map[string]any{"enabled": false},
+			expected: false,
+		},
+		{
+			name:     "no pro block is not a squash",
+			settings: map[string]any{},
+			metadata: map[string]any{"enabled": false},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, metadataDisabledPro(tc.settings, tc.metadata))
+		})
+	}
+}

--- a/pkg/list/list_instances_pro_test.go
+++ b/pkg/list/list_instances_pro_test.go
@@ -363,7 +363,7 @@ func TestExtractProSettings(t *testing.T) {
 		expectDrift bool
 	}{
 		{
-			// The Neon core-gbl-* bug case: component disabled upstream via
+			// The reported bug case: component disabled upstream via
 			// metadata.enabled, but pro.enabled + drift both true.
 			name: "metadata disabled forces pro and drift off",
 			settings: map[string]any{"pro": map[string]any{

--- a/pkg/list/list_instances_pro_test.go
+++ b/pkg/list/list_instances_pro_test.go
@@ -146,6 +146,23 @@ func TestIsProEnabled(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// Regression: the pro subtree parsed from YAML can be
+			// map[interface{}]interface{}. The effective-state helpers must
+			// normalize it (sanitizeForJSON) before reading enabled, otherwise a
+			// valid Pro config reads as disabled.
+			name: "YAML-shaped pro block (map[interface{}]interface{}) is pro-enabled",
+			instance: &schema.Instance{
+				Component: "vpc",
+				Stack:     "dev",
+				Settings: map[string]interface{}{
+					"pro": map[interface{}]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -201,6 +218,15 @@ func TestCountEnabledDisabled(t *testing.T) {
 			"drift_detection": map[string]any{"enabled": true},
 		}},
 		Metadata: map[string]any{"enabled": false},
+	}
+	// Regression: pro and the nested drift_detection block parsed from YAML can
+	// be map[interface{}]interface{}. The helpers must normalize these before
+	// counting, otherwise this enabled+drift instance is miscounted as disabled.
+	yamlShapedDriftInst := schema.Instance{
+		Settings: map[string]any{"pro": map[interface{}]interface{}{
+			"enabled":         true,
+			"drift_detection": map[interface{}]interface{}{"enabled": true},
+		}},
 	}
 
 	testCases := []struct {
@@ -290,6 +316,15 @@ func TestCountEnabledDisabled(t *testing.T) {
 			instances:        []schema.Instance{enabledWithDriftInst, disabledWithDriftInst, enabledInst, noProInst},
 			expectedEnabled:  2,
 			expectedDisabled: 2,
+			expectedDrift:    1,
+		},
+		{
+			// YAML-shaped (map[interface{}]interface{}) pro + drift blocks must be
+			// counted as enabled with drift on.
+			name:             "YAML-shaped pro and drift blocks counted correctly",
+			instances:        []schema.Instance{yamlShapedDriftInst},
+			expectedEnabled:  1,
+			expectedDisabled: 0,
 			expectedDrift:    1,
 		},
 	}
@@ -467,4 +502,10 @@ func TestExtractProSettingsIsolation(t *testing.T) {
 	// Mutating the source after extraction must not affect the already-returned result.
 	srcPro["enabled"] = "changed-after"
 	assert.Equal(t, "mutated", pro["enabled"], "result must be independent of later source mutation")
+
+	// Same reverse-direction check for the nested drift_detection block: mutating
+	// the source drift map must not reach into the already-returned result.
+	resultDrift := pro["drift_detection"].(map[string]any)
+	srcDrift["enabled"] = "changed-after"
+	assert.Equal(t, "mutated", resultDrift["enabled"], "result drift_detection must be independent of later source mutation")
 }

--- a/pkg/list/list_instances_pro_test.go
+++ b/pkg/list/list_instances_pro_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/schema"
 )
@@ -59,7 +60,10 @@ func TestIsProEnabled(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "pro enabled missing (drift_detection alone is not enough)",
+			// pro.enabled defaults to true when a pro block is present, matching
+			// the Atmos Pro server-side default. A drift_detection block alone is
+			// therefore enough for the instance to be pro-enabled.
+			name: "pro enabled defaults true when pro block present (drift_detection only)",
 			instance: &schema.Instance{
 				Component: "vpc",
 				Stack:     "dev",
@@ -71,7 +75,7 @@ func TestIsProEnabled(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "no pro settings",
@@ -94,7 +98,9 @@ func TestIsProEnabled(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "enabled not a bool (string)",
+			// A non-boolean enabled value (malformed config) defaults to true,
+			// matching the Atmos Pro server-side default.
+			name: "enabled not a bool (string) defaults true",
 			instance: &schema.Instance{
 				Component: "vpc",
 				Stack:     "dev",
@@ -104,7 +110,41 @@ func TestIsProEnabled(t *testing.T) {
 					},
 				},
 			},
+			expected: true,
+		},
+		{
+			// metadata.enabled: false forces pro off regardless of pro.enabled.
+			name: "metadata.enabled false overrides pro.enabled true",
+			instance: &schema.Instance{
+				Component: "vpc",
+				Stack:     "dev",
+				Settings: map[string]interface{}{
+					"pro": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				Metadata: map[string]interface{}{
+					"enabled": false,
+				},
+			},
 			expected: false,
+		},
+		{
+			// metadata.enabled: true is the default and does not change anything.
+			name: "metadata.enabled true keeps pro.enabled true",
+			instance: &schema.Instance{
+				Component: "vpc",
+				Stack:     "dev",
+				Settings: map[string]interface{}{
+					"pro": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				Metadata: map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			expected: true,
 		},
 	}
 
@@ -117,8 +157,11 @@ func TestIsProEnabled(t *testing.T) {
 }
 
 // TestCountEnabledDisabled verifies the tally used in the success toast.
-// "Disabled" covers both explicit `pro.enabled: false` and instances with no `pro` config.
-// Drift counts instances where `pro.drift_detection.enabled: true`, independent of pro.enabled.
+// The tally uses the effective state (metadata.enabled > pro.enabled >
+// drift_detection.enabled), so it matches exactly what is uploaded.
+// "Disabled" covers explicit `pro.enabled: false`, `metadata.enabled: false`,
+// and instances with no `pro` config. Drift counts instances where
+// `pro.drift_detection.enabled: true` AND the instance is effectively pro-enabled.
 func TestCountEnabledDisabled(t *testing.T) {
 	enabledInst := schema.Instance{
 		Settings: map[string]any{"pro": map[string]any{"enabled": true}},
@@ -149,6 +192,15 @@ func TestCountEnabledDisabled(t *testing.T) {
 			"enabled":         true,
 			"drift_detection": map[string]any{"enabled": false},
 		}},
+	}
+	// metadata.enabled: false forces pro (and therefore drift) off even though
+	// pro.enabled and drift_detection.enabled are both true.
+	metadataDisabledInst := schema.Instance{
+		Settings: map[string]any{"pro": map[string]any{
+			"enabled":         true,
+			"drift_detection": map[string]any{"enabled": true},
+		}},
+		Metadata: map[string]any{"enabled": false},
 	}
 
 	testCases := []struct {
@@ -187,10 +239,11 @@ func TestCountEnabledDisabled(t *testing.T) {
 			expectedDrift:    0,
 		},
 		{
-			name:             "non-bool enabled counts as disabled (strict bool)",
+			// A non-bool enabled value defaults to true (matches Atmos Pro).
+			name:             "non-bool enabled defaults to enabled",
 			instances:        []schema.Instance{nonBoolEnabledInst},
-			expectedEnabled:  0,
-			expectedDisabled: 1,
+			expectedEnabled:  1,
+			expectedDisabled: 0,
 			expectedDrift:    0,
 		},
 		{
@@ -208,11 +261,21 @@ func TestCountEnabledDisabled(t *testing.T) {
 			expectedDrift:    1,
 		},
 		{
-			name:             "drift counted even when pro disabled",
+			// Drift requires effective pro-enabled, so an instance with
+			// pro.enabled: false is not counted as drift-enabled.
+			name:             "drift not counted when pro disabled",
 			instances:        []schema.Instance{disabledWithDriftInst},
 			expectedEnabled:  0,
 			expectedDisabled: 1,
-			expectedDrift:    1,
+			expectedDrift:    0,
+		},
+		{
+			// metadata.enabled: false forces pro and drift off.
+			name:             "metadata.enabled false disables pro and drift",
+			instances:        []schema.Instance{metadataDisabledInst},
+			expectedEnabled:  0,
+			expectedDisabled: 1,
+			expectedDrift:    0,
 		},
 		{
 			name:             "drift_detection.enabled false not counted",
@@ -222,11 +285,12 @@ func TestCountEnabledDisabled(t *testing.T) {
 			expectedDrift:    0,
 		},
 		{
+			// disabledWithDriftInst is pro-disabled, so its drift does not count.
 			name:             "mixed with drift",
 			instances:        []schema.Instance{enabledWithDriftInst, disabledWithDriftInst, enabledInst, noProInst},
 			expectedEnabled:  2,
 			expectedDisabled: 2,
-			expectedDrift:    2,
+			expectedDrift:    1,
 		},
 	}
 
@@ -238,4 +302,169 @@ func TestCountEnabledDisabled(t *testing.T) {
 			assert.Equal(t, tc.expectedDrift, drift, "drift count")
 		})
 	}
+}
+
+// proMap is a helper for reading the nested pro block from an extractProSettings result.
+func proMap(t *testing.T, got map[string]any) map[string]any {
+	t.Helper()
+	require.NotNil(t, got, "expected a non-nil result")
+	pro, ok := got["pro"].(map[string]any)
+	require.True(t, ok, "expected result[\"pro\"] to be a map, got %T", got["pro"])
+	return pro
+}
+
+// TestExtractProSettings verifies that the upload payload collapses the enabled
+// hierarchy metadata.enabled > pro.enabled > drift_detection.enabled so the
+// values Atmos Pro persists already reflect any outer disable.
+func TestExtractProSettings(t *testing.T) {
+	testCases := []struct {
+		name          string
+		settings      map[string]any
+		metadata      map[string]any
+		expectNil     bool
+		expectEnabled bool
+		// expectDrift is only asserted when the source had a drift_detection block.
+		hasDrift    bool
+		expectDrift bool
+	}{
+		{
+			// The Neon core-gbl-* bug case: component disabled upstream via
+			// metadata.enabled, but pro.enabled + drift both true.
+			name: "metadata disabled forces pro and drift off",
+			settings: map[string]any{"pro": map[string]any{
+				"enabled":         true,
+				"drift_detection": map[string]any{"enabled": true},
+			}},
+			metadata:      map[string]any{"enabled": false},
+			expectEnabled: false,
+			hasDrift:      true,
+			expectDrift:   false,
+		},
+		{
+			// metadata disabled, no explicit pro.enabled (defaults true), drift on.
+			name: "metadata disabled with implicit pro.enabled and drift on",
+			settings: map[string]any{"pro": map[string]any{
+				"drift_detection": map[string]any{"enabled": true},
+			}},
+			metadata:      map[string]any{"enabled": false},
+			expectEnabled: false,
+			hasDrift:      true,
+			expectDrift:   false,
+		},
+		{
+			name: "enabled component keeps pro and drift on",
+			settings: map[string]any{"pro": map[string]any{
+				"enabled":         true,
+				"drift_detection": map[string]any{"enabled": true},
+			}},
+			metadata:      map[string]any{"enabled": true},
+			expectEnabled: true,
+			hasDrift:      true,
+			expectDrift:   true,
+		},
+		{
+			name: "no metadata defaults to enabled",
+			settings: map[string]any{"pro": map[string]any{
+				"enabled":         true,
+				"drift_detection": map[string]any{"enabled": true},
+			}},
+			metadata:      nil,
+			expectEnabled: true,
+			hasDrift:      true,
+			expectDrift:   true,
+		},
+		{
+			name: "pro disabled forces drift off",
+			settings: map[string]any{"pro": map[string]any{
+				"enabled":         false,
+				"drift_detection": map[string]any{"enabled": true},
+			}},
+			metadata:      nil,
+			expectEnabled: false,
+			hasDrift:      true,
+			expectDrift:   false,
+		},
+		{
+			name: "implicit pro.enabled defaults true",
+			settings: map[string]any{"pro": map[string]any{
+				"drift_detection": map[string]any{"enabled": false},
+			}},
+			metadata:      nil,
+			expectEnabled: true,
+			hasDrift:      true,
+			expectDrift:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractProSettings(tc.settings, tc.metadata)
+			pro := proMap(t, got)
+
+			enabled, ok := pro["enabled"].(bool)
+			require.True(t, ok, "expected pro.enabled to be a bool")
+			assert.Equal(t, tc.expectEnabled, enabled, "pro.enabled")
+
+			if tc.hasDrift {
+				drift, ok := pro["drift_detection"].(map[string]any)
+				require.True(t, ok, "expected drift_detection block to be preserved")
+				driftEnabled, ok := drift["enabled"].(bool)
+				require.True(t, ok, "expected drift_detection.enabled to be a bool")
+				assert.Equal(t, tc.expectDrift, driftEnabled, "drift_detection.enabled")
+			}
+		})
+	}
+}
+
+// TestExtractProSettingsEdgeCases covers nil/absent/malformed inputs.
+func TestExtractProSettingsEdgeCases(t *testing.T) {
+	t.Run("nil settings returns nil", func(t *testing.T) {
+		assert.Nil(t, extractProSettings(nil, nil))
+	})
+
+	t.Run("no pro key returns nil", func(t *testing.T) {
+		assert.Nil(t, extractProSettings(map[string]any{"spacelift": map[string]any{}}, nil))
+	})
+
+	t.Run("non-map pro passes through unchanged", func(t *testing.T) {
+		got := extractProSettings(map[string]any{"pro": "invalid"}, nil)
+		require.NotNil(t, got)
+		assert.Equal(t, "invalid", got["pro"])
+	})
+
+	t.Run("no drift_detection block is not synthesized", func(t *testing.T) {
+		got := extractProSettings(map[string]any{"pro": map[string]any{"enabled": true}}, nil)
+		pro := proMap(t, got)
+		_, hasDrift := pro["drift_detection"]
+		assert.False(t, hasDrift, "drift_detection should not be synthesized when absent")
+	})
+}
+
+// TestExtractProSettingsIsolation verifies the result is a copy: mutating it does
+// not affect the source instance, and the source is not aliased into the result.
+func TestExtractProSettingsIsolation(t *testing.T) {
+	settings := map[string]any{"pro": map[string]any{
+		"enabled":         true,
+		"drift_detection": map[string]any{"enabled": true},
+	}}
+	metadata := map[string]any{"enabled": false}
+
+	got := extractProSettings(settings, metadata)
+	pro := proMap(t, got)
+
+	// The collapse must not have mutated the source settings.
+	srcPro := settings["pro"].(map[string]any)
+	assert.Equal(t, true, srcPro["enabled"], "source pro.enabled must be untouched")
+	srcDrift := srcPro["drift_detection"].(map[string]any)
+	assert.Equal(t, true, srcDrift["enabled"], "source drift_detection.enabled must be untouched")
+
+	// Mutating the result must not reach back into the source.
+	pro["enabled"] = "mutated"
+	pro["drift_detection"].(map[string]any)["enabled"] = "mutated"
+	assert.Equal(t, true, srcPro["enabled"], "mutating result must not affect source pro.enabled")
+	assert.Equal(t, true, srcDrift["enabled"], "mutating result must not affect source drift_detection.enabled")
+
+	// Mutating the source after extraction must not affect the already-returned result.
+	srcPro["enabled"] = "changed-after"
+	assert.Equal(t, "mutated", pro["enabled"], "result must be independent of later source mutation")
 }

--- a/website/docs/cli/commands/list/list-instances.mdx
+++ b/website/docs/cli/commands/list/list-instances.mdx
@@ -57,7 +57,7 @@ The `atmos list instances` command displays all component instances defined acro
   <dd>Sort by column:order (e.g., `stack:asc,component:desc`)</dd>
 
   <dt>`--upload`</dt>
-  <dd>Upload instances to Atmos Pro API (requires Pro configuration). Every real (non-abstract) instance is uploaded; `settings.pro.enabled` is preserved verbatim in the payload so Atmos Pro can reconcile enabled vs. disabled state server-side.</dd>
+  <dd>Upload instances to Atmos Pro API (requires Pro configuration). Every real (non-abstract) instance is uploaded — including disabled ones, so Atmos Pro can show them as disabled rather than losing track of them. Before upload, Atmos collapses the enabled hierarchy (`metadata.enabled` &gt; `settings.pro.enabled` &gt; `settings.pro.drift_detection.enabled`), so the uploaded values already reflect any outer disable.</dd>
 
   <dt>`--output-file` / `-o`</dt>
   <dd>Write output to file in `key=value` format (for `$GITHUB_OUTPUT`). Only supported with `--format=matrix`.</dd>
@@ -141,7 +141,15 @@ Upload instances to Atmos Pro:
 atmos list instances --upload
 ```
 
-The upload includes **every real (non-abstract) instance**, regardless of whether Atmos Pro is enabled for it. The `settings.pro.enabled` flag is preserved verbatim in the payload, so Atmos Pro can reconcile which instances are active vs. disabled on the server side (e.g., grey out disabled instances in the UI rather than losing track of them):
+The upload includes **every real (non-abstract) instance**, regardless of whether Atmos Pro is enabled for it, so Atmos Pro can keep disabled instances visible (e.g., grey them out in the UI) rather than losing track of them.
+
+Before upload, Atmos collapses the enabled hierarchy so the values it sends already reflect any outer disable:
+
+```
+metadata.enabled  >  settings.pro.enabled  >  settings.pro.drift_detection.enabled
+```
+
+An outer disable always wins: a component disabled with `metadata.enabled: false` is uploaded as `settings.pro.enabled: false` and `settings.pro.drift_detection.enabled: false`, so Atmos Pro never dispatches it for drift detection.
 
 ```yaml
 components:
@@ -149,22 +157,32 @@ components:
     vpc:
       settings:
         pro:
-          enabled: true    # Uploaded as enabled
+          enabled: true            # Uploaded as enabled
+          drift_detection:
+            enabled: true          # Uploaded with drift enabled
     app:
       settings:
         pro:
-          enabled: false   # Uploaded as disabled — Atmos Pro keeps it visible but marks it inactive
+          enabled: false           # Uploaded as disabled
     db:
       # No pro config — uploaded as disabled
+    monitoring:
+      metadata:
+        enabled: false             # Disabled component…
+      settings:
+        pro:
+          enabled: true
+          drift_detection:
+            enabled: true          # …collapsed to enabled:false, drift:false before upload
 ```
 
 On completion, the command reports a tally:
 
 ```
-Successfully uploaded 3 instances to Atmos Pro API (1 enabled, 2 disabled, 1 drift enabled).
+Successfully uploaded 4 instances to Atmos Pro API (1 enabled, 3 disabled, 1 drift enabled).
 ```
 
-The `drift enabled` count reflects instances with `settings.pro.drift_detection.enabled: true` and is independent of `pro.enabled` — an instance can have drift detection enabled even if its `pro.enabled` flag is `false`.
+The tally reflects the **effective** state — the same values that are uploaded. The `drift enabled` count requires the instance to be effectively Pro-enabled, so an instance with `settings.pro.enabled: false` (or `metadata.enabled: false`) is never counted as drift-enabled even if `settings.pro.drift_detection.enabled: true`.
 
 If the repository has no instances at all, the command prints `No instances found; nothing to upload.` and exits successfully.
 
@@ -352,7 +370,7 @@ atmos list instances --columns "stack,component,vars.region,enabled"
 - Use `--format tree --provenance` to visualize component import hierarchies
 - Use the `--filter` flag for complex filtering with YQ syntax
 - Combine `--stack` (glob pattern) with `--filter` (YQ expression) for precise filtering
-- The `--upload` flag sends every real instance to Atmos Pro; `settings.pro.enabled` is included in the payload so Atmos Pro decides enabled vs. disabled server-side
+- The `--upload` flag sends every real instance to Atmos Pro; the effective `settings.pro.enabled` (collapsed from `metadata.enabled` &gt; `pro.enabled`) is included in the payload so Atmos Pro shows enabled vs. disabled state
 - Use `--format json` or `--format yaml` for programmatic processing
 :::
 

--- a/website/docs/cli/configuration/settings/pro.mdx
+++ b/website/docs/cli/configuration/settings/pro.mdx
@@ -67,6 +67,27 @@ settings:
 ## Configuration Reference
 
 <dl>
+  <dt>`settings.pro.enabled`</dt>
+  <dd>
+    Master switch for Atmos Pro on a component or stack. When `atmos list instances --upload`
+    sends the inventory to Atmos Pro, this value controls whether the instance is tracked as
+    active or shown as disabled.
+
+    Atmos collapses an enabled hierarchy before upload, so an outer disable always wins:
+
+    ```
+    metadata.enabled  >  settings.pro.enabled  >  settings.pro.drift_detection.enabled
+    ```
+
+    Disabling a component with [`metadata.enabled: false`](/stacks/components/component-metadata#enabled)
+    forces `settings.pro.enabled` (and therefore `settings.pro.drift_detection.enabled`) off in the
+    uploaded payload — a disabled component is never dispatched for drift detection or workflow runs,
+    regardless of its `pro` settings.
+
+    - **Type:** `boolean`
+    - **Default:** `true` (when a `settings.pro` block is present)
+  </dd>
+
   <dt>`settings.pro.base_url`</dt>
   <dd>
     Base URL for the Atmos Pro API.
@@ -337,6 +358,12 @@ settings:
   <dt>`settings.pro.drift_detection.enabled`</dt>
   <dd>
     Enable Atmos Pro drift detection for this stack.
+
+    Effective drift detection also requires the component to be effectively Pro-enabled. An outer
+    [`metadata.enabled: false`](/stacks/components/component-metadata#enabled) or
+    `settings.pro.enabled: false` disables drift detection regardless of this value — Atmos
+    collapses the hierarchy (`metadata.enabled` &gt; `pro.enabled` &gt; `drift_detection.enabled`)
+    before upload so a disabled component is never dispatched for drift.
 
     - **Type:** `boolean`
     - **Default:** `false`


### PR DESCRIPTION
## what

- `atmos list instances --upload` now collapses the Atmos Pro enabled hierarchy (`metadata.enabled` > `settings.pro.enabled` > `settings.pro.drift_detection.enabled`) before uploading, so the values Atmos Pro persists already reflect any outer disable.
- A shared `effectiveEnabledState` helper is the single source of truth for both the upload payload (`extractProSettings`) and the success-toast counts, so they can no longer diverge.
- Disabled components are still uploaded (as `pro.enabled: false`) rather than omitted, so Atmos Pro shows them disabled instead of orphaning them.
- Reference docs corrected (`settings/pro.mdx` gains a `settings.pro.enabled` entry + precedence note; `list/list-instances.mdx` drops the now-false "preserved verbatim" / "drift is independent of pro.enabled" claims), plus a `docs/fixes/` write-up.

## why

- Components disabled upstream via `metadata.enabled: false` kept failing scheduled drift detection (`dispatchError: "missing_plan_result"`, `drift_status: error`): the CLI skips planning them, but the upload serialized the raw `settings.pro` block and never sent `metadata.enabled`, so Atmos Pro (whose ingestion contract has no `metadata` field) persisted them as `enabled:true, drift_enabled:true` and legitimately dispatched drift.
- Fixing it in the CLI keeps the determination where it is already resolved and needs no Atmos Pro change: the stuck `error` rows self-heal to `disabled` on the next upload, with no data migration.
- `pro.enabled` defaults to `true` (matching the Pro server-side default) so the collapse only ever turns things off when an outer level is explicitly disabled — it never regresses default-enabled components.

## references

- `docs/fixes/2026-06-03-drift-dispatch-ignores-metadata-enabled.md` (root-cause analysis, Neon `instances` evidence, verification steps)
- Source of truth for the disabled determination: `internal/exec/component_utils.go` (`isComponentEnabled`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolve upload so component enablement honors metadata.enabled, preventing metadata-disabled components from remaining scheduled for drift and correcting counts; disabled components are uploaded as disabled rather than omitted.

* **Documentation**
  * Clarify enablement precedence (metadata.enabled > settings.pro.enabled > drift_detection.enabled), upload behavior, and how effective Pro/drift state is reflected in UI counts.

* **Tests**
  * Add unit and end-to-end tests validating effective enablement resolution, drift counting, and uploaded payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->