### PR TITLE
fix(auth): deduplicate ECR, ECR Public, and EKS integrations to once per process

### DIFF
--- a/pkg/auth/manager_integrations.go
+++ b/pkg/auth/manager_integrations.go
@@ -25,10 +25,7 @@ var processIntegrationCache sync.Map
 // resetProcessIntegrationCache clears the integration execution cache.
 // Intended for use in tests to ensure isolation between test cases.
 func resetProcessIntegrationCache() {
-	processIntegrationCache.Range(func(key, _ any) bool {
-		processIntegrationCache.Delete(key)
-		return true
-	})
+	processIntegrationCache.Clear()
 }
 
 // integrationTargetKey returns a canonical cache key for an integration.

--- a/pkg/auth/manager_integrations.go
+++ b/pkg/auth/manager_integrations.go
@@ -42,6 +42,9 @@ func integrationTargetKey(name string, cfg schema.Integration) string {
 		if cfg.Spec != nil && cfg.Spec.Registry != nil {
 			return "aws/ecr:" + cfg.Spec.Registry.AccountID + ":" + cfg.Spec.Registry.Region
 		}
+	case integrations.KindAWSECRPublic:
+		// ECR Public is a single global registry — no account or region discriminator needed.
+		return integrations.KindAWSECRPublic
 	case integrations.KindAWSEKS:
 		if cfg.Spec != nil && cfg.Spec.Cluster != nil {
 			return "aws/eks:" + cfg.Spec.Cluster.Name + ":" + cfg.Spec.Cluster.Region

--- a/pkg/auth/manager_integrations.go
+++ b/pkg/auth/manager_integrations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth/integrations"
@@ -13,9 +14,46 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
+// processIntegrationCache tracks integrations already executed in this process.
+// Auto-provisioned integrations (e.g. ECR login, EKS kubeconfig) should run only once per
+// process regardless of how many times Authenticate is called or which AuthManager instance
+// triggers them. The key is the integration's canonical target (e.g. "aws/ecr:account:region")
+// rather than its config name, so two integration entries in a merged config that point to
+// the same ECR registry or EKS cluster are deduplicated to a single execution.
+var processIntegrationCache sync.Map
+
+// resetProcessIntegrationCache clears the integration execution cache.
+// Intended for use in tests to ensure isolation between test cases.
+func resetProcessIntegrationCache() {
+	processIntegrationCache.Range(func(key, _ any) bool {
+		processIntegrationCache.Delete(key)
+		return true
+	})
+}
+
+// integrationTargetKey returns a canonical cache key for an integration.
+// For ECR integrations: "aws/ecr:<account_id>:<region>" — two configs pointing at the same
+// registry (e.g. a global + component-level duplicate) collapse to a single login.
+// For EKS integrations: "aws/eks:<cluster_name>:<region>" — same dedup logic for kubeconfig.
+// All other integration types fall back to the config name to preserve existing behaviour.
+func integrationTargetKey(name string, cfg schema.Integration) string {
+	switch cfg.Kind {
+	case integrations.KindAWSECR:
+		if cfg.Spec != nil && cfg.Spec.Registry != nil {
+			return "aws/ecr:" + cfg.Spec.Registry.AccountID + ":" + cfg.Spec.Registry.Region
+		}
+	case integrations.KindAWSEKS:
+		if cfg.Spec != nil && cfg.Spec.Cluster != nil {
+			return "aws/eks:" + cfg.Spec.Cluster.Name + ":" + cfg.Spec.Cluster.Region
+		}
+	}
+	return name
+}
+
 // triggerIntegrations executes integrations that reference this identity with auto_provision enabled.
 // This is a non-fatal operation - integration failures don't block authentication.
 // Skipped when context contains skipIntegrationsKey (used by ExecuteIntegration to avoid duplicate execution).
+// Each integration target is executed at most once per process (deduplicated via processIntegrationCache).
 func (m *manager) triggerIntegrations(ctx context.Context, identityName string, creds types.ICredentials) {
 	defer perf.Track(nil, "auth.Manager.triggerIntegrations")()
 
@@ -33,10 +71,19 @@ func (m *manager) triggerIntegrations(ctx context.Context, identityName string, 
 
 	log.Debug("Triggering linked integrations", logKeyIdentity, identityName, "count", len(linkedIntegrations))
 
-	// Execute each linked integration.
+	// Execute each linked integration, skipping any whose target has already been provisioned.
+	// cacheKey is based on the integration's effective target (registry URL, cluster name) rather
+	// than its config name so that duplicate entries from merged global+component configs that
+	// point to the same endpoint are collapsed to a single execution.
 	for _, integrationName := range linkedIntegrations {
+		cacheKey := integrationTargetKey(integrationName, m.config.Integrations[integrationName])
+		if _, alreadyRan := processIntegrationCache.LoadOrStore(cacheKey, struct{}{}); alreadyRan {
+			log.Debug("Skipping already-executed integration", "integration", integrationName, "target", cacheKey)
+			continue
+		}
 		if err := m.executeIntegration(ctx, integrationName, creds); err != nil {
-			// Non-fatal: log warning and continue.
+			// Non-fatal: evict the cache entry so a retry on the next command is possible.
+			processIntegrationCache.Delete(cacheKey)
 			log.Warn("Integration failed", "integration", integrationName, "error", err)
 		}
 	}

--- a/pkg/auth/manager_integrations_test.go
+++ b/pkg/auth/manager_integrations_test.go
@@ -250,6 +250,18 @@ func TestIntegrationTargetKey(t *testing.T) {
 			want: "my-eks",
 		},
 		{
+			name:        "ECR Public always returns fixed key",
+			intName:     "my-ecr-public",
+			integration: schema.Integration{Kind: "aws/ecr-public"},
+			want:        "aws/ecr-public",
+		},
+		{
+			name:        "ECR Public with spec also returns fixed key",
+			intName:     "ecr-public-component",
+			integration: schema.Integration{Kind: "aws/ecr-public", Spec: &schema.IntegrationSpec{Registry: &schema.ECRRegistry{Region: "us-east-1"}}},
+			want:        "aws/ecr-public",
+		},
+		{
 			name:    "unknown kind uses name",
 			intName: "custom-integration",
 			integration: schema.Integration{

--- a/pkg/auth/manager_integrations_test.go
+++ b/pkg/auth/manager_integrations_test.go
@@ -204,6 +204,104 @@ func TestManager_ExecuteIntegration_EmptyIdentity(t *testing.T) {
 	assert.Contains(t, err.Error(), "no identity configured")
 }
 
+func TestIntegrationTargetKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		intName     string
+		integration schema.Integration
+		want        string
+	}{
+		{
+			name:    "ECR with registry",
+			intName: "my-ecr",
+			integration: schema.Integration{
+				Kind: "aws/ecr",
+				Spec: &schema.IntegrationSpec{
+					Registry: &schema.ECRRegistry{AccountID: "123456789012", Region: "us-east-1"},
+				},
+			},
+			want: "aws/ecr:123456789012:us-east-1",
+		},
+		{
+			name:    "ECR without spec falls back to name",
+			intName: "my-ecr",
+			integration: schema.Integration{
+				Kind: "aws/ecr",
+			},
+			want: "my-ecr",
+		},
+		{
+			name:    "EKS with cluster",
+			intName: "my-eks",
+			integration: schema.Integration{
+				Kind: "aws/eks",
+				Spec: &schema.IntegrationSpec{
+					Cluster: &schema.EKSCluster{Name: "prod-cluster", Region: "us-west-2"},
+				},
+			},
+			want: "aws/eks:prod-cluster:us-west-2",
+		},
+		{
+			name:    "EKS without spec falls back to name",
+			intName: "my-eks",
+			integration: schema.Integration{
+				Kind: "aws/eks",
+			},
+			want: "my-eks",
+		},
+		{
+			name:    "unknown kind uses name",
+			intName: "custom-integration",
+			integration: schema.Integration{
+				Kind: "custom/type",
+			},
+			want: "custom-integration",
+		},
+		{
+			name:    "two ECR integrations same registry produce same key",
+			intName: "ecr-component",
+			integration: schema.Integration{
+				Kind: "aws/ecr",
+				Spec: &schema.IntegrationSpec{
+					Registry: &schema.ECRRegistry{AccountID: "123456789012", Region: "us-east-1"},
+				},
+			},
+			want: "aws/ecr:123456789012:us-east-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := integrationTargetKey(tt.intName, tt.integration)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIntegrationTargetKey_Deduplication verifies that two ECR integrations pointing at the
+// same registry are treated as one execution (the second is skipped via the process cache).
+func TestIntegrationTargetKey_Deduplication(t *testing.T) {
+	resetProcessIntegrationCache()
+	t.Cleanup(resetProcessIntegrationCache)
+
+	registrySpec := &schema.IntegrationSpec{
+		Registry: &schema.ECRRegistry{AccountID: "123456789012", Region: "us-east-1"},
+	}
+
+	// Two different integration names, same registry.
+	keyA := integrationTargetKey("ecr-global", schema.Integration{Kind: "aws/ecr", Spec: registrySpec})
+	keyB := integrationTargetKey("ecr-component", schema.Integration{Kind: "aws/ecr", Spec: registrySpec})
+	assert.Equal(t, keyA, keyB, "same registry must produce the same cache key")
+
+	// First store: should not already be present.
+	_, alreadyRan := processIntegrationCache.LoadOrStore(keyA, struct{}{})
+	assert.False(t, alreadyRan, "first integration should not be cached yet")
+
+	// Second store with same key: should be skipped.
+	_, alreadyRan = processIntegrationCache.LoadOrStore(keyB, struct{}{})
+	assert.True(t, alreadyRan, "second integration pointing at same registry must be deduplicated")
+}
+
 func TestManager_ExecuteIdentityIntegrations_Errors(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## What

  Adds a process-level execution cache to `triggerIntegrations` so that
  auto-provisioned integrations (`aws/ecr`, `aws/ecr-public`, `aws/eks`)
  fire at most once per `atmos` invocation, regardless of how many times
  `Authenticate` is called or how many `AuthManager` instances are created.

  The cache key is the integration's canonical target endpoint rather than
  its config entry name:
  - `aws/ecr`        → `"aws/ecr:<account_id>:<region>"`
  - `aws/ecr-public` → `"aws/ecr-public"` (single global registry)
  - `aws/eks`        → `"aws/eks:<cluster_name>:<region>"`
  - everything else  → integration name (no behaviour change)

  This means two config entries that point at the same registry — e.g. one
  from global `atmos.yaml` and one from a component stack file — are
  collapsed to a single execution.

  ## Why

  `atmos terraform plan` calls `Authenticate` from at least three internal
  paths: `setupTerraformAuth`, `TerraformPreHook`, and one call per YAML
  function (`!store.get`, `!terraform.state`). With a 6-tool `.tool-versions`
  this produced 6 ECR logins per command. Switching to a name-keyed cache
  reduced it to 2 because merged configs can carry two integration entries
  with different names for the same registry. Keying by target endpoint
  reduces this to exactly 1.

  ## Changes

  - `pkg/auth/manager_integrations.go` — adds `processIntegrationCache
    sync.Map`, `resetProcessIntegrationCache()` (test helper),
    `integrationTargetKey()` (canonical key helper covering `aws/ecr`,
    `aws/ecr-public`, `aws/eks`); updates `triggerIntegrations` to use
    `LoadOrStore` on the target key.
  - `pkg/auth/manager_integrations_test.go` — adds
    `TestIntegrationTargetKey` (table-driven tests for all key variants
    including ECR Public) and `TestIntegrationTargetKey_Deduplication`
    (verifies that two same-registry entries produce one cache hit).

  ## Notes

  `aws/ecr-public` was added to `upstream/main` in #2231 after this branch
  diverged; coverage for it was added here to keep deduplication consistent
  across all three AWS integration kinds.

## references

ECR / ECR Public Login Executes Multiple Times Per atmos terraform Invocation
 [#2562](https://github.com/cloudposse/atmos/issues/2562)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process-level deduplication for auto-provisioned integrations to prevent redundant provisioning of the same target within a single process.
  * Failed provisioning attempts are evicted from the dedupe cache so retries can proceed.

* **Tests**
  * Added unit tests validating cache key behavior and deduplication scenarios to ensure consistent provisioning outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->