### PR TITLE
fix(list): prevent nil pointer panic when spinner exits early

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -80,6 +80,7 @@ var (
 	ErrTerminalTooNarrow                     = errors.New("terminal too narrow")
 	ErrSpinnerReturnedNilModel               = errors.New("spinner returned nil model")
 	ErrSpinnerUnexpectedModelType            = errors.New("spinner returned unexpected model type")
+	ErrSpinnerOperationInterrupted           = errors.New("operation was interrupted")
 
 	// Theme-related errors.
 	ErrThemeNotFound = errors.New("theme not found")
@@ -675,6 +676,7 @@ var (
 	ErrTopologicalOrder             = errors.New("topological sort failed")
 	ErrFormatForLogging             = errors.New("format affected for logging failed")
 	ErrQueryEvaluation              = errors.New("query evaluation failed")
+	ErrNilResult                    = errors.New("nil result")
 
 	// Cache-related errors.
 	ErrCacheLocked    = errors.New("cache file is locked")

--- a/pkg/list/list_affected.go
+++ b/pkg/list/list_affected.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/auth"
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -136,6 +137,10 @@ func ExecuteListAffectedCmd(opts *AffectedCommandOptions) error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to get affected components: %w", err)
+	}
+
+	if result == nil {
+		return fmt.Errorf("%w: getAffectedComponents returned a nil result", errUtils.ErrNilResult)
 	}
 
 	if len(result.Affected) == 0 {

--- a/pkg/ui/spinner/spinner.go
+++ b/pkg/ui/spinner/spinner.go
@@ -69,12 +69,15 @@ func ExecWithSpinner(progressMsg, completedMsg string, operation func() error) e
 // reported completion (e.g. the user pressed ctrl+c).
 func evaluateSpinnerResult(finalModel tea.Model, spinnerErr error) error {
 	if spinnerErr != nil {
-		return fmt.Errorf("spinner error: %w", spinnerErr)
+		return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrTUIRun, spinnerErr)
+	}
+	if finalModel == nil {
+		return errUtils.ErrSpinnerReturnedNilModel
 	}
 
 	m, ok := finalModel.(spinnerModel)
 	if !ok {
-		return nil
+		return fmt.Errorf("%w: got %T", errUtils.ErrSpinnerUnexpectedModelType, finalModel)
 	}
 	if m.err != nil {
 		return m.err
@@ -213,12 +216,15 @@ func ExecWithSpinnerDynamic(progressMsg string, operation func() (string, error)
 // ctrl+c).
 func evaluateDynamicSpinnerResult(finalModel tea.Model, spinnerErr error) error {
 	if spinnerErr != nil {
-		return fmt.Errorf("spinner error: %w", spinnerErr)
+		return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrTUIRun, spinnerErr)
+	}
+	if finalModel == nil {
+		return errUtils.ErrSpinnerReturnedNilModel
 	}
 
 	m, ok := finalModel.(dynamicSpinnerModel)
 	if !ok {
-		return nil
+		return fmt.Errorf("%w: got %T", errUtils.ErrSpinnerUnexpectedModelType, finalModel)
 	}
 	if m.err != nil {
 		return m.err

--- a/pkg/ui/spinner/spinner.go
+++ b/pkg/ui/spinner/spinner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/internal/tui/templates/term"
 	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/perf"
@@ -45,19 +46,41 @@ func ExecWithSpinner(progressMsg, completedMsg string, operation func() error) e
 		tea.WithoutSignalHandler(),
 	)
 
-	// Run operation in background.
+	// goroutineDone is closed once the operation finishes, guaranteeing that any
+	// side effects of the operation have completed before ExecWithSpinner returns.
+	goroutineDone := make(chan struct{})
 	go func() {
+		defer close(goroutineDone)
 		err := operation()
 		p.Send(opCompleteMsg{err: err})
 	}()
 
-	finalModel, err := p.Run()
-	if err != nil {
-		return fmt.Errorf("spinner error: %w", err)
+	finalModel, spinnerErr := p.Run()
+
+	// Always wait for the operation goroutine to finish before returning.
+	<-goroutineDone
+
+	return evaluateSpinnerResult(finalModel, spinnerErr)
+}
+
+// evaluateSpinnerResult interprets the outcome of a finished ExecWithSpinner run.
+// It returns a spinner-level error, the operation's own error, or
+// ErrSpinnerOperationInterrupted if the spinner exited before the operation
+// reported completion (e.g. the user pressed ctrl+c).
+func evaluateSpinnerResult(finalModel tea.Model, spinnerErr error) error {
+	if spinnerErr != nil {
+		return fmt.Errorf("spinner error: %w", spinnerErr)
 	}
 
-	if m, ok := finalModel.(spinnerModel); ok && m.err != nil {
+	m, ok := finalModel.(spinnerModel)
+	if !ok {
+		return nil
+	}
+	if m.err != nil {
 		return m.err
+	}
+	if !m.done {
+		return errUtils.ErrSpinnerOperationInterrupted
 	}
 
 	return nil
@@ -163,19 +186,45 @@ func ExecWithSpinnerDynamic(progressMsg string, operation func() (string, error)
 		tea.WithoutSignalHandler(),
 	)
 
-	// Run operation in background.
+	// goroutineDone is closed once the operation finishes, guaranteeing that any
+	// values the operation wrote (e.g. via a closure) are visible to the caller
+	// after ExecWithSpinnerDynamic returns.
+	goroutineDone := make(chan struct{})
 	go func() {
+		defer close(goroutineDone)
 		completedMsg, err := operation()
 		p.Send(opCompleteDynamicMsg{completedMsg: completedMsg, err: err})
 	}()
 
-	finalModel, err := p.Run()
-	if err != nil {
-		return fmt.Errorf("spinner error: %w", err)
+	finalModel, spinnerErr := p.Run()
+
+	// Always wait for the operation goroutine to finish before returning.
+	// This prevents callers from reading uninitialized closure variables when
+	// the bubbletea program exits before the operation completes (e.g. ctrl+c).
+	<-goroutineDone
+
+	return evaluateDynamicSpinnerResult(finalModel, spinnerErr)
+}
+
+// evaluateDynamicSpinnerResult interprets the outcome of a finished
+// ExecWithSpinnerDynamic run. It returns a spinner-level error, the
+// operation's own error, or ErrSpinnerOperationInterrupted if the spinner
+// exited before the operation reported completion (e.g. the user pressed
+// ctrl+c).
+func evaluateDynamicSpinnerResult(finalModel tea.Model, spinnerErr error) error {
+	if spinnerErr != nil {
+		return fmt.Errorf("spinner error: %w", spinnerErr)
 	}
 
-	if m, ok := finalModel.(dynamicSpinnerModel); ok && m.err != nil {
+	m, ok := finalModel.(dynamicSpinnerModel)
+	if !ok {
+		return nil
+	}
+	if m.err != nil {
 		return m.err
+	}
+	if !m.done {
+		return errUtils.ErrSpinnerOperationInterrupted
 	}
 
 	return nil

--- a/pkg/ui/spinner/spinner_test.go
+++ b/pkg/ui/spinner/spinner_test.go
@@ -8,6 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 func TestNewSpinnerModel(t *testing.T) {
@@ -164,6 +166,104 @@ func TestExecWithSpinner_NonTTY(t *testing.T) {
 		// Either way, we should get some error back.
 		_ = err // Accept either error
 	})
+}
+
+// TestEvaluateSpinnerResults covers evaluateSpinnerResult and
+// evaluateDynamicSpinnerResult together via a shared table, since both
+// functions interpret the same {spinnerErr, m.done, m.err} outcomes for
+// their respective model types.
+func TestEvaluateSpinnerResults(t *testing.T) {
+	spinnerErr := errors.New("tea program failed")
+	opErr := errors.New("operation failed")
+
+	tests := []struct {
+		name       string
+		eval       func(tea.Model, error) error
+		finalModel tea.Model
+		spinnerErr error
+		wantErr    error
+	}{
+		{
+			name:       "spinnerModel: returns spinner error wrapped when p.Run fails",
+			eval:       evaluateSpinnerResult,
+			finalModel: spinnerModel{},
+			spinnerErr: spinnerErr,
+			wantErr:    spinnerErr,
+		},
+		{
+			name:       "spinnerModel: returns operation error from completed model",
+			eval:       evaluateSpinnerResult,
+			finalModel: spinnerModel{done: true, err: opErr},
+			wantErr:    opErr,
+		},
+		{
+			name:       "spinnerModel: returns nil for a normally completed model",
+			eval:       evaluateSpinnerResult,
+			finalModel: spinnerModel{done: true, err: nil},
+		},
+		{
+			// This reproduces the scenario where the bubbletea program exits
+			// (e.g. ctrl+c) before the operation goroutine sends its completion
+			// message: m.done stays false and m.err stays nil.
+			name:       "spinnerModel: returns ErrSpinnerOperationInterrupted when model never completed",
+			eval:       evaluateSpinnerResult,
+			finalModel: spinnerModel{done: false, err: nil},
+			wantErr:    errUtils.ErrSpinnerOperationInterrupted,
+		},
+		{
+			name:       "spinnerModel: returns nil when final model has unexpected type",
+			eval:       evaluateSpinnerResult,
+			finalModel: dynamicSpinnerModel{},
+		},
+		{
+			name:       "dynamicSpinnerModel: returns spinner error wrapped when p.Run fails",
+			eval:       evaluateDynamicSpinnerResult,
+			finalModel: dynamicSpinnerModel{},
+			spinnerErr: spinnerErr,
+			wantErr:    spinnerErr,
+		},
+		{
+			name:       "dynamicSpinnerModel: returns operation error from completed model",
+			eval:       evaluateDynamicSpinnerResult,
+			finalModel: dynamicSpinnerModel{done: true, err: opErr},
+			wantErr:    opErr,
+		},
+		{
+			name:       "dynamicSpinnerModel: returns nil for a normally completed model",
+			eval:       evaluateDynamicSpinnerResult,
+			finalModel: dynamicSpinnerModel{done: true, err: nil},
+		},
+		{
+			// This reproduces the `atmos list affected` crash: the bubbletea
+			// program exits (e.g. ctrl+c) before the operation goroutine sends
+			// opCompleteDynamicMsg, so m.done stays false and m.err stays nil.
+			// Previously this fell through to `return nil`, leaving the
+			// caller's result variable nil and causing a nil pointer
+			// dereference.
+			name:       "dynamicSpinnerModel: returns ErrSpinnerOperationInterrupted when model never completed",
+			eval:       evaluateDynamicSpinnerResult,
+			finalModel: dynamicSpinnerModel{done: false, err: nil},
+			wantErr:    errUtils.ErrSpinnerOperationInterrupted,
+		},
+		{
+			name:       "dynamicSpinnerModel: returns nil when final model has unexpected type",
+			eval:       evaluateDynamicSpinnerResult,
+			finalModel: spinnerModel{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.eval(tt.finalModel, tt.spinnerErr)
+
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }
 
 // Tests for dynamicSpinnerModel.

--- a/pkg/ui/spinner/spinner_test.go
+++ b/pkg/ui/spinner/spinner_test.go
@@ -177,18 +177,26 @@ func TestEvaluateSpinnerResults(t *testing.T) {
 	opErr := errors.New("operation failed")
 
 	tests := []struct {
-		name       string
-		eval       func(tea.Model, error) error
-		finalModel tea.Model
-		spinnerErr error
-		wantErr    error
+		name        string
+		eval        func(tea.Model, error) error
+		finalModel  tea.Model
+		spinnerErr  error
+		wantErr     error
+		wantErrAlso error // additional sentinel that must also match via errors.Is.
 	}{
 		{
-			name:       "spinnerModel: returns spinner error wrapped when p.Run fails",
+			name:        "spinnerModel: returns spinner error wrapped when p.Run fails",
+			eval:        evaluateSpinnerResult,
+			finalModel:  spinnerModel{},
+			spinnerErr:  spinnerErr,
+			wantErr:     spinnerErr,
+			wantErrAlso: errUtils.ErrTUIRun,
+		},
+		{
+			name:       "spinnerModel: returns ErrSpinnerReturnedNilModel when final model is nil",
 			eval:       evaluateSpinnerResult,
-			finalModel: spinnerModel{},
-			spinnerErr: spinnerErr,
-			wantErr:    spinnerErr,
+			finalModel: nil,
+			wantErr:    errUtils.ErrSpinnerReturnedNilModel,
 		},
 		{
 			name:       "spinnerModel: returns operation error from completed model",
@@ -211,16 +219,24 @@ func TestEvaluateSpinnerResults(t *testing.T) {
 			wantErr:    errUtils.ErrSpinnerOperationInterrupted,
 		},
 		{
-			name:       "spinnerModel: returns nil when final model has unexpected type",
+			name:       "spinnerModel: returns ErrSpinnerUnexpectedModelType when final model has unexpected type",
 			eval:       evaluateSpinnerResult,
 			finalModel: dynamicSpinnerModel{},
+			wantErr:    errUtils.ErrSpinnerUnexpectedModelType,
 		},
 		{
-			name:       "dynamicSpinnerModel: returns spinner error wrapped when p.Run fails",
+			name:        "dynamicSpinnerModel: returns spinner error wrapped when p.Run fails",
+			eval:        evaluateDynamicSpinnerResult,
+			finalModel:  dynamicSpinnerModel{},
+			spinnerErr:  spinnerErr,
+			wantErr:     spinnerErr,
+			wantErrAlso: errUtils.ErrTUIRun,
+		},
+		{
+			name:       "dynamicSpinnerModel: returns ErrSpinnerReturnedNilModel when final model is nil",
 			eval:       evaluateDynamicSpinnerResult,
-			finalModel: dynamicSpinnerModel{},
-			spinnerErr: spinnerErr,
-			wantErr:    spinnerErr,
+			finalModel: nil,
+			wantErr:    errUtils.ErrSpinnerReturnedNilModel,
 		},
 		{
 			name:       "dynamicSpinnerModel: returns operation error from completed model",
@@ -246,15 +262,20 @@ func TestEvaluateSpinnerResults(t *testing.T) {
 			wantErr:    errUtils.ErrSpinnerOperationInterrupted,
 		},
 		{
-			name:       "dynamicSpinnerModel: returns nil when final model has unexpected type",
+			name:       "dynamicSpinnerModel: returns ErrSpinnerUnexpectedModelType when final model has unexpected type",
 			eval:       evaluateDynamicSpinnerResult,
 			finalModel: spinnerModel{},
+			wantErr:    errUtils.ErrSpinnerUnexpectedModelType,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.eval(tt.finalModel, tt.spinnerErr)
+
+			if tt.wantErrAlso != nil {
+				assert.ErrorIs(t, err, tt.wantErrAlso)
+			}
 
 			if tt.wantErr == nil {
 				assert.NoError(t, err)


### PR DESCRIPTION
## what

  - Fix `atmos list affected` panicking with a nil pointer dereference (`result.Affected`) when the spinner program exits before the background operation reports completion.
  - `ExecWithSpinner` / `ExecWithSpinnerDynamic` now wait for the operation goroutine to finish (`<-goroutineDone`) before returning.
  - New `evaluateSpinnerResult` / `evaluateDynamicSpinnerResult` helpers distinguish three outcomes: a spinner-level error, the operation's own error, or an interrupted/never-completed run (new
  `ErrSpinnerOperationInterrupted`).
  - `ExecuteListAffectedCmd` now defensively checks for a `nil` result and returns a wrapped `ErrNilResult` instead of dereferencing it.
  - Added a table-driven test (`TestEvaluateSpinnerResults`) covering both spinner result evaluators across all outcome combinations.

  ## why

  - `atmos list affected` could crash with `runtime error: invalid memory address or nil pointer dereference` at `pkg/list/list_affected.go:141`. This happened when the bubbletea spinner's `p.Run()`
  returned before the background goroutine running `getAffectedComponents` finished — e.g. when many concurrent stderr writes (such as repeated ECR login messages, see #2564) corrupted the spinner's
  render loop, or when the user pressed ctrl+c.
  - The previous code only checked `finalModel.err != nil` and otherwise returned `nil`, so the caller proceeded with a `nil` result and panicked.
  - This makes the spinner helpers robust regardless of *why* the bubbletea program exits early, giving `list affected` (and any other caller of `ExecWithSpinnerDynamic`) a clear error instead of a
  crash.

  ## references

  - Closes #2590
  - Related: #2564 (reduces how often this race is triggered, but doesn't fix the underlying synchronization bug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spinner completion and error handling for interrupted operations
  * Added detection and reporting of nil-result cases to avoid crashes
  * Standardized error propagation and messaging for spinner-related failures

* **Tests**
  * Added tests covering spinner completion, interruption, nil results, unexpected outcomes, and error mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->