### PR TITLE
fix(ci): use localhost endpoints in LocalStack demo to avoid DNS hangs

### DIFF
--- a/examples/demo-localstack/README.md
+++ b/examples/demo-localstack/README.md
@@ -1,7 +1,9 @@
 
 ## Notes
 
-When running Terraform with LocalStack, if you get the following warning from Terraform, you should not enable `skip_requesting_account_id`. Older versions of LocalStack required this, but not anymore.
+When running Terraform with LocalStack, this example uses path-style S3 on `http://localhost:4566` and enables `skip_requesting_account_id` so the AWS provider does not block on account identity lookups or wildcard DNS/TLS resolution in CI. Without these settings, Terraform can hang before printing the first plan when LocalStack-backed provider setup is slow or incomplete.
+
+The following Terraform warning is expected with this setting:
 
 ```console
 Warning: AWS account ID not found for provider

--- a/examples/demo-localstack/stacks/mixins/localstack.yaml
+++ b/examples/demo-localstack/stacks/mixins/localstack.yaml
@@ -12,15 +12,16 @@ terraform:
       region: "us-east-1"
       access_key: "test"
       secret_key: "test"
-      s3_use_path_style: false
+      s3_use_path_style: true
       skip_credentials_validation: true
       skip_metadata_api_check: true
+      skip_requesting_account_id: true
       endpoints:
-        # An alias for the default LocalStack URL
-        sts: &localstack_url "https://localhost.localstack.cloud:4566"
+        # An alias for the default LocalStack URL exposed by the GitHub Actions service.
+        sts: &localstack_url "http://localhost:4566"
 
-        # S3 is an exception, and requires a TLS endpoint
-        s3: "https://localhost.localstack.cloud:4566"
+        # Use path-style S3 on localhost to avoid wildcard DNS/TLS flakiness in CI.
+        s3: *localstack_url
 
         # Everything else can use HTTP on localhost
         apigateway: *localstack_url


### PR DESCRIPTION
## what

- Switch the `demo-localstack` example's AWS provider endpoints from `https://localhost.localstack.cloud:4566` to `http://localhost:4566`
- Enable `s3_use_path_style: true` so S3 operations don't depend on wildcard `*.localhost.localstack.cloud` DNS/TLS
- Add `skip_requesting_account_id: true` so provider configure doesn't block on identity lookups
- Update the example README to document the settings and the expected "AWS account ID not found for provider" warning

## why

The `[localstack] demo-localstack` CI job started hanging until the 20-minute timeout across **all branches** beginning 2026-06-10 ~02:18 UTC, with no corresponding code change (identical commits both passed and failed; the LocalStack image is pinned at `1.4.0` with the same build hash in green and red runs).

Root cause: `localhost.localstack.cloud` is a public DNS record hosted by LocalStack that resolves to `127.0.0.1`. After LocalStack EOL'd Community Edition (repo archived March 2026), their DNS zone was restructured on **2026-06-08 18:53 UTC** (SOA serial; the record is now a freshly delegated Route53 subzone). GitHub's Azure runners began intermittently failing to resolve the name ~31h later as resolver caches expired. The Terraform AWS provider treats DNS failure as retryable and backs off past the job timeout — hanging silently before its first API call.

Evidence:

- Every failed run hangs at the identical point: after `terraform workspace new dev-demo`, before the provider's first API call. The LocalStack container log shows exactly one completed request (`sts.GetSessionToken => 200` — issued by atmos auth, which uses `http://localhost:4566` and always succeeds). The provider's first call via `localhost.localstack.cloud` never arrives.
- A/B proof: on `osterman/fix-post-merge-sha`, a run with the old endpoints timed out at 13:43 UTC; the identical change in this PR passed at 13:53 UTC (run 27281214186).

Extending the timeout would not help — the provider's retry backoff exceeds any reasonable limit when DNS is failing.

## references

- Failing runs (examples): 27248701025, 27283701712, 27282384395, 27300390150 — all cancelled at the 20-min `[localstack]` job timeout
- Green run with this exact change: 27281214186
- LocalStack Community EOL: https://blog.localstack.cloud/the-road-ahead-for-localstack/ (the DNS zone change itself is unannounced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LocalStack example documentation and configuration for improved CI compatibility, clarifying expected Terraform behavior and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->