### PR TITLE
feat: add store-backed secrets with GCP Secret Manager and identity defaults

### DIFF
--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -120,8 +120,7 @@ func loadServiceAndConfig(scope secretScope) (*secrets.Service, *schema.AtmosCon
 
 	// Bridge auth credentials into identity-aware secret stores (lazy resolution).
 	if authManager != nil {
-		resolver := authbridge.NewResolver(authManager, authManager.GetStackInfo())
-		atmosConfig.Stores.SetAuthContextResolver(resolver)
+		injectSecretStoreAuthResolver(&atmosConfig, authManager, scope)
 	}
 
 	section, err := e.ExecuteDescribeComponent(&e.ExecuteDescribeComponentParams{
@@ -139,6 +138,26 @@ func loadServiceAndConfig(scope secretScope) (*secrets.Service, *schema.AtmosCon
 	}
 
 	return secrets.NewService(&atmosConfig, scope.Stack, scope.Component, section), &atmosConfig, nil
+}
+
+func injectSecretStoreAuthResolver(atmosConfig *schema.AtmosConfiguration, authManager auth.AuthManager, scope secretScope) {
+	resolver := authbridge.NewResolver(authManager, authManager.GetStackInfo())
+	atmosConfig.Stores.SetAuthContextResolverWithDefaultIdentity(resolver, secretStoreDefaultIdentity(authManager, scope.Identity))
+}
+
+func secretStoreDefaultIdentity(authManager auth.AuthManager, requestedIdentity string) string {
+	switch requestedIdentity {
+	case cfg.IdentityFlagDisabledValue:
+		return ""
+	case "", cfg.IdentityFlagSelectValue:
+		chain := authManager.GetChain()
+		if len(chain) == 0 {
+			return ""
+		}
+		return chain[len(chain)-1]
+	default:
+		return requestedIdentity
+	}
 }
 
 // buildAuthManager merges component auth and creates an authenticated manager for the scope.

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -149,6 +149,8 @@ func injectSecretStoreAuthResolver(atmosConfig *schema.AtmosConfiguration, authM
 	atmosConfig.Stores.SetAuthContextResolverWithDefaultIdentity(resolver, secretStoreDefaultIdentity(authManager, scope.Identity))
 }
 
+// secretStoreDefaultIdentity resolves secret store identity: disabled returns none,
+// empty/select uses the last authenticated identity, and explicit values pass through.
 func secretStoreDefaultIdentity(authManager auth.AuthManager, requestedIdentity string) string {
 	switch requestedIdentity {
 	case cfg.IdentityFlagDisabledValue:

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -37,7 +37,7 @@ func parseFacets(cmd *cobra.Command) (secretScope, error) {
 		Stack:         v.GetString(cfg.StackStr),
 		Component:     v.GetString("component"),
 		ComponentType: v.GetString("type"),
-		Identity:      v.GetString(cfg.IdentityFlagName),
+		Identity:      secretScopeIdentity(v),
 	}, nil
 }
 
@@ -54,7 +54,7 @@ func parseScope(cmd *cobra.Command, args []string) (secretScope, error) {
 		Stack:         v.GetString(cfg.StackStr),
 		Component:     v.GetString("component"),
 		ComponentType: v.GetString("type"),
-		Identity:      v.GetString(cfg.IdentityFlagName),
+		Identity:      secretScopeIdentity(v),
 	}
 
 	if scope.Stack == "" {
@@ -87,6 +87,10 @@ func parseScope(cmd *cobra.Command, args []string) (secretScope, error) {
 			Err()
 	}
 	return scope, nil
+}
+
+func secretScopeIdentity(v *viper.Viper) string {
+	return cfg.NormalizeIdentityValue(v.GetString(cfg.IdentityFlagName))
 }
 
 // loadService initializes config + auth and returns a secrets.Service scoped to (stack,

--- a/cmd/secret/shared_loaders_test.go
+++ b/cmd/secret/shared_loaders_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	mockTypes "github.com/cloudposse/atmos/pkg/auth/types"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 )
 
 // writeMinimalAtmosProject writes a self-contained Atmos project (config + one stack + one
@@ -125,4 +128,60 @@ func TestBuildAuthManager_ComponentNotFound(t *testing.T) {
 	_, err = buildAuthManager(atmosConfig, secretScope{Stack: "dev", Component: "missing"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load component config for auth")
+}
+
+func TestSecretStoreDefaultIdentity(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		setup     func(*mockTypes.MockAuthManager)
+		want      string
+	}{
+		{
+			name:      "explicit identity",
+			requested: "gcp/prod-secrets",
+			want:      "gcp/prod-secrets",
+		},
+		{
+			name:      "empty identity uses final authenticated chain entry",
+			requested: "",
+			setup: func(m *mockTypes.MockAuthManager) {
+				m.EXPECT().GetChain().Return([]string{"gcp", "gcp/prod-secrets"})
+			},
+			want: "gcp/prod-secrets",
+		},
+		{
+			name:      "selected identity uses final authenticated chain entry",
+			requested: cfg.IdentityFlagSelectValue,
+			setup: func(m *mockTypes.MockAuthManager) {
+				m.EXPECT().GetChain().Return([]string{"gcp", "gcp/staging-secrets"})
+			},
+			want: "gcp/staging-secrets",
+		},
+		{
+			name:      "empty chain leaves store default empty",
+			requested: "",
+			setup: func(m *mockTypes.MockAuthManager) {
+				m.EXPECT().GetChain().Return([]string{})
+			},
+			want: "",
+		},
+		{
+			name:      "disabled identity does not inherit chain",
+			requested: cfg.IdentityFlagDisabledValue,
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			authManager := mockTypes.NewMockAuthManager(ctrl)
+			if tt.setup != nil {
+				tt.setup(authManager)
+			}
+
+			assert.Equal(t, tt.want, secretStoreDefaultIdentity(authManager, tt.requested))
+		})
+	}
 }

--- a/cmd/secret/shared_loaders_test.go
+++ b/cmd/secret/shared_loaders_test.go
@@ -13,6 +13,7 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	mockTypes "github.com/cloudposse/atmos/pkg/auth/types"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/schema"
 )
 
 // writeMinimalAtmosProject writes a self-contained Atmos project (config + one stack + one
@@ -129,6 +130,17 @@ func TestBuildAuthManager_ComponentNotFound(t *testing.T) {
 	_, err = buildAuthManager(atmosConfig, secretScope{Stack: "dev", Component: "missing"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load component config for auth")
+}
+
+func TestInjectSecretStoreAuthResolver(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	authManager := mockTypes.NewMockAuthManager(ctrl)
+	authManager.EXPECT().GetStackInfo().Return(&schema.ConfigAndStacksInfo{})
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	require.NotPanics(t, func() {
+		injectSecretStoreAuthResolver(atmosConfig, authManager, secretScope{Identity: "terraform-ci"})
+	})
 }
 
 func TestSecretStoreDefaultIdentity(t *testing.T) {

--- a/cmd/secret/shared_loaders_test.go
+++ b/cmd/secret/shared_loaders_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -182,6 +183,28 @@ func TestSecretStoreDefaultIdentity(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, secretStoreDefaultIdentity(authManager, tt.requested))
+		})
+	}
+}
+
+func TestSecretScopeIdentityNormalizesDisabledValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "explicit identity", input: "terraform", want: "terraform"},
+		{name: "false disables auth", input: "false", want: cfg.IdentityFlagDisabledValue},
+		{name: "off disables auth", input: "off", want: cfg.IdentityFlagDisabledValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.Set(cfg.IdentityFlagName, tt.input)
+
+			assert.Equal(t, tt.want, secretScopeIdentity(v))
 		})
 	}
 }

--- a/docs/prd/secrets-management.md
+++ b/docs/prd/secrets-management.md
@@ -868,6 +868,7 @@ stores:
   gcp-secrets:
     type: google-secret-manager
     secret: true
+    identity: gcp/prod-secrets
     options: { project_id: my-project }
 
   # 1Password — local dev (service account) or 1Password Connect for services inside a VPC.
@@ -888,6 +889,10 @@ stores:
 ```
 
 - Path generation reuses the store's existing namespacing: `{prefix}/{stack}/{component}/{secret_name}`.
+  Stack-scoped secrets omit the component segment (`{prefix}/{stack}/{secret_name}`); provider-specific delimiters still apply
+  (for example, GCP Secret Manager uses `_` because secret IDs cannot contain `/`).
+- Status/existence checks used by `list` and `validate` must be metadata-only and must not read the payload
+  (for example, GCP Secret Manager uses `GetSecret`, not `AccessSecretVersion`).
 - Encryption-at-rest + the sensitivity flag follow the [Store Sensitivity PRD](secrets-masking/store-sensitivity.md) — a `secret: true` store always writes the sensitive variant (e.g. SSM `SecureString`).
 
 ### Track 2: Non-store (SOPS)
@@ -1099,7 +1104,7 @@ pkg/schema/
 
 ### Phase 5: Non-store backends (Track 2) + remaining store types
 - **SOPS** native provider (`pkg/secrets/providers/sops.go`): `sops/age`, `sops/aws-kms`, `sops/gcp-kms`, `sops/gpg`
-- Wire Azure Key Vault and GCP Secret Manager (existing store types) for `secret: true` use
+- Wire GCP Secret Manager first for `secret: true` use; Azure Key Vault follows the same store-adapter contract as a follow-up
 - Future: vals-style read-only loaders as additional non-store providers
 
 ## Documentation Deliverables

--- a/docs/prd/secrets-management.md
+++ b/docs/prd/secrets-management.md
@@ -236,6 +236,9 @@ import:
 Each declaration references its backend by name: `store: <name>` for a `secret: true`
 store (track 1), or `sops: <name>` for a SOPS provider (track 2). The referenced
 backend carries provider/region/prefix/identity, so the declaration stays terse.
+Store-backed declarations may set `store_stack` and `store_component` to read/write an
+existing shared store namespace during migration from `!store <store> <stack> <component> <key>`.
+When omitted, the normal secret coordinate is derived from the current stack/component and scope.
 
 ### Component-Level Secrets (Stack Files)
 
@@ -250,6 +253,11 @@ components:
             description: "Datadog API key for monitoring"
             store: app-secrets
             required: true
+          SHARED_CLIENT_SECRET:
+            description: "Migrated from !store app-secrets atmos shared client_secret"
+            store: app-secrets
+            store_stack: atmos
+            store_component: shared
           REDIS_URL:
             description: "Redis connection string"
             store: app-secrets

--- a/docs/prd/secrets-masking/store-sensitivity.md
+++ b/docs/prd/secrets-masking/store-sensitivity.md
@@ -73,7 +73,8 @@ boolean, the provider must persist the sensitivity flag explicitly:
 - **Azure Key Vault** — write the reserved tag `atmos-sensitive=true` on the secret;
   read tags on `GetSecret`.
 - **GCP Secret Manager** — write the reserved label `atmos-sensitive=true` on the
-  secret; read labels on access.
+  secret; read labels from secret metadata. Existence/status checks should use
+  `GetSecret` metadata only and must not call `AccessSecretVersion`.
 
 > **Why the separator differs:** AWS Secrets Manager tag keys permit a colon, so the
 > colon form `atmos:sensitive=true` is used there. Azure Key Vault and GCP Secret

--- a/internal/gcp/auth.go
+++ b/internal/gcp/auth.go
@@ -1,12 +1,15 @@
 package gcp
 
 import (
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // AuthOptions contains configuration for Google Cloud authentication.
@@ -78,6 +81,35 @@ func GetClientOptions(opts AuthOptions) []option.ClientOption {
 	// If no explicit credentials or access token, Google Cloud client libraries
 	// will automatically use ADC (Application Default Credentials).
 	return clientOpts
+}
+
+// GetSecretManagerClientOptions returns Google Secret Manager client options.
+// When SECRET_MANAGER_EMULATOR_HOST is set, it configures the client for a local
+// plaintext gRPC emulator such as floci-gcp. Secret Manager has no official
+// emulator, so the Go SDK does not auto-detect this environment variable.
+func GetSecretManagerClientOptions(opts AuthOptions) []option.ClientOption {
+	if host := secretManagerEmulatorHost(); host != "" {
+		return []option.ClientOption{
+			option.WithEndpoint(host),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		}
+	}
+
+	return GetClientOptions(opts)
+}
+
+func secretManagerEmulatorHost() string {
+	host := strings.TrimSpace(os.Getenv("SECRET_MANAGER_EMULATOR_HOST"))
+	if host == "" {
+		return ""
+	}
+	if strings.Contains(host, "://") {
+		if parsed, err := url.Parse(host); err == nil && parsed.Host != "" {
+			return parsed.Host
+		}
+	}
+	return host
 }
 
 // GetCredentialsFromBackend extracts credentials from a Terraform backend configuration.

--- a/internal/gcp/auth_test.go
+++ b/internal/gcp/auth_test.go
@@ -61,6 +61,67 @@ func TestGetClientOptions(t *testing.T) {
 	}
 }
 
+func TestGetSecretManagerClientOptions(t *testing.T) {
+	t.Run("uses regular auth options without emulator", func(t *testing.T) {
+		t.Setenv("SECRET_MANAGER_EMULATOR_HOST", "")
+
+		clientOpts := GetSecretManagerClientOptions(AuthOptions{
+			Credentials: `{"type": "service_account", "project_id": "test"}`,
+		})
+		if len(clientOpts) != 1 {
+			t.Errorf("GetSecretManagerClientOptions() returned %d options, expected regular credentials option", len(clientOpts))
+		}
+	})
+
+	t.Run("uses plaintext emulator options when configured", func(t *testing.T) {
+		t.Setenv("SECRET_MANAGER_EMULATOR_HOST", "localhost:4588")
+
+		clientOpts := GetSecretManagerClientOptions(AuthOptions{
+			Credentials: `{"type": "service_account", "project_id": "test"}`,
+		})
+		if len(clientOpts) != 3 {
+			t.Errorf("GetSecretManagerClientOptions() returned %d options, expected emulator endpoint/auth/dial options", len(clientOpts))
+		}
+	})
+}
+
+func TestSecretManagerEmulatorHost(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "host port",
+			env:  "localhost:4588",
+			want: "localhost:4588",
+		},
+		{
+			name: "http URL",
+			env:  "http://localhost:4588",
+			want: "localhost:4588",
+		},
+		{
+			name: "https URL with path",
+			env:  "https://floci-gcp:4588/api",
+			want: "floci-gcp:4588",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SECRET_MANAGER_EMULATOR_HOST", tt.env)
+			if got := secretManagerEmulatorHost(); got != tt.want {
+				t.Errorf("secretManagerEmulatorHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetCredentialsFromBackend(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/secrets/registry.go
+++ b/pkg/secrets/registry.go
@@ -37,6 +37,8 @@ func ExtractDeclarations(componentSection map[string]any) map[string]Declaration
 		if spec, ok := raw.(map[string]any); ok {
 			decl.Description = stringField(spec, "description")
 			decl.Reference = stringField(spec, "reference")
+			decl.StoreStack = stringField(spec, "store_stack")
+			decl.StoreComponent = stringField(spec, "store_component")
 			decl.Required = boolField(spec, "required")
 			decl.Scope = scopeField(spec)
 			if store := stringField(spec, "store"); store != "" {

--- a/pkg/secrets/registry_test.go
+++ b/pkg/secrets/registry_test.go
@@ -12,9 +12,11 @@ func TestExtractDeclarations(t *testing.T) {
 		"secrets": map[string]any{
 			"vars": map[string]any{
 				"DATADOG_API_KEY": map[string]any{
-					"description": "Datadog API key",
-					"store":       "app-secrets",
-					"required":    true,
+					"description":     "Datadog API key",
+					"store":           "app-secrets",
+					"store_stack":     "atmos",
+					"store_component": "shared",
+					"required":        true,
 				},
 				"GITHUB_APP_KEY": map[string]any{
 					"sops": "dev-sops",
@@ -32,6 +34,8 @@ func TestExtractDeclarations(t *testing.T) {
 	dd := decls["DATADOG_API_KEY"]
 	assert.Equal(t, BackendStore, dd.BackendType)
 	assert.Equal(t, "app-secrets", dd.BackendName)
+	assert.Equal(t, "atmos", dd.StoreStack)
+	assert.Equal(t, "shared", dd.StoreComponent)
 	assert.True(t, dd.Required)
 	assert.Equal(t, "Datadog API key", dd.Description)
 

--- a/pkg/secrets/scope_test.go
+++ b/pkg/secrets/scope_test.go
@@ -28,6 +28,36 @@ func TestCoordinateForDeclaration_Scope(t *testing.T) {
 	assert.Equal(t, ScopeInstance, coord.Scope)
 }
 
+func TestCoordinateForDeclaration_StoreCoordinateOverride(t *testing.T) {
+	decl := &Declaration{
+		Name:           "KIND_CLIENT_SECRET",
+		BackendType:    BackendStore,
+		Scope:          ScopeInstance,
+		StoreStack:     "atmos",
+		StoreComponent: "shared",
+	}
+
+	coord := coordinateForDeclaration(decl, "fuecoco-stg", "kinde")
+	assert.Equal(t, "atmos", coord.Stack)
+	assert.Equal(t, "shared", coord.Component)
+	assert.Equal(t, "KIND_CLIENT_SECRET", coord.Key)
+	assert.Equal(t, ScopeInstance, coord.Scope)
+}
+
+func TestCoordinateForDeclaration_StoreStackOverrideWithoutComponent(t *testing.T) {
+	decl := &Declaration{
+		Name:        "GLOBAL_SECRET",
+		BackendType: BackendStore,
+		Scope:       ScopeStack,
+		StoreStack:  "atmos",
+	}
+
+	coord := coordinateForDeclaration(decl, "fuecoco-stg", "kinde")
+	assert.Equal(t, "atmos", coord.Stack)
+	assert.Empty(t, coord.Component)
+	assert.Equal(t, ScopeStack, coord.Scope)
+}
+
 // TestTagScope_StampsAndResolvesOverride proves position-derived scope tagging plus the standard
 // deep-merge semantics: a component-level (instance) tag overrides an inherited stack-level (stack)
 // tag, and a stack-only secret keeps stack scope. It also proves the input is not mutated.

--- a/pkg/secrets/scope_test.go
+++ b/pkg/secrets/scope_test.go
@@ -44,6 +44,20 @@ func TestCoordinateForDeclaration_StoreCoordinateOverride(t *testing.T) {
 	assert.Equal(t, ScopeInstance, coord.Scope)
 }
 
+func TestCoordinateForDeclaration_StoreComponentForcesInstanceScope(t *testing.T) {
+	decl := &Declaration{
+		Name:           "STACK_DECLARED_SHARED_SECRET",
+		BackendType:    BackendStore,
+		Scope:          ScopeStack,
+		StoreComponent: "shared",
+	}
+
+	coord := coordinateForDeclaration(decl, "fuecoco-stg", "kinde")
+	assert.Equal(t, "fuecoco-stg", coord.Stack)
+	assert.Equal(t, "shared", coord.Component)
+	assert.Equal(t, ScopeInstance, coord.Scope)
+}
+
 func TestCoordinateForDeclaration_StoreStackOverrideWithoutComponent(t *testing.T) {
 	decl := &Declaration{
 		Name:        "GLOBAL_SECRET",

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -104,6 +104,7 @@ func coordinateForDeclaration(decl *Declaration, stack, component string) provid
 		}
 		if decl.StoreComponent != "" {
 			coord.Component = decl.StoreComponent
+			// A component segment addresses an instance-level store coordinate.
 			coord.Scope = ScopeInstance
 		}
 	}

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -43,6 +43,11 @@ type Declaration struct {
 	// {{ .atmos_component }}). When set it overrides Name as the backend key; backends that key
 	// off the declaration name (most stores, SOPS) ignore it.
 	Reference string
+	// StoreStack optionally overrides the stack segment for store-backed secrets. This supports
+	// migrations from legacy !store usage that kept shared secrets under a fixed namespace.
+	StoreStack string
+	// StoreComponent optionally overrides the component segment for store-backed secrets.
+	StoreComponent string
 	// Required marks the secret as required for validation.
 	Required bool
 	// Scope is the addressing level (stack vs instance). It is derived from declaration position
@@ -92,6 +97,15 @@ func coordinateForDeclaration(decl *Declaration, stack, component string) provid
 	coord := providers.Coordinate{Stack: stack, Key: key, Scope: scope}
 	if scope != ScopeStack {
 		coord.Component = component
+	}
+	if decl.BackendType == BackendStore {
+		if decl.StoreStack != "" {
+			coord.Stack = decl.StoreStack
+		}
+		if decl.StoreComponent != "" {
+			coord.Component = decl.StoreComponent
+			coord.Scope = ScopeInstance
+		}
 	}
 	return coord
 }

--- a/pkg/store/google_secret_manager_store.go
+++ b/pkg/store/google_secret_manager_store.go
@@ -119,7 +119,7 @@ func (s *GSMStore) SetAuthContext(resolver AuthContextResolver, identityName str
 func (s *GSMStore) initDefaultClient() error {
 	ctx := context.Background()
 
-	clientOpts := gcp.GetClientOptions(gcp.AuthOptions{
+	clientOpts := gcp.GetSecretManagerClientOptions(gcp.AuthOptions{
 		Credentials: gcp.GetCredentialsFromStore(s.credentials),
 	})
 
@@ -150,7 +150,7 @@ func (s *GSMStore) initIdentityClient() error {
 		return fmt.Errorf("%w: failed to resolve GCP auth context for identity %q: %w", ErrAuthContextNotAvailable, s.identityName, err)
 	}
 
-	clientOpts := gcp.GetClientOptions(s.identityAuthOptions(authContext))
+	clientOpts := gcp.GetSecretManagerClientOptions(s.identityAuthOptions(authContext))
 
 	client, err := secretmanager.NewClient(ctx, clientOpts...)
 	if err != nil {

--- a/pkg/store/google_secret_manager_store.go
+++ b/pkg/store/google_secret_manager_store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -29,6 +28,7 @@ type GSMClient interface {
 	CreateSecret(ctx context.Context, req *secretmanagerpb.CreateSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	AddSecretVersion(ctx context.Context, req *secretmanagerpb.AddSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error)
 	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest, opts ...gax.CallOption) error
 	Close() error
 }
@@ -251,6 +251,14 @@ func (s *GSMStore) getKey(stack string, component string, key string) (string, e
 	return baseKey, nil
 }
 
+func (s *GSMStore) secretResourceName(secretID string) string {
+	return fmt.Sprintf("projects/%s/secrets/%s", s.projectID, secretID)
+}
+
+func (s *GSMStore) secretVersionResourceName(secretID string) string {
+	return fmt.Sprintf("%s/versions/latest", s.secretResourceName(secretID))
+}
+
 // createSecret creates a new secret in Google Secret Manager, returning an existing one if already present.
 func (s *GSMStore) createSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error) {
 	parent := fmt.Sprintf("projects/%s", s.projectID)
@@ -268,10 +276,10 @@ func (s *GSMStore) createSecret(ctx context.Context, secretID string) (*secretma
 			switch st.Code() {
 			case codes.AlreadyExists:
 				return &secretmanagerpb.Secret{
-					Name: fmt.Sprintf("projects/%s/secrets/%s", s.projectID, secretID),
+					Name: s.secretResourceName(secretID),
 				}, nil
 			case codes.NotFound:
-				return nil, fmt.Errorf(errWrapFormatWithID, ErrResourceNotFound, fmt.Sprintf("projects/%s/secrets/%s", s.projectID, secretID), err)
+				return nil, fmt.Errorf(errWrapFormatWithID, ErrResourceNotFound, s.secretResourceName(secretID), err)
 			case codes.PermissionDenied:
 				return nil, fmt.Errorf(errWrapFormatWithID, ErrPermissionDenied, fmt.Sprintf("project %s", s.projectID), err)
 			}
@@ -309,9 +317,6 @@ func (s *GSMStore) addSecretVersion(ctx context.Context, secret *secretmanagerpb
 func (s *GSMStore) Set(stack string, component string, key string, value any) error {
 	if stack == "" {
 		return ErrEmptyStack
-	}
-	if component == "" {
-		return ErrEmptyComponent
 	}
 	if key == "" {
 		return ErrEmptyKey
@@ -357,9 +362,6 @@ func (s *GSMStore) Get(stack string, component string, key string) (any, error) 
 	if stack == "" {
 		return nil, ErrEmptyStack
 	}
-	if component == "" {
-		return nil, ErrEmptyComponent
-	}
 	if key == "" {
 		return nil, ErrEmptyKey
 	}
@@ -378,7 +380,7 @@ func (s *GSMStore) Get(stack string, component string, key string) (any, error) 
 	}
 
 	// Build the resource name for the latest version
-	name := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", s.projectID, secretID)
+	name := s.secretVersionResourceName(secretID)
 
 	// Access the secret version
 	result, err := s.client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
@@ -412,9 +414,6 @@ func (s *GSMStore) Delete(stack string, component string, key string) error {
 	if stack == "" {
 		return ErrEmptyStack
 	}
-	if component == "" {
-		return ErrEmptyComponent
-	}
 	if key == "" {
 		return ErrEmptyKey
 	}
@@ -431,7 +430,7 @@ func (s *GSMStore) Delete(stack string, component string, key string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), gsmOperationTimeout)
 	defer cancel()
 
-	name := fmt.Sprintf("projects/%s/secrets/%s", s.projectID, secretID)
+	name := s.secretResourceName(secretID)
 	err = s.client.DeleteSecret(ctx, &secretmanagerpb.DeleteSecretRequest{
 		Name: name,
 	})
@@ -450,16 +449,43 @@ func (s *GSMStore) Delete(stack string, component string, key string) error {
 	return nil
 }
 
-// Has reports whether a secret exists for the given stack, component, and key. It performs a
-// Get and maps a not-found result to false; any other error is propagated.
+// Has reports whether a secret exists for the given stack, component, and key. It checks
+// Secret Manager metadata only and never accesses the secret payload.
 func (s *GSMStore) Has(stack string, component string, key string) (bool, error) {
-	_, err := s.Get(stack, component, key)
-	if err != nil {
-		if errors.Is(err, ErrResourceNotFound) {
-			return false, nil
-		}
+	if stack == "" {
+		return false, ErrEmptyStack
+	}
+	if key == "" {
+		return false, ErrEmptyKey
+	}
+
+	if err := s.ensureClient(); err != nil {
 		return false, err
 	}
+
+	secretID, err := s.getKey(stack, component, key)
+	if err != nil {
+		return false, fmt.Errorf(errWrapFormat, ErrGetKey, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gsmOperationTimeout)
+	defer cancel()
+
+	_, err = s.client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
+		Name: s.secretResourceName(secretID),
+	})
+	if err != nil {
+		if st, ok := status.FromError(err); ok {
+			switch st.Code() {
+			case codes.NotFound:
+				return false, nil
+			case codes.PermissionDenied:
+				return false, fmt.Errorf(errWrapFormatWithID, ErrPermissionDenied, fmt.Sprintf("secret %s", secretID), err)
+			}
+		}
+		return false, fmt.Errorf(errWrapFormatWithID, ErrGetSecret, secretID, err)
+	}
+
 	return true, nil
 }
 
@@ -482,7 +508,7 @@ func (s *GSMStore) GetKey(key string) (interface{}, error) {
 	}
 
 	// Construct the full secret name
-	fullSecretName := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", s.projectID, secretName)
+	fullSecretName := s.secretVersionResourceName(secretName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), gsmOperationTimeout)
 	defer cancel()

--- a/pkg/store/google_secret_manager_store_test.go
+++ b/pkg/store/google_secret_manager_store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -162,6 +163,56 @@ func gsmClientSecretCreationMock(projectID string, secretId string, secretPayloa
 			return req.Parent == expectedReq.Parent &&
 				string(req.Payload.Data) == string(expectedReq.Payload.Data)
 		})).Return(ret, err)
+	}
+}
+
+func TestGSMStore_CreateSecretStatusErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    codes.Code
+		wantErr error
+		wantID  string
+	}{
+		{
+			name: "already exists returns existing resource name",
+			code: codes.AlreadyExists,
+		},
+		{
+			name:    "not found wraps resource name",
+			code:    codes.NotFound,
+			wantErr: ErrResourceNotFound,
+			wantID:  "projects/test-project/secrets/app-secret",
+		},
+		{
+			name:    "permission denied wraps project name",
+			code:    codes.PermissionDenied,
+			wantErr: ErrPermissionDenied,
+			wantID:  "project test-project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := new(MockGSMClient)
+			store := newGSMStoreWithClient(mockClient, GSMStoreOptions{ProjectID: "test-project"})
+			const secretID = "app-secret"
+			const resourceName = "projects/test-project/secrets/app-secret"
+
+			mockClient.On("CreateSecret", mock.Anything, mock.MatchedBy(func(req *secretmanagerpb.CreateSecretRequest) bool {
+				return req.Parent == "projects/test-project" && req.SecretId == secretID
+			})).Return(nil, status.Error(tt.code, tt.name))
+
+			secret, err := store.createSecret(context.Background(), secretID)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Contains(t, err.Error(), tt.wantID)
+				assert.Nil(t, secret)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, resourceName, secret.GetName())
+			}
+			mockClient.AssertExpectations(t)
+		})
 	}
 }
 
@@ -656,6 +707,35 @@ func TestGSMStore_Has(t *testing.T) {
 			},
 			want:    false,
 			wantErr: ErrPermissionDenied,
+		},
+		{
+			name:      "generic get secret error",
+			stack:     "dev-usw2",
+			component: "app/service",
+			key:       "config-key",
+			mockFn: func(m *MockGSMClient) {
+				matchGetSecret(m, componentSecretName, nil, ErrInternalError)
+			},
+			want:    false,
+			wantErr: ErrGetSecret,
+		},
+		{
+			name:      "empty stack",
+			stack:     "",
+			component: "app/service",
+			key:       "config-key",
+			mockFn:    func(m *MockGSMClient) {},
+			want:      false,
+			wantErr:   ErrEmptyStack,
+		},
+		{
+			name:      "empty key",
+			stack:     "dev-usw2",
+			component: "app/service",
+			key:       "",
+			mockFn:    func(m *MockGSMClient) {},
+			want:      false,
+			wantErr:   ErrEmptyKey,
 		},
 	}
 

--- a/pkg/store/google_secret_manager_store_test.go
+++ b/pkg/store/google_secret_manager_store_test.go
@@ -53,6 +53,15 @@ func (m *MockGSMClient) AccessSecretVersion(ctx context.Context, req *secretmana
 	return args.Get(0).(*secretmanagerpb.AccessSecretVersionResponse), args.Error(1)
 }
 
+// GetSecret mocks the GSM GetSecret API call.
+func (m *MockGSMClient) GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error) {
+	args := m.Called(mock.Anything, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*secretmanagerpb.Secret), args.Error(1)
+}
+
 // DeleteSecret mocks the GSM DeleteSecret API call.
 func (m *MockGSMClient) DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest, opts ...gax.CallOption) error {
 	args := m.Called(mock.Anything, req)
@@ -280,13 +289,12 @@ func TestGSMStore_Set(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "empty component",
+			name:      "successful stack-scoped set",
 			stack:     "dev-usw2",
 			component: "",
 			key:       "config-key",
 			value:     "test-value",
-			mockFn:    func(m *MockGSMClient) {},
-			wantErr:   true,
+			mockFn:    gsmClientSecretCreationMock("test-project", "test-prefix_dev_usw2_config-key", `"test-value"`, nil, nil),
 		},
 		{
 			name:      "empty key",
@@ -420,13 +428,24 @@ func TestGSMStore_Get(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "empty component",
+			name:      "successful stack-scoped get",
 			stack:     "dev-usw2",
 			component: "",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) {},
-			want:      nil,
-			wantErr:   true,
+			mockFn: func(m *MockGSMClient) {
+				m.On("AccessSecretVersion", mock.Anything, mock.MatchedBy(func(req *secretmanagerpb.AccessSecretVersionRequest) bool {
+					expectedReq := &secretmanagerpb.AccessSecretVersionRequest{
+						Name: "projects/test-project/secrets/test-prefix_dev_usw2_config-key/versions/latest",
+					}
+					return req.Name == expectedReq.Name
+				})).Return(&secretmanagerpb.AccessSecretVersionResponse{
+					Payload: &secretmanagerpb.SecretPayload{
+						Data: []byte(`"test-value"`),
+					},
+				}, nil)
+			},
+			want:    "test-value",
+			wantErr: false,
 		},
 		{
 			name:      "empty key",
@@ -472,9 +491,10 @@ func TestGSMStore_Get(t *testing.T) {
 func TestGSMStore_Delete(t *testing.T) {
 	testPrefix := "test-prefix"
 	testDelimiter := "-"
-	const secretName = "projects/test-project/secrets/test-prefix_dev_usw2_app_service_config-key"
+	const componentSecretName = "projects/test-project/secrets/test-prefix_dev_usw2_app_service_config-key"
+	const stackSecretName = "projects/test-project/secrets/test-prefix_dev_usw2_config-key"
 
-	matchDelete := func(m *MockGSMClient, err error) {
+	matchDelete := func(m *MockGSMClient, secretName string, err error) {
 		m.On("DeleteSecret", mock.Anything, mock.MatchedBy(func(req *secretmanagerpb.DeleteSecretRequest) bool {
 			return req.Name == secretName
 		})).Return(err)
@@ -493,30 +513,34 @@ func TestGSMStore_Delete(t *testing.T) {
 			stack:     "dev-usw2",
 			component: "app/service",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) { matchDelete(m, nil) },
+			mockFn:    func(m *MockGSMClient) { matchDelete(m, componentSecretName, nil) },
 		},
 		{
 			name:      "not found",
 			stack:     "dev-usw2",
 			component: "app/service",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) { matchDelete(m, status.Error(codes.NotFound, "resource not found")) },
-			wantErr:   ErrResourceNotFound,
+			mockFn: func(m *MockGSMClient) {
+				matchDelete(m, componentSecretName, status.Error(codes.NotFound, "resource not found"))
+			},
+			wantErr: ErrResourceNotFound,
 		},
 		{
 			name:      "permission denied",
 			stack:     "dev-usw2",
 			component: "app/service",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) { matchDelete(m, status.Error(codes.PermissionDenied, "permission denied")) },
-			wantErr:   ErrPermissionDenied,
+			mockFn: func(m *MockGSMClient) {
+				matchDelete(m, componentSecretName, status.Error(codes.PermissionDenied, "permission denied"))
+			},
+			wantErr: ErrPermissionDenied,
 		},
 		{
 			name:      "generic error wrapped as delete failure",
 			stack:     "dev-usw2",
 			component: "app/service",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) { matchDelete(m, ErrInternalError) },
+			mockFn:    func(m *MockGSMClient) { matchDelete(m, componentSecretName, ErrInternalError) },
 			wantErr:   ErrDeleteSecret,
 		},
 		{
@@ -528,12 +552,11 @@ func TestGSMStore_Delete(t *testing.T) {
 			wantErr:   ErrEmptyStack,
 		},
 		{
-			name:      "empty component",
+			name:      "stack-scoped success",
 			stack:     "dev-usw2",
 			component: "",
 			key:       "config-key",
-			mockFn:    func(m *MockGSMClient) {},
-			wantErr:   ErrEmptyComponent,
+			mockFn:    func(m *MockGSMClient) { matchDelete(m, stackSecretName, nil) },
 		},
 		{
 			name:      "empty key",
@@ -570,11 +593,12 @@ func TestGSMStore_Delete(t *testing.T) {
 func TestGSMStore_Has(t *testing.T) {
 	testPrefix := "test-prefix"
 	testDelimiter := "-"
-	const accessName = "projects/test-project/secrets/test-prefix_dev_usw2_app_service_config-key/versions/latest"
+	const componentSecretName = "projects/test-project/secrets/test-prefix_dev_usw2_app_service_config-key"
+	const stackSecretName = "projects/test-project/secrets/test-prefix_dev_usw2_config-key"
 
-	matchAccess := func(m *MockGSMClient, resp *secretmanagerpb.AccessSecretVersionResponse, err error) {
-		call := m.On("AccessSecretVersion", mock.Anything, mock.MatchedBy(func(req *secretmanagerpb.AccessSecretVersionRequest) bool {
-			return req.Name == accessName
+	matchGetSecret := func(m *MockGSMClient, secretName string, resp *secretmanagerpb.Secret, err error) {
+		call := m.On("GetSecret", mock.Anything, mock.MatchedBy(func(req *secretmanagerpb.GetSecretRequest) bool {
+			return req.Name == secretName
 		}))
 		if err != nil {
 			call.Return(nil, err)
@@ -584,28 +608,52 @@ func TestGSMStore_Has(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		mockFn  func(*MockGSMClient)
-		want    bool
-		wantErr error
+		name      string
+		stack     string
+		component string
+		key       string
+		mockFn    func(*MockGSMClient)
+		want      bool
+		wantErr   error
 	}{
 		{
-			name: "present",
+			name:      "present",
+			stack:     "dev-usw2",
+			component: "app/service",
+			key:       "config-key",
 			mockFn: func(m *MockGSMClient) {
-				matchAccess(m, &secretmanagerpb.AccessSecretVersionResponse{
-					Payload: &secretmanagerpb.SecretPayload{Data: []byte(`"test-value"`)},
-				}, nil)
+				matchGetSecret(m, componentSecretName, &secretmanagerpb.Secret{Name: componentSecretName}, nil)
 			},
 			want: true,
 		},
 		{
-			name:   "absent",
-			mockFn: func(m *MockGSMClient) { matchAccess(m, nil, status.Error(codes.NotFound, "resource not found")) },
-			want:   false,
+			name:      "stack-scoped present",
+			stack:     "dev-usw2",
+			component: "",
+			key:       "config-key",
+			mockFn: func(m *MockGSMClient) {
+				matchGetSecret(m, stackSecretName, &secretmanagerpb.Secret{Name: stackSecretName}, nil)
+			},
+			want: true,
 		},
 		{
-			name:    "other error propagated",
-			mockFn:  func(m *MockGSMClient) { matchAccess(m, nil, status.Error(codes.PermissionDenied, "permission denied")) },
+			name:      "absent",
+			stack:     "dev-usw2",
+			component: "app/service",
+			key:       "config-key",
+			mockFn: func(m *MockGSMClient) {
+				matchGetSecret(m, componentSecretName, nil, status.Error(codes.NotFound, "resource not found"))
+			},
+			want: false,
+		},
+		{
+			name:      "other error propagated",
+			stack:     "dev-usw2",
+			component: "app/service",
+			key:       "config-key",
+			mockFn: func(m *MockGSMClient) {
+				matchGetSecret(m, componentSecretName, nil, status.Error(codes.PermissionDenied, "permission denied"))
+			},
 			want:    false,
 			wantErr: ErrPermissionDenied,
 		},
@@ -622,7 +670,7 @@ func TestGSMStore_Has(t *testing.T) {
 				StackDelimiter: &testDelimiter,
 			})
 
-			got, err := store.Has("dev-usw2", "app/service", "config-key")
+			got, err := store.Has(tt.stack, tt.component, tt.key)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {
@@ -732,6 +780,16 @@ func TestGSMStore_GetKey(t *testing.T) {
 			component:      "app/service",
 			key:            "config/key",
 			expected:       "test-prefix_dev_usw2_app_service_config_key",
+			wantErr:        false,
+		},
+		{
+			name:           "stack-scoped path omits component segment",
+			prefix:         "test-prefix",
+			stackDelimiter: stringPtr("-"),
+			stack:          "dev-usw2",
+			component:      "",
+			key:            "config",
+			expected:       "test-prefix_dev_usw2_config",
 			wantErr:        false,
 		},
 		{

--- a/tests/fixtures/scenarios/floci-gcp-secrets/atmos.yaml
+++ b/tests/fixtures/scenarios/floci-gcp-secrets/atmos.yaml
@@ -1,0 +1,25 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+    command: terraform
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "deploy/**/*"
+  excluded_paths:
+    - "**/_defaults.yaml"
+  name_template: "{{ .vars.stage }}"
+
+logs:
+  level: Info
+
+stores:
+  floci-gsm:
+    type: google-secret-manager
+    secret: true
+    options:
+      project_id: test-project
+      stack_delimiter: "-"

--- a/tests/fixtures/scenarios/floci-gcp-secrets/stacks/deploy/local.yaml
+++ b/tests/fixtures/scenarios/floci-gcp-secrets/stacks/deploy/local.yaml
@@ -1,0 +1,15 @@
+vars:
+  stage: local
+
+components:
+  terraform:
+    app:
+      vars:
+        token_value: !secret API_TOKEN
+      secrets:
+        vars:
+          API_TOKEN:
+            store: floci-gsm
+            store_stack: local
+            store_component: app
+            description: Token stored in floci-gcp Secret Manager for integration tests.

--- a/tests/secret_floci_gcp_test.go
+++ b/tests/secret_floci_gcp_test.go
@@ -1,0 +1,263 @@
+//nolint:forbidigo // This opt-in integration test is configured through environment variables.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	flociGCPDefaultEndpoint = "localhost:4588"
+	flociGCPProjectID       = "test-project"
+)
+
+func TestSecretFlociGCPSecretManager(t *testing.T) {
+	endpoint := requireFlociGCPEndpoint(t)
+
+	ensureAtmosRunner(t)
+
+	workdir := filepath.Join("fixtures", "scenarios", "floci-gcp-secrets")
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	testID := uniqueFlociTestID(t)
+	value := "floci-gcp-secret-value-" + testID
+	env := flociGCPSecretCommandEnv(endpoint, absWorkdir)
+	client := newFlociGCPSecretManagerClient(t, endpoint)
+	secretName := flociGCPSecretResourceName("local", "API_TOKEN")
+	defer bestEffortFlociGCPSecretDelete(t, client, secretName)
+
+	stdout, stderr, err := runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"secret", "set",
+		"-s", "local",
+		"-c", "app",
+		"--type", "terraform",
+		"API_TOKEN="+value,
+	)
+	require.NoError(t, err, "secret set failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	requireFlociGCPSecretExists(t, client, secretName)
+
+	stdout, stderr, err = runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"secret", "get",
+		"-s", "local",
+		"-c", "app",
+		"--type", "terraform",
+		"--raw",
+		"API_TOKEN",
+	)
+	require.NoError(t, err, "secret get failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	require.Equal(t, value, stdout)
+
+	stdout, stderr, err = runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"secret", "list",
+		"-s", "local",
+		"-c", "app",
+		"--type", "terraform",
+		"--format", "json",
+	)
+	require.NoError(t, err, "secret list failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	requireFlociGCPSecretListStatus(t, stdout, "API_TOKEN", "initialized")
+
+	stdout, stderr, err = runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"describe", "component", "app",
+		"-s", "local",
+		"--format", "json",
+	)
+	require.NoError(t, err, "describe component failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	require.Contains(t, stdout, value, "describe component should resolve !secret when masking is disabled")
+
+	stdout, stderr, err = runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"secret", "delete",
+		"-s", "local",
+		"-c", "app",
+		"--type", "terraform",
+		"--force",
+		"API_TOKEN",
+	)
+	require.NoError(t, err, "secret delete failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	requireFlociGCPSecretGone(t, client, secretName)
+
+	stdout, stderr, err = runFlociAtmosInDir(
+		t, absWorkdir, env, 2*time.Minute,
+		"secret", "list",
+		"-s", "local",
+		"-c", "app",
+		"--type", "terraform",
+		"--format", "json",
+	)
+	require.NoError(t, err, "secret list after delete failed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	requireFlociGCPSecretListStatus(t, stdout, "API_TOKEN", "missing")
+}
+
+func requireFlociGCPSecretListStatus(t *testing.T, output, secret, status string) {
+	t.Helper()
+
+	var entries []struct {
+		Secret string
+		Status string
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "secret list output should be JSON")
+
+	for _, entry := range entries {
+		if entry.Secret == secret {
+			require.Equal(t, status, entry.Status)
+			return
+		}
+	}
+	require.Failf(t, "secret not listed", "expected secret %q in output:\n%s", secret, output)
+}
+
+func requireFlociGCPEndpoint(t *testing.T) string {
+	t.Helper()
+
+	if os.Getenv("ATMOS_TEST_FLOCI_GCP") != "true" {
+		t.Skip("set ATMOS_TEST_FLOCI_GCP=true and start floci-gcp before running this integration test")
+	}
+
+	endpoint := os.Getenv("SECRET_MANAGER_EMULATOR_HOST")
+	if endpoint == "" {
+		endpoint = os.Getenv("FLOCI_GCP_ENDPOINT")
+	}
+	if endpoint == "" {
+		endpoint = flociGCPDefaultEndpoint
+	}
+	endpoint = normalizeFlociGCPGRPCEndpoint(endpoint)
+
+	conn, err := net.DialTimeout("tcp", endpoint, 2*time.Second)
+	if err != nil {
+		t.Skipf("floci-gcp is not reachable at %s: %v", endpoint, err)
+	}
+	require.NoError(t, conn.Close())
+
+	return endpoint
+}
+
+func flociGCPSecretCommandEnv(endpoint, absWorkdir string) map[string]string {
+	return map[string]string{
+		"ATMOS_CLI_CONFIG_PATH":        absWorkdir,
+		"ATMOS_MASK":                   "false",
+		"FLOCI_GCP_ENDPOINT":           "http://" + endpoint,
+		"FLOCI_GCP_PROJECT":            flociGCPProjectID,
+		"GOOGLE_CLOUD_PROJECT":         flociGCPProjectID,
+		"SECRET_MANAGER_EMULATOR_HOST": endpoint,
+	}
+}
+
+func normalizeFlociGCPGRPCEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if strings.Contains(endpoint, "://") {
+		if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+			return parsed.Host
+		}
+	}
+	return endpoint
+}
+
+func newFlociGCPSecretManagerClient(t *testing.T, endpoint string) *secretmanager.Client {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client, err := secretmanager.NewClient(ctx, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Logf("closing floci-gcp secret manager client: %v", err)
+		}
+		if err := conn.Close(); err != nil && status.Code(err) != codes.Canceled {
+			t.Logf("closing floci-gcp grpc connection: %v", err)
+		}
+	})
+
+	return client
+}
+
+func flociGCPSecretResourceName(testID, key string) string {
+	return fmt.Sprintf("projects/%s/secrets/%s", flociGCPProjectID, flociGCPSecretID(testID, key))
+}
+
+func flociGCPSecretID(testID, key string) string {
+	parts := append(strings.Split(testID, "-"), "app", key)
+	secretID := strings.Join(parts, "_")
+	secretID = strings.ReplaceAll(secretID, "__", "_")
+	return strings.Trim(secretID, "_")
+}
+
+func requireFlociGCPSecretExists(t *testing.T, client *secretmanager.Client, name string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		exists, err := flociGCPSecretExists(client, name)
+		if err != nil {
+			t.Logf("checking floci-gcp secret %s: %v", name, err)
+			return false
+		}
+		return exists
+	}, 10*time.Second, 200*time.Millisecond, "expected floci-gcp secret %s to exist", name)
+}
+
+func requireFlociGCPSecretGone(t *testing.T, client *secretmanager.Client, name string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		exists, err := flociGCPSecretExists(client, name)
+		if err != nil {
+			t.Logf("checking floci-gcp secret %s: %v", name, err)
+			return false
+		}
+		return !exists
+	}, 10*time.Second, 200*time.Millisecond, "expected floci-gcp secret %s to be deleted", name)
+}
+
+func flociGCPSecretExists(client *secretmanager.Client, name string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{Name: name})
+	if err == nil {
+		return true, nil
+	}
+	if status.Code(err) == codes.NotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func bestEffortFlociGCPSecretDelete(t *testing.T, client *secretmanager.Client, name string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.DeleteSecret(ctx, &secretmanagerpb.DeleteSecretRequest{Name: name})
+	if err == nil || status.Code(err) == codes.NotFound {
+		return
+	}
+	t.Logf("best-effort floci-gcp secret cleanup failed for %s: %v", name, err)
+}

--- a/website/docs/cli/configuration/secrets.mdx
+++ b/website/docs/cli/configuration/secrets.mdx
@@ -302,6 +302,12 @@ Each declaration accepts:
   <dt>`reference`</dt>
   <dd>Optional backend-specific address for reference-based stores (1Password). For a 1Password store this is an `op://vault/item/field` reference and may contain Go-template vars (`{{ .atmos_stack }}`, `{{ .atmos_component }}`). Name-keyed backends (AWS, Azure, GCP, Vault, SOPS) ignore it.</dd>
 
+  <dt>`store_stack`</dt>
+  <dd>Optional store namespace override for store-backed secrets. Use it when migrating a legacy `!store <store> <stack> <component> <key>` secret without moving the remote value.</dd>
+
+  <dt>`store_component`</dt>
+  <dd>Optional component namespace override for store-backed secrets. Use with `store_stack` to target an existing shared store path such as `atmos/shared`.</dd>
+
   <dt>`required`</dt>
   <dd>When `true`, [`atmos secret validate`](/cli/commands/secret/validate) fails if the secret is not initialized.</dd>
 </dl>


### PR DESCRIPTION
## Summary
- wire GCP Secret Manager as the first store-backed secrets provider for stack-scoped and component-scoped secrets
- make GCP secret status checks metadata-only via `GetSecret`, so `list`/`validate` do not access payload versions
- propagate the authenticated/default identity into secret stores that do not define an explicit `stores.<name>.identity`
- update the PRDs to document the GCP path, metadata-only status checks, and Azure follow-up scope

## Tests
- `rtk go test ./pkg/store -run 'TestGSMStore|TestSecret|TestSetAuthContextResolver'`
- `rtk go test ./cmd/secret -run 'TestSecretStoreDefaultIdentity|TestLoadService'`
- `rtk go test ./pkg/store ./cmd/secret`

Stacked on #1911 (`osterman/secrets-management`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved secret-store identity handling: normalization, explicit “disabled” option, and sensible defaulting
  * Added store-backed namespace overrides (store_stack, store_component) to support migrating secrets to shared store paths
  * Support for stack-scoped secrets (omit component) in Google Secret Manager and metadata-only existence checks

* **Documentation**
  * Updated secrets management and sensitivity docs with migration examples, identity guidance, and metadata-only checks

* **Tests**
  * Added tests for identity normalization/defaulting and stack-scoped/store-backed behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->