### PR TITLE
fix(terraform): restore init + workspace in terraform shell, add --skip-init

### DIFF
--- a/cmd/terraform/shell.go
+++ b/cmd/terraform/shell.go
@@ -69,6 +69,9 @@ as you would in a typical setup, but within the configured Atmos environment.`,
 		dryRun := v.GetBool("dry-run")
 		identity := v.GetString("identity")
 		withSecrets := v.GetBool("with-secrets")
+		// --skip-init is a shared terraform persistent flag (inherited from terraformCmd);
+		// honor it so users can enter the shell without running `terraform init`.
+		skipInit := v.GetBool("skip-init")
 
 		// Prompt for stack if missing.
 		if stack == "" {
@@ -107,6 +110,7 @@ as you would in a typical setup, but within the configured Atmos environment.`,
 			DryRun:      dryRun,
 			Identity:    identity,
 			WithSecrets: withSecrets,
+			SkipInit:    skipInit,
 			ProcessingOptions: e.ProcessingOptions{
 				ProcessTemplates: processTemplates,
 				ProcessFunctions: processFunctions,

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -708,8 +708,22 @@ func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *sch
 		return componentPath, err
 	}
 
+	if err = executeTerraformInitCommand(atmosConfig, info, newPath, varFile, opts...); err != nil {
+		return newPath, err
+	}
+
+	return newPath, nil
+}
+
+// executeTerraformInitCommand runs the `terraform init` subprocess against an already-resolved
+// componentPath and dispatches the after.terraform.init provisioners. Unlike
+// executeTerraformInitPhase it does NOT run prepareInitExecution — it skips cleanTerraformWorkspace,
+// the before.terraform.init provisioners, and workdir-path resolution. Callers that have already
+// performed that preparation (e.g. ExecuteTerraformShell, which fires the before.terraform.init
+// provisioners itself) use this directly to avoid running the provisioners twice.
+func executeTerraformInitCommand(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, componentPath, varFile string, opts ...ShellCommandOption) error {
 	initArgs := buildInitArgs(atmosConfig, info, varFile)
-	err = executeShellCommandWithRetry(
+	err := executeShellCommandWithRetry(
 		atmosConfig,
 		info,
 		"init",
@@ -718,7 +732,7 @@ func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *sch
 				*atmosConfig,
 				info.Command,
 				initArgs,
-				newPath,
+				componentPath,
 				info.ComponentEnvList,
 				info.DryRun,
 				info.RedirectStdErr,
@@ -728,12 +742,12 @@ func executeTerraformInitPhase(atmosConfig *schema.AtmosConfiguration, info *sch
 		opts...,
 	)
 	if err != nil {
-		return newPath, err
+		return err
 	}
 
-	dispatchAfterInit(atmosConfig, info, newPath)
+	dispatchAfterInit(atmosConfig, info, componentPath)
 
-	return newPath, nil
+	return nil
 }
 
 // dispatchAfterInit fires the after.terraform.init provisioners (e.g. the multi-platform

--- a/internal/exec/terraform_shell.go
+++ b/internal/exec/terraform_shell.go
@@ -166,7 +166,17 @@ func ExecuteTerraformShell(opts *ShellOptions, atmosConfig *schema.AtmosConfigur
 		return nil
 	}
 
-	if err := prepareShellExecution(atmosConfig, &info, cfg, opts.WithSecrets); err != nil {
+	return runShellSession(atmosConfig, &info, cfg, opts.WithSecrets)
+}
+
+// runShellSession performs the per-component setup (prepareShellExecution) and then runs
+// `terraform init`/`workspace` and launches the interactive shell (executeShellLifecycle).
+// It is split out of ExecuteTerraformShell so the post-ProcessStacks lifecycle can be unit-tested
+// without resolving real stacks or launching a shell.
+func runShellSession(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, cfg *shellConfig, withSecrets bool) error {
+	defer perf.Track(atmosConfig, "exec.runShellSession")()
+
+	if err := prepareShellExecution(atmosConfig, info, cfg, withSecrets); err != nil {
 		return err
 	}
 
@@ -181,7 +191,7 @@ func ExecuteTerraformShell(opts *ShellOptions, atmosConfig *schema.AtmosConfigur
 		}()
 	}
 
-	return executeShellLifecycle(atmosConfig, &info, cfg)
+	return executeShellLifecycle(atmosConfig, info, cfg)
 }
 
 // Seams for testing the shell lifecycle without launching real subprocesses or an interactive

--- a/internal/exec/terraform_shell.go
+++ b/internal/exec/terraform_shell.go
@@ -49,6 +49,7 @@ func shellInfoFromOptions(opts *ShellOptions) schema.ConfigAndStacksInfo {
 		SubCommand:       "shell",
 		DryRun:           opts.DryRun,
 		Identity:         opts.Identity,
+		SkipInit:         opts.SkipInit,
 	}
 }
 
@@ -165,20 +166,109 @@ func ExecuteTerraformShell(opts *ShellOptions, atmosConfig *schema.AtmosConfigur
 		return nil
 	}
 
+	if err := prepareShellExecution(atmosConfig, &info, cfg, opts.WithSecrets); err != nil {
+		return err
+	}
+
+	// Remove the temporary Terraform CLI config (TF_CLI_CONFIG_FILE) after init, workspace, and
+	// the whole interactive shell session complete. Deferred here (not in prepareShellExecution)
+	// so the file survives every subprocess and the shell.
+	if info.RCCleanup != nil {
+		defer func() {
+			if cleanupErr := info.RCCleanup(); cleanupErr != nil {
+				log.Debug("Failed to remove temporary Terraform CLI config", "error", cleanupErr)
+			}
+		}()
+	}
+
+	return executeShellLifecycle(atmosConfig, &info, cfg)
+}
+
+// Seams for testing the shell lifecycle without launching real subprocesses or an interactive
+// shell. They default to the real implementations (mirrors the execTerraformFn pattern).
+var (
+	shellInitFn      = executeTerraformInitCommand
+	shellWorkspaceFn = runWorkspaceSetup
+	shellExecFn      = execTerraformShellCommand
+)
+
+// executeShellLifecycle runs `terraform init` and selects/creates the workspace before launching
+// the interactive shell, so the user lands in an initialized component and the correct workspace
+// (not `default`). This matches the documented behavior and the pre-v1.202.0 flow where shell ran
+// through the shared ExecuteTerraform pipeline. The before.terraform.init provisioners already ran
+// in ExecuteTerraformShell, so init uses the provisioner-free path to avoid running them twice.
+func executeShellLifecycle(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, cfg *shellConfig) error {
+	defer perf.Track(atmosConfig, "exec.executeShellLifecycle")()
+
+	if shouldRunTerraformInit(atmosConfig, info) {
+		// Mirror prepareInitExecution's non-workdir cleanup of .terraform/environment so
+		// Terraform doesn't prompt for workspace selection. Skipped for workdir components.
+		if _, isWorkdir := info.ComponentSection[provWorkdir.WorkdirPathKey].(string); !isWorkdir {
+			cleanTerraformWorkspace(*atmosConfig, cfg.componentPath)
+		}
+		if err := shellInitFn(atmosConfig, info, cfg.componentPath, cfg.varFile); err != nil {
+			return err
+		}
+	}
+
+	// Select (or create) the workspace. No-op for the http backend or when TF_WORKSPACE is set
+	// (see shouldSkipWorkspaceSetup); resolves to `default` when workspaces_enabled: false.
+	if err := shellWorkspaceFn(atmosConfig, info, cfg.componentPath); err != nil {
+		return err
+	}
+
+	return shellExecFn(atmosConfig, info.ComponentFromArg, info.Stack,
+		info.ComponentEnvList, cfg.varFile, cfg.workingDir, info.TerraformWorkspace, cfg.componentPath)
+}
+
+// prepareShellExecution performs the per-component setup the shell needs before running
+// `terraform init`/`workspace` and launching the interactive shell: resolving the terraform/tofu
+// binary (including the toolchain), writing the disk-safe varfile, generating backend and
+// provider-override config files, and assembling the component environment. It registers
+// info.RCCleanup so the temporary Terraform CLI config survives init, workspace, and the shell.
+func prepareShellExecution(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, cfg *shellConfig, withSecrets bool) error {
+	defer perf.Track(atmosConfig, "exec.prepareShellExecution")()
+
+	// Resolve the terraform/tofu binary (config + toolchain) so init/workspace and the shell
+	// all use the correct executable.
+	resolveTerraformCommand(atmosConfig, info)
+	tenv, err := resolveAndInstallToolchainDeps(atmosConfig, info)
+	if err != nil {
+		return err
+	}
+	info.Command = tenv.Resolve(info.Command)
+
 	// Keep resolved secrets out of the on-disk varfile. With --with-secrets, export them
 	// into the interactive shell as TF_VAR_* env vars; otherwise they are not available
 	// (terraform commands in the shell that need them will prompt or fail).
-	computeTerraformSecretVarKeys(&info)
+	computeTerraformSecretVarKeys(info)
 
-	varFilePath := constructTerraformComponentVarfilePath(atmosConfig, &info)
-	if err := u.WriteToFileAsJSON(varFilePath, diskSafeVars(&info), filePermissions); err != nil {
+	varFilePath := constructTerraformComponentVarfilePath(atmosConfig, info)
+	if err := u.WriteToFileAsJSON(varFilePath, diskSafeVars(info), filePermissions); err != nil {
 		return err
 	}
 
-	if err := applyShellSecretEnv(&info, opts.WithSecrets); err != nil {
+	// Generate backend + provider-override files so `terraform init` configures the backend.
+	if err := generateConfigFiles(atmosConfig, info, cfg.workingDir); err != nil {
 		return err
 	}
 
-	return execTerraformShellCommand(atmosConfig, info.ComponentFromArg, info.Stack,
-		info.ComponentEnvList, cfg.varFile, cfg.workingDir, info.TerraformWorkspace, cfg.componentPath)
+	// Assemble env vars (TF_IN_AUTOMATION, ATMOS_BASE_PATH, plugin cache, TF_CLI_CONFIG_FILE,
+	// toolchain PATH). assembleComponentEnvVars injects secret TF_VAR_* unconditionally, so
+	// suppress that here (snapshot/clear/restore TerraformSecretVarKeys) and instead route
+	// secrets through applyShellSecretEnv, preserving the "secrets withheld unless --with-secrets"
+	// shell behavior.
+	secretKeys := info.TerraformSecretVarKeys
+	info.TerraformSecretVarKeys = nil
+	err = assembleComponentEnvVars(atmosConfig, info, tenv)
+	info.TerraformSecretVarKeys = secretKeys
+	if err != nil {
+		return err
+	}
+
+	if err := applyShellSecretEnv(info, withSecrets); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/exec/terraform_shell_test.go
+++ b/internal/exec/terraform_shell_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -485,6 +486,242 @@ func TestExecuteShellLifecycle_SkipInit_KeepsWorkspace(t *testing.T) {
 	require.NoError(t, executeShellLifecycle(atmosConfig, &info, cfg))
 	assert.Equal(t, []string{"workspace", "shell"}, *calls,
 		"--skip-init must skip init but still select the workspace and launch the shell")
+}
+
+// newShellPrepInfo builds a minimal ConfigAndStacksInfo whose component working dir resolves to
+// tmpDir (via the workdir provisioner key), so prepareShellExecution writes its varfile there and
+// generateConfigFiles no-ops (no backend/providers configured).
+func newShellPrepInfo(tmpDir string) *schema.ConfigAndStacksInfo {
+	return &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "vpc",
+		FinalComponent:   "vpc",
+		ComponentType:    "terraform",
+		Stack:            "dev",
+		ComponentSection: map[string]any{provWorkdir.WorkdirPathKey: tmpDir},
+		ComponentVarsSection: map[string]any{
+			"name": "vpc-test",
+		},
+	}
+}
+
+// TestPrepareShellExecution_HappyPath exercises the full per-component setup the shell performs
+// before init/workspace/shell: binary + toolchain resolution, secret-key computation, disk-safe
+// varfile write, backend/provider config generation, env assembly, and RC cleanup registration.
+func TestPrepareShellExecution_HappyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := newShellPrepInfo(tmpDir)
+	cfg := &shellConfig{componentPath: tmpDir, workingDir: tmpDir, varFile: "dev-vpc.terraform.tfvars.json"}
+
+	err := prepareShellExecution(atmosConfig, info, cfg, false)
+	require.NoError(t, err)
+
+	// RC cleanup is registered so the temporary Terraform CLI config survives init/workspace/shell;
+	// run it here to avoid leaking the temp file.
+	if info.RCCleanup != nil {
+		t.Cleanup(func() { _ = info.RCCleanup() })
+	}
+
+	// The terraform binary was resolved.
+	assert.NotEmpty(t, info.Command, "terraform/tofu command must be resolved")
+
+	// The disk-safe varfile was written into the resolved working dir.
+	varfilePath := constructTerraformComponentVarfilePath(atmosConfig, info)
+	assert.FileExists(t, varfilePath, "disk-safe varfile must be written")
+
+	// Standard Atmos env vars were assembled for the subprocess/shell.
+	assert.Contains(t, info.ComponentEnvList, "TF_IN_AUTOMATION=true",
+		"component env must be assembled before launching the shell")
+}
+
+// TestPrepareShellExecution_WithSecrets routes a secret-bearing var through the shell env when
+// --with-secrets is set: it must be exported as TF_VAR_* but never written to the on-disk varfile.
+func TestPrepareShellExecution_WithSecrets(t *testing.T) {
+	const secret = "prepare-shell-secret-7a6b5c"
+	iolib.RegisterSecret(secret)
+
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := newShellPrepInfo(tmpDir)
+	info.ComponentVarsSection = map[string]any{"token": secret, "region": "us-east-1-prepareshell"}
+	cfg := &shellConfig{componentPath: tmpDir, workingDir: tmpDir, varFile: "dev-vpc.terraform.tfvars.json"}
+
+	require.NoError(t, prepareShellExecution(atmosConfig, info, cfg, true))
+	if info.RCCleanup != nil {
+		t.Cleanup(func() { _ = info.RCCleanup() })
+	}
+
+	// The secret is exported into the shell env as TF_VAR_token.
+	var exported bool
+	for _, e := range info.ComponentEnvList {
+		if e == "TF_VAR_token="+secret {
+			exported = true
+		}
+	}
+	assert.True(t, exported, "with --with-secrets the secret must be exported as TF_VAR_token")
+
+	// The secret must NOT be written to the on-disk varfile.
+	varfilePath := constructTerraformComponentVarfilePath(atmosConfig, info)
+	data, err := os.ReadFile(varfilePath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), secret, "secret must never be written to the on-disk varfile")
+}
+
+// TestPrepareShellExecution_VarfileWriteError verifies an error from writing the varfile is
+// propagated. The working dir resolves to a path nested under a regular file, so the write fails.
+func TestPrepareShellExecution_VarfileWriteError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a regular file, then point the working dir at a path *inside* it so the varfile
+	// write (and its parent-dir creation) fails.
+	blocker := filepath.Join(tmpDir, "not-a-dir")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	badDir := filepath.Join(blocker, "sub")
+
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := newShellPrepInfo(badDir)
+	cfg := &shellConfig{componentPath: badDir, workingDir: badDir, varFile: "dev-vpc.terraform.tfvars.json"}
+
+	err := prepareShellExecution(atmosConfig, info, cfg, false)
+	require.Error(t, err, "varfile write into a non-directory path must fail")
+}
+
+// TestExecuteShellLifecycle_WorkdirComponent_SkipsWorkspaceClean covers the workdir branch: when
+// the component is provisioned into a workdir, executeShellLifecycle skips the .terraform/environment
+// cleanup but still runs init -> workspace -> shell in order.
+func TestExecuteShellLifecycle_WorkdirComponent_SkipsWorkspaceClean(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+	info.ComponentSection = map[string]any{provWorkdir.WorkdirPathKey: tmpDir}
+	cfg := &shellConfig{componentPath: tmpDir, workingDir: tmpDir, varFile: "dev-vpc.tfvars.json"}
+
+	require.NoError(t, executeShellLifecycle(atmosConfig, &info, cfg))
+	assert.Equal(t, []string{"init", "workspace", "shell"}, *calls,
+		"workdir components still run init, workspace, and shell in order")
+}
+
+// TestExecuteTerraformInitCommand_DryRun covers the provisioner-free init helper used by the shell:
+// in dry-run mode it builds the init args and dispatches after.terraform.init without launching a
+// real subprocess, returning no error.
+func TestExecuteTerraformInitCommand_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "vpc",
+		FinalComponent:   "vpc",
+		ComponentType:    "terraform",
+		Stack:            "dev",
+		Command:          "terraform",
+		DryRun:           true,
+		ComponentSection: map[string]any{},
+	}
+
+	err := executeTerraformInitCommand(atmosConfig, info, tmpDir, "dev-vpc.terraform.tfvars.json")
+	require.NoError(t, err, "dry-run init must not launch a subprocess and must not error")
+}
+
+// TestRunShellSession_PreparesThenRunsLifecycle covers the post-ProcessStacks glue of the shell
+// entry point: prepareShellExecution runs, the RC cleanup is registered, and the lifecycle
+// (init -> workspace -> shell) runs in order. The lifecycle subprocess/shell steps are stubbed.
+func TestRunShellSession_PreparesThenRunsLifecycle(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := newShellPrepInfo(tmpDir)
+	cfg := &shellConfig{componentPath: tmpDir, workingDir: tmpDir, varFile: "dev-vpc.terraform.tfvars.json"}
+
+	require.NoError(t, runShellSession(atmosConfig, info, cfg, false))
+
+	// prepareShellExecution ran (binary resolved, env assembled).
+	assert.NotEmpty(t, info.Command, "prepareShellExecution must resolve the terraform binary")
+	assert.Contains(t, info.ComponentEnvList, "TF_IN_AUTOMATION=true")
+	// The lifecycle ran in order.
+	assert.Equal(t, []string{"init", "workspace", "shell"}, *calls)
+}
+
+// TestRunShellSession_PrepareErrorSkipsLifecycle verifies that when prepareShellExecution fails,
+// the lifecycle (init/workspace/shell) never runs.
+func TestRunShellSession_PrepareErrorSkipsLifecycle(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+
+	tmpDir := t.TempDir()
+	// Point the working dir at a path nested under a regular file so the varfile write fails.
+	blocker := filepath.Join(tmpDir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	badDir := filepath.Join(blocker, "sub")
+
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := newShellPrepInfo(badDir)
+	cfg := &shellConfig{componentPath: badDir, workingDir: badDir, varFile: "dev-vpc.terraform.tfvars.json"}
+
+	err := runShellSession(atmosConfig, info, cfg, false)
+	require.Error(t, err, "prepare failure must propagate")
+	assert.Empty(t, *calls, "the init/workspace/shell lifecycle must not run when prepare fails")
+}
+
+// TestExecuteShellLifecycle_WorkspaceErrorStopsBeforeShell verifies a workspace-setup failure
+// aborts the lifecycle (after init) before the interactive shell is launched.
+func TestExecuteShellLifecycle_WorkspaceErrorStopsBeforeShell(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+	wantErr := errors.New("workspace failed")
+	shellWorkspaceFn = func(_ *schema.AtmosConfiguration, _ *schema.ConfigAndStacksInfo, _ string, _ ...ShellCommandOption) error {
+		*calls = append(*calls, "workspace")
+		return wantErr
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+	cfg := &shellConfig{componentPath: t.TempDir(), workingDir: t.TempDir(), varFile: "dev-vpc.tfvars.json"}
+
+	err := executeShellLifecycle(atmosConfig, &info, cfg)
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, []string{"init", "workspace"}, *calls, "shell must not launch after workspace setup fails")
+}
+
+// TestExecuteTerraformInitPhase_DryRun covers the standard init pre-step (prepareInitExecution +
+// executeTerraformInitCommand) in dry-run mode: it returns the resolved path without launching a
+// real subprocess.
+func TestExecuteTerraformInitPhase_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "vpc",
+		FinalComponent:   "vpc",
+		ComponentType:    "terraform",
+		Stack:            "dev",
+		Command:          "terraform",
+		DryRun:           true,
+		ComponentSection: map[string]any{provWorkdir.WorkdirPathKey: tmpDir},
+	}
+
+	newPath, err := executeTerraformInitPhase(atmosConfig, info, tmpDir, "dev-vpc.terraform.tfvars.json")
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir, newPath, "workdir components return the workdir path")
+}
+
+// TestExecuteTerraformInitPhase_SubprocessError covers the init error path: when the terraform
+// binary cannot be executed, both executeTerraformInitPhase and executeTerraformInitCommand
+// propagate the failure (no dry-run, so the subprocess actually runs and fails fast).
+func TestExecuteTerraformInitPhase_SubprocessError(t *testing.T) {
+	tmpDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{BasePath: tmpDir}
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "vpc",
+		FinalComponent:   "vpc",
+		ComponentType:    "terraform",
+		Stack:            "dev",
+		// A binary that does not exist on any platform, so `init` fails fast without a real terraform.
+		Command:          "atmos-nonexistent-terraform-binary-for-tests",
+		DryRun:           false,
+		ComponentSection: map[string]any{provWorkdir.WorkdirPathKey: tmpDir},
+	}
+
+	_, err := executeTerraformInitPhase(atmosConfig, info, tmpDir, "dev-vpc.terraform.tfvars.json")
+	require.Error(t, err, "init must fail when the terraform binary cannot be executed")
 }
 
 // TestExecuteShellLifecycle_InitErrorStopsBeforeShell verifies an init failure aborts the

--- a/internal/exec/terraform_shell_test.go
+++ b/internal/exec/terraform_shell_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"testing"
 
@@ -13,6 +14,9 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui"
 )
+
+// errTestInitFailed is a sentinel used to assert init-failure propagation in the shell lifecycle.
+var errTestInitFailed = errors.New("init failed")
 
 func TestShellInfoFromOptions(t *testing.T) {
 	tests := []struct {
@@ -374,4 +378,130 @@ func TestApplyShellSecretEnv(t *testing.T) {
 			assert.NotContains(t, e, "TF_VAR_token", "secret must not be exported without --with-secrets")
 		}
 	})
+}
+
+// TestShellInfoFromOptions_MapsSkipInit verifies the --skip-init flag value flows from
+// ShellOptions into ConfigAndStacksInfo so shouldRunTerraformInit can honor it.
+func TestShellInfoFromOptions_MapsSkipInit(t *testing.T) {
+	t.Run("skip-init true", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev", SkipInit: true})
+		assert.True(t, info.SkipInit)
+	})
+	t.Run("skip-init false (default)", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+		assert.False(t, info.SkipInit)
+	})
+}
+
+// TestShouldRunTerraformInit_Shell guards the regression: the shell subcommand must run
+// `terraform init` by default, and --skip-init must disable it.
+func TestShouldRunTerraformInit_Shell(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	t.Run("shell runs init by default", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+		assert.True(t, shouldRunTerraformInit(atmosConfig, &info),
+			"terraform shell must run init by default (pre-v1.202.0 behavior)")
+	})
+
+	t.Run("--skip-init disables init", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev", SkipInit: true})
+		assert.False(t, shouldRunTerraformInit(atmosConfig, &info))
+	})
+}
+
+// TestShouldSkipWorkspaceSetup_Shell guards the regression: the shell subcommand must NOT skip
+// workspace selection (so the user lands in the component's workspace, not `default`), except for
+// the http backend or when TF_WORKSPACE is already set.
+func TestShouldSkipWorkspaceSetup_Shell(t *testing.T) {
+	t.Run("shell selects workspace", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+		assert.False(t, shouldSkipWorkspaceSetup(&info),
+			"terraform shell must select/create the workspace (pre-v1.202.0 behavior)")
+	})
+
+	t.Run("http backend skips workspace", func(t *testing.T) {
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+		info.ComponentBackendType = "http"
+		assert.True(t, shouldSkipWorkspaceSetup(&info))
+	})
+
+	t.Run("TF_WORKSPACE set skips workspace", func(t *testing.T) {
+		t.Setenv("TF_WORKSPACE", "dev")
+		info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+		assert.True(t, shouldSkipWorkspaceSetup(&info))
+	})
+}
+
+// swapShellLifecycleSeams overrides the shell-lifecycle function seams with recorders and restores
+// them on cleanup. Returns a pointer to the ordered list of recorded step names.
+func swapShellLifecycleSeams(t *testing.T) *[]string {
+	t.Helper()
+	calls := &[]string{}
+
+	origInit, origWs, origExec := shellInitFn, shellWorkspaceFn, shellExecFn
+	t.Cleanup(func() {
+		shellInitFn, shellWorkspaceFn, shellExecFn = origInit, origWs, origExec
+	})
+
+	shellInitFn = func(_ *schema.AtmosConfiguration, _ *schema.ConfigAndStacksInfo, _, _ string, _ ...ShellCommandOption) error {
+		*calls = append(*calls, "init")
+		return nil
+	}
+	shellWorkspaceFn = func(_ *schema.AtmosConfiguration, _ *schema.ConfigAndStacksInfo, _ string, _ ...ShellCommandOption) error {
+		*calls = append(*calls, "workspace")
+		return nil
+	}
+	shellExecFn = func(_ *schema.AtmosConfiguration, _, _ string, _ []string, _, _, _, _ string) error {
+		*calls = append(*calls, "shell")
+		return nil
+	}
+	return calls
+}
+
+// TestExecuteShellLifecycle_RunsInitThenWorkspaceThenShell is the core regression test: by default
+// `terraform shell` must run init, then select/create the workspace, then launch the shell — in
+// that order. Against the v1.202.0–v1.279.x code the init and workspace steps were missing.
+func TestExecuteShellLifecycle_RunsInitThenWorkspaceThenShell(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+	cfg := &shellConfig{componentPath: t.TempDir(), workingDir: t.TempDir(), varFile: "dev-vpc.tfvars.json"}
+
+	require.NoError(t, executeShellLifecycle(atmosConfig, &info, cfg))
+	assert.Equal(t, []string{"init", "workspace", "shell"}, *calls)
+}
+
+// TestExecuteShellLifecycle_SkipInit_KeepsWorkspace verifies the levers are decoupled: --skip-init
+// suppresses init but the workspace is still selected before the shell launches.
+func TestExecuteShellLifecycle_SkipInit_KeepsWorkspace(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev", SkipInit: true})
+	cfg := &shellConfig{componentPath: t.TempDir(), workingDir: t.TempDir(), varFile: "dev-vpc.tfvars.json"}
+
+	require.NoError(t, executeShellLifecycle(atmosConfig, &info, cfg))
+	assert.Equal(t, []string{"workspace", "shell"}, *calls,
+		"--skip-init must skip init but still select the workspace and launch the shell")
+}
+
+// TestExecuteShellLifecycle_InitErrorStopsBeforeShell verifies an init failure aborts the
+// lifecycle before the workspace is touched or the shell is launched.
+func TestExecuteShellLifecycle_InitErrorStopsBeforeShell(t *testing.T) {
+	calls := swapShellLifecycleSeams(t)
+	wantErr := errTestInitFailed
+	shellInitFn = func(_ *schema.AtmosConfiguration, _ *schema.ConfigAndStacksInfo, _, _ string, _ ...ShellCommandOption) error {
+		*calls = append(*calls, "init")
+		return wantErr
+	}
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := shellInfoFromOptions(&ShellOptions{Component: "vpc", Stack: "dev"})
+	cfg := &shellConfig{componentPath: t.TempDir(), workingDir: t.TempDir(), varFile: "dev-vpc.tfvars.json"}
+
+	err := executeShellLifecycle(atmosConfig, &info, cfg)
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, []string{"init"}, *calls, "workspace and shell must not run after init fails")
 }

--- a/pkg/terraform/options.go
+++ b/pkg/terraform/options.go
@@ -50,6 +50,9 @@ type ShellOptions struct {
 	// as TF_VAR_<name> environment variables. By default they are not exported (and never
 	// written to the on-disk varfile), so terraform inside the shell will not see them.
 	WithSecrets bool
+	// SkipInit, when true, skips `terraform init` before launching the shell (from --skip-init).
+	// Workspace selection is unaffected and stays governed by the workspaces_enabled setting.
+	SkipInit bool
 	ProcessingOptions
 }
 

--- a/website/docs/cli/commands/terraform/terraform-shell.mdx
+++ b/website/docs/cli/commands/terraform/terraform-shell.mdx
@@ -218,6 +218,25 @@ atmos terraform shell infra/vpc -s tenant1-ue2-dev --identity dev-role
         atmos terraform shell <component> -s <stack> --with-secrets
         ```
     </dd>
+
+    <dt>`--skip-init` <em>(optional)</em></dt>
+    <dd>
+        Skip running `terraform init` before launching the shell. By default Atmos runs
+        `terraform init` (and selects/creates the workspace) so you enter an initialized
+        component, matching the behavior described above. Use this to enter the shell faster
+        when the component is already initialized.
+
+        Workspace selection is unaffected by this flag — it stays governed by the
+        [`workspaces_enabled`](/cli/configuration/components/terraform) setting. For a shell that
+        neither initializes nor switches workspaces, combine `--skip-init` with
+        `workspaces_enabled: false`.
+
+        Can also be set via the `ATMOS_SKIP_INIT` environment variable.
+
+        ```shell
+        atmos terraform shell <component> -s <stack> --skip-init
+        ```
+    </dd>
 </dl>
 
 ## Related Commands


### PR DESCRIPTION
## what

- Restore `terraform init` and Terraform workspace `select`/`new` to `atmos terraform shell` so the interactive shell again starts in an **initialized** component and the **correct workspace** (not `default`).
- Extract a provisioner-free `executeTerraformInitCommand` from `executeTerraformInitPhase` so the shell can run `init` without re-firing the `before.terraform.init` provisioners it already runs (no double execution). Main `ExecuteTerraform` pipeline behavior is unchanged.
- The shell now resolves the terraform/tofu binary (and toolchain), generates backend/provider-override files, and assembles the full component environment before launching — matching the shared pipeline.
- Add a `--skip-init` opt-out to `atmos terraform shell` (reuses the existing terraform flag; no new flag definition). Workspace selection stays governed by `workspaces_enabled`.
- Add regression tests for the init → workspace → shell ordering, the `--skip-init` decoupling, and the shell's `shouldRunTerraformInit`/`shouldSkipWorkspaceSetup` contract; document `--skip-init` in the command docs.

## why

- This was an accidental regression introduced in **v1.202.0** by #1813, which migrated `terraform shell` to a standalone `ExecuteTerraformShell` and silently dropped the `init` + workspace steps that the shared `ExecuteTerraform` pipeline used to run.
- The result contradicted the published docs (which promise the command generates a backend file and creates the component's workspace) and forced users to pin old versions.
- `--with-secrets` behavior is preserved: secrets are still kept out of the on-disk varfile and withheld from the shell unless explicitly requested.

## references

- Regression introduced in #1813 (first released in v1.202.0).
