### PR TITLE
fix(templates): honor ignore_missing_template_values for stack name_template (#2345)

### DIFF
--- a/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
+++ b/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
@@ -23,7 +23,7 @@ added in PR #2158.
 
 Users who set this flag still hit hard errors like:
 
-```
+```text
 template: ...name-template...: executing "..." at <.vars.tenant>: map has no entry for key "tenant"
 ```
 

--- a/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
+++ b/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
@@ -1,0 +1,119 @@
+# Honor `ignore_missing_template_values` for stack `name_template` rendering
+
+**Issue:** [#2345](https://github.com/cloudposse/atmos/issues/2345)
+**Date:** 2026-06-15
+**Status:** Fixed
+**Scope:** This is **PR 1 of 3** in the split of the rejected omnibus PR
+[#2387](https://github.com/cloudposse/atmos/pull/2387). It is intentionally small and
+self-contained (a flag-routing fix) so it can be reviewed and merged independently of the
+larger `locals` / stack-name-derivation work. See
+[`locals-current-state.md`](./locals-current-state.md) §12–§13 for the full split plan.
+
+---
+
+## Problem
+
+Atmos supports a global template setting:
+
+```yaml
+# atmos.yaml
+templates:
+  settings:
+    ignore_missing_template_values: true
+```
+
+When `true`, Go template processing must **not** fail if a referenced variable is missing;
+the missing reference renders as `<no value>` instead of aborting with an error. This flag was
+added in PR #2158.
+
+Users who set this flag still hit hard errors like:
+
+```
+template: ...name-template...: executing "..." at <.vars.tenant>: map has no entry for key "tenant"
+```
+
+…specifically when the error originated from rendering the **stack `name_template`** (the
+`stacks.name_template` used to derive a logical stack name), rather than from rendering a stack
+manifest body. Setting the global flag had no effect on these code paths.
+
+## Root cause
+
+`ProcessTmpl` takes an explicit `ignoreMissingTemplateValues bool` as its last parameter
+(`internal/exec/template_utils.go`). When `false`, the template option is `missingkey=error`;
+when `true`, it is `missingkey=default` (renders `<no value>`).
+
+Every call site that rendered a **name template** passed a hardcoded `false`, ignoring the
+user's global `atmosConfig.Templates.Settings.IgnoreMissingTemplateValues`. So the global flag
+was silently bypassed for all name-template rendering, regardless of the user's configuration.
+
+## Fix
+
+Replace the hardcoded `false` with `atmosConfig.Templates.Settings.IgnoreMissingTemplateValues`
+at every name-template `ProcessTmpl` call site. At each of these sites `atmosConfig` is already
+dereferenced in the same expression (e.g. `atmosConfig.Stacks.NameTemplate`), so no additional
+nil-guard is required.
+
+This is a behavior-preserving change for existing users: the flag defaults to `false`, so any
+configuration that does not opt in renders exactly as before. The fix only changes behavior when
+the user has explicitly set `ignore_missing_template_values: true`.
+
+### Affected call sites (11)
+
+| File | Template name |
+|---|---|
+| `internal/exec/atlantis_generate_repo_config.go` | `atlantis-stack-name-template` |
+| `internal/exec/aws_eks_update_kubeconfig.go` | `cluster_name_template` |
+| `internal/exec/describe_affected_utils_2.go` | `spacelift-admin-stack-name-template` |
+| `internal/exec/describe_affected_utils_2.go` | `spacelift-stack-name-template` |
+| `internal/exec/describe_locals.go` | `describe-locals-name-template` |
+| `internal/exec/spacelift_utils.go` | `name-template` |
+| `internal/exec/stack_utils.go` | `terraform-workspace-stacks-name-template` |
+| `internal/exec/terraform_generate_backends.go` | `terraform-generate-backends-template` |
+| `internal/exec/terraform_generate_varfiles.go` | `terraform-generate-varfiles-template` |
+| `internal/exec/utils.go` | `name-template` |
+| `internal/exec/validate_stacks.go` | `validate-stacks-name-template` |
+
+> Note: the `describe-locals-name-template` site lives inside `deriveStackNameFromTemplate`,
+> which PR 2 of the split will rework further (to also read `settings`/`env` and to walk imports).
+> Routing the flag here now is forward-compatible with that work.
+
+## Tests
+
+`internal/exec/stack_utils_test.go` →
+`TestBuildTerraformWorkspace_IgnoreMissingTemplateValues`.
+
+`BuildTerraformWorkspace` is a stable, low-setup caller of a name-template `ProcessTmpl` site,
+chosen so the regression test is independent of the larger derivation rework in PR 2. The test
+configures a `name_template` that references a key absent from the component section and asserts
+both directions:
+
+- **flag disabled** → rendering errors (`missingkey=error`), preserving the strict default.
+- **flag enabled** → rendering succeeds; the present key resolves and the missing key renders as
+  `<no value>` (result `"acme-<no value>"`).
+
+Verified to **fail before** the fix (the flag-enabled case errored with
+`map has no entry for key "missing_key"`) and **pass after**. The full `internal/exec` package
+test suite passes.
+
+## Incidental cleanup in `stack_utils.go` (err113)
+
+Touching `stack_utils.go` for the `terraform-workspace-stacks-name-template` site caused
+`gofumpt` to reformat two adjacent, pre-existing `fmt.Errorf` calls (in
+`BuildDependentStackNameFromDependsOnLegacy` and `BuildDependentStackNameFromDependsOn`).
+That reformatting marked those lines "new" relative to `origin/main`, so
+`golangci-lint --new-from-rev=origin/main` flagged the pre-existing `err113` debt on them
+("do not define dynamic errors").
+
+Rather than suppress it, those two errors were converted to the repository's mandated
+static-wrapped-error pattern: two new sentinels in `errors/errors.go`
+(`ErrInvalidDependsOn`, `ErrInvalidSettingsDependsOn`), wrapped with `%w`. Messages are
+otherwise unchanged. New tests `TestBuildDependentStackNameFromDependsOnLegacy` and
+`TestBuildDependentStackNameFromDependsOn` cover both the resolution branches and the
+`errors.Is` sentinel behavior on the unresolved path.
+
+## Out of scope (handled by later PRs in the split)
+
+- #2374 / #2343 — stack-name derivation reading imported `vars`/`settings`/`env` and walking
+  imports (PR 2).
+- #2343 deeper bug — the import-recursion vars clobber gated by `localsContextResult`, and the
+  #2344 perf validation (PR 3).

--- a/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
+++ b/docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md
@@ -3,11 +3,6 @@
 **Issue:** [#2345](https://github.com/cloudposse/atmos/issues/2345)
 **Date:** 2026-06-15
 **Status:** Fixed
-**Scope:** This is **PR 1 of 3** in the split of the rejected omnibus PR
-[#2387](https://github.com/cloudposse/atmos/pull/2387). It is intentionally small and
-self-contained (a flag-routing fix) so it can be reviewed and merged independently of the
-larger `locals` / stack-name-derivation work. See
-[`locals-current-state.md`](./locals-current-state.md) §12–§13 for the full split plan.
 
 ---
 
@@ -59,19 +54,19 @@ the user has explicitly set `ignore_missing_template_values: true`.
 
 ### Affected call sites (11)
 
-| File | Template name |
-|---|---|
-| `internal/exec/atlantis_generate_repo_config.go` | `atlantis-stack-name-template` |
-| `internal/exec/aws_eks_update_kubeconfig.go` | `cluster_name_template` |
-| `internal/exec/describe_affected_utils_2.go` | `spacelift-admin-stack-name-template` |
-| `internal/exec/describe_affected_utils_2.go` | `spacelift-stack-name-template` |
-| `internal/exec/describe_locals.go` | `describe-locals-name-template` |
-| `internal/exec/spacelift_utils.go` | `name-template` |
-| `internal/exec/stack_utils.go` | `terraform-workspace-stacks-name-template` |
-| `internal/exec/terraform_generate_backends.go` | `terraform-generate-backends-template` |
-| `internal/exec/terraform_generate_varfiles.go` | `terraform-generate-varfiles-template` |
-| `internal/exec/utils.go` | `name-template` |
-| `internal/exec/validate_stacks.go` | `validate-stacks-name-template` |
+| File                                             | Template name                              |
+|--------------------------------------------------|--------------------------------------------|
+| `internal/exec/atlantis_generate_repo_config.go` | `atlantis-stack-name-template`             |
+| `internal/exec/aws_eks_update_kubeconfig.go`     | `cluster_name_template`                    |
+| `internal/exec/describe_affected_utils_2.go`     | `spacelift-admin-stack-name-template`      |
+| `internal/exec/describe_affected_utils_2.go`     | `spacelift-stack-name-template`            |
+| `internal/exec/describe_locals.go`               | `describe-locals-name-template`            |
+| `internal/exec/spacelift_utils.go`               | `name-template`                            |
+| `internal/exec/stack_utils.go`                   | `terraform-workspace-stacks-name-template` |
+| `internal/exec/terraform_generate_backends.go`   | `terraform-generate-backends-template`     |
+| `internal/exec/terraform_generate_varfiles.go`   | `terraform-generate-varfiles-template`     |
+| `internal/exec/utils.go`                         | `name-template`                            |
+| `internal/exec/validate_stacks.go`               | `validate-stacks-name-template`            |
 
 > Note: the `describe-locals-name-template` site lives inside `deriveStackNameFromTemplate`,
 > which PR 2 of the split will rework further (to also read `settings`/`env` and to walk imports).
@@ -110,10 +105,3 @@ static-wrapped-error pattern: two new sentinels in `errors/errors.go`
 otherwise unchanged. New tests `TestBuildDependentStackNameFromDependsOnLegacy` and
 `TestBuildDependentStackNameFromDependsOn` cover both the resolution branches and the
 `errors.Is` sentinel behavior on the unresolved path.
-
-## Out of scope (handled by later PRs in the split)
-
-- #2374 / #2343 — stack-name derivation reading imported `vars`/`settings`/`env` and walking
-  imports (PR 2).
-- #2343 deeper bug — the import-recursion vars clobber gated by `localsContextResult`, and the
-  #2344 perf validation (PR 3).

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1217,6 +1217,16 @@ var (
 	ErrLSPNoContentLengthHeader = errors.New("no Content-Length header found")
 )
 
+// Stack dependency (`depends_on`) resolution errors.
+var (
+	// ErrInvalidDependsOn indicates a legacy `settings.spacelift.depends_on` value
+	// does not resolve to a known stack or to a component in the current stack.
+	ErrInvalidDependsOn = errors.New("invalid 'depends_on' dependency")
+	// ErrInvalidSettingsDependsOn indicates a `settings.depends_on` value does not
+	// resolve to a known component in a known stack.
+	ErrInvalidSettingsDependsOn = errors.New("invalid 'settings.depends_on' dependency")
+)
+
 // ExitCodeError is a typed error that preserves subcommand exit codes.
 // This allows the root command to exit with the same code as the subcommand.
 // When Code is 0, it indicates successful completion that should exit cleanly without printing errors.

--- a/internal/exec/atlantis_generate_repo_config.go
+++ b/internal/exec/atlantis_generate_repo_config.go
@@ -401,7 +401,7 @@ func ExecuteAtlantisGenerateRepoConfig(
 
 				switch {
 				case stackNameTemplate != "":
-					stackSlug, err = ProcessTmpl(atmosConfig, "atlantis-stack-name-template", stackNameTemplate, configAndStacksInfo.ComponentSection, false)
+					stackSlug, err = ProcessTmpl(atmosConfig, "atlantis-stack-name-template", stackNameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 					if err != nil {
 						return err
 					}

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -194,7 +194,7 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 			if atmosConfig.Components.Helmfile.ClusterName != "" {
 				clusterName = atmosConfig.Components.Helmfile.ClusterName
 			} else if atmosConfig.Components.Helmfile.ClusterNameTemplate != "" {
-				clusterName, err = ProcessTmpl(&atmosConfig, "cluster_name_template", atmosConfig.Components.Helmfile.ClusterNameTemplate, configAndStacksInfo.ComponentSection, false)
+				clusterName, err = ProcessTmpl(&atmosConfig, "cluster_name_template", atmosConfig.Components.Helmfile.ClusterNameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 				if err != nil {
 					return fmt.Errorf("failed to process cluster_name_template: %w", err)
 				}

--- a/internal/exec/describe_affected_utils_2.go
+++ b/internal/exec/describe_affected_utils_2.go
@@ -470,7 +470,7 @@ func addAffectedSpaceliftAdminStack(
 	var adminStackContextPrefix string
 
 	if atmosConfig.Stacks.NameTemplate != "" {
-		adminStackContextPrefix, err = ProcessTmpl(atmosConfig, "spacelift-admin-stack-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+		adminStackContextPrefix, err = ProcessTmpl(atmosConfig, "spacelift-admin-stack-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 		if err != nil {
 			return nil, err
 		}
@@ -509,7 +509,7 @@ func addAffectedSpaceliftAdminStack(
 							var contextPrefix string
 
 							if atmosConfig.Stacks.NameTemplate != "" {
-								contextPrefix, err = ProcessTmpl(atmosConfig, "spacelift-stack-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+								contextPrefix, err = ProcessTmpl(atmosConfig, "spacelift-stack-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 								if err != nil {
 									return nil, err
 								}

--- a/internal/exec/describe_locals.go
+++ b/internal/exec/describe_locals.go
@@ -515,7 +515,7 @@ func deriveStackNameFromTemplate(
 		"vars": varsSection,
 	}
 
-	stackName, err := ProcessTmpl(atmosConfig, "describe-locals-name-template", atmosConfig.Stacks.NameTemplate, templateData, false)
+	stackName, err := ProcessTmpl(atmosConfig, "describe-locals-name-template", atmosConfig.Stacks.NameTemplate, templateData, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 	if err != nil {
 		log.Debug("Failed to evaluate name template for stack", "file", stackFileName, "error", err)
 		return ""

--- a/internal/exec/spacelift_utils.go
+++ b/internal/exec/spacelift_utils.go
@@ -108,7 +108,7 @@ func BuildSpaceliftStackNameFromComponentConfig(
 		context.Component = strings.Replace(configAndStacksInfo.ComponentFromArg, "/", "-", -1)
 
 		if atmosConfig.Stacks.NameTemplate != "" {
-			contextPrefix, err = ProcessTmpl(atmosConfig, "name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+			contextPrefix, err = ProcessTmpl(atmosConfig, "name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 			if err != nil {
 				return "", err
 			}

--- a/internal/exec/stack_utils.go
+++ b/internal/exec/stack_utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -31,7 +32,7 @@ func BuildTerraformWorkspace(atmosConfig *schema.AtmosConfiguration, configAndSt
 	case configAndStacksInfo.StackManifestName != "":
 		contextPrefix = configAndStacksInfo.StackManifestName
 	case atmosConfig.Stacks.NameTemplate != "":
-		tmpl, err = ProcessTmpl(atmosConfig, "terraform-workspace-stacks-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+		tmpl, err = ProcessTmpl(atmosConfig, "terraform-workspace-stacks-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 		if err != nil {
 			return "", err
 		}
@@ -139,14 +140,16 @@ func BuildDependentStackNameFromDependsOnLegacy(
 	} else if u.SliceContainsString(componentNamesInCurrentStack, dep) {
 		dependentStackName = fmt.Sprintf("%s-%s", currentStackName, dep)
 	} else {
-		errorMessage := fmt.Errorf("the component '%[1]s' in the stack '%[2]s' specifies 'depends_on' dependency '%[3]s', "+
-			"but '%[3]s' is not a stack and not a component in the '%[2]s' stack",
+		return "", fmt.Errorf(
+			"%w: the component '%s' in the stack '%s' specifies 'depends_on' dependency '%s', "+
+				"but '%s' is not a stack and not a component in the '%s' stack",
+			errUtils.ErrInvalidDependsOn,
 			currentComponentName,
 			currentStackName,
 			dependsOn,
+			dependsOn,
+			currentStackName,
 		)
-
-		return "", errorMessage
 	}
 
 	return dependentStackName, nil
@@ -168,15 +171,17 @@ func BuildDependentStackNameFromDependsOn(
 		return dep, nil
 	}
 
-	errorMessage := fmt.Errorf("the component '%[1]s' in the stack '%[2]s' specifies 'settings.depends_on' dependency "+
-		"on the component '%[3]s' in the stack '%[4]s', but '%[3]s' is not defined in the '%[4]s' stack, or the component and stack names are not correct",
+	return "", fmt.Errorf(
+		"%w: the component '%s' in the stack '%s' specifies 'settings.depends_on' dependency "+
+			"on the component '%s' in the stack '%s', but '%s' is not defined in the '%s' stack, or the component and stack names are not correct",
+		errUtils.ErrInvalidSettingsDependsOn,
 		currentComponentName,
 		currentStackName,
 		dependsOnComponentName,
 		dependsOnStackName,
+		dependsOnComponentName,
+		dependsOnStackName,
 	)
-
-	return "", errorMessage
 }
 
 // BuildComponentPath builds component path (path to the component's physical location on disk).

--- a/internal/exec/stack_utils_test.go
+++ b/internal/exec/stack_utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
@@ -98,6 +99,92 @@ func TestBuildTerraformWorkspace(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildTerraformWorkspace_IgnoreMissingTemplateValues verifies that the global
+// `templates.settings.ignore_missing_template_values` flag is honored when the stack
+// `name_template` is rendered to build the Terraform workspace.
+//
+// Regression test for #2345: the `ProcessTmpl` call site for the name template
+// hardcoded `ignoreMissingTemplateValues=false`, so a `name_template` that referenced
+// a missing key always errored even when the user set the global flag to `true`.
+func TestBuildTerraformWorkspace_IgnoreMissingTemplateValues(t *testing.T) {
+	// The template references `.vars.missing_key`, which is absent from the component section.
+	const nameTemplate = "{{ .vars.tenant }}-{{ .vars.missing_key }}"
+
+	newConfig := func(ignoreMissing bool) *schema.AtmosConfiguration {
+		return &schema.AtmosConfiguration{
+			Components: schema.Components{
+				Terraform: schema.Terraform{WorkspacesEnabled: boolPtr(true)},
+			},
+			Stacks: schema.Stacks{NameTemplate: nameTemplate},
+			Templates: schema.Templates{
+				Settings: schema.TemplatesSettings{IgnoreMissingTemplateValues: ignoreMissing},
+			},
+		}
+	}
+
+	info := schema.ConfigAndStacksInfo{
+		ComponentBackendType: "s3",
+		Component:            "test-component",
+		Stack:                "dev/us-east-1",
+		ComponentSection: map[string]any{
+			"vars": map[string]any{"tenant": "acme"},
+		},
+	}
+
+	t.Run("flag disabled: missing template key errors", func(t *testing.T) {
+		_, err := BuildTerraformWorkspace(newConfig(false), info)
+		assert.Error(t, err, "with ignore_missing_template_values=false, a missing name_template key must error")
+	})
+
+	t.Run("flag enabled: missing template key tolerated", func(t *testing.T) {
+		workspace, err := BuildTerraformWorkspace(newConfig(true), info)
+		assert.NoError(t, err, "with ignore_missing_template_values=true, a missing name_template key must not error")
+		// `tenant` resolves; the missing key renders as `<no value>` (missingkey=default).
+		assert.Equal(t, "acme-<no value>", workspace, "tenant must resolve and the missing key must not abort rendering")
+	})
+}
+
+// TestBuildDependentStackNameFromDependsOnLegacy covers both resolution branches and the
+// unresolved path, which now returns a wrapped static error (errUtils.ErrInvalidDependsOn).
+func TestBuildDependentStackNameFromDependsOnLegacy(t *testing.T) {
+	allStacks := []string{"prod-ue1", "dev-ue1"}
+	componentsInStack := []string{"vpc", "eks"}
+
+	t.Run("resolves to a stack", func(t *testing.T) {
+		got, err := BuildDependentStackNameFromDependsOnLegacy("prod-ue1", allStacks, "dev-ue1", componentsInStack, "app")
+		assert.NoError(t, err)
+		assert.Equal(t, "prod-ue1", got)
+	})
+
+	t.Run("resolves to a component in the current stack", func(t *testing.T) {
+		got, err := BuildDependentStackNameFromDependsOnLegacy("vpc", allStacks, "dev-ue1", componentsInStack, "app")
+		assert.NoError(t, err)
+		assert.Equal(t, "dev-ue1-vpc", got)
+	})
+
+	t.Run("unresolved dependency returns ErrInvalidDependsOn", func(t *testing.T) {
+		_, err := BuildDependentStackNameFromDependsOnLegacy("nope", allStacks, "dev-ue1", componentsInStack, "app")
+		assert.ErrorIs(t, err, errUtils.ErrInvalidDependsOn)
+	})
+}
+
+// TestBuildDependentStackNameFromDependsOn covers the resolution and unresolved paths; the
+// unresolved path now returns a wrapped static error (errUtils.ErrInvalidSettingsDependsOn).
+func TestBuildDependentStackNameFromDependsOn(t *testing.T) {
+	allStacks := []string{"prod-ue1-vpc", "dev-ue1-eks"}
+
+	t.Run("resolves component in stack", func(t *testing.T) {
+		got, err := BuildDependentStackNameFromDependsOn("app", "dev-ue1", "vpc", "prod-ue1", allStacks)
+		assert.NoError(t, err)
+		assert.Equal(t, "prod-ue1-vpc", got)
+	})
+
+	t.Run("unresolved dependency returns ErrInvalidSettingsDependsOn", func(t *testing.T) {
+		_, err := BuildDependentStackNameFromDependsOn("app", "dev-ue1", "missing", "prod-ue1", allStacks)
+		assert.ErrorIs(t, err, errUtils.ErrInvalidSettingsDependsOn)
+	})
 }
 
 func TestBuildComponentPath(t *testing.T) {

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -216,7 +216,7 @@ func ExecuteTerraformGenerateBackends(
 				// Stack name
 				var stackName string
 				if atmosConfig.Stacks.NameTemplate != "" {
-					stackName, err = ProcessTmpl(atmosConfig, "terraform-generate-backends-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+					stackName, err = ProcessTmpl(atmosConfig, "terraform-generate-backends-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 					if err != nil {
 						return err
 					}

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -170,7 +170,7 @@ func ExecuteTerraformGenerateVarfiles(
 				// Stack name
 				var stackName string
 				if atmosConfig.Stacks.NameTemplate != "" {
-					stackName, err = ProcessTmpl(atmosConfig, "terraform-generate-varfiles-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+					stackName, err = ProcessTmpl(atmosConfig, "terraform-generate-varfiles-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 					if err != nil {
 						return err
 					}

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -407,7 +407,7 @@ func processStackContextPrefix(
 
 	switch {
 	case atmosConfig.Stacks.NameTemplate != "":
-		tmpl, err := ProcessTmpl(atmosConfig, "name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+		tmpl, err := ProcessTmpl(atmosConfig, "name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 		if err != nil {
 			return err
 		}

--- a/internal/exec/validate_stacks.go
+++ b/internal/exec/validate_stacks.go
@@ -363,7 +363,7 @@ func createComponentStackMap(
 
 					// Find Atmos stack name
 					if atmosConfig.Stacks.NameTemplate != "" {
-						stackName, err = ProcessTmpl(atmosConfig, "validate-stacks-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, false)
+						stackName, err = ProcessTmpl(atmosConfig, "validate-stacks-name-template", atmosConfig.Stacks.NameTemplate, configAndStacksInfo.ComponentSection, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 						if err != nil {
 							return nil, err
 						}


### PR DESCRIPTION
## what

- Route the global `templates.settings.ignore_missing_template_values` flag into every stack `name_template` rendering site. Previously all 11 name-template `ProcessTmpl(...)` call sites passed a hardcoded `false`, so the flag was silently ignored for name-template rendering.
- Sites updated: atlantis stack name, EKS cluster name, spacelift admin/stack name (describe affected), `describe locals` name, spacelift utils, terraform workspace, terraform generate backends/varfiles, the shared name-template util, and validate stacks.
- Add `TestBuildTerraformWorkspace_IgnoreMissingTemplateValues` asserting both directions (flag off → error; flag on → `<no value>`).
- Incidental cleanup: `gofumpt` reformatting two adjacent pre-existing `fmt.Errorf` calls in `stack_utils.go` - `err113` debt under `golangci-lint --new-from-rev=origin/main`. Converted them to the mandated static-wrapped-error pattern (new sentinels `ErrInvalidDependsOn` / `ErrInvalidSettingsDependsOn` in `errors/errors.go`) with tests covering both resolution branches and the `errors.Is` behavior.

## why

- When a user sets `templates.settings.ignore_missing_template_values: true`, they still hit hard errors like `map has no entry for key "..."` whenever the error originated from rendering the stack `name_template` — because the name-template `ProcessTmpl` sites bypassed the flag.
- The fix is behavior-preserving: the flag defaults to `false`, so existing configurations render exactly as before; behavior only changes for users who explicitly opt in.
- The `err113` conversion follows the repository's mandated static-error pattern and keeps the pre-commit/CI lint green; messages are unchanged.

## references

- Closes #2345
- Fix doc: `docs/fixes/2026-06-15-name-template-ignore-missing-template-values.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated template rendering to consistently honor `ignore_missing_template_values` across stack- and dependency-related name derivations (including Terraform workspace and generated stack naming).
  * Added clearer error handling for invalid `depends_on` inputs via dedicated sentinel errors.

* **Tests**
  * Added regression tests covering enabled/disabled `ignore_missing_template_values` behavior and dependency resolution success/failure.

* **Documentation**
  * Added a documentation page explaining the corrected `ignore_missing_template_values` behavior for stack name template rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->