### PR TITLE
fix(toolchain): harden cosign verifier bootstrap

### DIFF
--- a/pkg/toolchain/installer/installer.go
+++ b/pkg/toolchain/installer/installer.go
@@ -44,6 +44,10 @@ const (
 
 	// Windows constants.
 	windowsExeExt = ".exe"
+
+	// Pin cosign verifier bootstrap so verification does not depend on live
+	// GitHub latest-release lookup before cosign is available.
+	defaultCosignVerifierVersion = "v3.0.6"
 )
 
 // EnsureWindowsExeExtension appends .exe to the binary name on Windows if not already present.
@@ -399,6 +403,10 @@ func (r verifierCommandRunner) Run(ctx context.Context, name string, args ...str
 }
 
 func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, error) {
+	if version, ok := pinnedVerifierInstallVersion(owner, repo); ok {
+		return version, nil
+	}
+
 	var lookupErrs []error
 
 	if i.useConfiguredReg {
@@ -420,6 +428,13 @@ func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, e
 	}
 
 	return "", verifierVersionUnavailableError(owner, repo, lookupErrs)
+}
+
+func pinnedVerifierInstallVersion(owner, repo string) (string, bool) {
+	if owner == "sigstore" && repo == "cosign" {
+		return defaultCosignVerifierVersion, true
+	}
+	return "", false
 }
 
 func (i *Installer) aquaVerifierRegistry() registry.ToolRegistry {

--- a/pkg/toolchain/installer/installer.go
+++ b/pkg/toolchain/installer/installer.go
@@ -46,7 +46,7 @@ const (
 	windowsExeExt = ".exe"
 
 	// Fallback cosign verifier bootstrap version for transient GitHub latest-release lookup failures.
-	// renovate: datasource=github-releases depName=sigstore/cosign
+	// renovate: datasource=github-releases depName=sigstore/cosign.
 	defaultCosignVerifierVersion = "v3.0.6"
 )
 

--- a/pkg/toolchain/installer/installer.go
+++ b/pkg/toolchain/installer/installer.go
@@ -45,8 +45,8 @@ const (
 	// Windows constants.
 	windowsExeExt = ".exe"
 
-	// Pin cosign verifier bootstrap so verification does not depend on live
-	// GitHub latest-release lookup before cosign is available.
+	// Fallback cosign verifier bootstrap version for transient GitHub latest-release lookup failures.
+	// renovate: datasource=github-releases depName=sigstore/cosign
 	defaultCosignVerifierVersion = "v3.0.6"
 )
 
@@ -403,10 +403,6 @@ func (r verifierCommandRunner) Run(ctx context.Context, name string, args ...str
 }
 
 func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, error) {
-	if version, ok := pinnedVerifierInstallVersion(owner, repo); ok {
-		return version, nil
-	}
-
 	var lookupErrs []error
 
 	if i.useConfiguredReg {
@@ -427,10 +423,21 @@ func (i *Installer) resolveVerifierInstallVersion(owner, repo string) (string, e
 		lookupErrs = append(lookupErrs, err)
 	}
 
+	if version, ok := fallbackVerifierInstallVersion(owner, repo); ok && len(lookupErrs) > 0 {
+		log.Debug(
+			"Using fallback verifier bootstrap version after latest lookup failure",
+			logFieldOwner, owner,
+			logFieldRepo, repo,
+			logFieldVersion, version,
+			"lookup_errors", errors.Join(lookupErrs...),
+		)
+		return version, nil
+	}
+
 	return "", verifierVersionUnavailableError(owner, repo, lookupErrs)
 }
 
-func pinnedVerifierInstallVersion(owner, repo string) (string, bool) {
+func fallbackVerifierInstallVersion(owner, repo string) (string, bool) {
 	if owner == "sigstore" && repo == "cosign" {
 		return defaultCosignVerifierVersion, true
 	}

--- a/pkg/toolchain/installer/verifier_command_test.go
+++ b/pkg/toolchain/installer/verifier_command_test.go
@@ -90,7 +90,7 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 	defer ts.Close()
 
 	reg := &verifierBootstrapRegistry{
-		latestErr: errors.New("latest version lookup should not be called for pinned cosign"),
+		latest: "v3.1.1",
 		tool: &registry.Tool{
 			Type:       "http",
 			RepoOwner:  "sigstore",
@@ -119,8 +119,53 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 	}.Run(context.Background(), "cosign", "-test.run=TestVerifierCommandHelperProcess", "--", "success")
 
 	require.NoError(t, err)
-	assert.Equal(t, "v3.0.6", reg.requestedVersion)
-	assert.Zero(t, reg.latestCalls, "pinned cosign bootstrap must not call latest version lookup")
+	assert.Equal(t, "v3.1.1", reg.requestedVersion)
+	assert.Equal(t, 1, reg.latestCalls, "cosign bootstrap should prefer latest when lookup succeeds")
+}
+
+func TestVerifierCommandRunnerAutoInstallFallsBackToPinnedCosignWhenLatestLookupFails(t *testing.T) {
+	testBinary, err := os.ReadFile(os.Args[0])
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(testBinary)
+	}))
+	defer ts.Close()
+
+	configuredReg := &verifierBootstrapRegistry{
+		latestErr: errConfiguredLatest,
+		tool: &registry.Tool{
+			Type:       "http",
+			RepoOwner:  "sigstore",
+			RepoName:   "cosign",
+			Asset:      ts.URL + "/{{.Version}}/cosign",
+			Format:     "raw",
+			BinaryName: "cosign",
+		},
+	}
+	aquaReg := &verifierBootstrapRegistry{latestErr: errAquaLatest}
+	inst := &Installer{
+		cacheDir:         t.TempDir(),
+		binDir:           t.TempDir(),
+		configuredReg:    configuredReg,
+		useConfiguredReg: true,
+		registryFactory:  verifierBootstrapFactory{registry: aquaReg},
+	}
+
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("ATMOS_VERIFIER_HELPER_PROCESS", "1")
+
+	err = verifierCommandRunner{
+		installer: inst,
+		policy: verification.Policy{
+			VerifierInstall: verification.VerifierInstallAuto,
+		},
+	}.Run(context.Background(), "cosign", "-test.run=TestVerifierCommandHelperProcess", "--", "success")
+
+	require.NoError(t, err)
+	assert.Equal(t, "v3.0.6", configuredReg.requestedVersion)
+	assert.Equal(t, 1, configuredReg.latestCalls)
+	assert.Equal(t, 1, aquaReg.latestCalls)
 }
 
 func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.T) {

--- a/pkg/toolchain/installer/verifier_command_test.go
+++ b/pkg/toolchain/installer/verifier_command_test.go
@@ -90,7 +90,7 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 	defer ts.Close()
 
 	reg := &verifierBootstrapRegistry{
-		latest: "v3.0.6",
+		latestErr: errors.New("latest version lookup should not be called for pinned cosign"),
 		tool: &registry.Tool{
 			Type:       "http",
 			RepoOwner:  "sigstore",
@@ -120,6 +120,7 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "v3.0.6", reg.requestedVersion)
+	assert.Zero(t, reg.latestCalls, "pinned cosign bootstrap must not call latest version lookup")
 }
 
 func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.T) {
@@ -127,11 +128,11 @@ func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.
 		latest: "",
 		tool: &registry.Tool{
 			Type:       "http",
-			RepoOwner:  "sigstore",
-			RepoName:   "cosign",
-			Asset:      "https://example.com/{{.Version}}/cosign",
+			RepoOwner:  "slsa-framework",
+			RepoName:   "slsa-verifier",
+			Asset:      "https://example.com/{{.Version}}/slsa-verifier",
 			Format:     "raw",
-			BinaryName: "cosign",
+			BinaryName: "slsa-verifier",
 		},
 	}
 	inst := &Installer{
@@ -149,7 +150,7 @@ func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.
 		policy: verification.Policy{
 			VerifierInstall: verification.VerifierInstallAuto,
 		},
-	}.Run(context.Background(), "cosign", "-test.run=TestVerifierCommandHelperProcess", "--", "success")
+	}.Run(context.Background(), "slsa-verifier", "-test.run=TestVerifierCommandHelperProcess", "--", "success")
 
 	require.ErrorIs(t, err, verification.ErrVerifierCommandRequired)
 	assert.Empty(t, reg.requestedVersion, "bootstrap install must not be called with literal latest")
@@ -164,7 +165,7 @@ func TestResolveVerifierInstallVersionPreservesLookupErrors(t *testing.T) {
 		registryFactory:  verifierBootstrapFactory{registry: aquaReg},
 	}
 
-	version, err := inst.resolveVerifierInstallVersion("sigstore", "cosign")
+	version, err := inst.resolveVerifierInstallVersion("slsa-framework", "slsa-verifier")
 
 	require.Empty(t, version)
 	require.ErrorIs(t, err, ErrVerifierVersionUnavailable)
@@ -206,6 +207,7 @@ type verifierBootstrapRegistry struct {
 	mu               sync.Mutex
 	latest           string
 	latestErr        error
+	latestCalls      int
 	tool             *registry.Tool
 	requestedVersion string
 }
@@ -222,6 +224,10 @@ func (r *verifierBootstrapRegistry) GetToolWithVersion(_, _, version string) (*r
 }
 
 func (r *verifierBootstrapRegistry) GetLatestVersion(_, _ string) (string, error) {
+	r.mu.Lock()
+	r.latestCalls++
+	r.mu.Unlock()
+
 	if r.latestErr != nil {
 		return "", r.latestErr
 	}

--- a/pkg/toolchain/installer/verifier_command_test.go
+++ b/pkg/toolchain/installer/verifier_command_test.go
@@ -124,13 +124,18 @@ func TestVerifierCommandRunnerAutoInstallUsesResolvedVersion(t *testing.T) {
 }
 
 func TestVerifierCommandRunnerAutoInstallFailsBeforeInstallingLatest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected verifier install", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
 	reg := &verifierBootstrapRegistry{
 		latest: "",
 		tool: &registry.Tool{
 			Type:       "http",
 			RepoOwner:  "slsa-framework",
 			RepoName:   "slsa-verifier",
-			Asset:      "https://example.com/{{.Version}}/slsa-verifier",
+			Asset:      ts.URL + "/{{.Version}}/slsa-verifier",
 			Format:     "raw",
 			BinaryName: "slsa-verifier",
 		},

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update fallback cosign verifier bootstrap version",
+      "managerFilePatterns": [
+        "/^pkg/toolchain/installer/installer\\.go$/"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+defaultCosignVerifierVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "semver-coerced"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
         "/^pkg/toolchain/installer/installer\\.go$/"
       ],
       "matchStrings": [
-        "// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+defaultCosignVerifierVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s.]+)\\.?\\s+defaultCosignVerifierVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "semver-coerced"
     }


### PR DESCRIPTION
## what

- Keep verifier bootstrap version resolution latest-first, using the existing authenticated GitHub/Aqua lookup path.
- Add a `sigstore/cosign@v3.0.6` fallback only when latest-version lookup fails.
- Add Renovate regex-manager coverage for the fallback cosign version so the safety pin is updateable.
- Update installer tests to prove latest wins when available, cosign falls back when lookup fails, and non-pinned verifier lookup errors still surface.

## why

- Prevent OpenTofu toolchain installs from failing when cosign auto-install hits a slow or unavailable GitHub releases API.
- Avoid making the fallback version the default forever; normal installs still use the latest resolved cosign release when GitHub lookup succeeds.
- Preserve existing escape hatches: existing `cosign` on `PATH` still wins, and `verifier_install: path_only` still disables auto-install.

## references

- Failing run: https://github.com/cloudposse/atmos/actions/runs/27661641040/job/81808473011
- Fallback cosign release: https://github.com/sigstore/cosign/releases/tag/v3.0.6
