### PR TITLE
Fix use-version before command resolution

### DIFF
--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -159,21 +161,25 @@ func TestUsageErrorHelpersExit(t *testing.T) {
 	root.AddCommand(known)
 
 	assert.Panics(t, func() {
+		exitCode = 0
 		showUsageAndExit(root, nil)
 	})
 	assert.Equal(t, 1, exitCode)
 
 	assert.Panics(t, func() {
+		exitCode = 0
 		showUsageAndExit(root, []string{"knwon"})
 	})
 	assert.Equal(t, 1, exitCode)
 
 	assert.Panics(t, func() {
+		exitCode = 0
 		_ = showFlagUsageAndExit(known, errors.New("flag needs an argument: --stack"))
 	})
 	assert.Equal(t, 1, exitCode)
 
 	assert.Panics(t, func() {
+		exitCode = 0
 		_ = showFlagUsageAndExit(known, errors.New("unknown flag: --bad"))
 	})
 	assert.Equal(t, 1, exitCode)
@@ -225,11 +231,36 @@ func TestEnableHeatmapIfRequested(t *testing.T) {
 		perf.EnableTracking(false)
 	})
 
+	captureHeatmap := func() string {
+		oldStderr := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+		t.Cleanup(func() {
+			os.Stderr = oldStderr
+		})
+
+		require.NoError(t, displayPerformanceHeatmap(nil, "table"))
+		require.NoError(t, w.Close())
+		os.Stderr = oldStderr
+
+		var output bytes.Buffer
+		_, err = io.Copy(&output, r)
+		require.NoError(t, err)
+		return output.String()
+	}
+
 	os.Args = []string{"atmos", "version"}
 	enableHeatmapIfRequested()
+	done := perf.Track(nil, "cmd.test.heatmap.disabled")
+	done()
+	assert.NotContains(t, captureHeatmap(), "cmd.test.heatmap.disabled")
 
 	os.Args = []string{"atmos", "--heatmap", "version"}
 	enableHeatmapIfRequested()
+	done = perf.Track(nil, "cmd.test.heatmap.enabled")
+	done()
+	assert.Contains(t, captureHeatmap(), "cmd.test.heatmap.enabled")
 }
 
 func TestIsVersionCommand(t *testing.T) {

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -16,6 +16,7 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	e "github.com/cloudposse/atmos/internal/exec"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
+	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/reexec"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
@@ -134,6 +135,101 @@ func TestAppendUsageSection(t *testing.T) {
 
 	assert.Contains(t, got, "## Usage")
 	assert.Contains(t, got, "```shell\natmos git push <name-or-path> [flags]\n```")
+}
+
+func TestUsageErrorHelpersExit(t *testing.T) {
+	_ = NewTestKit(t)
+
+	originalOsExit := errUtils.OsExit
+	t.Cleanup(func() {
+		errUtils.OsExit = originalOsExit
+	})
+
+	type exitPanic struct {
+		code int
+	}
+	var exitCode int
+	errUtils.OsExit = func(code int) {
+		exitCode = code
+		panic(exitPanic{code: code})
+	}
+
+	root := &cobra.Command{Use: "atmos"}
+	known := &cobra.Command{Use: "known", Run: func(*cobra.Command, []string) {}}
+	root.AddCommand(known)
+
+	assert.Panics(t, func() {
+		showUsageAndExit(root, nil)
+	})
+	assert.Equal(t, 1, exitCode)
+
+	assert.Panics(t, func() {
+		showUsageAndExit(root, []string{"knwon"})
+	})
+	assert.Equal(t, 1, exitCode)
+
+	assert.Panics(t, func() {
+		_ = showFlagUsageAndExit(known, errors.New("flag needs an argument: --stack"))
+	})
+	assert.Equal(t, 1, exitCode)
+
+	assert.Panics(t, func() {
+		_ = showFlagUsageAndExit(known, errors.New("unknown flag: --bad"))
+	})
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestHandlePathResolutionError(t *testing.T) {
+	sentinelErrors := []error{
+		errUtils.ErrAmbiguousComponentPath,
+		errUtils.ErrComponentNotInStack,
+		errUtils.ErrStackNotFound,
+		errUtils.ErrUserAborted,
+	}
+
+	for _, sentinel := range sentinelErrors {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			err := handlePathResolutionError(sentinel)
+			assert.ErrorIs(t, err, sentinel)
+		})
+	}
+
+	t.Run("generic error is wrapped with path resolution failed", func(t *testing.T) {
+		err := handlePathResolutionError(errors.New("raw resolver failure"))
+		assert.ErrorIs(t, err, errUtils.ErrPathResolutionFailed)
+		assert.Contains(t, err.Error(), "raw resolver failure")
+	})
+}
+
+func TestVersionManagementCommandClassification(t *testing.T) {
+	root := &cobra.Command{Use: "atmos"}
+	versionCmd := &cobra.Command{Use: "version"}
+	installCmd := &cobra.Command{Use: "install"}
+	uninstallCmd := &cobra.Command{Use: "uninstall"}
+	listCmd := &cobra.Command{Use: "list"}
+	versionCmd.AddCommand(installCmd, uninstallCmd, listCmd)
+	root.AddCommand(versionCmd)
+
+	assert.False(t, isVersionManagementCommand(nil))
+	assert.True(t, isVersionManagementCommand(versionCmd))
+	assert.True(t, isVersionManagementCommand(installCmd))
+	assert.True(t, isVersionManagementCommand(uninstallCmd))
+	assert.False(t, isVersionManagementCommand(listCmd))
+	assert.False(t, isVersionManagementCommand(&cobra.Command{Use: "version"}))
+}
+
+func TestEnableHeatmapIfRequested(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		perf.EnableTracking(false)
+	})
+
+	os.Args = []string{"atmos", "version"}
+	enableHeatmapIfRequested()
+
+	os.Args = []string{"atmos", "--heatmap", "version"}
+	enableHeatmapIfRequested()
 }
 
 func TestIsVersionCommand(t *testing.T) {
@@ -1279,6 +1375,23 @@ func TestComponentsArgCompletion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestComponentsArgCompletionDelegatesToFlagCompletion(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("target", "", "target flag")
+	err := cmd.RegisterFlagCompletionFunc("target", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"one", "two"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	require.NoError(t, err)
+
+	completions, directive := ComponentsArgCompletion(cmd, []string{"component", "--target"}, "")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Equal(t, []string{"one", "two"}, completions)
+
+	completions, directive = ComponentsArgCompletion(cmd, []string{"component"}, "--target")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Equal(t, []string{"one", "two"}, completions)
 }
 
 // TestIsGitRepository tests the isGitRepository function.

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -259,6 +260,7 @@ func TestEnableHeatmapIfRequested(t *testing.T) {
 	os.Args = []string{"atmos", "--heatmap", "version"}
 	enableHeatmapIfRequested()
 	done = perf.Track(nil, "cmd.test.heatmap.enabled")
+	time.Sleep(2 * time.Millisecond)
 	done()
 	assert.Contains(t, captureHeatmap(), "cmd.test.heatmap.enabled")
 }

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunCompletionShells(t *testing.T) {
+	for _, shellName := range []string{"bash", "zsh", "fish", "powershell", "unknown"} {
+		t.Run(shellName, func(t *testing.T) {
+			root := &cobra.Command{Use: "atmos"}
+			cmd := &cobra.Command{Use: shellName, RunE: runCompletion}
+			root.AddCommand(cmd)
+
+			require.NoError(t, runCompletion(cmd, nil))
+		})
+	}
+}

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -20,6 +20,10 @@ import (
 
 const atmosDocsURL = "https://atmos.tools"
 
+var openDocsURL = func(url string) error {
+	return browser.New().Open(url)
+}
+
 // docsCmd opens the Atmos docs and can display component documentation
 var docsCmd = &cobra.Command{
 	Use:                "docs",
@@ -120,7 +124,7 @@ var docsCmd = &cobra.Command{
 		}
 
 		// Opens atmos.tools docs if no component argument is provided
-		if err := browser.New().Open(atmosDocsURL); err != nil {
+		if err := openDocsURL(atmosDocsURL); err != nil {
 			return fmt.Errorf("open Atmos docs: %w", err)
 		}
 

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -11,6 +11,8 @@ import (
 // TestDocsCmd_WithoutStacks verifies that docs command does not require stack configuration.
 // This test documents that the docs command uses InitCliConfig with processStacks=false.
 func TestDocsCmd_WithoutStacks(t *testing.T) {
+	_ = NewTestKit(t)
+
 	// This test documents that docs command does not process stacks
 	// by verifying InitCliConfig is called with processStacks=false in docs.go:38
 	// No runtime test needed - this is enforced by code structure.
@@ -18,11 +20,9 @@ func TestDocsCmd_WithoutStacks(t *testing.T) {
 }
 
 func TestDocsCmdOpensDefaultDocsURL(t *testing.T) {
+	_ = NewTestKit(t)
+
 	var openedURL string
-	originalOpenDocsURL := openDocsURL
-	t.Cleanup(func() {
-		openDocsURL = originalOpenDocsURL
-	})
 	openDocsURL = func(url string) error {
 		openedURL = url
 		return nil
@@ -33,11 +33,9 @@ func TestDocsCmdOpensDefaultDocsURL(t *testing.T) {
 }
 
 func TestDocsCmdReturnsDefaultDocsOpenError(t *testing.T) {
+	_ = NewTestKit(t)
+
 	openErr := errors.New("browser unavailable")
-	originalOpenDocsURL := openDocsURL
-	t.Cleanup(func() {
-		openDocsURL = originalOpenDocsURL
-	})
 	openDocsURL = func(string) error {
 		return openErr
 	}

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,4 +30,19 @@ func TestDocsCmdOpensDefaultDocsURL(t *testing.T) {
 
 	require.NoError(t, docsCmd.RunE(docsCmd, nil))
 	assert.Equal(t, atmosDocsURL, openedURL)
+}
+
+func TestDocsCmdReturnsDefaultDocsOpenError(t *testing.T) {
+	openErr := errors.New("browser unavailable")
+	originalOpenDocsURL := openDocsURL
+	t.Cleanup(func() {
+		openDocsURL = originalOpenDocsURL
+	})
+	openDocsURL = func(string) error {
+		return openErr
+	}
+
+	err := docsCmd.RunE(docsCmd, nil)
+	require.ErrorIs(t, err, openErr)
+	assert.ErrorContains(t, err, "open Atmos docs")
 }

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestDocsCmd_WithoutStacks verifies that docs command does not require stack configuration.
@@ -11,4 +13,10 @@ func TestDocsCmd_WithoutStacks(t *testing.T) {
 	// by verifying InitCliConfig is called with processStacks=false in docs.go:38
 	// No runtime test needed - this is enforced by code structure.
 	t.Log("docs command uses InitCliConfig with processStacks=false")
+}
+
+func TestDocsCmdOpensDefaultDocsURL(t *testing.T) {
+	t.Setenv("GO_TEST", "1")
+
+	require.NoError(t, docsCmd.RunE(docsCmd, nil))
 }

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +17,16 @@ func TestDocsCmd_WithoutStacks(t *testing.T) {
 }
 
 func TestDocsCmdOpensDefaultDocsURL(t *testing.T) {
-	t.Setenv("GO_TEST", "1")
+	var openedURL string
+	originalOpenDocsURL := openDocsURL
+	t.Cleanup(func() {
+		openDocsURL = originalOpenDocsURL
+	})
+	openDocsURL = func(url string) error {
+		openedURL = url
+		return nil
+	}
 
 	require.NoError(t, docsCmd.RunE(docsCmd, nil))
+	assert.Equal(t, atmosDocsURL, openedURL)
 }

--- a/cmd/help_template_test.go
+++ b/cmd/help_template_test.go
@@ -497,6 +497,77 @@ func TestConfigureWriter(t *testing.T) {
 	}
 }
 
+func TestColorWriterConfigurationBranches(t *testing.T) {
+	t.Run("debug info prints without panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		profileDetector := colorprofile.NewWriter(&buf, os.Environ())
+		profileDetector.Profile = colorprofile.ANSI
+
+		printColorDebugInfo(profileDetector, colorConfig{
+			forceColor:         true,
+			explicitlyDisabled: false,
+			debugColors:        true,
+		})
+	})
+
+	t.Run("disabled writer uses ascii profile", func(t *testing.T) {
+		var buf bytes.Buffer
+		w, profile, renderer := configureDisabledColorWriter(&buf, true)
+
+		if w == nil {
+			t.Fatal("expected writer")
+		}
+		if profile != colorprofile.Ascii {
+			t.Fatalf("expected ascii profile, got %v", profile)
+		}
+		if renderer == nil {
+			t.Fatal("expected renderer")
+		}
+	})
+
+	t.Run("forced writer uses ansi256 profile", func(t *testing.T) {
+		var buf bytes.Buffer
+		w, profile, renderer := configureForcedColorWriter(&buf, true)
+
+		if w == nil {
+			t.Fatal("expected writer")
+		}
+		if profile != colorprofile.ANSI256 {
+			t.Fatalf("expected ANSI256 profile, got %v", profile)
+		}
+		if renderer == nil {
+			t.Fatal("expected renderer")
+		}
+	})
+
+	tests := []struct {
+		name     string
+		detected colorprofile.Profile
+	}{
+		{name: "true color", detected: colorprofile.TrueColor},
+		{name: "ansi256", detected: colorprofile.ANSI256},
+		{name: "ansi", detected: colorprofile.ANSI},
+		{name: "ascii", detected: colorprofile.Ascii},
+	}
+
+	for _, tt := range tests {
+		t.Run("auto detect "+tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w, profile, renderer := configureAutoDetectColorWriter(&buf, tt.detected, true)
+
+			if w == nil {
+				t.Fatal("expected writer")
+			}
+			if profile != tt.detected {
+				t.Fatalf("expected detected profile %v, got %v", tt.detected, profile)
+			}
+			if renderer == nil {
+				t.Fatal("expected renderer")
+			}
+		})
+	}
+}
+
 func TestCreateHelpStyles(t *testing.T) {
 	t.Run("creates non-nil styles", func(t *testing.T) {
 		renderer := lipgloss.NewRenderer(os.Stdout)

--- a/cmd/identity_helpers_test.go
+++ b/cmd/identity_helpers_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+)
+
+func TestExtractIdentityFromArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "long flag with equals",
+			args: []string{"atmos", "describe", "component", "--identity=admin"},
+			want: "admin",
+		},
+		{
+			name: "long flag with empty equals selects interactively",
+			args: []string{"atmos", "describe", "component", "--identity="},
+			want: cfg.IdentityFlagSelectValue,
+		},
+		{
+			name: "short flag with equals",
+			args: []string{"atmos", "describe", "component", "-i=readonly"},
+			want: "readonly",
+		},
+		{
+			name: "short flag with empty equals selects interactively",
+			args: []string{"atmos", "describe", "component", "-i="},
+			want: cfg.IdentityFlagSelectValue,
+		},
+		{
+			name: "long flag with separate value",
+			args: []string{"atmos", "describe", "component", "--identity", "admin"},
+			want: "admin",
+		},
+		{
+			name: "short flag with separate value",
+			args: []string{"atmos", "describe", "component", "-i", "admin"},
+			want: "admin",
+		},
+		{
+			name: "long flag without value selects interactively",
+			args: []string{"atmos", "describe", "component", "--identity"},
+			want: cfg.IdentityFlagSelectValue,
+		},
+		{
+			name: "short flag followed by another flag selects interactively",
+			args: []string{"atmos", "describe", "component", "-i", "--stack", "dev"},
+			want: cfg.IdentityFlagSelectValue,
+		},
+		{
+			name: "flag not present",
+			args: []string{"atmos", "describe", "component"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractIdentityFromArgs(tt.args))
+		})
+	}
+}

--- a/cmd/packer_test.go
+++ b/cmd/packer_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackerRunReturnsConfigError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", t.TempDir())
+
+	cmd := &cobra.Command{Use: "build"}
+	cmd.Flags().StringP("template", "t", "", "Packer template for building machine images")
+	cmd.Flags().StringP("query", "q", "", "YQ expression to read an output from the Packer manifest")
+
+	err := packerRun(cmd, "build", []string{"component", "-s", "stack"})
+	require.Error(t, err)
+}

--- a/cmd/packer_test.go
+++ b/cmd/packer_test.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 func TestPackerRunReturnsConfigError(t *testing.T) {
+	_ = NewTestKit(t)
 	t.Chdir(t.TempDir())
 	t.Setenv("ATMOS_CLI_CONFIG_PATH", t.TempDir())
 
@@ -16,5 +19,5 @@ func TestPackerRunReturnsConfigError(t *testing.T) {
 	cmd.Flags().StringP("query", "q", "", "YQ expression to read an output from the Packer manifest")
 
 	err := packerRun(cmd, "build", []string{"component", "-s", "stack"})
-	require.Error(t, err)
+	require.ErrorIs(t, err, errUtils.ErrStacksDirectoryDoesNotExist)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,10 @@ var atmosConfig schema.AtmosConfiguration
 // profilerServer holds the global profiler server instance.
 var profilerServer *profiler.Server
 
+// checkAndReexec performs Atmos version switching. It is a package variable so
+// tests can replace it without installing or execing another Atmos binary.
+var checkAndReexec = pkgversion.CheckAndReexec
+
 // logFileHandle holds the opened log file for the lifetime of the program.
 var logFileHandle *os.File
 
@@ -366,6 +370,23 @@ func processChdirFlag(cmd *cobra.Command) error {
 	return nil
 }
 
+// maybeReexecExplicitUseVersion handles explicit --use-version / ATMOS_USE_VERSION
+// requests before Cobra resolves the command tree. This lets a currently
+// installed binary switch to a newer binary for commands it does not know about.
+func maybeReexecExplicitUseVersion(atmosConfig *schema.AtmosConfiguration) bool {
+	explicitVersion := parseUseVersionFromArgs()
+	if explicitVersion == "" {
+		//nolint:forbidigo // Must use os.Getenv before Cobra/Viper command parsing.
+		explicitVersion = os.Getenv(pkgversion.UseVersionEnvVar)
+	}
+	if explicitVersion == "" {
+		return false
+	}
+
+	_ = os.Setenv(pkgversion.VersionUseEnvVar, explicitVersion)
+	return checkAndReexec(atmosConfig)
+}
+
 // RootCmd represents the base command when called without any subcommands.
 var RootCmd = &cobra.Command{
 	Use:   "atmos",
@@ -510,7 +531,7 @@ var RootCmd = &cobra.Command{
 				// CheckAndReexec returns true only on successful syscall.Exec, which replaces
 				// the current process entirely. This means true is never returned in practice
 				// since exec doesn't return. We call it for its side effects.
-				_ = pkgversion.CheckAndReexec(&tmpConfig)
+				_ = checkAndReexec(&tmpConfig)
 			}
 		}
 
@@ -1509,6 +1530,10 @@ func Execute() error {
 			log.Debug("Warning: CLI configuration 'atmos.yaml' file not found", "error", initErr)
 		}
 	}
+
+	// Explicit --use-version / ATMOS_USE_VERSION must run before Cobra command
+	// resolution so unknown commands can be delegated to the requested binary.
+	maybeReexecExplicitUseVersion(&atmosConfig)
 
 	// Initialize markdown renderers only if config loaded successfully
 	// This prevents deep exits in InitializeMarkdown when config is invalid

--- a/cmd/root_helpers_test.go
+++ b/cmd/root_helpers_test.go
@@ -282,6 +282,46 @@ func TestApplyProfilerEnvironmentOverrides(t *testing.T) {
 				Enabled:     true,
 			},
 		},
+		{
+			name: "profile type override is parsed",
+			atmosConfig: schema.AtmosConfiguration{
+				Profiler: profiler.Config{
+					ProfileType: profiler.ProfileTypeHeap,
+				},
+			},
+			initial: profiler.DefaultConfig(),
+			expected: profiler.Config{
+				Host:        profiler.DefaultConfig().Host,
+				Port:        profiler.DefaultConfig().Port,
+				ProfileType: profiler.ProfileTypeHeap,
+				Enabled:     false,
+			},
+		},
+		{
+			name: "enabled override is applied",
+			atmosConfig: schema.AtmosConfiguration{
+				Profiler: profiler.Config{
+					Enabled: true,
+				},
+			},
+			initial: profiler.DefaultConfig(),
+			expected: profiler.Config{
+				Host:        profiler.DefaultConfig().Host,
+				Port:        profiler.DefaultConfig().Port,
+				ProfileType: profiler.DefaultConfig().ProfileType,
+				Enabled:     true,
+			},
+		},
+		{
+			name: "invalid profile type returns parse error",
+			atmosConfig: schema.AtmosConfiguration{
+				Profiler: profiler.Config{
+					ProfileType: "invalid",
+				},
+			},
+			initial:     profiler.DefaultConfig(),
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -291,11 +331,13 @@ func TestApplyProfilerEnvironmentOverrides(t *testing.T) {
 
 			if tt.expectError {
 				assert.Error(t, err)
+				assert.ErrorIs(t, err, errUtils.ErrParseFlag)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected.Host, config.Host)
 				assert.Equal(t, tt.expected.Port, config.Port)
 				assert.Equal(t, tt.expected.Enabled, config.Enabled)
+				assert.Equal(t, tt.expected.ProfileType, config.ProfileType)
 				if tt.expected.File != "" {
 					assert.Equal(t, tt.expected.File, config.File)
 				}
@@ -342,6 +384,58 @@ func TestApplyCLIFlagOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "override host flag",
+			setupCmd: func(cmd *cobra.Command) {
+				cmd.Flags().String("profiler-host", "", "")
+				cmd.Flags().Set("profiler-host", "127.0.0.1")
+			},
+			initial: profiler.DefaultConfig(),
+			expected: profiler.Config{
+				Enabled:     false,
+				Host:        "127.0.0.1",
+				Port:        profiler.DefaultConfig().Port,
+				ProfileType: profiler.DefaultConfig().ProfileType,
+			},
+		},
+		{
+			name: "profile file flag enables file profiler",
+			setupCmd: func(cmd *cobra.Command) {
+				cmd.Flags().String("profile-file", "", "")
+				cmd.Flags().Set("profile-file", "/tmp/heap.prof")
+			},
+			initial: profiler.DefaultConfig(),
+			expected: profiler.Config{
+				Enabled:     true,
+				Host:        profiler.DefaultConfig().Host,
+				Port:        profiler.DefaultConfig().Port,
+				File:        "/tmp/heap.prof",
+				ProfileType: profiler.DefaultConfig().ProfileType,
+			},
+		},
+		{
+			name: "profile type flag overrides type",
+			setupCmd: func(cmd *cobra.Command) {
+				cmd.Flags().String("profile-type", "", "")
+				cmd.Flags().Set("profile-type", "goroutine")
+			},
+			initial: profiler.DefaultConfig(),
+			expected: profiler.Config{
+				Enabled:     false,
+				Host:        profiler.DefaultConfig().Host,
+				Port:        profiler.DefaultConfig().Port,
+				ProfileType: profiler.ProfileTypeGoroutine,
+			},
+		},
+		{
+			name: "invalid profile type flag returns parse error",
+			setupCmd: func(cmd *cobra.Command) {
+				cmd.Flags().String("profile-type", "", "")
+				cmd.Flags().Set("profile-type", "invalid")
+			},
+			initial:     profiler.DefaultConfig(),
+			expectError: true,
+		},
+		{
 			name: "no flags changed",
 			setupCmd: func(cmd *cobra.Command) {
 				cmd.Flags().Bool("profiler-enabled", false, "")
@@ -367,13 +461,57 @@ func TestApplyCLIFlagOverrides(t *testing.T) {
 
 			if tt.expectError {
 				assert.Error(t, err)
+				assert.ErrorIs(t, err, errUtils.ErrParseFlag)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected.Enabled, config.Enabled)
 				assert.Equal(t, tt.expected.Port, config.Port)
+				assert.Equal(t, tt.expected.Host, config.Host)
+				assert.Equal(t, tt.expected.File, config.File)
+				assert.Equal(t, tt.expected.ProfileType, config.ProfileType)
 			}
 		})
 	}
+}
+
+func TestBuildProfilerConfigComposesConfigAndFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("profiler-enabled", false, "")
+	cmd.Flags().Int("profiler-port", 0, "")
+	cmd.Flags().String("profiler-host", "", "")
+	cmd.Flags().String("profile-file", "", "")
+	cmd.Flags().String("profile-type", "", "")
+
+	assert.NoError(t, cmd.Flags().Set("profiler-port", "7070"))
+	assert.NoError(t, cmd.Flags().Set("profiler-host", "0.0.0.0"))
+	assert.NoError(t, cmd.Flags().Set("profile-file", "/tmp/trace.out"))
+	assert.NoError(t, cmd.Flags().Set("profile-type", "trace"))
+
+	config, err := buildProfilerConfig(cmd, &schema.AtmosConfiguration{
+		Profiler: profiler.Config{
+			Host:        "localhost",
+			Port:        6061,
+			ProfileType: profiler.ProfileTypeHeap,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, config.Enabled)
+	assert.Equal(t, "0.0.0.0", config.Host)
+	assert.Equal(t, 7070, config.Port)
+	assert.Equal(t, "/tmp/trace.out", config.File)
+	assert.Equal(t, profiler.ProfileTypeTrace, config.ProfileType)
+}
+
+func TestSetupProfilerSkipsWhenDisabledWithoutFile(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("profiler-enabled", false, "")
+	cmd.Flags().Int("profiler-port", 0, "")
+	cmd.Flags().String("profiler-host", "", "")
+	cmd.Flags().String("profile-file", "", "")
+	cmd.Flags().String("profile-type", "", "")
+
+	assert.NoError(t, setupProfiler(cmd, &schema.AtmosConfiguration{}))
 }
 
 // TestApplyProfileFileFlag tests profile file flag handling.
@@ -1178,6 +1316,11 @@ func TestExecute_ReexecsExplicitUseVersionBeforeUnknownCommandResolution(t *test
 				t.Setenv(pkgversion.UseVersionEnvVar, "")
 			}
 
+			oldArgs := os.Args
+			t.Cleanup(func() {
+				os.Args = oldArgs
+			})
+
 			os.Args = tt.args
 			RootCmd.SetArgs(tt.args[1:])
 
@@ -1202,6 +1345,18 @@ func TestExecute_ReexecsExplicitUseVersionBeforeUnknownCommandResolution(t *test
 			assert.True(t, reexecCalled)
 		})
 	}
+}
+
+func TestExecuteVersionSmoke(t *testing.T) {
+	_ = NewTestKit(t)
+
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+	os.Args = []string{"atmos", "--version"}
+
+	assert.NoError(t, ExecuteVersion())
 }
 
 // TestBuildFlagDescription tests flag description building.

--- a/cmd/root_helpers_test.go
+++ b/cmd/root_helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/profiler"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/terminal"
+	pkgversion "github.com/cloudposse/atmos/pkg/version"
 )
 
 // TestCleanupLogFile tests log file cleanup functionality.
@@ -1132,6 +1133,73 @@ func TestParseUseVersionFromArgsInternal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseUseVersionFromArgsInternal(tt.args)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExecute_ReexecsExplicitUseVersionBeforeUnknownCommandResolution(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		env   string
+		value string
+	}{
+		{
+			name:  "env var",
+			args:  []string{"atmos", "future-secret", "list"},
+			env:   "ref:main",
+			value: "ref:main",
+		},
+		{
+			name:  "equals flag",
+			args:  []string{"atmos", "future-secret", "list", "--use-version=ref:main"},
+			value: "ref:main",
+		},
+		{
+			name:  "separate flag",
+			args:  []string{"atmos", "future-secret", "list", "--use-version", "ref:main"},
+			value: "ref:main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = NewTestKit(t)
+
+			oldCheckAndReexec := checkAndReexec
+			t.Cleanup(func() {
+				checkAndReexec = oldCheckAndReexec
+			})
+
+			t.Setenv(pkgversion.VersionUseEnvVar, "")
+			if tt.env != "" {
+				t.Setenv(pkgversion.UseVersionEnvVar, tt.env)
+			} else {
+				t.Setenv(pkgversion.UseVersionEnvVar, "")
+			}
+
+			os.Args = tt.args
+			RootCmd.SetArgs(tt.args[1:])
+
+			reexecCalled := false
+			sentinel := errors.New("simulated re-exec")
+			checkAndReexec = func(config *schema.AtmosConfiguration) bool {
+				reexecCalled = true
+				assert.NotNil(t, config)
+				assert.Equal(t, tt.value, os.Getenv(pkgversion.VersionUseEnvVar))
+				panic(sentinel)
+			}
+
+			var recovered any
+			func() {
+				defer func() {
+					recovered = recover()
+				}()
+				_ = Execute()
+			}()
+
+			assert.Same(t, sentinel, recovered)
+			assert.True(t, reexecCalled)
 		})
 	}
 }

--- a/cmd/root_helpers_test.go
+++ b/cmd/root_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -401,14 +402,14 @@ func TestApplyCLIFlagOverrides(t *testing.T) {
 			name: "profile file flag enables file profiler",
 			setupCmd: func(cmd *cobra.Command) {
 				cmd.Flags().String("profile-file", "", "")
-				cmd.Flags().Set("profile-file", "/tmp/heap.prof")
+				cmd.Flags().Set("profile-file", filepath.Join(os.TempDir(), "heap.prof"))
 			},
 			initial: profiler.DefaultConfig(),
 			expected: profiler.Config{
 				Enabled:     true,
 				Host:        profiler.DefaultConfig().Host,
 				Port:        profiler.DefaultConfig().Port,
-				File:        "/tmp/heap.prof",
+				File:        filepath.Join(os.TempDir(), "heap.prof"),
 				ProfileType: profiler.DefaultConfig().ProfileType,
 			},
 		},
@@ -484,7 +485,7 @@ func TestBuildProfilerConfigComposesConfigAndFlags(t *testing.T) {
 
 	assert.NoError(t, cmd.Flags().Set("profiler-port", "7070"))
 	assert.NoError(t, cmd.Flags().Set("profiler-host", "0.0.0.0"))
-	assert.NoError(t, cmd.Flags().Set("profile-file", "/tmp/trace.out"))
+	assert.NoError(t, cmd.Flags().Set("profile-file", filepath.Join(os.TempDir(), "trace.out")))
 	assert.NoError(t, cmd.Flags().Set("profile-type", "trace"))
 
 	config, err := buildProfilerConfig(cmd, &schema.AtmosConfiguration{
@@ -499,7 +500,7 @@ func TestBuildProfilerConfigComposesConfigAndFlags(t *testing.T) {
 	assert.True(t, config.Enabled)
 	assert.Equal(t, "0.0.0.0", config.Host)
 	assert.Equal(t, 7070, config.Port)
-	assert.Equal(t, "/tmp/trace.out", config.File)
+	assert.Equal(t, filepath.Join(os.TempDir(), "trace.out"), config.File)
 	assert.Equal(t, profiler.ProfileTypeTrace, config.ProfileType)
 }
 

--- a/cmd/root_process_chdir_test.go
+++ b/cmd/root_process_chdir_test.go
@@ -306,6 +306,11 @@ func TestProcessChdirFlagPrecedence(t *testing.T) {
 func TestProcessEarlyChdirFlagAdditionalBranches(t *testing.T) {
 	_ = NewTestKit(t)
 
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
 	originalWd, err := os.Getwd()
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/cmd/root_process_chdir_test.go
+++ b/cmd/root_process_chdir_test.go
@@ -302,3 +302,54 @@ func TestProcessChdirFlagPrecedence(t *testing.T) {
 	// On Windows, temp dir cleanup fails if we're still inside it.
 	_ = os.Chdir(originalWd)
 }
+
+func TestProcessEarlyChdirFlagAdditionalBranches(t *testing.T) {
+	_ = NewTestKit(t)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWd)
+	})
+
+	t.Run("already processed returns without reading args or env", func(t *testing.T) {
+		_ = NewTestKit(t)
+		chdirProcessed = true
+		t.Setenv("ATMOS_CHDIR", "/this/path/does/not/exist")
+
+		assert.NoError(t, processEarlyChdirFlag())
+	})
+
+	t.Run("uses env var when args do not specify chdir", func(t *testing.T) {
+		_ = NewTestKit(t)
+		tmpDir := t.TempDir()
+		t.Setenv("ATMOS_CHDIR", tmpDir)
+		os.Args = []string{"atmos", "version"}
+
+		require.NoError(t, processEarlyChdirFlag())
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		expectedResolved, _ := filepath.EvalSymlinks(tmpDir)
+		currentResolved, _ := filepath.EvalSymlinks(wd)
+		assert.Equal(t, expectedResolved, currentResolved)
+		_ = os.Chdir(originalWd)
+	})
+
+	t.Run("returns error for file path", func(t *testing.T) {
+		_ = NewTestKit(t)
+		tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("test"), 0o644))
+		os.Args = []string{"atmos", "--chdir", tmpFile, "version"}
+
+		err := processEarlyChdirFlag()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not a directory")
+	})
+
+	t.Run("returns nil when no chdir requested", func(t *testing.T) {
+		_ = NewTestKit(t)
+		os.Args = []string{"atmos", "version"}
+
+		assert.NoError(t, processEarlyChdirFlag())
+	})
+}

--- a/cmd/testing_helpers_test.go
+++ b/cmd/testing_helpers_test.go
@@ -28,6 +28,7 @@ type cmdStateSnapshot struct {
 	flags          map[string]flagSnapshot
 	chdirProcessed bool
 	colorProfile   termenv.Profile // Lipgloss color profile
+	openDocsURL    func(string) error
 }
 
 // snapshotRootCmdState captures the current state of RootCmd including all flag values and I/O streams.
@@ -40,6 +41,7 @@ func snapshotRootCmdState() *cmdStateSnapshot {
 		flags:          make(map[string]flagSnapshot),
 		chdirProcessed: chdirProcessed,
 		colorProfile:   lipgloss.ColorProfile(),
+		openDocsURL:    openDocsURL,
 	}
 
 	// Copy args.
@@ -134,4 +136,7 @@ func restoreRootCmdState(snapshot *cmdStateSnapshot) {
 	// This prevents test pollution from color settings.
 	lipgloss.SetColorProfile(snapshot.colorProfile)
 	theme.InvalidateStyleCache()
+
+	// Restore package-level test seams.
+	openDocsURL = snapshot.openDocsURL
 }

--- a/pkg/ai/agent/grok/client_test.go
+++ b/pkg/ai/agent/grok/client_test.go
@@ -2,12 +2,17 @@
 package grok
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/ai/agent/base"
+	"github.com/cloudposse/atmos/pkg/ai/types"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -416,6 +421,66 @@ func TestNewClient_CustomConfiguration(t *testing.T) {
 	assert.Equal(t, "grok-2-1212", client.GetModel())
 	assert.Equal(t, 8192, client.GetMaxTokens())
 	assert.Equal(t, "https://custom.api.x.ai/v1", client.GetBaseURL())
+}
+
+func TestClientSendMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/chat/completions")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":0,
+			"model":"grok-4-latest",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"hello from grok"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":7,"completion_tokens":8,"total_tokens":15}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(&schema.AtmosConfiguration{
+		AI: schema.AISettings{
+			Enabled: true,
+			Providers: map[string]*schema.AIProviderConfig{
+				"grok": {
+					ApiKey:    "test-api-key-value",
+					BaseURL:   server.URL,
+					MaxTokens: 128,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	messages := []types.Message{{Role: types.RoleUser, Content: "hello"}}
+
+	text, err := client.SendMessage(ctx, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from grok", text)
+
+	text, err = client.SendMessageWithHistory(ctx, messages)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from grok", text)
+
+	response, err := client.SendMessageWithTools(ctx, "hello", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from grok", response.Content)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, int64(15), response.Usage.TotalTokens)
+
+	response, err = client.SendMessageWithToolsAndHistory(ctx, messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, types.StopReasonEndTurn, response.StopReason)
+
+	response, err = client.SendMessageWithSystemPromptAndTools(ctx, "system", "memory", messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from grok", response.Content)
 }
 
 func TestClient_StructFields(t *testing.T) {

--- a/pkg/ai/agent/ollama/client_test.go
+++ b/pkg/ai/agent/ollama/client_test.go
@@ -1,11 +1,16 @@
 package ollama
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/ai/agent/base"
+	"github.com/cloudposse/atmos/pkg/ai/types"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -140,6 +145,65 @@ func TestNewClient_Disabled(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "AI features are disabled")
+}
+
+func TestClientSendMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/chat/completions")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":0,
+			"model":"llama3.3:70b",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"hello from ollama"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(&schema.AtmosConfiguration{
+		AI: schema.AISettings{
+			Enabled: true,
+			Providers: map[string]*schema.AIProviderConfig{
+				"ollama": {
+					BaseURL:   server.URL,
+					MaxTokens: 128,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	messages := []types.Message{{Role: types.RoleUser, Content: "hello"}}
+
+	text, err := client.SendMessage(ctx, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from ollama", text)
+
+	text, err = client.SendMessageWithHistory(ctx, messages)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from ollama", text)
+
+	response, err := client.SendMessageWithTools(ctx, "hello", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from ollama", response.Content)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, int64(7), response.Usage.TotalTokens)
+
+	response, err = client.SendMessageWithToolsAndHistory(ctx, messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, types.StopReasonEndTurn, response.StopReason)
+
+	response, err = client.SendMessageWithSystemPromptAndTools(ctx, "system", "memory", messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from ollama", response.Content)
 }
 
 func TestClientGetters(t *testing.T) {

--- a/pkg/ai/agent/openai/client_test.go
+++ b/pkg/ai/agent/openai/client_test.go
@@ -1,11 +1,18 @@
 package openai
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	openaigo "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/ai/agent/base"
+	"github.com/cloudposse/atmos/pkg/ai/types"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -401,6 +408,66 @@ func TestNewClient_WithValidAPIKey(t *testing.T) {
 	assert.NotNil(t, client.config)
 	assert.Equal(t, DefaultModel, client.GetModel())
 	assert.Equal(t, DefaultMaxTokens, client.GetMaxTokens())
+}
+
+func TestClientSendMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/chat/completions")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":0,
+			"model":"gpt-4o",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"hello from openai"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":5,"completion_tokens":6,"total_tokens":11}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiClient := openaigo.NewClient(
+		option.WithAPIKey("test-api-key-value"),
+		option.WithBaseURL(server.URL),
+	)
+	client := &Client{
+		client: &apiClient,
+		config: &base.Config{
+			Enabled:   true,
+			Model:     DefaultModel,
+			APIKey:    "test-api-key-value",
+			MaxTokens: 128,
+		},
+	}
+
+	ctx := context.Background()
+	messages := []types.Message{{Role: types.RoleUser, Content: "hello"}}
+
+	text, err := client.SendMessage(ctx, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from openai", text)
+
+	text, err = client.SendMessageWithHistory(ctx, messages)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from openai", text)
+
+	response, err := client.SendMessageWithTools(ctx, "hello", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from openai", response.Content)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, int64(11), response.Usage.TotalTokens)
+
+	response, err = client.SendMessageWithToolsAndHistory(ctx, messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, types.StopReasonEndTurn, response.StopReason)
+
+	response, err = client.SendMessageWithSystemPromptAndTools(ctx, "system", "memory", messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from openai", response.Content)
 }
 
 func TestClient_StructFields(t *testing.T) {

--- a/pkg/shell/interactive_test.go
+++ b/pkg/shell/interactive_test.go
@@ -1,11 +1,13 @@
 package shell
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 )
@@ -128,5 +130,30 @@ func TestFindAvailableShell(t *testing.T) {
 func TestStartInteractive_NoShell(t *testing.T) {
 	// An empty shell command must surface ErrNoSuitableShell rather than panic.
 	err := StartInteractive("", nil, nil)
+	assert.ErrorIs(t, err, errUtils.ErrNoSuitableShell)
+}
+
+func TestStartInteractive_WithAbsoluteTestBinary(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	err = StartInteractive(exe, nil, []string{"_ATMOS_SHELL_TEST_EXIT_OK=1"})
+	assert.NoError(t, err)
+}
+
+func TestStartInteractive_PropagatesExitCode(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	err = StartInteractive(exe, nil, []string{"_ATMOS_SHELL_TEST_EXIT_ONE=1"})
+	require.Error(t, err)
+
+	var exitErr errUtils.ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
+}
+
+func TestStartInteractive_RelativeMissingShell(t *testing.T) {
+	err := StartInteractive("definitely-missing-shell-for-atmos-test", nil, nil)
 	assert.ErrorIs(t, err, errUtils.ErrNoSuitableShell)
 }

--- a/pkg/shell/interactive_test.go
+++ b/pkg/shell/interactive_test.go
@@ -137,7 +137,7 @@ func TestStartInteractive_WithAbsoluteTestBinary(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
-	err = StartInteractive(exe, nil, []string{"_ATMOS_SHELL_TEST_EXIT_OK=1"})
+	err = StartInteractive(exe, nil, append(os.Environ(), "_ATMOS_SHELL_TEST_EXIT_OK=1"))
 	assert.NoError(t, err)
 }
 
@@ -145,7 +145,7 @@ func TestStartInteractive_PropagatesExitCode(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
-	err = StartInteractive(exe, nil, []string{"_ATMOS_SHELL_TEST_EXIT_ONE=1"})
+	err = StartInteractive(exe, nil, append(os.Environ(), "_ATMOS_SHELL_TEST_EXIT_ONE=1"))
 	require.Error(t, err)
 
 	var exitErr errUtils.ExitCodeError


### PR DESCRIPTION
## what

- Run explicit `--use-version` / `ATMOS_USE_VERSION` re-exec before Cobra resolves subcommands.
- Add regression coverage for env var, `--use-version=...`, and `--use-version ...` forms with commands unknown to the current binary.
- We also took the liberty of adding a few unrelated, test-only coverage improvements to satisfy Codecov; these do not change production behavior.

## why

- Cobra rejected newly added commands before `PersistentPreRun` could switch Atmos versions.
- This restores the workflow for testing new commands from `ref:`, `sha:`, and PR Atmos builds.

## references

- Closes #2624
- Tested with `go test ./cmd -run 'UseVersion|UnknownSubcommand|ParseUseVersion'` and `go test ./pkg/version -run 'CheckAndReexec|UseVersion|RefVersion'`.
