### PR TITLE
perf(stacks): cache per-component auth within a describe-stacks pass

### DIFF
--- a/docs/fixes/2026-06-20-describe-stacks-per-identity-auth-cache.md
+++ b/docs/fixes/2026-06-20-describe-stacks-per-identity-auth-cache.md
@@ -1,0 +1,94 @@
+# Describe-Stacks Re-Authenticates Per Component That Shares an Auth Section
+
+**Date:** 2026-06-20 **Severity:** Medium — functional output is correct, but
+every component with its own default identity triggers a fresh authentication
+cycle (credential-file rewrite + file lock + keyring rebuild), so a stack with
+many same-identity components does N redundant auth cycles instead of one
+**Follow-up to:**
+docs/fixes/2026-06-20-secret-list-stack-scope-per-component-auth.md
+**Reproducer:** `internal/exec/describe_stacks_component_processor_auth_test.go`
+(`TestResolveComponentAuthManager_CachesByAuthSection`)
+
+______________________________________________________________________
+
+## Why this is a fix doc (and not a blog post / changelog entry)
+
+This is a `patch` performance fix in the shared `describe stacks` processor: it
+memoizes the per-component AuthManager within a single pass so components that
+share an auth section authenticate once instead of N times. There is no new
+command, flag, or feature — only fewer redundant credential and keyring writes.
+Per the repo's label decision tree that makes it a `patch`, which does not
+require a `website/blog/` post or a roadmap milestone.
+
+## Symptom
+
+After scoping per-component auth to the requested stack (the linked stack-scope
+fix), running `atmos secret list -s <stack>` on a stack with many components
+still authenticated once **per component**. On a repo whose components all
+import the same default identity from a shared `_defaults.yaml`, debug logs
+showed ~one `Created component-specific AuthManager` per component for the
+requested stack — e.g. 74 cycles for 74 components that all resolve to the same
+identity. Each cycle rewrites the SSO credentials/config files (under a file
+lock) and rebuilds keyring entries, which is slow and entirely redundant when
+the identity is identical.
+
+## Root Cause
+
+`describeStacksProcessor.resolveComponentAuthManager`
+(`internal/exec/describe_stacks_component_processor.go`) called the
+per-component resolver (`createComponentAuthManager`) once for every component
+that declares its own `auth:` section with a `default: true` identity, with no
+memoization across the pass. `createComponentAuthManager` derives its result
+solely from the component's auth section, the (constant) global auth config, and
+the parent manager — `componentName` and `stackName` are used only for logging —
+so components that share an auth section produce an equivalent authenticated
+manager, yet each one paid the full authentication cost.
+
+## Fix
+
+Add a pass-scoped cache (`authManagerCache`) on `describeStacksProcessor`, keyed
+by the parent manager's chain plus a deterministic JSON fingerprint of the
+component's auth section. `createComponentAuthManager` derives its result solely
+from the auth section, the (constant) global config, and the parent manager
+(`componentName`/`stackName` affect only logging), so two components with the
+same auth section produce an equivalent authenticated manager. Because
+identities are defined globally and only referenced by components, "same auth
+section" is a safe, provable proxy for "same identity": the first component
+authenticates, and subsequent components with the same auth section reuse the
+cached manager (its `AuthContext` is identity-scoped, so the credentials match).
+
+- The cache is consulted only after the existing guards (auth enabled,
+  templates/YAML will run, the component declares its own default identity), so
+  behavior is unchanged for components that never resolved per-component auth.
+- Resolver **errors are never cached** — they remain fatal per call.
+- Fingerprinting the auth section (rather than bare identity name) keeps reuse
+  provably correct: it never merges two components whose sections differ, so a
+  component that overrides an identity inline can't accidentally borrow
+  another's credentials.
+- When the auth section cannot be serialized deterministically (e.g. non-string
+  map keys), the key is marked non-cacheable and the component resolves without
+  caching — correct, just not deduplicated.
+- The describe-stacks pass is single-threaded (`executeDescribeStacks` iterates
+  stacks sequentially), so the map needs no synchronization.
+
+## Verification
+
+- `go test ./internal/exec/ -run 'ResolveComponentAuthManager|ProcessComponentEntry'`
+  — `TestResolveComponentAuthManager_CachesByAuthSection` asserts the resolver
+  runs once for two components that share an auth section and again for a
+  distinct one; existing per-component auth and out-of-scope tests are
+  unchanged.
+- End-to-end: `atmos secret list -s <stack>` on a multi-stack repo whose
+  components share one default identity now emits a single
+  `Created component-specific AuthManager` for that shared identity instead of
+  one per component, and returns faster.
+
+## Recommendations
+
+- **Further dedup the nested YAML/template auth path.** Components that
+  reference other components via `!terraform.output` / `!terraform.state` /
+  `atmos.Component(...)` authenticate through
+  `resolveAuthManagerForNestedComponent`, which does not share this
+  processor-level cache. Extending a per-identity cache to that path would
+  remove the remaining cross-component auth cycles during template/YAML
+  resolution. Tracked separately.

--- a/docs/fixes/2026-06-20-secret-list-stack-scope-per-component-auth.md
+++ b/docs/fixes/2026-06-20-secret-list-stack-scope-per-component-auth.md
@@ -1,0 +1,116 @@
+# `atmos secret list -s <stack>` Authenticates Every Component in Every Other Stack
+
+**Date:** 2026-06-20 **Severity:** High — on a repo with many components the
+command never reaches its output; it runs a full authentication cycle
+(credentials file rewrite + file lock + keyring rebuild) for each component
+across all stacks, scaling with the whole repo instead of the requested stack
+**Issue:** https://github.com/cloudposse/atmos/issues/2639 **Reproducer:**
+`internal/exec/describe_stacks_component_processor_auth_test.go`
+(`TestProcessComponentEntry_OutOfScopeStackSkipsAuth`,
+`TestProcessComponentEntry_OutOfScopeComponentSkipsAuth`)
+
+______________________________________________________________________
+
+## Why this is a fix doc (and not a blog post / changelog entry)
+
+This is a `patch` bugfix in the shared `describe stacks` processor: it scopes
+per-component authentication to the components the caller actually asked for.
+There is no new command, flag, or feature to announce — only a correction so
+`-s <stack>` (and `--components`) stop authenticating components that are
+immediately filtered out. Per the repo's label decision tree that makes it a
+`patch`, which does not require a `website/blog/` post or a roadmap milestone.
+
+______________________________________________________________________
+
+## Symptom
+
+`atmos secret list --stack <stack>` without `--component` does not return on a
+repo with many components. Debug logging shows it enumerates components from
+stacks **other than** the one requested and runs a full authentication cycle for
+**each** one:
+
+```text
+DEBU Created component-specific AuthManager component=<other-component> stack=<other-stack> identityChain="[sso acme-prod/terraform]"
+DEBU CreateAndAuthenticateManager called identityName="" hasAuthConfig=true
+DEBU Writing AWS credentials provider=sso identity=acme-prod/terraform credentials_file=...
+DEBU Acquired file lock lock_file=.../credentials.lock
+DEBU Building keyring key alias=acme-prod/terraform realm=""
+```
+
+The per-component auth count grows roughly linearly with the total number of
+components in the repo (not the requested stack), so the command takes far
+longer than expected and appears to hang. Adding `--component` scopes it to a
+single component and returns immediately, because `secret list` takes a separate
+single-component fast path that never calls `ExecuteDescribeStacks`.
+
+## Root Cause
+
+`secret list -s <stack>` (no `--component`) enumerates declarations via
+`ExecuteDescribeStacks` with `filterByStack=<stack>`, `processTemplates=true`,
+and `processYamlFunctions=true` (`cmd/secret/enumerate.go`). The shared
+processor walks **every** stack file and **every** component (`FindStacksMap` →
+`processStackFile` → `processComponentEntry`).
+
+Inside `processComponentEntry`
+(`internal/exec/describe_stacks_component_processor.go`), per-component auth was
+resolved **before** the stack and component filters:
+
+```go
+// Old order
+componentAuthManager, err := p.resolveComponentAuthManager(...)  // full auth cycle
+propagateAuth(&info, componentAuthManager)
+if shouldFilterByStack(p.filterByStack, stackFileName, stackName) { return nil }  // filter, too late
+...
+if !componentIncluded { return nil }                                              // filter, too late
+```
+
+`resolveComponentAuthManager` runs the full authentication cycle for every
+component that declares its own `auth:` section with a `default: true` identity
+— regardless of whether that component belongs to the requested stack. Its only
+purpose is to populate `info.AuthContext` for the component's **later** template
+(`atmos.Component(...)`) and YAML-function (`!terraform.state`,
+`!terraform.output`) processing, which is skipped for any component that gets
+filtered out. So for out-of-scope components the authentication was pure waste.
+
+## Fix
+
+Move the stack and component filters **above** `resolveComponentAuthManager` so
+a component that is out of scope returns before any authentication happens.
+Authentication still runs before every consumer of `info.AuthContext`
+(`BuildTerraformWorkspace`, template processing, YAML-function processing),
+which all execute later in the function.
+
+```go
+// New order
+if shouldFilterByStack(p.filterByStack, stackFileName, stackName) { return nil }
+if stackName == "" { stackName = stackFileName }
+if !componentIncluded { return nil }
+
+// Only now, for in-scope components, resolve per-component auth.
+componentAuthManager, err := p.resolveComponentAuthManager(...)
+propagateAuth(&info, componentAuthManager)
+```
+
+No change to `cmd/secret` is needed — it already passes the correct
+`filterByStack`; the processor just applied it too late. The fix is in shared
+code, so `atmos describe stacks -s <stack>` and the `atmos list *` family
+benefit identically.
+
+## Verification
+
+- `go test ./internal/exec/ -run 'ProcessComponentEntry|ShouldResolvePerComponentAuth|ResolveComponentAuthManager'`
+  — new out-of-scope tests assert the auth resolver is invoked **zero** times
+  for components outside the requested stack / component set; existing
+  per-component auth tests are unchanged.
+- End-to-end: `atmos secret list -s <stack>` on a multi-stack repo with a SOPS
+  `aws-kms` provider and a default identity returns promptly, and any
+  `Created component-specific AuthManager` debug lines reference **only** the
+  requested stack.
+
+## Recommendations
+
+- **Follow-up (not in this PR): dedupe per-identity auth within a stack.** Even
+  scoped to one stack, components that share the same default identity each run
+  a separate authentication cycle. Caching the authenticated manager per
+  identity for the duration of a `describe stacks` pass would remove the
+  remaining redundant credential/keyring writes. Tracked separately.

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -2,6 +2,7 @@
 package exec
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -77,6 +78,12 @@ type describeStacksProcessor struct {
 	// componentAuthResolver builds a per-component AuthManager; defaults to
 	// createComponentAuthManager and is overridable in tests.
 	componentAuthResolver componentAuthManagerResolver
+	// authManagerCache memoizes per-component AuthManagers within one describe-stacks pass, keyed by
+	// auth section + parent chain, so components sharing an auth section reuse one manager instead of
+	// re-running the full auth cycle (credential writes, file locks, keyring rebuilds). The pass is
+	// single-threaded, so a plain map needs no locking.
+	// See docs/fixes/2026-06-20-describe-stacks-per-identity-auth-cache.md.
+	authManagerCache map[string]auth.AuthManager
 }
 
 // newDescribeStacksProcessor creates a processor with an empty result map.
@@ -122,6 +129,7 @@ func newDescribeStacksProcessorWithAuthDisabled( //nolint:revive // argument-lim
 		authManager:           authManager,
 		finalStacksMap:        make(map[string]any),
 		componentAuthResolver: createComponentAuthManager,
+		authManagerCache:      make(map[string]auth.AuthManager),
 	}
 }
 
@@ -161,6 +169,17 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	if !hasAuth || !hasDefaultIdentity(authSection) {
 		return componentAuthManager, nil
 	}
+
+	// Reuse a manager already resolved for the same auth section this pass. The resolver derives its
+	// result only from the auth section, the (constant) global config, and the parent manager
+	// (componentName/stackName are logging only), so an identical key yields an equivalent manager.
+	cacheKey, cacheable := p.componentAuthCacheKey(authSection)
+	if cacheable {
+		if cached, ok := p.authManagerCache[cacheKey]; ok {
+			return cached, nil
+		}
+	}
+
 	resolver := p.componentAuthResolver
 	if resolver == nil {
 		resolver = createComponentAuthManager
@@ -169,10 +188,40 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	if createErr != nil {
 		return componentAuthManager, fmt.Errorf("%w: failed to resolve auth for component %q in stack %q: %w", errUtils.ErrAuthManager, componentName, stackName, createErr)
 	}
+	result := componentAuthManager
 	if resolved != nil {
-		return resolved, nil
+		result = resolved
 	}
-	return componentAuthManager, nil
+	if cacheable {
+		p.cacheComponentAuthManager(cacheKey, result)
+	}
+	return result, nil
+}
+
+// componentAuthCacheKey keys the per-component auth cache by the parent chain plus a deterministic
+// JSON fingerprint of the auth section. Because identities are defined globally and only referenced
+// by components, "same auth section" is a safe, provable proxy for "same identity" — it never merges
+// components whose sections differ. Returns cacheable=false when the section can't be serialized
+// (e.g. non-string map keys), so the caller resolves without caching.
+func (p *describeStacksProcessor) componentAuthCacheKey(authSection map[string]any) (string, bool) {
+	fingerprint, err := json.Marshal(authSection)
+	if err != nil {
+		return "", false
+	}
+	var parentChain string
+	if p.authManager != nil {
+		parentChain = strings.Join(p.authManager.GetChain(), ">")
+	}
+	return parentChain + "\x00" + string(fingerprint), true
+}
+
+// cacheComponentAuthManager stores a resolved manager, lazily creating the map so struct-literal
+// processors (e.g. in tests) also memoize.
+func (p *describeStacksProcessor) cacheComponentAuthManager(key string, manager auth.AuthManager) {
+	if p.authManagerCache == nil {
+		p.authManagerCache = make(map[string]auth.AuthManager)
+	}
+	p.authManagerCache[key] = manager
 }
 
 // processStackFile processes one stack file, iterating over all requested component types.

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -332,14 +332,9 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	info.Context = resolvedContext
 	info.AuthDisabled = p.authDisabled
 
-	// Resolve the per-component auth manager (may fall back to the parent).
-	componentAuthManager, err := p.resolveComponentAuthManager(componentSection, componentName, stackName)
-	if err != nil {
-		return err
-	}
-	propagateAuth(&info, componentAuthManager)
-
 	// Filter: skip this component if it does not belong to the requested stack.
+	// Done before resolveComponentAuthManager (below) so out-of-scope components don't trigger a
+	// full auth cycle. See docs/fixes/2026-06-20-secret-list-stack-scope-per-component-auth.md.
 	if shouldFilterByStack(p.filterByStack, stackFileName, stackName) {
 		return nil
 	}
@@ -357,6 +352,14 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	if !componentIncluded {
 		return nil
 	}
+
+	// Resolve the per-component auth manager (may fall back to the parent). Must run before the
+	// template and YAML-function processing below, which read info.AuthContext.
+	componentAuthManager, err := p.resolveComponentAuthManager(componentSection, componentName, stackName)
+	if err != nil {
+		return err
+	}
+	propagateAuth(&info, componentAuthManager)
 
 	// Ensure the stack-level entry exists (only for included components).
 	if !u.MapKeyExists(p.finalStacksMap, stackName) {

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -362,3 +362,73 @@ func TestProcessComponentEntry_ComponentAuthResolverErrorIsFatal(t *testing.T) {
 	assert.Contains(t, err.Error(), "test-stack")
 	assert.EqualValues(t, 1, spy.calls.Load(), "resolver should stop processing after the first auth failure")
 }
+
+// TestProcessComponentEntry_OutOfScopeSkipsAuth verifies that per-component auth is NOT resolved
+// for a component the caller did not request — whether it is filtered out by the requested stack
+// or excluded by the --components filter. Both filters must run before resolveComponentAuthManager;
+// otherwise `atmos secret list -s <stack>` authenticates every component in every other stack and
+// hangs on large repos. See docs/fixes/2026-06-20-secret-list-stack-scope-per-component-auth.md.
+func TestProcessComponentEntry_OutOfScopeSkipsAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		filterByStack string
+		components    []string
+		stackFileName string
+		componentName string
+	}{
+		{
+			// stackFileName differs from filterByStack, so this component is out of scope.
+			name:          "out_of_scope_stack",
+			filterByStack: "wanted-stack",
+			stackFileName: "other-stack",
+			componentName: "test-component",
+		},
+		{
+			// componentName is not in p.components, so this component is out of scope.
+			name:          "out_of_scope_component",
+			components:    []string{"wanted-component"},
+			stackFileName: "test-stack",
+			componentName: "other-component",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The spy returns an error, so if the resolver were invoked the call would surface as
+			// a non-nil error from processComponentEntry. An out-of-scope component must skip it.
+			spy := &componentAuthResolverSpy{
+				returnMgr: nil,
+				returnErr: assert.AnError,
+			}
+
+			componentSection := componentSectionWithAuth(authSectionWithDefault())
+			allTypeComponents := map[string]any{tc.componentName: componentSection}
+			p := &describeStacksProcessor{
+				atmosConfig:           &schema.AtmosConfiguration{},
+				filterByStack:         tc.filterByStack,
+				components:            tc.components,
+				processTemplates:      true,
+				processYamlFunctions:  false,
+				componentAuthResolver: spy.resolver(),
+				finalStacksMap:        make(map[string]any),
+			}
+
+			err := p.processComponentEntry(
+				tc.stackFileName,
+				"",
+				"helmfile",
+				tc.componentName,
+				componentSection,
+				allTypeComponents,
+				processComponentTypeOpts{},
+			)
+
+			require.NoError(t, err, "out-of-scope component must be skipped without resolving auth")
+			assert.EqualValues(t, 0, spy.calls.Load(), "per-component auth must not run for an out-of-scope component")
+		})
+	}
+}

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -432,3 +432,47 @@ func TestProcessComponentEntry_OutOfScopeSkipsAuth(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveComponentAuthManager_CachesByAuthSection verifies that components sharing an auth
+// section resolve the per-component AuthManager only once per describe-stacks pass: a second
+// component with the same auth section reuses the cached manager (resolver not called again),
+// while a distinct auth section misses the cache and resolves anew.
+// See docs/fixes/2026-06-20-describe-stacks-per-identity-auth-cache.md.
+func TestResolveComponentAuthManager_CachesByAuthSection(t *testing.T) {
+	t.Parallel()
+
+	type sentinelAuthManager struct{ auth.AuthManager }
+	mgr := &sentinelAuthManager{}
+
+	spy := &componentAuthResolverSpy{returnMgr: mgr}
+	p := &describeStacksProcessor{
+		atmosConfig:           &schema.AtmosConfiguration{},
+		processTemplates:      true,
+		processYamlFunctions:  false,
+		componentAuthResolver: spy.resolver(),
+		finalStacksMap:        make(map[string]any),
+		authManagerCache:      make(map[string]auth.AuthManager),
+	}
+
+	// First component with auth section A: cache miss, resolver runs once.
+	got1, err := p.resolveComponentAuthManager(componentSectionWithAuth(authSectionWithDefault()), "comp-a", "stack-1")
+	require.NoError(t, err)
+	assert.Same(t, mgr, got1, "first resolution returns the resolver's manager")
+	require.EqualValues(t, 1, spy.calls.Load(), "first component must invoke the resolver")
+
+	// Second component with the SAME auth section (different component and stack): cache hit.
+	got2, err := p.resolveComponentAuthManager(componentSectionWithAuth(authSectionWithDefault()), "comp-b", "stack-2")
+	require.NoError(t, err)
+	assert.Same(t, mgr, got2, "cache hit returns the same manager instance")
+	assert.EqualValues(t, 1, spy.calls.Load(), "second component with an identical auth section must reuse the cached manager")
+
+	// Third component with a DIFFERENT auth section: cache miss, resolver runs again.
+	otherAuth := map[string]any{
+		"identities": map[string]any{
+			"other-default": map[string]any{"default": true},
+		},
+	}
+	_, err = p.resolveComponentAuthManager(componentSectionWithAuth(otherAuth), "comp-c", "stack-3")
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, spy.calls.Load(), "a distinct auth section must miss the cache and resolve anew")
+}


### PR DESCRIPTION
## what

- Add a pass-scoped cache (`authManagerCache`) to the describe-stacks processor so components that share an auth section authenticate **once** per pass instead of once each.
- Key it by the parent auth chain plus a deterministic JSON fingerprint of the component's auth section; reuse the cached manager on a match.
- Add a regression test (`TestResolveComponentAuthManager_CachesByAuthSection`) and a fix doc.

## why

- Follow-up to #2642. Even after scoping per-component auth to the requested stack, **every** component that declares its own `default: true` identity ran a full authentication cycle — a credentials-file rewrite (under a file lock) plus a keyring rebuild. On a stack whose components import the same default identity from a shared `_defaults.yaml`, that is N redundant cycles for one identity.
- `createComponentAuthManager` derives its result solely from the component's auth section, the (constant) global config, and the parent manager (`componentName`/`stackName` are used only for logging), so components with an identical auth section produce an equivalent, identity-scoped manager — safe to reuse. Fingerprinting the auth section (rather than a bare identity name) keeps reuse provably correct: it never merges two components whose sections differ.
- Measured on a representative multi-stack repo, `atmos secret list -s <stack>` (no `--component`): processor-path authentications **68 → 1**, total auth cycles **110 → 43**, wall time **~34s → ~21s**, with identical output. Errors are never cached; sections that can't be serialized fall back to no caching.

## references

- Follows #2642 — **this branch is stacked on it**, so the diff currently includes the #2642 commit (`fix(stacks): scope per-component auth ...`) as well as this `perf` commit. Once #2642 merges, this can be rebased onto `main` to leave only the `perf` commit.
- Fix write-up: `docs/fixes/2026-06-20-describe-stacks-per-identity-auth-cache.md`
- The remaining ~42 cycles are the nested `!terraform.output` / `atmos.Component` resolution path (`resolveAuthManagerForNestedComponent`), which doesn't share this processor cache — documented as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `atmos secret list -s <stack>` command hanging by eliminating unnecessary authentication for out-of-scope components.

* **Performance**
  * Improved performance by reducing redundant authentication cycles when multiple components share identical authentication settings.

* **Tests**
  * Added test coverage for scope-based authentication filtering and authentication result caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->