### PR TITLE
fix(stacks): scope and cache per-component auth in describe stacks

### DIFF
--- a/docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md
+++ b/docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md
@@ -1,0 +1,98 @@
+# `atmos describe stacks -s <stack>` Authenticates Every Component in Every Other Stack
+
+**Date:** 2026-06-22
+**Severity:** High — on a large multi-stack repo, `describe stacks -s <stack>` (and other auth-enabled describe-stacks callers) authenticate every component in every stack before filtering, re-authenticating each one from scratch; the command runs for minutes or appears to hang
+**Issue:** https://github.com/cloudposse/atmos/issues/2639 (originally reported against `atmos secret list`; that command was fixed separately by #2646)
+**Reproducer:** `internal/exec/describe_stacks_component_processor_auth_test.go` (`TestProcessComponentEntry_OutOfScopeSkipsAuth`, `TestResolveComponentAuthManager_CachesByAuthSection`)
+
+______________________________________________________________________
+
+## Why this is a fix doc (and not a blog post / changelog entry)
+
+This is a `patch` bug fix in the shared describe-stacks processor: it scopes per-component
+authentication to the components the caller actually requested, and reuses one authenticated manager
+per identity within a pass. There is no new command, flag, or feature — only a correction so
+auth-enabled `describe stacks` / `list` / `terraform --all` stop authenticating out-of-scope
+components and stop re-authenticating the same identity once per component. Per the repo's label
+decision tree that makes it a `patch`, which does not require a `website/blog/` post or a roadmap
+milestone.
+
+## Symptom
+
+`atmos describe stacks -s <stack>` on a repo with many components — where components declare their
+own `default: true` identity — does not return promptly. Debug logging shows it authenticates
+components from stacks **other than** the one requested, running a full authentication cycle
+(credentials-file rewrite under a file lock + keyring rebuild) for each. On a representative
+multi-stack repo the command authenticated 1,000+ components across all stacks and effectively hung.
+
+The same shape applies to every auth-enabled `ExecuteDescribeStacks` caller: `atmos list values` /
+`list instances`, `atmos terraform --all` / `--query`, etc. `atmos secret list` was the originally
+reported case in #2639; #2646 fixed that command specifically by disabling per-component auth during
+secret-list enumeration, but the shared processor was left unchanged.
+
+## Root Cause
+
+In `processComponentEntry` (`internal/exec/describe_stacks_component_processor.go`), per-component
+auth was resolved **before** the stack and component filters, and was never memoized:
+
+```go
+// Old order
+componentAuthManager, err := p.resolveComponentAuthManager(...)  // full auth cycle, every component
+propagateAuth(&info, componentAuthManager)
+if shouldFilterByStack(p.filterByStack, stackFileName, stackName) { return nil }  // filter, too late
+...
+if !componentIncluded { return nil }                                              // filter, too late
+```
+
+Because `ExecuteDescribeStacks` walks every stack file, this authenticated every component that
+declares its own default identity — in every stack — before discarding the out-of-scope ones.
+Per-component auth exists only to populate `info.AuthContext` for that component's **later** template
+(`atmos.Component(...)`) and YAML-function (`!terraform.state`, `!terraform.output`) processing,
+which is skipped for filtered-out components. And because there was no cache, components that resolve
+to the same identity each re-ran the full authentication cycle.
+
+## Fix
+
+Two changes in `processComponentEntry` / `resolveComponentAuthManager`:
+
+1. **Scope — filter before auth.** Move the stack and component filters above
+   `resolveComponentAuthManager` so only in-scope components authenticate. Authentication still
+   precedes every consumer of `info.AuthContext` (`BuildTerraformWorkspace`, template processing,
+   YAML-function processing), which all run later in the function.
+
+1. **Reuse — cache per identity.** Add a pass-scoped cache keyed by the parent chain plus a
+   deterministic JSON fingerprint of the component auth section. `createComponentAuthManager` derives
+   its result solely from the auth section, the constant global config, and the parent manager
+   (`componentName`/`stackName` affect only logging), so components sharing an auth section produce an
+   equivalent, identity-scoped manager — safe to reuse. Fingerprinting the auth section (rather than a
+   bare identity name) keeps reuse provably correct: it never merges components whose sections differ.
+   Errors are never cached; sections that can't be serialized fall back to no caching.
+
+No `cmd/secret` change is needed — #2646 already made `secret list` credential-free. The fix lives in
+shared code, so `describe stacks -s`, `list values/instances`, and `terraform --all/--query` all
+benefit.
+
+## Verification
+
+- `go test ./internal/exec/ -run 'ProcessComponentEntry|ResolveComponentAuthManager'` — the
+  out-of-scope tests assert the resolver is invoked **zero** times for components outside the
+  requested stack/component set; the cache test asserts two components sharing an auth section resolve
+  **once** and a distinct section resolves anew.
+- End-to-end on a representative multi-stack repo, running the **identical** command
+  `atmos describe stacks -s <stack> --logs-level Debug` under a 45s budget with **only the atmos
+  binary varying**:
+  - **Latest release (v1.221.1):** did not complete within 45s — authenticated mostly components in
+    stacks *other than* the requested one.
+  - **Current main (post-#2646):** did not complete within 45s — same out-of-scope per-component
+    authentication.
+  - **With this fix:** completed in ~18s — 43 authentications, with in-scope processor-path auth
+    reduced to **2**; the remaining ~42 are the nested `!terraform.output` / `atmos.Component`
+    resolution path.
+
+## Recommendations
+
+- **Further dedup the nested YAML/template auth path.** Components that reference other components via
+  `!terraform.output` / `!terraform.state` / `atmos.Component(...)` authenticate through
+  `resolveAuthManagerForNestedComponent`, which does not share this processor-level cache. Extending a
+  per-identity cache to that path would remove the remaining cross-component auth cycles during
+  template/YAML resolution. Tracked separately.

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -2,6 +2,7 @@
 package exec
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -77,6 +78,12 @@ type describeStacksProcessor struct {
 	// componentAuthResolver builds a per-component AuthManager; defaults to
 	// createComponentAuthManager and is overridable in tests.
 	componentAuthResolver componentAuthManagerResolver
+	// authManagerCache memoizes per-component AuthManagers within one describe-stacks pass, keyed by
+	// auth section + parent chain, so components sharing an auth section reuse one manager instead of
+	// re-running the full auth cycle (credential writes, file locks, keyring rebuilds). The pass is
+	// single-threaded, so a plain map needs no locking.
+	// See docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md.
+	authManagerCache map[string]auth.AuthManager
 }
 
 // newDescribeStacksProcessor creates a processor with an empty result map.
@@ -122,6 +129,7 @@ func newDescribeStacksProcessorWithAuthDisabled( //nolint:revive // argument-lim
 		authManager:           authManager,
 		finalStacksMap:        make(map[string]any),
 		componentAuthResolver: createComponentAuthManager,
+		authManagerCache:      make(map[string]auth.AuthManager),
 	}
 }
 
@@ -161,6 +169,17 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	if !hasAuth || !hasDefaultIdentity(authSection) {
 		return componentAuthManager, nil
 	}
+
+	// Reuse a manager already resolved for the same auth section this pass. The resolver derives its
+	// result only from the auth section, the (constant) global config, and the parent manager
+	// (componentName/stackName are logging only), so an identical key yields an equivalent manager.
+	cacheKey, cacheable := p.componentAuthCacheKey(authSection)
+	if cacheable {
+		if cached, ok := p.authManagerCache[cacheKey]; ok {
+			return cached, nil
+		}
+	}
+
 	resolver := p.componentAuthResolver
 	if resolver == nil {
 		resolver = createComponentAuthManager
@@ -169,10 +188,40 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	if createErr != nil {
 		return componentAuthManager, fmt.Errorf("%w: failed to resolve auth for component %q in stack %q: %w", errUtils.ErrAuthManager, componentName, stackName, createErr)
 	}
+	result := componentAuthManager
 	if resolved != nil {
-		return resolved, nil
+		result = resolved
 	}
-	return componentAuthManager, nil
+	if cacheable {
+		p.cacheComponentAuthManager(cacheKey, result)
+	}
+	return result, nil
+}
+
+// componentAuthCacheKey keys the per-component auth cache by the parent chain plus a deterministic
+// JSON fingerprint of the auth section. Because identities are defined globally and only referenced
+// by components, "same auth section" is a safe, provable proxy for "same identity" — it never merges
+// components whose sections differ. Returns cacheable=false when the section can't be serialized
+// (e.g. non-string map keys), so the caller resolves without caching.
+func (p *describeStacksProcessor) componentAuthCacheKey(authSection map[string]any) (string, bool) {
+	fingerprint, err := json.Marshal(authSection)
+	if err != nil {
+		return "", false
+	}
+	var parentChain string
+	if p.authManager != nil {
+		parentChain = strings.Join(p.authManager.GetChain(), ">")
+	}
+	return parentChain + "\x00" + string(fingerprint), true
+}
+
+// cacheComponentAuthManager stores a resolved manager, lazily creating the map so struct-literal
+// processors (e.g. in tests) also memoize.
+func (p *describeStacksProcessor) cacheComponentAuthManager(key string, manager auth.AuthManager) {
+	if p.authManagerCache == nil {
+		p.authManagerCache = make(map[string]auth.AuthManager)
+	}
+	p.authManagerCache[key] = manager
 }
 
 // processStackFile processes one stack file, iterating over all requested component types.
@@ -332,14 +381,9 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	info.Context = resolvedContext
 	info.AuthDisabled = p.authDisabled
 
-	// Resolve the per-component auth manager (may fall back to the parent).
-	componentAuthManager, err := p.resolveComponentAuthManager(componentSection, componentName, stackName)
-	if err != nil {
-		return err
-	}
-	propagateAuth(&info, componentAuthManager)
-
 	// Filter: skip this component if it does not belong to the requested stack.
+	// Done before resolveComponentAuthManager (below) so out-of-scope components don't trigger a
+	// full auth cycle. See docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md.
 	if shouldFilterByStack(p.filterByStack, stackFileName, stackName) {
 		return nil
 	}
@@ -357,6 +401,14 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 	if !componentIncluded {
 		return nil
 	}
+
+	// Resolve the per-component auth manager (may fall back to the parent). Must run before the
+	// template and YAML-function processing below, which read info.AuthContext.
+	componentAuthManager, err := p.resolveComponentAuthManager(componentSection, componentName, stackName)
+	if err != nil {
+		return err
+	}
+	propagateAuth(&info, componentAuthManager)
 
 	// Ensure the stack-level entry exists (only for included components).
 	if !u.MapKeyExists(p.finalStacksMap, stackName) {

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -362,3 +362,117 @@ func TestProcessComponentEntry_ComponentAuthResolverErrorIsFatal(t *testing.T) {
 	assert.Contains(t, err.Error(), "test-stack")
 	assert.EqualValues(t, 1, spy.calls.Load(), "resolver should stop processing after the first auth failure")
 }
+
+// TestProcessComponentEntry_OutOfScopeSkipsAuth verifies that per-component auth is NOT resolved
+// for a component the caller did not request — whether it is filtered out by the requested stack
+// or excluded by the --components filter. Both filters must run before resolveComponentAuthManager;
+// otherwise `atmos secret list -s <stack>` authenticates every component in every other stack and
+// hangs on large repos. See docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md.
+func TestProcessComponentEntry_OutOfScopeSkipsAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		filterByStack string
+		components    []string
+		stackFileName string
+		componentName string
+	}{
+		{
+			// stackFileName differs from filterByStack, so this component is out of scope.
+			name:          "out_of_scope_stack",
+			filterByStack: "wanted-stack",
+			stackFileName: "other-stack",
+			componentName: "test-component",
+		},
+		{
+			// componentName is not in p.components, so this component is out of scope.
+			name:          "out_of_scope_component",
+			components:    []string{"wanted-component"},
+			stackFileName: "test-stack",
+			componentName: "other-component",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The spy returns an error, so if the resolver were invoked the call would surface as
+			// a non-nil error from processComponentEntry. An out-of-scope component must skip it.
+			spy := &componentAuthResolverSpy{
+				returnMgr: nil,
+				returnErr: assert.AnError,
+			}
+
+			componentSection := componentSectionWithAuth(authSectionWithDefault())
+			allTypeComponents := map[string]any{tc.componentName: componentSection}
+			p := &describeStacksProcessor{
+				atmosConfig:           &schema.AtmosConfiguration{},
+				filterByStack:         tc.filterByStack,
+				components:            tc.components,
+				processTemplates:      true,
+				processYamlFunctions:  false,
+				componentAuthResolver: spy.resolver(),
+				finalStacksMap:        make(map[string]any),
+			}
+
+			err := p.processComponentEntry(
+				tc.stackFileName,
+				"",
+				"helmfile",
+				tc.componentName,
+				componentSection,
+				allTypeComponents,
+				processComponentTypeOpts{},
+			)
+
+			require.NoError(t, err, "out-of-scope component must be skipped without resolving auth")
+			require.EqualValues(t, 0, spy.calls.Load(), "per-component auth must not run for an out-of-scope component")
+		})
+	}
+}
+
+// TestResolveComponentAuthManager_CachesByAuthSection verifies that components sharing an auth
+// section resolve the per-component AuthManager only once per describe-stacks pass: a second
+// component with the same auth section reuses the cached manager (resolver not called again),
+// while a distinct auth section misses the cache and resolves anew.
+// See docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md.
+func TestResolveComponentAuthManager_CachesByAuthSection(t *testing.T) {
+	t.Parallel()
+
+	type sentinelAuthManager struct{ auth.AuthManager }
+	mgr := &sentinelAuthManager{}
+
+	spy := &componentAuthResolverSpy{returnMgr: mgr}
+	p := &describeStacksProcessor{
+		atmosConfig:           &schema.AtmosConfiguration{},
+		processTemplates:      true,
+		processYamlFunctions:  false,
+		componentAuthResolver: spy.resolver(),
+		finalStacksMap:        make(map[string]any),
+		authManagerCache:      make(map[string]auth.AuthManager),
+	}
+
+	// First component with auth section A: cache miss, resolver runs once.
+	got1, err := p.resolveComponentAuthManager(componentSectionWithAuth(authSectionWithDefault()), "comp-a", "stack-1")
+	require.NoError(t, err)
+	assert.Same(t, mgr, got1, "first resolution returns the resolver's manager")
+	require.EqualValues(t, 1, spy.calls.Load(), "first component must invoke the resolver")
+
+	// Second component with the SAME auth section (different component and stack): cache hit.
+	got2, err := p.resolveComponentAuthManager(componentSectionWithAuth(authSectionWithDefault()), "comp-b", "stack-2")
+	require.NoError(t, err)
+	assert.Same(t, mgr, got2, "cache hit returns the same manager instance")
+	require.EqualValues(t, 1, spy.calls.Load(), "second component with an identical auth section must reuse the cached manager")
+
+	// Third component with a DIFFERENT auth section: cache miss, resolver runs again.
+	otherAuth := map[string]any{
+		"identities": map[string]any{
+			"other-default": map[string]any{"default": true},
+		},
+	}
+	_, err = p.resolveComponentAuthManager(componentSectionWithAuth(otherAuth), "comp-c", "stack-3")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, spy.calls.Load(), "a distinct auth section must miss the cache and resolve anew")
+}


### PR DESCRIPTION
## what

- Move the stack and component filters above `resolveComponentAuthManager` in `processComponentEntry` so only in-scope components authenticate (auth still precedes `BuildTerraformWorkspace`, template, and YAML-function processing).
- Add a pass-scoped auth cache keyed by the parent chain + a deterministic JSON fingerprint of the component auth section, so components that share an auth section reuse one authenticated manager.
- Regression tests: out-of-scope skip + cache reuse.

## why

Any auth-enabled `ExecuteDescribeStacks` caller — `atmos describe stacks`, `atmos list values`/`instances`, `atmos terraform --all`/`--query` — resolves per-component auth **before** the stack/component filters and never reuses it. On a multi-stack repo where components declare their own `default: true` identity, `atmos describe stacks -s <stack>` authenticates components in **other** stacks before discarding them, and re-authenticates each same-identity component from scratch — so the command effectively hangs.

Per-component auth exists only to populate `info.AuthContext` for that component's later template (`atmos.Component(...)`) and YAML-function (`!terraform.state`, `!terraform.output`) processing, which is skipped for filtered-out components — so authenticating them is wasted work.

#2646 fixed `atmos secret list` by disabling per-component auth for that command; it did not touch the shared processor, so every other caller still hits this.

**Measured** with the identical command `atmos describe stacks -s <stack> --logs-level Debug` under a 45s budget, only the atmos binary varying:

| binary                       | result                                                                  |
| ---------------------------- | ----------------------------------------------------------------------- |
| latest release (v1.221.1)    | did not complete within 45s (authenticating mostly out-of-scope stacks) |
| current `main` (`aa68d85be`) | did not complete within 45s                                             |
| this PR                      | completed in ~18s                                                       |

With the fix, in-scope processor-path authentications drop to **2** and out-of-scope ones to **zero** (the ~42 remaining auths are legitimate nested `!terraform.output` / `atmos.Component` reads).

## references

- Related to #2639; supersedes #2642 and #2644.
- Fix write-up: `docs/fixes/2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md`
