### PR TITLE
fix(auth): retry transient auth on freshly-brokered STS git clones

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,8 +40,12 @@ jobs:
 
       - name: Install Go tools
         run: |
-          # Install gofumpt for pre-commit
-          go install mvdan.cc/gofumpt@latest
+          # Install gofumpt for pre-commit.
+          # Pin to the gofumpt bundled by golangci-lint v2.5.0 (the gofumpt formatter in
+          # .golangci.yml) so the standalone hook and the linter stay in lockstep. Floating
+          # @latest drifted to v0.10.0, which reformats v0.9.x-clean code and broke unrelated
+          # files that fell into the PR diff range.
+          go install mvdan.cc/gofumpt@v0.9.1
 
           # Install golangci-lint v2
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0

--- a/pkg/auth/broker/broker.go
+++ b/pkg/auth/broker/broker.go
@@ -47,6 +47,14 @@ var (
 	// The ensureOnce guard makes EnsureCredentials run the brokers at most once per process,
 	// so repeated remote reads within a single command do not re-provision.
 	ensureOnce sync.Once
+
+	// The brokeredMu mutex guards brokeredCredentials.
+	brokeredMu sync.Mutex
+	// The brokeredCredentials flag records whether any enabled broker provisioned a
+	// non-empty environment this process (e.g., Atmos Pro github/sts minted a token).
+	// Consumers use HasBrokeredCredentials to decide whether to tolerate a freshly minted
+	// token's brief post-creation auth window (see HasBrokeredCredentials).
+	brokeredCredentials bool
 )
 
 // Register adds a credential broker to the registry. It is safe to call from init().
@@ -87,17 +95,43 @@ func runEnabledBrokers(ctx context.Context, atmosConfig *schema.AtmosConfigurati
 		log.Debug("Running credential broker", "broker", p.Name())
 		env, err := p.Provision(ctx, atmosConfig)
 		if err != nil {
-			// Non-fatal: a private read will surface its own auth error downstream.
-			log.Debug("Credential broker failed", "broker", p.Name(), "error", err)
+			// Non-fatal, but surfaced at Warn (not Debug): when a broker fails, the private
+			// reads it was meant to authorize will fail downstream with a bare
+			// `git Authentication failed`, and at the default Warning log level a Debug line
+			// here would be invisible — leaving the user no causal link to the real cause.
+			log.Warn("Credential broker failed; private reads may fail without these credentials", "broker", p.Name(), "error", err)
 			continue
+		}
+
+		if len(env) > 0 {
+			markBrokered()
 		}
 
 		for key, value := range env {
 			if err := os.Setenv(key, value); err != nil {
-				log.Debug("Failed to export credential broker variable", "broker", p.Name(), "key", key, "error", err)
+				log.Warn("Failed to export credential broker variable", "broker", p.Name(), "key", key, "error", err)
 			}
 		}
 	}
+}
+
+// markBrokered records that a broker provisioned credentials this process.
+func markBrokered() {
+	brokeredMu.Lock()
+	brokeredCredentials = true
+	brokeredMu.Unlock()
+}
+
+// HasBrokeredCredentials reports whether any enabled broker provisioned credentials (a
+// non-empty environment) this process. The git downloader uses this to enable bounded
+// retry of transient auth failures: a freshly minted GitHub token can briefly return 401
+// before GitHub propagates it across its git frontends, and Atmos should tolerate that
+// window only when it minted the token — never for ordinary static credentials, where a
+// wrong/expired token must fail fast.
+func HasBrokeredCredentials() bool {
+	brokeredMu.Lock()
+	defer brokeredMu.Unlock()
+	return brokeredCredentials
 }
 
 // SwapRegistryForTest clears the broker registry and the once guard, returning a restore function
@@ -112,13 +146,23 @@ func SwapRegistryForTest() func() {
 	registry = nil
 	ensureOnce = sync.Once{}
 	registryMu.Unlock()
+	resetBrokeredForTest()
 
 	return func() {
 		registryMu.Lock()
 		registry = prev
 		ensureOnce = sync.Once{}
 		registryMu.Unlock()
+		resetBrokeredForTest()
 	}
+}
+
+// resetBrokeredForTest clears the brokered-credentials flag so a test observes only what
+// its own registered providers provision. Pairs with SwapRegistryForTest.
+func resetBrokeredForTest() {
+	brokeredMu.Lock()
+	brokeredCredentials = false
+	brokeredMu.Unlock()
 }
 
 // snapshot returns a copy of the registry so brokers run without holding the lock.

--- a/pkg/auth/broker/broker.go
+++ b/pkg/auth/broker/broker.go
@@ -103,14 +103,19 @@ func runEnabledBrokers(ctx context.Context, atmosConfig *schema.AtmosConfigurati
 			continue
 		}
 
-		if len(env) > 0 {
-			markBrokered()
-		}
-
+		// Mark brokered only after at least one variable is actually exported: if every
+		// os.Setenv failed there are no usable credentials in the process env, and enabling
+		// downstream auth-retry would be wrong.
+		exported := false
 		for key, value := range env {
 			if err := os.Setenv(key, value); err != nil {
 				log.Warn("Failed to export credential broker variable", "broker", p.Name(), "key", key, "error", err)
+				continue
 			}
+			exported = true
+		}
+		if exported {
+			markBrokered()
 		}
 	}
 }

--- a/pkg/auth/broker/broker_test.go
+++ b/pkg/auth/broker/broker_test.go
@@ -38,6 +38,7 @@ func resetRegistry() {
 	registry = nil
 	registryMu.Unlock()
 	ensureOnce = sync.Once{}
+	resetBrokeredForTest()
 }
 
 func TestRegister_IgnoresNil(t *testing.T) {
@@ -115,4 +116,67 @@ func TestEnsureCredentials_NoProviders(t *testing.T) {
 	assert.NotPanics(t, func() {
 		EnsureCredentials(context.Background(), &schema.AtmosConfiguration{})
 	})
+}
+
+func TestHasBrokeredCredentials_TrueAfterNonEmptyProvision(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	key := "ATMOS_BROKER_TEST_BROKERED"
+	require.NoError(t, os.Unsetenv(key))
+
+	assert.False(t, HasBrokeredCredentials(), "no brokering should have happened yet")
+
+	Register(&fakeProvider{name: "mints", enabled: true, env: map[string]string{key: "tok"}})
+	runEnabledBrokers(context.Background(), &schema.AtmosConfiguration{})
+
+	assert.True(t, HasBrokeredCredentials(), "a non-empty provision must mark brokered credentials")
+	require.NoError(t, os.Unsetenv(key))
+}
+
+func TestHasBrokeredCredentials_FalseWhenEmptyOrErrored(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	// Enabled but returns an empty env (no token), and an enabled broker that errors.
+	Register(&fakeProvider{name: "empty", enabled: true, env: map[string]string{}})
+	Register(&fakeProvider{name: "boom", enabled: true, err: errors.New("mint failed")})
+	runEnabledBrokers(context.Background(), &schema.AtmosConfiguration{})
+
+	assert.False(t, HasBrokeredCredentials(), "no token was provisioned, so nothing is brokered")
+}
+
+// TestEnsureCredentials_ConcurrentProvisionOnce proves the sync.Once happens-before barrier:
+// concurrent callers provision exactly once AND every caller observes the exported env after
+// EnsureCredentials returns (the credential is in place before any caller proceeds to clone).
+// Run under -race to catch ordering regressions if vendoring is ever parallelized.
+func TestEnsureCredentials_ConcurrentProvisionOnce(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	key := "ATMOS_BROKER_TEST_CONCURRENT"
+	require.NoError(t, os.Unsetenv(key))
+
+	p := &fakeProvider{name: "once", enabled: true, env: map[string]string{key: "ready"}}
+	Register(p)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	observed := make([]string, goroutines)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			EnsureCredentials(context.Background(), &schema.AtmosConfiguration{})
+			observed[idx] = os.Getenv(key)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, p.provisioned, "concurrent EnsureCredentials must provision exactly once")
+	assert.True(t, HasBrokeredCredentials())
+	for i, v := range observed {
+		assert.Equal(t, "ready", v, "goroutine %d must observe the exported credential after EnsureCredentials returns", i)
+	}
+	require.NoError(t, os.Unsetenv(key))
 }

--- a/pkg/auth/broker/broker_test.go
+++ b/pkg/auth/broker/broker_test.go
@@ -118,6 +118,8 @@ func TestEnsureCredentials_NoProviders(t *testing.T) {
 	})
 }
 
+// TestHasBrokeredCredentials_TrueAfterNonEmptyProvision asserts that a broker which exports
+// a non-empty environment flips HasBrokeredCredentials to true.
 func TestHasBrokeredCredentials_TrueAfterNonEmptyProvision(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
@@ -134,6 +136,8 @@ func TestHasBrokeredCredentials_TrueAfterNonEmptyProvision(t *testing.T) {
 	require.NoError(t, os.Unsetenv(key))
 }
 
+// TestHasBrokeredCredentials_FalseWhenEmptyOrErrored asserts that an empty-env or erroring
+// broker does not mark brokered credentials, so downstream auth-retry stays disabled.
 func TestHasBrokeredCredentials_FalseWhenEmptyOrErrored(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
@@ -144,6 +148,21 @@ func TestHasBrokeredCredentials_FalseWhenEmptyOrErrored(t *testing.T) {
 	runEnabledBrokers(context.Background(), &schema.AtmosConfiguration{})
 
 	assert.False(t, HasBrokeredCredentials(), "no token was provisioned, so nothing is brokered")
+}
+
+// TestHasBrokeredCredentials_FalseWhenExportFails asserts that when every os.Setenv fails
+// (here via an invalid empty key), no credentials reach the process env and brokered state
+// is NOT marked — so downstream auth-retry is not enabled without usable credentials.
+func TestHasBrokeredCredentials_FalseWhenExportFails(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	// An empty key is rejected by os.Setenv on all platforms, so the export loop fails for
+	// every entry.
+	Register(&fakeProvider{name: "unexportable", enabled: true, env: map[string]string{"": "value"}})
+	runEnabledBrokers(context.Background(), &schema.AtmosConfiguration{})
+
+	assert.False(t, HasBrokeredCredentials(), "no variable was exported, so nothing is brokered")
 }
 
 // TestEnsureCredentials_ConcurrentProvisionOnce proves the sync.Once happens-before barrier:

--- a/pkg/downloader/get_git.go
+++ b/pkg/downloader/get_git.go
@@ -66,12 +66,14 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/go-version"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/retry"
+	"github.com/cloudposse/atmos/pkg/schema"
 )
 
 // Constants for git operations.
@@ -292,16 +294,67 @@ func getRunCommand(cmd *exec.Cmd) error {
 	return fmt.Errorf("%w: %s: %s", errUtils.ErrGitCommandFailed, cmd.Path, buf.String())
 }
 
+// Bounded retry policy for brokered git operations. A just-minted GitHub App installation
+// token can briefly 401 before GitHub propagates it across its git frontends; the atmos-pro
+// server self-heals its own API calls on 401, and these give the CLI git path the same
+// tolerance — bounded to the propagation window, not minutes.
+const (
+	// The total time cap for retrying transient auth failures.
+	stsAuthRetryWindow = 30 * time.Second
+	// The first backoff delay.
+	stsAuthRetryInitialDelay = 1 * time.Second
+	// The per-attempt backoff delay cap.
+	stsAuthRetryMaxDelay = 8 * time.Second
+	// The exponential backoff growth factor.
+	stsAuthRetryMultiplier = 2.0
+	// The jitter fraction that randomizes delays to avoid synchronized retries.
+	stsAuthRetryJitter = 0.2
+)
+
+// defaultBrokeredAuthRetryConfig is the retry policy used for brokered git operations when
+// the source has no explicit `retry:` config. It is bounded by elapsed time (not just an
+// attempt count) with exponential backoff and jitter so we keep retrying across the short
+// post-mint propagation window without hammering GitHub.
+func defaultBrokeredAuthRetryConfig() *schema.RetryConfig {
+	initialDelay := stsAuthRetryInitialDelay
+	maxDelay := stsAuthRetryMaxDelay
+	maxElapsed := stsAuthRetryWindow
+	jitter := stsAuthRetryJitter
+	multiplier := stsAuthRetryMultiplier
+	return &schema.RetryConfig{
+		BackoffStrategy: schema.BackoffExponential,
+		InitialDelay:    &initialDelay,
+		MaxDelay:        &maxDelay,
+		MaxElapsedTime:  &maxElapsed,
+		RandomJitter:    &jitter,
+		Multiplier:      &multiplier,
+		// MaxAttempts left nil => unlimited attempts, bounded by MaxElapsedTime.
+	}
+}
+
 // getRunCommandWithRetry wraps getRunCommand with retry logic for transient errors.
 func (g *CustomGitGetter) getRunCommandWithRetry(ctx context.Context, cmd *exec.Cmd) error {
+	cfg := g.RetryConfig
+	shouldRetry := isRetryableGitError
+
+	if g.RetryAuthErrors {
+		// Atmos brokered a fresh token this process: also tolerate the brief post-mint
+		// window where GitHub may 401 a valid token. Fall back to a bounded default policy
+		// when the source did not configure its own `retry:`.
+		shouldRetry = isRetryableGitOrAuthError
+		if cfg == nil {
+			cfg = defaultBrokeredAuthRetryConfig()
+		}
+	}
+
 	// Skip retry if no config, or if MaxAttempts is explicitly set to 1 (single attempt).
 	// nil MaxAttempts means unlimited retries, so we should proceed with retry logic.
-	if g.RetryConfig == nil || (g.RetryConfig.MaxAttempts != nil && *g.RetryConfig.MaxAttempts == 1) {
+	if cfg == nil || (cfg.MaxAttempts != nil && *cfg.MaxAttempts == 1) {
 		return getRunCommand(cmd)
 	}
 
 	attempt := 0
-	return retry.WithPredicate(ctx, g.RetryConfig, func() error {
+	err := retry.WithPredicate(ctx, cfg, func() error {
 		attempt++
 		// exec.Cmd can only run once, so we need to recreate it for retries.
 		if attempt > 1 {
@@ -314,7 +367,15 @@ func (g *CustomGitGetter) getRunCommandWithRetry(ctx context.Context, cmd *exec.
 			return getRunCommand(newCmd)
 		}
 		return getRunCommand(cmd)
-	}, isRetryableGitError)
+	}, shouldRetry)
+
+	if err != nil && g.RetryAuthErrors && matchesAuthFailure(err) {
+		// We brokered the token and still got rejected after the bounded window: this is no
+		// longer "not propagated yet" — most likely the STS trust policy does not grant this
+		// repo, or the token was revoked. Surface it instead of leaving a bare git error.
+		log.Error("GitHub token still rejected after the brokered-auth retry window; verify the STS trust policy grants this repository and that the token was not revoked", "error", err)
+	}
+	return err
 }
 
 // isRetryableGitError determines if a git error should trigger a retry.
@@ -350,6 +411,49 @@ func isRetryableGitError(err error) bool {
 			log.Warn("Retryable git error detected", "error", err)
 			return true
 		}
+	}
+	return false
+}
+
+// authFailurePatterns are git stderr substrings that indicate the remote rejected the
+// credentials. These are terminal by default (see isRetryableGitError) and only become
+// retryable when Atmos brokered a fresh token this process (isRetryableGitOrAuthError),
+// because a just-minted GitHub token can momentarily 401 before it propagates.
+var authFailurePatterns = []string{
+	"authentication failed",
+	"could not read username",
+	"could not read password",
+	"terminal prompts disabled",
+	"invalid username or password",
+}
+
+// matchesAuthFailure reports whether err looks like a git credential rejection. It does not
+// log, so it is safe to call both inside a retry predicate and afterward for reporting.
+func matchesAuthFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	for _, pattern := range authFailurePatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isRetryableGitOrAuthError extends isRetryableGitError to also treat authentication
+// failures as retryable. It is used ONLY when Atmos brokered a fresh token this process:
+// the token is valid but may not have propagated across GitHub's git frontends yet, so a
+// bounded retry (see defaultBrokeredAuthRetryConfig) clears the window. For ordinary static
+// credentials the default predicate keeps auth failures terminal so they fail fast.
+func isRetryableGitOrAuthError(err error) bool {
+	if isRetryableGitError(err) {
+		return true
+	}
+	if matchesAuthFailure(err) {
+		log.Warn("Transient auth failure on a brokered GitHub token; retrying (the freshly minted token may not have propagated yet)", "error", err)
+		return true
 	}
 	return false
 }

--- a/pkg/downloader/get_git_retry_test.go
+++ b/pkg/downloader/get_git_retry_test.go
@@ -483,6 +483,132 @@ func TestGetRunCommandWithRetry_NonRetryableError(t *testing.T) {
 	assert.Equal(t, 1, count, "expected 1 git invocation (non-retryable error, no retry)")
 }
 
+func TestIsRetryableGitOrAuthError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		// Auth failures ARE retryable in brokered mode (post-mint propagation window).
+		{
+			name:     "authentication failed",
+			err:      errors.New("fatal: Authentication failed for 'https://github.com/life360/atmos.git/'"),
+			expected: true,
+		},
+		{
+			name:     "could not read Username (no creds seen)",
+			err:      errors.New("fatal: could not read Username for 'https://github.com': terminal prompts disabled"),
+			expected: true,
+		},
+		// Transient network errors remain retryable.
+		{name: "connection reset", err: errors.New("read: connection reset by peer"), expected: true},
+		// Genuinely terminal errors are still not retryable, even in brokered mode.
+		{
+			name:     "repository not found",
+			err:      errors.New("fatal: repository 'https://github.com/org/repo' not found"),
+			expected: false,
+		},
+		{name: "reference not found", err: errors.New("fatal: couldn't find remote ref v9.9.9"), expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableGitOrAuthError(tt.err)
+			assert.Equal(t, tt.expected, result, "isRetryableGitOrAuthError(%v) = %v, want %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+// TestGetRunCommandWithRetry_BrokeredAuthRetried is the fix: when Atmos brokered a fresh
+// token this process (RetryAuthErrors=true), a transient "Authentication failed" is retried
+// and the second attempt — with the now-propagated token — succeeds.
+func TestGetRunCommandWithRetry_BrokeredAuthRetried(t *testing.T) {
+	counterFile := writeCountingFakeGit(t, 1, "fatal: Authentication failed for 'https://github.com/life360/atmos.git/'")
+
+	getter := &CustomGitGetter{
+		RetryAuthErrors: true,
+		RetryConfig: &schema.RetryConfig{
+			MaxAttempts:     intPtr(3),
+			InitialDelay:    durationPtr(10 * time.Millisecond),
+			MaxDelay:        durationPtr(100 * time.Millisecond),
+			MaxElapsedTime:  durationPtr(30 * time.Second),
+			BackoffStrategy: schema.BackoffConstant,
+		},
+	}
+
+	cmd := exec.Command("git", "version")
+	err := getter.getRunCommandWithRetry(context.Background(), cmd)
+
+	assert.NoError(t, err, "brokered auth failure should be retried and then succeed")
+	assert.Equal(t, 2, readCounter(t, counterFile), "expected 2 git invocations (1 auth failure + 1 success)")
+}
+
+// TestGetRunCommandWithRetry_AuthNotRetriedWhenNotBrokered is the guardrail/negative path:
+// without brokered credentials, an auth failure is terminal and fails fast (one attempt),
+// so a genuinely wrong/expired static credential never stalls in a retry loop.
+func TestGetRunCommandWithRetry_AuthNotRetriedWhenNotBrokered(t *testing.T) {
+	counterFile := writeCountingFakeGit(t, 10, "fatal: Authentication failed for 'https://github.com/org/repo.git/'")
+
+	getter := &CustomGitGetter{
+		// RetryAuthErrors deliberately left false.
+		RetryConfig: &schema.RetryConfig{
+			MaxAttempts:     intPtr(5),
+			InitialDelay:    durationPtr(10 * time.Millisecond),
+			MaxDelay:        durationPtr(100 * time.Millisecond),
+			MaxElapsedTime:  durationPtr(30 * time.Second),
+			BackoffStrategy: schema.BackoffConstant,
+		},
+	}
+
+	cmd := exec.Command("git", "version")
+	err := getter.getRunCommandWithRetry(context.Background(), cmd)
+
+	assert.Error(t, err, "non-brokered auth failure must fail fast")
+	assert.Equal(t, 1, readCounter(t, counterFile), "expected 1 git invocation (auth is terminal without brokered creds)")
+}
+
+// TestGetRunCommandWithRetry_BrokeredAuthBudgetExhausted asserts the bounded retry gives up
+// (rather than hanging) when the token is rejected for the whole window.
+func TestGetRunCommandWithRetry_BrokeredAuthBudgetExhausted(t *testing.T) {
+	counterFile := writeCountingFakeGit(t, 10, "fatal: Authentication failed for 'https://github.com/org/repo.git/'")
+
+	getter := &CustomGitGetter{
+		RetryAuthErrors: true,
+		RetryConfig: &schema.RetryConfig{
+			MaxAttempts:     intPtr(3),
+			InitialDelay:    durationPtr(10 * time.Millisecond),
+			MaxDelay:        durationPtr(100 * time.Millisecond),
+			MaxElapsedTime:  durationPtr(30 * time.Second),
+			BackoffStrategy: schema.BackoffConstant,
+		},
+	}
+
+	cmd := exec.Command("git", "version")
+	err := getter.getRunCommandWithRetry(context.Background(), cmd)
+
+	assert.Error(t, err, "persistent auth rejection must fail after the bounded window")
+	assert.Equal(t, 3, readCounter(t, counterFile), "expected exactly MaxAttempts invocations")
+}
+
+// TestGetRunCommandWithRetry_BrokeredAuthUsesDefaultConfig verifies that brokered mode
+// retries auth failures even when the source configured no explicit retry: a bounded
+// default policy is applied.
+func TestGetRunCommandWithRetry_BrokeredAuthUsesDefaultConfig(t *testing.T) {
+	counterFile := writeCountingFakeGit(t, 1, "fatal: Authentication failed for 'https://github.com/org/repo.git/'")
+
+	getter := &CustomGitGetter{
+		RetryAuthErrors: true,
+		RetryConfig:     nil, // no per-source retry configured.
+	}
+
+	cmd := exec.Command("git", "version")
+	err := getter.getRunCommandWithRetry(context.Background(), cmd)
+
+	assert.NoError(t, err, "brokered mode should apply a default retry policy and recover")
+	assert.Equal(t, 2, readCounter(t, counterFile), "expected 2 git invocations (1 failure + 1 success)")
+}
+
 func TestGetRunCommandWithRetry_ContextCancelled(t *testing.T) {
 	// Simulate context cancellation during retry.
 	counterFile := writeCountingFakeGit(t, 10, "connection reset by peer")

--- a/pkg/downloader/get_git_retry_test.go
+++ b/pkg/downloader/get_git_retry_test.go
@@ -483,6 +483,8 @@ func TestGetRunCommandWithRetry_NonRetryableError(t *testing.T) {
 	assert.Equal(t, 1, count, "expected 1 git invocation (non-retryable error, no retry)")
 }
 
+// TestIsRetryableGitOrAuthError covers the brokered-mode predicate: auth failures and
+// transient network errors are retryable, while genuinely terminal errors are not.
 func TestIsRetryableGitOrAuthError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/downloader/git_getter.go
+++ b/pkg/downloader/git_getter.go
@@ -16,6 +16,13 @@ type CustomGitGetter struct {
 	getter.GitGetter
 	// RetryConfig specifies retry behavior for git operations.
 	RetryConfig *schema.RetryConfig
+	// RetryAuthErrors tolerates transient authentication failures by retrying them within a
+	// bounded window. It is enabled ONLY when Atmos brokered a fresh GitHub token this
+	// process (see pkg/auth/broker.HasBrokeredCredentials): a just-minted GitHub App
+	// installation token can briefly return 401 before GitHub propagates it across its git
+	// frontends. For ordinary static credentials this stays false so a wrong/expired token
+	// fails fast instead of stalling.
+	RetryAuthErrors bool
 }
 
 // Get implements the custom getter logic removing symlinks.

--- a/pkg/downloader/gogetter_downloader.go
+++ b/pkg/downloader/gogetter_downloader.go
@@ -39,9 +39,16 @@ func (f *goGetterClientFactory) NewClient(ctx context.Context, src, dest string,
 	// remote read so private repositories are reachable. Brokers export GIT_CONFIG_*/tokens into
 	// the process env, which the git subprocess this client spawns inherits. Process-once and
 	// gated (CI + configured), so local-only fetches and non-Pro repos pay nothing.
-	if f.atmosConfig != nil && isRemoteSource(src) {
+	remote := f.atmosConfig != nil && isRemoteSource(src)
+	if remote {
 		broker.EnsureCredentials(ctx, f.atmosConfig)
 	}
+
+	// When Atmos brokered a fresh token this process, a freshly minted GitHub token can
+	// briefly 401 before GitHub propagates it. Let the git getter retry such auth failures
+	// within a bounded window — only for remote, brokered reads, so static credentials still
+	// fail fast.
+	retryAuthErrors := remote && broker.HasBrokeredCredentials()
 
 	registerCustomDetectors(f.atmosConfig, src)
 	switch mode {
@@ -67,7 +74,7 @@ func (f *goGetterClientFactory) NewClient(ctx context.Context, src, dest string,
 		DisableSymlinks: false,
 		Getters: map[string]getter.Getter{
 			// Overriding 'git'.
-			"git":   &CustomGitGetter{RetryConfig: f.retryConfig},
+			"git":   &CustomGitGetter{RetryConfig: f.retryConfig, RetryAuthErrors: retryAuthErrors},
 			"file":  &getter.FileGetter{},
 			"hg":    &getter.HgGetter{},
 			"http":  httpGetter,


### PR DESCRIPTION
## what

- Retry transient git authentication failures within a bounded window (default 30s, exponential backoff + jitter) **only** when Atmos brokered a fresh GitHub STS token this process — wired through a new `broker.HasBrokeredCredentials()` signal and a `CustomGitGetter.RetryAuthErrors` flag (existing per-source `retry:` config still takes precedence).
- Keep auth failures terminal (fail fast) for non-brokered/static-credential clones, so a genuinely wrong or expired token is never masked by retries.
- Surface previously-swallowed credential-broker failures at `Warn` (was `Debug`, invisible at the default `Warning` log level) and log an actionable `Error` when the brokered-auth retry window is exhausted.
- Add tests: brokered retry succeeds, non-brokered fails fast, bounded-budget exhaustion, and a `-race` concurrency guard proving `EnsureCredentials` provisions exactly once with a happens-before barrier.

## why

- Under Atmos Pro cross-repo STS, `atmos vendor pull` intermittently failed with `fatal: Authentication failed` even though the same run logged a successful token mint and OIDC auth — a subset of clones failed and a rerun was clean.
- Root cause is GitHub's brief post-creation 401 window: a just-minted installation token is not yet valid across all of GitHub's git frontends. The atmos-pro server already self-heals its own API calls on this 401 (Sentry `APP-CLOUDPOSSE-COM-AM2`), but the CLI git path did not — `isRetryableGitError` treated auth as terminal and vendor sources have no retry by default, so the earliest clones failed hard.
- This gives the CLI the same tolerance the server has, scoped narrowly to brokered tokens so static credentials still fail fast, and removes the observability gap that made the failure hard to diagnose.

## references

- Token TTL is GitHub's standard ~60 min (confirmed in atmos-pro `mint.ts` / token-provider), ruling out mid-run expiry; the post-mint propagation window is the cause.
- Follow-up (out of scope): `revoke_on_exit` cross-process token race on the shared, unlocked github/sts `state.json`.
