### PR TITLE
fix(describe): respect metadata.enabled when evaluating component functions

### DIFF
--- a/docs/fixes/2026-06-22-describe-respect-metadata-enabled.md
+++ b/docs/fixes/2026-06-22-describe-respect-metadata-enabled.md
@@ -1,0 +1,49 @@
+# Respect metadata.enabled when evaluating components in the describe pipeline
+
+## Summary
+
+`atmos describe affected` (and the shared `describe stacks` / `list` pipeline) evaluated the
+`!terraform.state` / `!terraform.output` YAML functions and the `atmos.Component(...)` template
+function for **every** component, regardless of `metadata.enabled`. A component disabled via
+`metadata.enabled: false` that references an unprovisioned component's state therefore caused a hard
+`terraform state not provisioned` failure, even though the disabled component is (correctly) excluded
+from the final affected list. See cloudposse/atmos#2654.
+
+## Root cause
+
+`describe affected` describes the current and base stacks via `ExecuteDescribeStacksWithAuthDisabled`,
+which runs the shared `describeStacksProcessor`. `processComponentEntry` processed templates and YAML
+functions for each component with no `metadata.enabled` gate. The enabled-aware filters
+(`shouldSkipComponent`, `FilterAbstractComponents`) only run when assembling the affected list — after
+the describe phase has already evaluated (and failed on) the disabled component.
+
+## Fix
+
+Gate live, state-reading evaluation on `metadata.enabled`, using the existing `isComponentEnabled`
+helper (which reads only `metadata.enabled`, never `vars.enabled`):
+
+- **YAML functions (`!terraform.state` / `!terraform.output`):** in `processComponentEntry`, when the
+  component is disabled, append the terraform state/output functions to a clone of the per-pass skip
+  list (`disabledComponentTerraformSkip`). A skipped function falls through unchanged, so the raw
+  `!terraform.*` string is preserved and no backend read occurs.
+- **Template function (`atmos.Component(...)`):** in `componentFunc`, when the *enclosing* component is
+  disabled (`enclosingComponentDisabled`, read from `info.ComponentSection`), return
+  `emptyComponentSections()` — the standard sections as empty maps, including an empty `outputs` — with
+  no describe and no state read. Empty maps keep `(atmos.Component …).outputs.x` / `.vars.x` nil-safe
+  instead of erroring.
+
+A nil info or absent metadata is treated as enabled, so non-describe template contexts (e.g.
+datasource templates built with an empty info) are never affected.
+
+## Scope and behavior
+
+The fix lives in the shared processor and `componentFunc`, so it covers `describe affected`,
+`describe stacks`, and `list` consistently. For a disabled component: `!terraform.*` values remain raw
+strings and `atmos.Component` returns empty sections. The gate keys strictly on `metadata.enabled` and
+never on `vars.enabled` — a component disabled only at the Terraform-module level (`vars.enabled: false`) still has its functions evaluated.
+
+## Example
+
+A stack containing a component disabled with `metadata.enabled: false` whose config references an
+unprovisioned component via `!terraform.state` now lets `atmos describe affected` complete instead of
+failing with `terraform state not provisioned`.

--- a/internal/exec/describe_respect_metadata_enabled_test.go
+++ b/internal/exec/describe_respect_metadata_enabled_test.go
@@ -1,0 +1,182 @@
+package exec
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestDisabledComponentTerraformSkip verifies the skip-list augmentation used to suppress
+// !terraform.* resolution for disabled components: the terraform state/output functions are added
+// (as bare names matching skipFunc), the base skip is preserved, and the base slice is not mutated.
+func TestDisabledComponentTerraformSkip(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"existing.func"}
+	got := disabledComponentTerraformSkip(base)
+
+	assert.Contains(t, got, "terraform.state", "must add the terraform.state skip (bare name)")
+	assert.Contains(t, got, "terraform.output", "must add the terraform.output skip (bare name)")
+	assert.Contains(t, got, "existing.func", "must preserve the base skip entries")
+	assert.Equal(t, []string{"existing.func"}, base, "must not mutate the caller's base skip slice")
+
+	gotNil := disabledComponentTerraformSkip(nil)
+	assert.Contains(t, gotNil, "terraform.state")
+	assert.Contains(t, gotNil, "terraform.output")
+}
+
+// TestEnclosingComponentDisabled verifies the gate used by atmos.Component: it reports disabled only
+// when the enclosing component's metadata.enabled is explicitly false. nil info, a missing
+// ComponentSection/metadata, or a vars.enabled flag must all be treated as enabled (no skip).
+func TestEnclosingComponentDisabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		info *schema.ConfigAndStacksInfo
+		want bool
+	}{
+		{"nil_info", nil, false},
+		{"no_component_section", &schema.ConfigAndStacksInfo{}, false},
+		{"empty_component_section", &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}, false},
+		{
+			"metadata_without_enabled",
+			&schema.ConfigAndStacksInfo{ComponentSection: map[string]any{cfg.MetadataSectionName: map[string]any{}}},
+			false,
+		},
+		{
+			"metadata_enabled_true",
+			&schema.ConfigAndStacksInfo{ComponentSection: map[string]any{cfg.MetadataSectionName: map[string]any{"enabled": true}}},
+			false,
+		},
+		{
+			"metadata_enabled_false",
+			&schema.ConfigAndStacksInfo{ComponentSection: map[string]any{cfg.MetadataSectionName: map[string]any{"enabled": false}}},
+			true,
+		},
+		{
+			// vars.enabled must NOT gate atmos.Component; only metadata.enabled does.
+			"vars_enabled_false_metadata_absent",
+			&schema.ConfigAndStacksInfo{ComponentSection: map[string]any{cfg.VarsSectionName: map[string]any{"enabled": false}}},
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, enclosingComponentDisabled(tc.info))
+		})
+	}
+}
+
+// TestComponentFunc_DisabledEnclosing_ReturnsEmptySections verifies that atmos.Component invoked from
+// a disabled enclosing component returns structurally-valid empty sections (including an empty
+// outputs map) without describing the target or reading state — so no Executor needs to be set.
+func TestComponentFunc_DisabledEnclosing_ReturnsEmptySections(t *testing.T) {
+	t.Parallel()
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "enclosing",
+		ComponentSection: map[string]any{
+			cfg.MetadataSectionName: map[string]any{"enabled": false},
+		},
+	}
+
+	got, err := componentFunc(&schema.AtmosConfiguration{}, info, "target", "some-stack")
+	require.NoError(t, err)
+
+	sections, ok := got.(map[string]any)
+	require.True(t, ok, "result must be a sections map")
+
+	outputs, ok := sections[cfg.OutputsSectionName].(map[string]any)
+	require.True(t, ok, "result must include an outputs section")
+	assert.Empty(t, outputs, "outputs must be empty for a disabled enclosing component")
+
+	vars, ok := sections[cfg.VarsSectionName].(map[string]any)
+	require.True(t, ok, "result must include a vars section so .vars.x stays nil-safe")
+	assert.Empty(t, vars)
+}
+
+// countingStateGetter is a TerraformStateGetter test double that records GetState invocations.
+type countingStateGetter struct {
+	calls atomic.Int64
+	ret   any
+}
+
+func (c *countingStateGetter) GetState(
+	_ *schema.AtmosConfiguration,
+	_ string,
+	_ string,
+	_ string,
+	_ string,
+	_ bool,
+	_ *schema.AuthContext,
+	_ any,
+) (any, error) {
+	c.calls.Add(1)
+	return c.ret, nil
+}
+
+// TestProcessComponentEntry_DisabledComponentSkipsTerraformState verifies the end-to-end gate: when a
+// component is disabled via metadata.enabled, processComponentEntry does not resolve its
+// !terraform.state (GetState is never called); enabled components — and components disabled only via
+// vars.enabled — still resolve it.
+func TestProcessComponentEntry_DisabledComponentSkipsTerraformState(t *testing.T) {
+	tests := []struct {
+		name           string
+		metadata       map[string]any
+		varsEnabled    *bool
+		expectResolved bool
+	}{
+		{"metadata_enabled_false_skips", map[string]any{"enabled": false}, nil, false},
+		{"metadata_enabled_true_resolves", map[string]any{"enabled": true}, nil, true},
+		{"no_metadata_enabled_resolves", map[string]any{}, nil, true},
+		{"vars_enabled_false_still_resolves", map[string]any{}, boolPtr(false), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &countingStateGetter{ret: "resolved-value"}
+			orig := stateGetter
+			stateGetter = spy
+			t.Cleanup(func() { stateGetter = orig })
+			ClearResolutionContext()
+			t.Cleanup(ClearResolutionContext)
+
+			vars := map[string]any{"x": "!terraform.state some/component someoutput"}
+			if tc.varsEnabled != nil {
+				vars["enabled"] = *tc.varsEnabled
+			}
+			componentSection := map[string]any{
+				cfg.VarsSectionName:     vars,
+				cfg.MetadataSectionName: tc.metadata,
+			}
+			allTypeComponents := map[string]any{"test-component": componentSection}
+
+			p := &describeStacksProcessor{
+				atmosConfig:          &schema.AtmosConfiguration{},
+				processYamlFunctions: true,
+				finalStacksMap:       make(map[string]any),
+			}
+
+			err := p.processComponentEntry(
+				"test-stack", "", cfg.HelmfileSectionName,
+				"test-component", componentSection, allTypeComponents,
+				processComponentTypeOpts{},
+			)
+			require.NoError(t, err)
+
+			if tc.expectResolved {
+				require.Positive(t, spy.calls.Load(), "enabled component must resolve !terraform.state")
+			} else {
+				require.Zero(t, spy.calls.Load(), "disabled component must not resolve !terraform.state")
+			}
+		})
+	}
+}

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -449,7 +449,15 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 
 	// Process YAML functions.
 	if p.processYamlFunctions {
-		componentSection, err = processComponentSectionYAMLFunctions(p.atmosConfig, &info, componentSection, p.skip)
+		// A component disabled via metadata.enabled has no deployed state, so its
+		// !terraform.state / !terraform.output must not be resolved — the backend read would
+		// fail with "state not provisioned". Gate on metadata.enabled only, independent of
+		// vars.enabled. See docs/fixes/2026-06-22-describe-respect-metadata-enabled.md.
+		skip := p.skip
+		if !isComponentEnabled(secs.metadata, componentName) {
+			skip = disabledComponentTerraformSkip(p.skip)
+		}
+		componentSection, err = processComponentSectionYAMLFunctions(p.atmosConfig, &info, componentSection, skip)
 		if err != nil {
 			return err
 		}
@@ -469,6 +477,18 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 // ---------------------------------------------------------------------------
 // Pure helper functions – independently unit-testable
 // ---------------------------------------------------------------------------
+
+// disabledComponentTerraformSkip returns baseSkip plus the terraform state/output YAML functions so a
+// component disabled via metadata.enabled keeps its !terraform.* values unresolved (no backend read).
+// The names are bare (no leading "!") to match skipFunc, which trims the tag prefix before comparing.
+// baseSkip is cloned so the processor's shared skip slice is never mutated.
+func disabledComponentTerraformSkip(baseSkip []string) []string {
+	return append(
+		slices.Clone(baseSkip),
+		strings.TrimPrefix(u.AtmosYamlFuncTerraformState, "!"),
+		strings.TrimPrefix(u.AtmosYamlFuncTerraformOutput, "!"),
+	)
+}
 
 // extractDescribeComponentSections returns all standard Atmos sections from a component map,
 // using empty maps (or empty string) as defaults when a section is absent.

--- a/internal/exec/template_funcs_component.go
+++ b/internal/exec/template_funcs_component.go
@@ -28,6 +28,16 @@ func componentFunc(
 
 	log.Debug("Executing template function", "function", functionName)
 
+	// Skip live resolution when the enclosing component is disabled via metadata.enabled.
+	// A disabled component has no deployed state; resolving atmos.Component would read remote
+	// state and fail. Return empty sections (including an empty `outputs`) so templates that index
+	// the result stay nil-safe. Gate on metadata.enabled only, independent of vars.enabled.
+	// See docs/fixes/2026-06-22-describe-respect-metadata-enabled.md.
+	if enclosingComponentDisabled(configAndStacksInfo) {
+		log.Debug("Skipping atmos.Component for disabled enclosing component", "function", functionName)
+		return emptyComponentSections(), nil
+	}
+
 	// If the result for the component in the stack already exists in the cache, return it
 	existingSections, found := componentFuncSyncMap.Load(stackSlug)
 	if found && existingSections != nil {
@@ -109,4 +119,37 @@ func componentFunc(
 	}
 
 	return sections, nil
+}
+
+// enclosingComponentDisabled reports whether the component whose template is being rendered (the
+// enclosing component carried by configAndStacksInfo, not the atmos.Component target) is disabled via
+// metadata.enabled. A nil info or absent metadata is treated as enabled, so non-describe template
+// contexts (e.g. datasource templates built with an empty info) are never affected.
+func enclosingComponentDisabled(info *schema.ConfigAndStacksInfo) bool {
+	if info == nil {
+		return false
+	}
+	metadata, ok := info.ComponentSection[cfg.MetadataSectionName].(map[string]any)
+	if !ok {
+		return false
+	}
+	return !isComponentEnabled(metadata, info.ComponentFromArg)
+}
+
+// emptyComponentSections returns the standard component sections as empty maps, including an empty
+// outputs map. It is the atmos.Component result for a disabled enclosing component: structurally
+// valid (so `.outputs.x`, `.vars.x`, etc. evaluate to nil instead of erroring) while performing no
+// describe and no terraform state/output read.
+func emptyComponentSections() map[string]any {
+	return map[string]any{
+		cfg.VarsSectionName:      map[string]any{},
+		cfg.SettingsSectionName:  map[string]any{},
+		cfg.EnvSectionName:       map[string]any{},
+		cfg.MetadataSectionName:  map[string]any{},
+		cfg.ProvidersSectionName: map[string]any{},
+		cfg.HooksSectionName:     map[string]any{},
+		cfg.OverridesSectionName: map[string]any{},
+		cfg.BackendSectionName:   map[string]any{},
+		cfg.OutputsSectionName:   map[string]any{},
+	}
 }


### PR DESCRIPTION
## what

- Respect `metadata.enabled` when the shared describe pipeline (`describe affected`, `describe stacks`, `list`) evaluates a component's functions:
  - **`!terraform.state` / `!terraform.output`** are skipped for components disabled via `metadata.enabled: false` — the raw function string is left unresolved (no backend read).
  - **`atmos.Component(...)`** returns empty sections (including an empty `outputs`) when the *enclosing* component is disabled — no describe, no state read, and template-safe (`.outputs.x` / `.vars.x` evaluate to nil instead of erroring).
- The gate keys strictly on `metadata.enabled` (via the existing `isComponentEnabled`), **independent of `vars.enabled`**.

## why

- `describe affected` describes the current and base stacks and evaluates every component's templates/YAML functions with no `metadata.enabled` gate. A component disabled with `metadata.enabled: false` that references an unprovisioned component's state therefore failed hard with `terraform state not provisioned` — even though disabled components are (correctly) excluded from the final affected list. The enabled-aware filters (`shouldSkipComponent`, `FilterAbstractComponents`) only run when assembling that list, after the describe phase has already failed.

Fixes #2654.

## references

- Fixes #2654
- Design notes: `docs/fixes/2026-06-22-describe-respect-metadata-enabled.md`

## test plan

- Unit tests: `disabledComponentTerraformSkip` (adds the terraform funcs, clones the base skip), `enclosingComponentDisabled` (nil/absent metadata ⇒ enabled; `vars.enabled:false` alone ⇒ enabled; `metadata.enabled:false` ⇒ disabled), `componentFunc` returns empty sections for a disabled enclosing component, and an end-to-end `processComponentEntry` test (disabled ⇒ `!terraform.state` not resolved; enabled / `vars.enabled:false`-only ⇒ resolved).
- `go build ./...`, `go vet ./internal/exec/...`, and `custom-gcl run --new-from-rev=main` (0 issues).

> Note: the `TestDescribeAffected*` integration tests are environment-sensitive and fail identically on a clean `main` checkout locally (macOS); they are unrelated to this change. CI (Linux) is authoritative.
