### PR TITLE
perf(stacks): dedupe per-identity auth in nested terraform.state resolution

### DIFF
--- a/docs/fixes/2026-06-22-dedupe-nested-component-auth.md
+++ b/docs/fixes/2026-06-22-dedupe-nested-component-auth.md
@@ -1,0 +1,70 @@
+# Dedupe per-identity auth in nested `!terraform.state` resolution
+
+## Summary
+
+Follow-up to the `describe stacks` per-component auth fix
+(`2026-06-22-describe-stacks-scope-and-cache-per-component-auth.md`). That change
+scoped and memoized per-component authentication at the **top level** of a
+`describe stacks` / `list` / `terraform --all` pass. This change extends the same
+per-identity memoization to the **nested** resolution path that runs while
+templates and YAML functions are evaluated.
+
+## Problem
+
+When a component references another component via `!terraform.state` /
+`!terraform.output`, resolution flows through:
+
+```text
+GetTerraformState (terraform_state_utils.go)
+  └─ resolveAuthManagerForNestedComponent (terraform_nested_auth_helper.go)
+       └─ createComponentAuthManager
+            └─ auth.CreateAndAuthenticateManagerWithAtmosConfig   // expensive: credential writes, file locks, keyring
+```
+
+`terraformStateCache` (keyed by `stack-component`) already short-circuits a
+**repeat read of the same target** before auth runs. The gap: **distinct target
+components that share one identity** each run a full auth cycle. On a large stack
+whose components fan out to many shared-identity targets, this reproduces the same
+N-auth blowup the top-level fix removed — just relocated into template/YAML
+resolution.
+
+`atmos.Component(...)` and `!terraform.output` only trigger auth cycles
+transitively (when the component they describe itself contains `!terraform.state`);
+they inherit the parent auth context directly and are not independent sources.
+
+## Fix
+
+Memoize `resolveAuthManagerForNestedComponent` results in a process-scoped cache
+(`nestedAuthManagerCache`), mirroring the existing `terraformStateCache` /
+`componentFuncSyncMap` pattern in this package.
+
+- **Key:** parent auth chain + a deterministic JSON fingerprint of the component's
+  auth section (`buildComponentAuthCacheKey`). Identities are defined globally and
+  only *referenced* by components, so "same auth section" is a provable proxy for
+  "same identity"; it never merges components whose auth differs. The parent chain
+  disambiguates an inherited identity from an auto-detected one. A section that
+  cannot be serialized is reported non-cacheable and resolves without caching.
+- **Shared key function:** `buildComponentAuthCacheKey` is now used by **both** the
+  `describe stacks` processor and the nested path, so the two keying strategies
+  cannot drift.
+- **Only successful, non-nil results are cached.** A resolver error is never
+  memoized, so a transient auth failure does not poison the cache.
+- **Reset:** `ResetNestedAuthManagerCache()` clears it; `ResetStateCache()` clears
+  it alongside the state cache, because the managers in `nestedAuthManagerCache`
+  are what read the state in `terraformStateCache` — clearing one while reusing the
+  other would be inconsistent. Neither is reset in production.
+
+## Safety
+
+Sharing one authenticated manager across components is safe **iff** the auth
+section (and therefore the resolved identity) is identical — the same assumption
+the top-level processor cache already relies on. Lifetime is process-scoped
+(command-per-process), identical to the sibling state/component caches; credentials
+do not expire within a single seconds-long pass.
+
+## Example
+
+For a stack `acme-use1-tools` whose components cross-reference shared-identity
+targets, the count of `CreateAndAuthenticateManager called` debug lines during
+`atmos describe stacks -s <stack>` drops from roughly one-per-distinct-target to
+roughly one-per-identity, with identical output.

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -2,7 +2,6 @@
 package exec
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -198,21 +197,11 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	return result, nil
 }
 
-// componentAuthCacheKey keys the per-component auth cache by the parent chain plus a deterministic
-// JSON fingerprint of the auth section. Because identities are defined globally and only referenced
-// by components, "same auth section" is a safe, provable proxy for "same identity" — it never merges
-// components whose sections differ. Returns cacheable=false when the section can't be serialized
-// (e.g. non-string map keys), so the caller resolves without caching.
+// componentAuthCacheKey delegates to the shared buildComponentAuthCacheKey so the describe-stacks
+// processor and the nested terraform.state path key per-component AuthManagers identically and cannot
+// drift. See buildComponentAuthCacheKey in terraform_nested_auth_helper.go.
 func (p *describeStacksProcessor) componentAuthCacheKey(authSection map[string]any) (string, bool) {
-	fingerprint, err := json.Marshal(authSection)
-	if err != nil {
-		return "", false
-	}
-	var parentChain string
-	if p.authManager != nil {
-		parentChain = strings.Join(p.authManager.GetChain(), ">")
-	}
-	return parentChain + "\x00" + string(fingerprint), true
+	return buildComponentAuthCacheKey(p.authManager, authSection)
 }
 
 // cacheComponentAuthManager stores a resolved manager, lazily creating the map so struct-literal

--- a/internal/exec/terraform_nested_auth_cache_test.go
+++ b/internal/exec/terraform_nested_auth_cache_test.go
@@ -1,0 +1,197 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/auth"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// fakeChainAuthManager is a minimal auth.AuthManager whose GetChain returns a fixed chain.
+// Only GetChain is exercised by buildComponentAuthCacheKey; the other methods inherit the embedded
+// nil interface and would panic if called, catching any unexpected use.
+type fakeChainAuthManager struct {
+	auth.AuthManager
+	chain []string
+}
+
+func (f *fakeChainAuthManager) GetChain() []string { return f.chain }
+
+// TestBuildComponentAuthCacheKey verifies the shared key strategy via pairwise comparisons:
+// identical sections with the same parent produce one key, while differing sections or parent chains
+// produce distinct keys.
+func TestBuildComponentAuthCacheKey(t *testing.T) {
+	t.Parallel()
+
+	sectionA := authSectionWithDefault()
+	sectionB := map[string]any{
+		"identities": map[string]any{"other-default": map[string]any{"default": true}},
+	}
+	coreTools := &fakeChainAuthManager{chain: []string{"core-tools/terraform"}}
+	other := &fakeChainAuthManager{chain: []string{"other/identity"}}
+
+	tests := []struct {
+		name      string
+		parentA   auth.AuthManager
+		sectionA  map[string]any
+		parentB   auth.AuthManager
+		sectionB  map[string]any
+		wantEqual bool
+	}{
+		{
+			name:    "identical sections with the same (nil) parent share a key",
+			parentA: nil, sectionA: sectionA,
+			parentB: nil, sectionB: authSectionWithDefault(),
+			wantEqual: true,
+		},
+		{
+			name:    "different auth sections do not collide",
+			parentA: nil, sectionA: sectionA,
+			parentB: nil, sectionB: sectionB,
+			wantEqual: false,
+		},
+		{
+			name:    "same section, inherited vs auto-detected parent differ",
+			parentA: nil, sectionA: sectionA,
+			parentB: coreTools, sectionB: sectionA,
+			wantEqual: false,
+		},
+		{
+			name:    "same section, distinct parent chains differ",
+			parentA: coreTools, sectionA: sectionA,
+			parentB: other, sectionB: sectionA,
+			wantEqual: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			keyA, okA := buildComponentAuthCacheKey(tc.parentA, tc.sectionA)
+			require.True(t, okA, "a string-keyed auth section must be cacheable")
+			keyB, okB := buildComponentAuthCacheKey(tc.parentB, tc.sectionB)
+			require.True(t, okB, "a string-keyed auth section must be cacheable")
+
+			if tc.wantEqual {
+				assert.Equal(t, keyA, keyB)
+			} else {
+				assert.NotEqual(t, keyA, keyB)
+			}
+		})
+	}
+}
+
+// TestBuildComponentAuthCacheKey_NonSerializable verifies that a section that cannot be JSON-encoded
+// is reported as non-cacheable instead of panicking.
+func TestBuildComponentAuthCacheKey_NonSerializable(t *testing.T) {
+	t.Parallel()
+
+	_, ok := buildComponentAuthCacheKey(nil, map[string]any{"identities": make(chan int)})
+	assert.False(t, ok, "a section that cannot be JSON-serialized must be reported non-cacheable")
+}
+
+// sentinelAuthManager is a distinguishable AuthManager used to assert pointer identity of cached results.
+type sentinelAuthManager struct{ auth.AuthManager }
+
+// TestResolveCachedComponentAuthManager_DedupesByIdentity verifies that components sharing an auth
+// section (same identity) resolve the nested AuthManager once per process, while a distinct section or
+// a distinct parent chain resolves independently.
+func TestResolveCachedComponentAuthManager_DedupesByIdentity(t *testing.T) {
+	// Not parallel: mutates the package-level nestedAuthManagerCache.
+	ResetNestedAuthManagerCache()
+	t.Cleanup(ResetNestedAuthManagerCache)
+
+	mgr := &sentinelAuthManager{}
+	spy := &componentAuthResolverSpy{returnMgr: mgr}
+	resolve := spy.resolver()
+	atmosCfg := &schema.AtmosConfiguration{}
+	sectionA := authSectionWithDefault()
+
+	// First component: cache miss, resolver runs once.
+	got1, err := resolveCachedComponentAuthManager(atmosCfg, componentSectionWithAuth(sectionA), "comp-a", "stack-1", nil, sectionA, resolve)
+	require.NoError(t, err)
+	assert.Same(t, mgr, got1, "first resolution returns the resolver's manager")
+	require.EqualValues(t, 1, spy.calls.Load(), "first component must invoke the resolver")
+
+	// Second component, SAME section (fresh copy), different component/stack: cache hit.
+	got2, err := resolveCachedComponentAuthManager(atmosCfg, componentSectionWithAuth(sectionA), "comp-b", "stack-2", nil, authSectionWithDefault(), resolve)
+	require.NoError(t, err)
+	assert.Same(t, mgr, got2, "cache hit must return the same manager instance")
+	require.EqualValues(t, 1, spy.calls.Load(), "identical auth section must reuse the cached manager")
+
+	// Distinct section: cache miss, resolver runs again.
+	sectionB := map[string]any{"identities": map[string]any{"other-default": map[string]any{"default": true}}}
+	_, err = resolveCachedComponentAuthManager(atmosCfg, componentSectionWithAuth(sectionB), "comp-c", "stack-3", nil, sectionB, resolve)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, spy.calls.Load(), "a distinct auth section must miss the cache")
+
+	// Same section A but a non-nil parent chain: distinct key → resolver runs again.
+	parent := &fakeChainAuthManager{chain: []string{"core-tools/terraform"}}
+	_, err = resolveCachedComponentAuthManager(atmosCfg, componentSectionWithAuth(sectionA), "comp-d", "stack-4", parent, sectionA, resolve)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, spy.calls.Load(), "a different parent chain must miss the cache")
+}
+
+// TestResolveCachedComponentAuthManager_DoesNotCacheErrors verifies a failed resolution is not
+// memoized: a subsequent call with the same key re-invokes the resolver, so a transient auth failure
+// does not poison the cache for the rest of the process.
+func TestResolveCachedComponentAuthManager_DoesNotCacheErrors(t *testing.T) {
+	ResetNestedAuthManagerCache()
+	t.Cleanup(ResetNestedAuthManagerCache)
+
+	spy := &componentAuthResolverSpy{returnMgr: nil, returnErr: assert.AnError}
+	resolve := spy.resolver()
+	section := authSectionWithDefault()
+
+	_, err := resolveCachedComponentAuthManager(&schema.AtmosConfiguration{}, componentSectionWithAuth(section), "comp-a", "stack-1", nil, section, resolve)
+	require.ErrorIs(t, err, assert.AnError)
+	require.EqualValues(t, 1, spy.calls.Load())
+
+	// Same key again: must re-run because the error path was not cached.
+	_, err = resolveCachedComponentAuthManager(&schema.AtmosConfiguration{}, componentSectionWithAuth(section), "comp-a", "stack-1", nil, authSectionWithDefault(), resolve)
+	require.ErrorIs(t, err, assert.AnError)
+	require.EqualValues(t, 2, spy.calls.Load(), "an errored resolution must not be cached")
+}
+
+// TestResolveCachedComponentAuthManager_UnserializableSectionAlwaysResolves verifies that a section
+// that cannot be fingerprinted is never cached: every call resolves anew rather than sharing a manager
+// under a bogus key.
+func TestResolveCachedComponentAuthManager_UnserializableSectionAlwaysResolves(t *testing.T) {
+	ResetNestedAuthManagerCache()
+	t.Cleanup(ResetNestedAuthManagerCache)
+
+	spy := &componentAuthResolverSpy{returnMgr: &sentinelAuthManager{}}
+	resolve := spy.resolver()
+	bad := map[string]any{"identities": make(chan int)}
+
+	for range 2 {
+		_, err := resolveCachedComponentAuthManager(&schema.AtmosConfiguration{}, nil, "comp", "stack", nil, bad, resolve)
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 2, spy.calls.Load(), "an unserializable section must resolve every time (never cached)")
+}
+
+// TestResetStateCacheClearsNestedAuthCache verifies the documented coupling: clearing the state cache
+// also drops memoized nested AuthManagers, so a JIT re-read does not reuse a stale auth manager.
+func TestResetStateCacheClearsNestedAuthCache(t *testing.T) {
+	ResetNestedAuthManagerCache()
+	t.Cleanup(ResetNestedAuthManagerCache)
+
+	spy := &componentAuthResolverSpy{returnMgr: &sentinelAuthManager{}}
+	resolve := spy.resolver()
+	section := authSectionWithDefault()
+
+	_, err := resolveCachedComponentAuthManager(&schema.AtmosConfiguration{}, componentSectionWithAuth(section), "comp", "stack", nil, section, resolve)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, spy.calls.Load())
+
+	ResetStateCache() // Must also clear nestedAuthManagerCache.
+
+	_, err = resolveCachedComponentAuthManager(&schema.AtmosConfiguration{}, componentSectionWithAuth(section), "comp", "stack", nil, authSectionWithDefault(), resolve)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, spy.calls.Load(), "ResetStateCache must clear the nested auth cache, forcing re-resolution")
+}

--- a/internal/exec/terraform_nested_auth_helper.go
+++ b/internal/exec/terraform_nested_auth_helper.go
@@ -1,12 +1,16 @@
 package exec
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	log "github.com/cloudposse/atmos/pkg/logger"
+	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -14,6 +18,78 @@ const (
 	logKeyComponent = "component"
 	logKeyStack     = "stack"
 )
+
+// nestedAuthManagerCache memoizes per-component AuthManagers resolved for nested terraform.state /
+// terraform.output references during one process. Many components in a stack reference other
+// components that share a single identity; without this cache each distinct target re-runs the full
+// auth cycle (credential writes, file locks, keyring rebuilds) inside resolveAuthManagerForNestedComponent.
+// Keyed by parent chain + auth-section fingerprint (see buildComponentAuthCacheKey), a provably-safe
+// proxy for "same identity" because identities are global and only referenced by components. Reset via
+// ResetNestedAuthManagerCache (also cleared by ResetStateCache); never reset in production.
+// See docs/fixes/2026-06-22-dedupe-nested-component-auth.md.
+var nestedAuthManagerCache sync.Map
+
+// ResetNestedAuthManagerCache clears the nested-component AuthManager cache.
+// Exported for tests to guarantee isolation between test functions; never called in production.
+func ResetNestedAuthManagerCache() {
+	defer perf.Track(nil, "exec.ResetNestedAuthManagerCache")()
+
+	nestedAuthManagerCache.Range(func(key, _ any) bool {
+		nestedAuthManagerCache.Delete(key)
+		return true
+	})
+}
+
+// buildComponentAuthCacheKey keys a per-component AuthManager by the parent auth chain plus a
+// deterministic JSON fingerprint of the component's auth section. Because identities are defined
+// globally and only referenced by components, "same auth section" is a safe, provable proxy for
+// "same identity" — it never merges components whose sections differ. The parent chain disambiguates
+// an inherited identity from an auto-detected one. Returns cacheable=false when the section cannot be
+// serialized (e.g. a channel/func value), so callers resolve without caching. Shared by
+// describeStacksProcessor and the nested terraform.state path so the two cannot drift.
+func buildComponentAuthCacheKey(parent auth.AuthManager, authSection map[string]any) (string, bool) {
+	fingerprint, err := json.Marshal(authSection)
+	if err != nil {
+		return "", false
+	}
+	var parentChain string
+	if parent != nil {
+		parentChain = strings.Join(parent.GetChain(), ">")
+	}
+	return parentChain + "\x00" + string(fingerprint), true
+}
+
+// resolveCachedComponentAuthManager returns a memoized AuthManager for authSection when one was
+// already resolved this process, otherwise it calls resolve and caches a successful, non-nil result.
+// resolve is injected so tests can substitute a counting fake; production passes createComponentAuthManager.
+func resolveCachedComponentAuthManager(
+	atmosConfig *schema.AtmosConfiguration,
+	componentConfig map[string]any,
+	component, stack string,
+	parentAuthManager auth.AuthManager,
+	authSection map[string]any,
+	resolve componentAuthManagerResolver,
+) (auth.AuthManager, error) {
+	cacheKey, cacheable := buildComponentAuthCacheKey(parentAuthManager, authSection)
+	if cacheable {
+		if cached, ok := nestedAuthManagerCache.Load(cacheKey); ok {
+			log.Debug("Reusing cached component-specific AuthManager",
+				logKeyComponent, component,
+				logKeyStack, stack,
+			)
+			return cached.(auth.AuthManager), nil
+		}
+	}
+
+	resolved, err := resolve(atmosConfig, componentConfig, component, stack, parentAuthManager)
+	if err != nil {
+		return resolved, err
+	}
+	if cacheable && resolved != nil {
+		nestedAuthManagerCache.Store(cacheKey, resolved)
+	}
+	return resolved, nil
+}
 
 // hasDefaultIdentity checks if the auth section contains at least one identity with default: true.
 func hasDefaultIdentity(authSection map[string]any) bool {
@@ -100,13 +176,15 @@ func resolveAuthManagerForNestedComponent(
 		return parentAuthManager, nil
 	}
 
-	// Component has auth config with default identity, create component-specific AuthManager.
+	// Component has auth config with default identity, create (or reuse) a component-specific AuthManager.
 	log.Debug("Component has auth config with default identity, creating component-specific AuthManager",
 		logKeyComponent, component,
 		logKeyStack, stack,
 	)
 
-	return createComponentAuthManager(atmosConfig, componentConfig, component, stack, parentAuthManager)
+	return resolveCachedComponentAuthManager(
+		atmosConfig, componentConfig, component, stack, parentAuthManager, authSection, createComponentAuthManager,
+	)
 }
 
 // getComponentConfigForAuthResolution retrieves component configuration without processing

--- a/internal/exec/terraform_state_utils.go
+++ b/internal/exec/terraform_state_utils.go
@@ -16,8 +16,11 @@ import (
 
 var terraformStateCache = sync.Map{}
 
-// ResetStateCache clears the terraform state cache.
-// This is exported for use in tests to ensure cache isolation between test functions.
+// ResetStateCache clears the terraform state cache and the nested-component AuthManager cache.
+// This is exported for use in tests to ensure cache isolation between test functions. The two caches
+// are cleared together because the managers in nestedAuthManagerCache are what read the state held in
+// terraformStateCache: clearing state to force a fresh backend read while reusing a stale auth manager
+// would be inconsistent. Neither cache is reset in production.
 func ResetStateCache() {
 	defer perf.Track(nil, "exec.ResetStateCache")()
 
@@ -25,6 +28,8 @@ func ResetStateCache() {
 		terraformStateCache.Delete(key)
 		return true
 	})
+
+	ResetNestedAuthManagerCache()
 }
 
 // GetTerraformState retrieves a specified Terraform output variable for a given component within a stack.


### PR DESCRIPTION
## what

- Extends the per-component `AuthManager` memoization introduced in #2652 from the top-level `describe stacks` pass into the **nested** resolution path that runs while templates and YAML functions are evaluated (`!terraform.state`, `!terraform.output`, `atmos.Component(...)`).
- Adds a process-scoped `nestedAuthManagerCache`, consulted by `resolveAuthManagerForNestedComponent`, keyed by the parent auth chain + a deterministic JSON fingerprint of the component's auth section.
- Extracts the key logic into a shared `buildComponentAuthCacheKey` used by **both** the processor cache (#2652) and this nested path, so the two keying strategies cannot drift.
- Caches only successful, non-nil resolutions; `ResetStateCache()` also clears the new cache (kept consistent with the `terraformStateCache` it pairs with). Neither is reset in production.

## why

- #2652 deduped per-component auth at the **top level**, but a component that references another component via `!terraform.state` still ran a **full auth cycle** (credential writes, file locks, keyring rebuilds) once per **distinct target** — even when every target resolves to the **same identity**. `terraformStateCache` only short-circuits a repeat read of the *same* target, not distinct targets that share an identity.
- The result was the same N-auth blowup #2652 removed, just relocated into template/YAML resolution. Memoizing by identity removes it.

**Measured** — `atmos describe stacks -s <stack>` on a large real-world stack (credentials provided via `auth exec`, 45s cap; only the binary under test varies):

| build                          | wall time   | per-component auth cycles |
| ------------------------------ | ----------- | ------------------------- |
| latest release                 | DNF (>45s)  | —                         |
| `main` (includes #2652)        | ~17–19s     | 44                        |
| this PR (#2652 + nested dedup) | **~10–11s** | **5**                     |

Output was verified equivalent to `main`: the remaining run-to-run differences are pre-existing `auto_provision_workdir_for_outputs` / `tofu output` provisioning nondeterminism present on **both** builds (same identity resolved throughout, no new errors). A matched-output pair differed by fewer lines than the `main`-vs-`main` noise floor.

The nested path is shared by `describe affected`, `list`, and `terraform --all/--query`. On a large multi-component change, the full per-identity auth cycles during `describe affected` likewise drop from scaling with the number of resolved components to roughly one-per-identity, with the rest served from the cache.

## test plan

- `go build ./... && go test ./internal/exec/...` — new unit tests cover key behavior, dedupe-by-identity, parent-chain isolation, errors-not-cached, unserializable-section-not-cached, and the `ResetStateCache` coupling.
- `custom-gcl run --new-from-rev=main` → 0 issues.
- Real-repo benchmark above.

## references

- Related to #2639
- Builds on #2652
- Design notes: `docs/fixes/2026-06-22-dedupe-nested-component-auth.md`
