### PR TITLE
fix(secret): skip remote-state reads in credential-free secret list

### DIFF
--- a/cmd/secret/enumerate.go
+++ b/cmd/secret/enumerate.go
@@ -28,8 +28,9 @@ var enumerateScopesFn = enumerateSecretScopes
 
 // enumerateSecretScopes lists every (stack, component) instance that declares secrets, narrowed by
 // the given facets (an empty Stack/Component means "all"). It resolves the stack manifests once via
-// describe-stacks with `!secret` resolution skipped — declarations and their derived scope are
-// available without retrieving any secret values.
+// describe-stacks with auth disabled and all credentialed read functions skipped (see
+// credentialFreeSkip) — declarations and their derived scope are available without retrieving any
+// secret values or reading any remote backend.
 func enumerateSecretScopes(facet secretScope) ([]scopeEntry, *schema.AtmosConfiguration, error) {
 	defer perf.Track(nil, "secret.enumerateSecretScopes")()
 
@@ -47,9 +48,14 @@ func enumerateSecretScopes(facet secretScope) ([]scopeEntry, *schema.AtmosConfig
 	// secrets.ExtractDeclarations); it never retrieves a secret value, so per-component auth is
 	// pure overhead. Disable it explicitly so a 72-component stack doesn't run 72 auth cycles
 	// (credentials-file rewrite + keyring rebuild) just to enumerate declarations.
+	//
+	// With auth disabled, every credentialed read function must also be skipped: an evaluated
+	// `!terraform.state`/`!terraform.output`/`!store` would fall back to the default AWS chain and
+	// fail (e.g. an unreachable EC2 IMDS endpoint) even though enumeration never needs the resolved
+	// value. See credentialFreeSkip.
 	stacksMap, err := e.ExecuteDescribeStacksWithAuthDisabled(
 		&atmosConfig, facet.Stack, components, nil, nil,
-		false, true, true, false, []string{"secret"}, nil, true,
+		false, true, true, false, credentialFreeSkip(), nil, true,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,7 +17,33 @@ import (
 	"github.com/cloudposse/atmos/pkg/secrets"
 	"github.com/cloudposse/atmos/pkg/store"
 	"github.com/cloudposse/atmos/pkg/store/authbridge"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
+
+// credentialFreeSkip lists the YAML functions that must NOT be evaluated during credential-free
+// secret operations (enumeration and `secret list` without `--verify`). Listing only needs the
+// static `secrets.vars` declarations (see secrets.ExtractDeclarations); it never needs a resolved
+// value. These functions all perform an authenticated backend read, so with auth disabled they
+// fall back to the default AWS credential chain and fail (e.g. the S3 backend assumes a role with
+// no base credentials and the SDK ultimately dials the EC2 IMDS endpoint, which is unreachable on
+// a workstation). Skipping them keeps listing genuinely credential-free: a skipped function leaves
+// its raw string in place, which the declaration extractor ignores. `!secret` is included because
+// retrieving secret values is a separate, explicit step.
+func credentialFreeSkip() []string {
+	// skipFunc compares against the tag with the leading "!" trimmed, so the skip tokens are bare.
+	tags := []string{
+		u.AtmosYamlFuncSecret,
+		u.AtmosYamlFuncStore,
+		u.AtmosYamlFuncStoreGet,
+		u.AtmosYamlFuncTerraformOutput,
+		u.AtmosYamlFuncTerraformState,
+	}
+	skip := make([]string, len(tags))
+	for i, tag := range tags {
+		skip[i] = strings.TrimPrefix(tag, "!")
+	}
+	return skip
+}
 
 // secretScope holds the parsed common flags for a secret subcommand.
 type secretScope struct {
@@ -168,9 +195,11 @@ func loadServiceForList(scope secretScope, verify bool) (*secrets.Service, error
 		ComponentType:        scope.ComponentType,
 		ProcessTemplates:     true,
 		ProcessYamlFunctions: true,
-		Skip:                 []string{"secret"}, // resolve includes etc., but never retrieve secrets here.
-		AuthManager:          nil,
-		AuthDisabled:         true, // listing reads declarations only — no identity, no decryption.
+		// Auth is disabled here, so any credentialed read function (e.g. !terraform.state) would
+		// fall back to the default AWS chain and fail. Skip them all — listing reads declarations only.
+		Skip:         credentialFreeSkip(),
+		AuthManager:  nil,
+		AuthDisabled: true, // listing reads declarations only — no identity, no decryption.
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load component config: %w", err)

--- a/cmd/secret/shared_test.go
+++ b/cmd/secret/shared_test.go
@@ -1,12 +1,14 @@
 package secret
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 func TestParseScope_MissingComponent(t *testing.T) {
@@ -18,4 +20,31 @@ func TestParseScope_MissingComponent(t *testing.T) {
 	err := runSecretSubcommand(t, "set", "API_KEY=v1", "--stack", "dev")
 	require.ErrorIs(t, err, errUtils.ErrRequiredFlagNotProvided)
 	assert.Empty(t, svc.setCalls)
+}
+
+// TestCredentialFreeSkip pins the set of YAML functions that credential-free secret listing must
+// skip. These all perform an authenticated backend read; if any were evaluated with auth disabled
+// (as `secret list` does) the read would fall back to the default AWS chain and fail at the EC2
+// IMDS endpoint. Referencing the u.AtmosYamlFunc* constants makes a rename a compile error here.
+func TestCredentialFreeSkip(t *testing.T) {
+	got := credentialFreeSkip()
+
+	want := []string{
+		strings.TrimPrefix(u.AtmosYamlFuncSecret, "!"),
+		strings.TrimPrefix(u.AtmosYamlFuncStore, "!"),
+		strings.TrimPrefix(u.AtmosYamlFuncStoreGet, "!"),
+		strings.TrimPrefix(u.AtmosYamlFuncTerraformOutput, "!"),
+		strings.TrimPrefix(u.AtmosYamlFuncTerraformState, "!"),
+	}
+	require.ElementsMatch(t, want, got, "credentialFreeSkip must skip every credentialed read function")
+
+	// skipFunc compares against the tag with the "!" trimmed, so tokens must be bare.
+	for _, tok := range got {
+		require.NotEmpty(t, tok)
+		assert.Falsef(t, strings.HasPrefix(tok, "!"), "skip token %q must not include the ! prefix", tok)
+	}
+
+	// The two functions that triggered the IMDS-fallback regression must be present.
+	assert.Contains(t, got, "terraform.state")
+	assert.Contains(t, got, "terraform.output")
 }

--- a/docs/fixes/2026-06-23-secret-list-credential-free-skip.md
+++ b/docs/fixes/2026-06-23-secret-list-credential-free-skip.md
@@ -1,0 +1,139 @@
+# `atmos secret list -s <stack>` Fails Reading Terraform State Even When Authenticated
+
+**Date:** 2026-06-23 **Severity:** High — on a repo whose components reference
+remote state via `!terraform.state` / `!terraform.output` (or `!store`),
+`atmos secret list -s <stack>` aborts with an AWS credentials error even
+immediately after a successful `atmos auth login`, because credential-free
+enumeration disables auth but still evaluates the credentialed function
+**Issue:** https://github.com/cloudposse/atmos/issues/2639 (the `secret list`
+credential-free enumeration path was introduced by #2646; this corrects a
+regression in that path) **Reproducer:** `cmd/secret/shared_test.go`
+(`TestCredentialFreeSkip`), plus the existing `cmd/secret` enumeration/list
+tests
+
+______________________________________________________________________
+
+## Why this is a fix doc (and not a blog post / changelog entry)
+
+This is a `patch` bug fix in the `cmd/secret` listing path: it makes
+credential-free secret listing genuinely credential-free by skipping the YAML
+functions that perform authenticated backend reads. There is no new command,
+flag, or feature — only a correction so `secret list` stops attempting
+remote-state reads it never needs. Per the repo's label decision tree that makes
+it a `patch`, which does not require a `website/blog/` post or a roadmap
+milestone.
+
+## Symptom
+
+Immediately after authenticating the stack's identity:
+
+```console
+$ atmos auth login -i <stack-default-identity>
+✓ Authentication successful!
+
+$ atmos secret list --stack=<stack>
+ WARN  Failed to read Terraform state after all retries exhausted \
+   file=<component>/<workspace>/terraform.tfstate bucket=<central-tfstate-bucket> attempts=3 \
+   error="operation error S3: GetObject, ... get credentials: failed to refresh cached credentials, \
+   operation error STS: AssumeRole, ... no EC2 IMDS role found, ... \
+   Get \"http://169.254.169.254/latest/meta-data/iam/security-credentials/\": \
+   dial tcp 169.254.169.254:80: connect: no route to host"
+
+ Error: failed to read Terraform state for component `<component>` in stack `<stack>`
+   in YAML function: `!terraform.state <component> .<output>`
+```
+
+Listing only needs the **static** secret declarations, so it should never read
+remote state at all. The same failure occurs for
+`atmos secret list -s <stack> -c <component>` without `--verify`.
+
+## Root Cause
+
+`secret list` is designed to be credential-free when it isn't fully scoped with
+`--verify`:
+
+- `enumerateSecretScopes` (`cmd/secret/enumerate.go`) resolves all stacks via
+  `ExecuteDescribeStacksWithAuthDisabled(...)`.
+- `loadServiceForList` (`cmd/secret/shared.go`) resolves a single component with
+  `AuthDisabled: true`.
+
+Both disabled authentication (the #2646 fix for #2639, so a large stack doesn't
+run one full auth cycle per component) **but left YAML-function processing on
+with a skip list of only `["secret"]`.** So a component's `!terraform.state` /
+`!terraform.output` / `!store` references in `vars` / `settings` were still
+evaluated. With auth disabled:
+
+1. `GetTerraformState` (`internal/exec/terraform_state_utils.go`) sees
+   `AuthDisabled`, skips per-component auth resolution, and reads the backend
+   with a **nil** auth context.
+2. `LoadConfigWithAuthAndEnv` (`pkg/aws/identity/identity.go`) logs *"Using
+   standard AWS SDK credential resolution (no auth context provided)"* and falls
+   back to the default chain.
+3. The S3 backend assumes its configured `role_arn` with no base credentials, so
+   the SDK ultimately dials the EC2 IMDS endpoint — unreachable on a workstation
+   → the error above.
+
+Before #2646, `secret list` authenticated per component, so these reads had
+credentials (slow but working). #2646 removed the authentication without
+removing the reads, turning a slow path into a hard failure for any repo whose
+component `vars` reference remote state.
+
+`secrets.ExtractDeclarations` (`pkg/secrets/registry.go`) only reads the static
+`secrets.vars` section (name, scope, backend type/name, description) — it never
+needs a resolved `!terraform.state` or `!store` value, so evaluating those
+functions during listing was pure, failure-prone overhead.
+
+## Fix
+
+Add `credentialFreeSkip()` (`cmd/secret/shared.go`) listing every credentialed
+read function and use it in both credential-free paths:
+
+```go
+func credentialFreeSkip() []string {
+    return []string{
+        strings.TrimPrefix(u.AtmosYamlFuncSecret, "!"),          // !secret
+        strings.TrimPrefix(u.AtmosYamlFuncStore, "!"),           // !store
+        strings.TrimPrefix(u.AtmosYamlFuncStoreGet, "!"),        // !store.get
+        strings.TrimPrefix(u.AtmosYamlFuncTerraformOutput, "!"), // !terraform.output
+        strings.TrimPrefix(u.AtmosYamlFuncTerraformState, "!"),  // !terraform.state
+    }
+}
+```
+
+- `enumerateSecretScopes` and `loadServiceForList` (non-`--verify`) now pass
+  `credentialFreeSkip()` instead of `["secret"]`. A skipped function leaves its
+  raw string in place, which `ExtractDeclarations` ignores, so declaration
+  discovery is unchanged.
+- The **authenticated** paths are untouched: `loadServiceAndConfig` (used by
+  `get` / `set` / `exec` / `shell` and `secret list --verify`) still passes only
+  `["secret"]`, because it has real credentials and may legitimately resolve
+  `!terraform.state` / `!store` for the component environment.
+
+## Verification
+
+- `go test ./cmd/secret/...` — `TestCredentialFreeSkip` pins the skip set and
+  asserts the tokens are bare (the `!` is trimmed, matching `skipFunc`); it
+  references the `u.AtmosYamlFunc*` constants so a rename is a compile error,
+  not a silent gap. Existing enumeration/list tests still pass.
+- End-to-end on a representative multi-account repo whose components reference
+  cross-account `!terraform.state`, running the **identical** command with only
+  the atmos binary varying:
+  - **Before:** `atmos secret list -s <stack>` aborted with the assume-role →
+    IMDS error above, even immediately after `atmos auth login` for that stack's
+    identity.
+  - **With this fix:** completes (`rc=0`) with **zero** state reads and **zero**
+    credential-resolution fallbacks in debug logs, reporting the declared
+    secrets (or "No secrets declared in stack "<stack>"" when none are
+    declared).
+
+## Recommendations
+
+- **Skip credentialed functions centrally when auth is disabled.** Rather than
+  relying on each credential-free caller to maintain its own skip list, the
+  describe pipeline could skip `!terraform.*` / `!store` whenever `authDisabled`
+  is set, so a future credential-free caller can't reintroduce this class of
+  failure. Tracked separately.
+- **Surface a clearer error.** When a credentialed function is evaluated with
+  auth disabled, the failure currently surfaces as a low-level AWS IMDS error. A
+  targeted message ("`!terraform.state` requires credentials but authentication
+  is disabled") would be far easier to diagnose.


### PR DESCRIPTION
## what

- Make credential-free `atmos secret list` skip the YAML functions that perform authenticated backend reads (`!terraform.state`, `!terraform.output`, `!store`, `!store.get`) while it enumerates secret declarations.
- Add a `credentialFreeSkip()` helper and use it in the two credential-free paths: `secret list -s <stack>` enumeration and the single-scope `secret list -s <stack> -c <component>` path without `--verify`.
- Authenticated paths (`get` / `set` / `exec` / `shell`, and `secret list --verify`) are unchanged — they keep skipping only `!secret`.
- Adds `TestCredentialFreeSkip` pinning the skip set and a `docs/fixes` write-up.

## why

- Secret listing is intentionally credential-free: it disables authentication so a large stack doesn't run one full auth cycle per component. But it still evaluated `!terraform.state` / `!terraform.output` / `!store` in component `vars` / `settings`. With auth disabled, the S3 backend assumes its configured role with no base credentials, the AWS SDK falls back to the default credential chain, and ultimately dials the EC2 IMDS endpoint — unreachable on a workstation — so the command aborts with a confusing assume-role/credentials error **even immediately after a successful `atmos auth login`**.
- Listing only needs the static `secrets.vars` declarations (`secrets.ExtractDeclarations`), which never require a resolved value. Evaluating these functions was unnecessary and failure-prone. A skipped function leaves its raw string in place, which the declaration extractor ignores, so discovery is unchanged.
- This is a regression: before credential-free enumeration was introduced, `secret list` authenticated per component, so these reads had credentials (slow, but working). Disabling auth removed the credentials without removing the reads.

## references

- Related to #2639 (originally reported against `atmos secret list`).
- Follow-up to #2646, which made secret-list enumeration credential-free but left the credentialed function evaluation in place.
- Write-up: `docs/fixes/2026-06-23-secret-list-credential-free-skip.md`
- Verified with `go test ./cmd/secret/...` and the repo's `custom-gcl` lint (both green), and end-to-end against a multi-account repo whose components reference cross-account `!terraform.state`: `secret list -s <stack>` aborted before, completes after (no state reads, no credential-resolution fallbacks).
