### PR TITLE
fix(hooks): store-output hooks inherit the run's default identity

### DIFF
--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -246,6 +246,13 @@ func verifyPlanModeFromBool(verify bool) schema.PlanfileVerifyMode {
 // atmosConfig as the store auth-context resolver so stores invoked by hooks can
 // resolve credentials lazily. It is a no-op when the inputs are nil or info holds
 // no usable AuthManager.
+//
+// Stores that omit `identity` inherit the run's auto-detected identity (the same one the apply ran
+// as), matching the main terraform path. Without this, the after-apply `store-outputs` hook would
+// fall back to the default AWS SDK credential chain — which is empty under Atmos auth (credentials
+// live in the keyring, not the environment) — and fail with "no EC2 IMDS role found". Inheritance is
+// guarded by HookStoreDefaultIdentity (returns "" when no identity is resolved), so runs without
+// Atmos auth keep their prior ambient/default-credential behavior.
 func injectHookStoreAuthResolver(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) {
 	if atmosConfig == nil || info == nil || info.AuthManager == nil {
 		return
@@ -257,7 +264,7 @@ func injectHookStoreAuthResolver(atmosConfig *schema.AtmosConfiguration, info *s
 	}
 
 	resolver := authbridge.NewResolver(authManager, info)
-	atmosConfig.Stores.SetAuthContextResolver(resolver)
+	atmosConfig.Stores.SetAuthContextResolverWithDefaultIdentity(resolver, e.HookStoreDefaultIdentity(authManager, info))
 }
 
 // runCIHooksForDeploy fires CI hooks using already-resolved info.

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -775,7 +775,7 @@ func TestRunHooksWithOutput_InjectsLastAuthContext(t *testing.T) {
 // the chain.
 //
 // Note: the per-store identity argument to SetAuthContext is computed by the store registry via
-// defaultIdentityForStore, which only applies the default to the concrete SSM/AKV/GSM store types
+// defaultIdentityForStore, which only applies the default to the concrete SSM/ASM/AKV/GSM store types
 // (a MockIdentityAwareStore receives ""). This test therefore asserts the seam behavior — chain
 // auto-detection (GetChain), info.Identity population, and resolver wiring. That identity-less
 // concrete stores actually receive the default is covered by pkg/store
@@ -785,8 +785,8 @@ func TestInjectHookStoreAuthResolver_InheritsDefaultIdentity(t *testing.T) {
 	tests := []struct {
 		name             string
 		identity         string
-		chain            []string // nil => GetChain must NOT be called
-		expectedIdentity string   // info.Identity after the call
+		chain            []string // nil => GetChain must NOT be called.
+		expectedIdentity string   // info.Identity after the call.
 	}{
 		{
 			name:             "no explicit identity auto-detects the chain leaf",

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -768,22 +768,43 @@ func TestRunHooksWithOutput_InjectsLastAuthContext(t *testing.T) {
 	assert.Equal(t, "mock-auth-manager", gotMgr)
 }
 
-func TestInjectHookStoreAuthResolver_ResolverOnly(t *testing.T) {
+// TestInjectHookStoreAuthResolver_InheritsDefaultIdentity verifies that the after-apply hook path
+// now wires the resolver AND lets identity-less stores inherit the run's auto-detected identity
+// (matching the main terraform path), so hook store writes work under Atmos auth. Auto-detection
+// runs only when no explicit identity is present; an explicit/disabled identity is not overridden by
+// the chain.
+//
+// Note: the per-store identity argument to SetAuthContext is computed by the store registry via
+// defaultIdentityForStore, which only applies the default to the concrete SSM/AKV/GSM store types
+// (a MockIdentityAwareStore receives ""). This test therefore asserts the seam behavior — chain
+// auto-detection (GetChain), info.Identity population, and resolver wiring. That identity-less
+// concrete stores actually receive the default is covered by pkg/store
+// TestSetAuthContextResolverWithDefaultIdentity_DefaultsOnlyEmptyStores, and end to end by the Floci
+// E2E TestAWSStoreHooks_InheritedIdentity_FlociE2E.
+func TestInjectHookStoreAuthResolver_InheritsDefaultIdentity(t *testing.T) {
 	tests := []struct {
-		name     string
-		identity string
+		name             string
+		identity         string
+		chain            []string // nil => GetChain must NOT be called
+		expectedIdentity string   // info.Identity after the call
 	}{
 		{
-			name:     "empty command identity does not inject default identity",
-			identity: "",
+			name:             "no explicit identity auto-detects the chain leaf",
+			identity:         "",
+			chain:            []string{"permission-set", "core-identity/devops"},
+			expectedIdentity: "core-identity/devops",
 		},
 		{
-			name:     "explicit command identity does not override store identity",
-			identity: "cli-admin",
+			name:             "explicit command identity is preserved (chain not consulted)",
+			identity:         "cli-admin",
+			chain:            nil,
+			expectedIdentity: "cli-admin",
 		},
 		{
-			name:     "disabled identity does not fall back to default identity",
-			identity: cfg.IdentityFlagDisabledValue,
+			name:             "disabled identity is not overridden by the chain",
+			identity:         cfg.IdentityFlagDisabledValue,
+			chain:            nil,
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
 		},
 	}
 
@@ -791,18 +812,21 @@ func TestInjectHookStoreAuthResolver_ResolverOnly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			authManager := authtypes.NewMockAuthManager(ctrl)
+			if tc.chain != nil {
+				authManager.EXPECT().GetChain().Return(tc.chain)
+			}
 			mockStore := storepkg.NewMockIdentityAwareStore(ctrl)
 
+			// The resolver must always be wired into the store (regardless of identity).
 			mockStore.EXPECT().
-				SetAuthContext(gomock.Not(nil), "").
-				Do(func(resolver storepkg.AuthContextResolver, identityName string) {
+				SetAuthContext(gomock.Not(nil), gomock.Any()).
+				Do(func(resolver storepkg.AuthContextResolver, _ string) {
 					assert.NotNil(t, resolver)
-					assert.Empty(t, identityName)
 				})
 
 			atmosConfig := &schema.AtmosConfiguration{
 				Stores: storepkg.StoreRegistry{
-					"explicit-identity-store": mockStore,
+					"store": mockStore,
 				},
 			}
 			info := &schema.ConfigAndStacksInfo{
@@ -811,6 +835,9 @@ func TestInjectHookStoreAuthResolver_ResolverOnly(t *testing.T) {
 			}
 
 			injectHookStoreAuthResolver(atmosConfig, info)
+
+			assert.Equal(t, tc.expectedIdentity, info.Identity,
+				"hook should auto-detect the active identity when none is explicitly set")
 		})
 	}
 }

--- a/docs/fixes/2026-06-27-store-hook-inherit-default-identity.md
+++ b/docs/fixes/2026-06-27-store-hook-inherit-default-identity.md
@@ -1,0 +1,126 @@
+# Fix: store-output hooks inherit the run's default identity
+
+**Date**: 2026-06-27
+
+**Related**: [#2625](https://github.com/cloudposse/atmos/pull/2625) (added store identity support;
+explicitly deferred identity-less inheritance in the hook path), and the fix doc
+`docs/fixes/2026-06-17-aws-stores-secrets-auth-and-gists.md`.
+
+## Problem
+
+Under Atmos auth, `atmos terraform apply` on a component with an after-apply `store-outputs` hook
+applies successfully, then **fails in the hook** when the target store has no `identity` of its own:
+
+```text
+INFO  Running hooks event=after.terraform.apply status=success
+✓ Fetching nat_gateway_public_ips output from vpc in plat-usw2-dev
+Error: failed to assume write role: failed to assume role
+arn:aws:iam::…:role/…-terraform: operation error STS: AssumeRole, … get identity:
+get credentials: failed to refresh cached credentials, no EC2 IMDS role found,
+operation error ec2imds: GetMetadata, … dial tcp 169.254.169.254:80: connect: no route to host
+```
+
+The same configuration worked before the move to Atmos auth (e.g. under Leapp), and `atmos auth
+whoami` shows a valid, current identity. Adding an explicit `identity:` to every store works around
+it, but that is verbose and easy to miss.
+
+## Root Cause
+
+Store credential resolution and the terraform lifecycle hooks resolve auth on two different code
+paths:
+
+- **Main terraform path** (`internal/exec.injectTerraformStoreAuthResolver`): after authenticating,
+  it persists the auto-detected identity and injects the store resolver with that identity as the
+  default, via `StoreRegistry.SetAuthContextResolverWithDefaultIdentity`. So `!store` reads during a
+  run, and stores without their own `identity`, inherit the run's identity.
+
+- **Hook path** (`cmd/terraform.prepareHookContext` → `injectHookStoreAuthResolver`): hooks run in a
+  **freshly loaded** Atmos config, so the apply-phase store registry (and its injected default
+  identity) is gone. The hook re-injected the resolver with `SetAuthContextResolver` — resolver
+  **only**, no default identity. Identity-less stores therefore fell through to the default AWS SDK
+  credential chain, which is empty under Atmos auth (credentials live in the keyring, not the
+  environment), so the SDK tried EC2 IMDS and failed.
+
+This asymmetry was intentional and called out in #2625 as a deferred compatibility decision
+("Component-identity inheritance for identity-less stores is intentionally left for a follow-up
+design decision"). This change makes that decision: the hook path should inherit the run's identity
+just like the main path.
+
+## Fix
+
+### What
+
+- The after-apply hook path now injects the store resolver **with the run's default identity** so
+  identity-less stores invoked by hooks inherit the same identity the component applied as.
+- A store that declares its own `identity` keeps it; a run without Atmos auth (no resolved identity)
+  keeps the prior ambient/default-SDK behavior.
+
+### Why
+
+- It removes a surprising asymmetry: `!store` reads during a run already inherit the run identity,
+  but hook writes did not. Users had to duplicate `identity:` onto every store solely to satisfy the
+  hook path.
+- It is the minimal, backward-compatible completion of the store-auth work started in #2625.
+
+### How
+
+- New helper `internal/exec.HookStoreDefaultIdentity(authManager, info)` mirrors the main path:
+  it calls `storeAutoDetectedIdentity` (populating `info.Identity` from the auth manager's chain leaf
+  when no explicit identity is set), then normalizes the value through `storeDefaultIdentity`
+  (empty / `--identity=select` / `--identity=disabled` → `""`, i.e. no inheritance). It returns `""`
+  when no auth manager is present.
+- `cmd/terraform.injectHookStoreAuthResolver` now calls
+  `atmosConfig.Stores.SetAuthContextResolverWithDefaultIdentity(resolver, e.HookStoreDefaultIdentity(authManager, info))`
+  instead of `SetAuthContextResolver(resolver)`.
+- `StoreRegistry.SetAuthContextResolverWithDefaultIdentity` applies the default only to identity-aware
+  stores that have no `identity` of their own.
+- Fixed an adjacent omission surfaced by the end-to-end test: `defaultIdentityForStore` (the helper
+  that decides which stores receive the default) handled `*SSMStore`, `*AzureKeyVaultStore`, and
+  `*GSMStore`, but **not** `*SecretsManagerStore` (`aws/asm`). AWS Secrets Manager stores without an
+  `identity` were therefore never given the default identity on any path. `*SecretsManagerStore` is
+  now included, so `aws/asm` behaves like `aws/ssm`.
+
+## Backward compatibility
+
+- `HookStoreDefaultIdentity` returns `""` whenever no identity is resolved (no auth manager, empty /
+  `select` / `disabled` identity). `SetAuthContextResolverWithDefaultIdentity("")` is a no-op for the
+  default, so runs without Atmos auth keep using ambient/default SDK credentials exactly as before.
+- Stores with an explicit `identity` are never overridden.
+
+## Tests
+
+- `internal/exec.TestHookStoreDefaultIdentity` — table test of the resolution/normalization logic:
+  nil manager, chain-leaf auto-detection, empty chain, explicit identity preserved (chain not
+  consulted), `select` sentinel resolves to chain leaf, `disabled` sentinel yields no inheritance.
+- `cmd/terraform.TestInjectHookStoreAuthResolver_InheritsDefaultIdentity` — replaces the previous
+  `..._ResolverOnly` test; asserts the hook now auto-detects the active identity (`GetChain`),
+  populates `info.Identity`, and still wires the resolver into stores.
+- `pkg/store.TestSetAuthContextResolverWithDefaultIdentity_DefaultsOnlyEmptyStores` — proves
+  identity-less concrete stores inherit the default while stores with their own identity keep it.
+  Updated so the identity-less `aws/asm` store now asserts inheritance (it previously asserted the
+  buggy empty-identity behavior).
+- `tests.TestAWSStoreHooks_InheritedIdentity_FlociE2E` — opt-in Floci E2E with fixture
+  `tests/fixtures/scenarios/aws-store-hooks-floci-inherit`: stores declare **no** `identity`, a
+  `default: true` identity is configured, ambient AWS credentials are cleared, and the after-apply
+  hook must still write to SSM and Secrets Manager. Fails on the old behavior, passes with the fix.
+
+Run the focused suite:
+
+```shell
+go test ./internal/exec ./cmd/terraform ./pkg/store -run 'HookStoreDefaultIdentity|InjectHookStoreAuthResolver|SetAuthContextResolverWithDefaultIdentity' -count=1
+```
+
+Run the Floci E2E against a running emulator:
+
+```shell
+ATMOS_TEST_FLOCI=true FLOCI_ENDPOINT_URL=http://localhost:4566 \
+  go test ./tests -run 'TestAWSStoreHooks(_InheritedIdentity_)?FlociE2E' -count=1 -v
+```
+
+## Expected Behavior
+
+- A component's after-apply `store-outputs` hook can write outputs to AWS SSM / Secrets Manager (and
+  the Azure/GCP equivalents) **without** a per-store `identity`, by inheriting the identity the run
+  authenticated as.
+- A store with an explicit `identity` continues to use it.
+- A run without Atmos auth keeps the prior ambient/default SDK credential behavior.

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -171,6 +171,25 @@ func storeDefaultIdentity(identity string) string {
 	}
 }
 
+// HookStoreDefaultIdentity resolves the identity that identity-less stores invoked by terraform
+// lifecycle hooks (e.g. the after-apply `store-outputs` hook) should inherit. It mirrors the main
+// terraform path (injectTerraformStoreAuthResolver): it auto-detects the active identity from the
+// auth manager's chain when info carries no explicit identity, then normalizes empty/select/disabled
+// to "" (meaning "no inheritance — keep ambient/default SDK credentials"). It returns "" when no auth
+// manager is present, preserving the prior behavior for runs without Atmos auth.
+//
+// The hook executes in a freshly loaded config (prepareHookContext), so it must re-derive this from
+// the persisted auth manager rather than relying on the apply-phase config.
+func HookStoreDefaultIdentity(authManager auth.AuthManager, info *schema.ConfigAndStacksInfo) string {
+	defer perf.Track(nil, "exec.HookStoreDefaultIdentity")()
+
+	if authManager == nil || info == nil {
+		return ""
+	}
+	storeAutoDetectedIdentity(authManager, info)
+	return storeDefaultIdentity(info.Identity)
+}
+
 // SetupTerraformAuthForCLI exposes terraform auth setup to command-layer callers
 // that need the same merged-auth and explicit-identity behavior as ExecuteTerraform.
 func SetupTerraformAuthForCLI(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (any, error) {

--- a/internal/exec/utils_auth_test.go
+++ b/internal/exec/utils_auth_test.go
@@ -448,7 +448,7 @@ func TestHookStoreDefaultIdentity(t *testing.T) {
 		nilManager       bool
 		initialIdentity  string
 		expectedReturn   string
-		expectedIdentity string // info.Identity after the call (auto-detect may populate it)
+		expectedIdentity string // info.Identity after the call (auto-detect may populate it).
 	}{
 		{
 			name:             "nil manager returns empty (ambient/default credentials preserved)",
@@ -482,7 +482,7 @@ func TestHookStoreDefaultIdentity(t *testing.T) {
 		{
 			name:             "explicit identity is preserved without consulting the chain",
 			initialIdentity:  "cli-admin",
-			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called
+			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called.
 			expectedReturn:   "cli-admin",
 			expectedIdentity: "cli-admin",
 		},
@@ -500,7 +500,7 @@ func TestHookStoreDefaultIdentity(t *testing.T) {
 		{
 			name:             "disabled sentinel yields no inheritance",
 			initialIdentity:  cfg.IdentityFlagDisabledValue,
-			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called
+			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called.
 			expectedReturn:   "",
 			expectedIdentity: cfg.IdentityFlagDisabledValue,
 		},

--- a/internal/exec/utils_auth_test.go
+++ b/internal/exec/utils_auth_test.go
@@ -441,6 +441,90 @@ func TestStoreAutoDetectedIdentity(t *testing.T) {
 	}
 }
 
+func TestHookStoreDefaultIdentity(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupMock        func(ctrl *gomock.Controller) *mockTypes.MockAuthManager
+		nilManager       bool
+		initialIdentity  string
+		expectedReturn   string
+		expectedIdentity string // info.Identity after the call (auto-detect may populate it)
+	}{
+		{
+			name:             "nil manager returns empty (ambient/default credentials preserved)",
+			nilManager:       true,
+			initialIdentity:  "",
+			expectedReturn:   "",
+			expectedIdentity: "",
+		},
+		{
+			name:            "no explicit identity inherits the auto-detected chain leaf",
+			initialIdentity: "",
+			setupMock: func(ctrl *gomock.Controller) *mockTypes.MockAuthManager {
+				m := mockTypes.NewMockAuthManager(ctrl)
+				m.EXPECT().GetChain().Return([]string{"permission-set", "core-identity/devops"})
+				return m
+			},
+			expectedReturn:   "core-identity/devops",
+			expectedIdentity: "core-identity/devops",
+		},
+		{
+			name:            "empty chain yields no inheritance",
+			initialIdentity: "",
+			setupMock: func(ctrl *gomock.Controller) *mockTypes.MockAuthManager {
+				m := mockTypes.NewMockAuthManager(ctrl)
+				m.EXPECT().GetChain().Return([]string{})
+				return m
+			},
+			expectedReturn:   "",
+			expectedIdentity: "",
+		},
+		{
+			name:             "explicit identity is preserved without consulting the chain",
+			initialIdentity:  "cli-admin",
+			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called
+			expectedReturn:   "cli-admin",
+			expectedIdentity: "cli-admin",
+		},
+		{
+			name:            "interactive select sentinel resolves to the chain leaf",
+			initialIdentity: cfg.IdentityFlagSelectValue,
+			setupMock: func(ctrl *gomock.Controller) *mockTypes.MockAuthManager {
+				m := mockTypes.NewMockAuthManager(ctrl)
+				m.EXPECT().GetChain().Return([]string{"core-identity/managers"})
+				return m
+			},
+			expectedReturn:   "core-identity/managers",
+			expectedIdentity: "core-identity/managers",
+		},
+		{
+			name:             "disabled sentinel yields no inheritance",
+			initialIdentity:  cfg.IdentityFlagDisabledValue,
+			setupMock:        mockTypes.NewMockAuthManager, // GetChain must NOT be called
+			expectedReturn:   "",
+			expectedIdentity: cfg.IdentityFlagDisabledValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			info := &schema.ConfigAndStacksInfo{Identity: tt.initialIdentity}
+
+			var got string
+			if tt.nilManager {
+				got = HookStoreDefaultIdentity(nil, info)
+			} else {
+				got = HookStoreDefaultIdentity(tt.setupMock(ctrl), info)
+			}
+
+			assert.Equal(t, tt.expectedReturn, got, "returned default identity")
+			assert.Equal(t, tt.expectedIdentity, info.Identity, "info.Identity after call")
+		})
+	}
+}
+
 func TestGetMergedAuthConfig_EmptyStackOrComponent(t *testing.T) {
 	// When stack is empty, should return global auth config without calling ExecuteDescribeComponent.
 	atmosConfig := &schema.AtmosConfiguration{

--- a/pkg/store/identity_test.go
+++ b/pkg/store/identity_test.go
@@ -97,7 +97,7 @@ func TestSetAuthContextResolverWithDefaultIdentity_DefaultsOnlyEmptyStores(t *te
 	assert.Equal(t, "aws-secrets", explicitASM.identityName)
 
 	assert.NotNil(t, defaultASM.authResolver)
-	assert.Empty(t, defaultASM.identityName)
+	assert.Equal(t, "terraform-ci", defaultASM.identityName)
 
 	assert.NotNil(t, defaultAzure.authResolver)
 	assert.Equal(t, "terraform-ci", defaultAzure.identityName)

--- a/pkg/store/registry.go
+++ b/pkg/store/registry.go
@@ -278,6 +278,10 @@ func defaultIdentityForStore(s Store, defaultIdentity string) string {
 		if typed.identityName == "" {
 			return defaultIdentity
 		}
+	case *SecretsManagerStore:
+		if typed.identityName == "" {
+			return defaultIdentity
+		}
 	case *AzureKeyVaultStore:
 		if typed.identityName == "" {
 			return defaultIdentity

--- a/tests/aws_store_hooks_inherit_floci_test.go
+++ b/tests/aws_store_hooks_inherit_floci_test.go
@@ -1,0 +1,56 @@
+// Opt-in AWS integration test (Floci): store-output hooks inherit the run's default identity.
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAWSStoreHooks_InheritedIdentity_FlociE2E proves the hook-path default-identity fix: the stores
+// declare NO `identity`, but a `default: true` Atmos auth identity is configured. With ambient AWS
+// credentials cleared, the after-apply `store-outputs` hook must still write to SSM/ASM by inheriting
+// the run's auto-detected identity (the same one the apply ran as).
+//
+// Before the fix the hook path was resolver-only — identity-less stores fell back to the default AWS
+// SDK credential chain (empty under Atmos auth) and failed with "no EC2 IMDS role found". This test
+// fails on the old behavior and passes with the fix.
+func TestAWSStoreHooks_InheritedIdentity_FlociE2E(t *testing.T) {
+	RequireTofu(t)
+
+	harness := newFlociHarness(t, flociHarnessOptions{
+		FixtureDir:  "fixtures/scenarios/aws-store-hooks-floci-inherit",
+		ClearAWSEnv: true,
+		ExtraEnv: map[string]string{
+			"FLOCI_STORE_HOOKS_SSM_PREFIX": "/atmos-tests/store-hooks-inherit/{test_id}",
+			"FLOCI_STORE_HOOKS_ASM_PREFIX": "atmos-tests/store-hooks-inherit/{test_id}",
+		},
+	})
+
+	ssmClient := harness.SSMClient(t)
+	asmClient := harness.SecretsManagerClient(t)
+	ssmPrefix := harness.Env["FLOCI_STORE_HOOKS_SSM_PREFIX"]
+	asmPrefix := harness.Env["FLOCI_STORE_HOOKS_ASM_PREFIX"]
+
+	defer cleanupFlociSSMParameters(t, ssmClient, []string{
+		ssmPrefix + "/producer/output-demo/demo_id",
+	})
+	defer cleanupFlociSecrets(t, asmClient, []string{
+		asmPrefix + "/producer/output-demo/demo_id",
+	})
+
+	_, stderr, err := harness.Run(t, 2*time.Minute, "validate", "stacks")
+	require.NoError(t, err, "validate stacks failed:\n%s", stderr)
+
+	// Apply: terraform succeeds, then the after-apply store-output hook must succeed by inheriting the
+	// default identity (no per-store `identity` configured, ambient AWS creds cleared).
+	_, stderr, err = harness.Run(
+		t, 3*time.Minute,
+		"terraform", "apply", "output-demo", "-s", "producer", "-auto-approve",
+	)
+	require.NoError(t, err, "apply with inherited store identity should succeed:\n%s", stderr)
+
+	requireFlociParameterValueContains(t, ssmClient, ssmPrefix+"/producer/output-demo/demo_id", "store-hooks-demo")
+	requireFlociSecretValueContains(t, asmClient, asmPrefix+"/producer/output-demo/demo_id", "store-hooks-demo")
+}

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
@@ -1,0 +1,50 @@
+base_path: "./"
+
+components:
+  terraform:
+    command: tofu
+    base_path: "components/terraform"
+    auto_generate_backend_file: false
+    apply_auto_approve: true
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "**/*.yaml"
+  name_pattern: "{stage}"
+
+templates:
+  settings:
+    enabled: true
+    evaluations: 1
+    sprig:
+      enabled: true
+
+stores:
+  outputs/ssm:
+    kind: aws/ssm
+    options:
+      region: us-east-1
+      prefix: !env FLOCI_STORE_HOOKS_SSM_PREFIX
+
+  outputs/asm:
+    kind: aws/asm
+    options:
+      region: us-east-1
+      prefix: !env FLOCI_STORE_HOOKS_ASM_PREFIX
+
+auth:
+  identities:
+    floci-superuser:
+      kind: aws/user
+      credentials:
+        access_key_id: test
+        secret_access_key: test
+        region: us-east-1
+      spec:
+        endpoint_url: !env FLOCI_ENDPOINT_URL
+      default: true
+
+logs:
+  file: /dev/stderr
+  level: Info

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
@@ -46,5 +46,4 @@ auth:
       default: true
 
 logs:
-  file: /dev/stderr
   level: Info

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/components/terraform/output-demo/main.tf
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/components/terraform/output-demo/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_version = ">= 1.3.0"
+}
+
+variable "same_stack_ssm" {
+  type    = any
+  default = null
+}
+
+variable "same_stack_asm" {
+  type    = any
+  default = null
+}
+
+variable "ssm_query" {
+  type    = any
+  default = null
+}
+
+variable "asm_query" {
+  type    = any
+  default = null
+}
+
+variable "ssm_raw_key" {
+  type    = any
+  default = null
+}
+
+variable "asm_raw_key" {
+  type    = any
+  default = null
+}
+
+variable "template_read" {
+  type    = any
+  default = null
+}
+
+variable "cold_start_default" {
+  type    = any
+  default = null
+}
+
+variable "cross_stack_ssm" {
+  type    = any
+  default = null
+}
+
+variable "cross_stack_asm" {
+  type    = any
+  default = null
+}
+
+variable "cross_stack_ssm_query" {
+  type    = any
+  default = null
+}
+
+variable "cross_stack_template" {
+  type    = any
+  default = null
+}

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/components/terraform/output-demo/outputs.tf
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/components/terraform/output-demo/outputs.tf
@@ -1,0 +1,35 @@
+output "demo_id" {
+  value = "store-hooks-demo"
+}
+
+output "structured_config" {
+  value = {
+    endpoint = "https://store-hooks.example.com"
+    ports    = [443, 8443]
+    nested = {
+      enabled = true
+    }
+  }
+}
+
+output "secret_like_value" {
+  value     = "demo-sensitive-output"
+  sensitive = true
+}
+
+output "received_values" {
+  value = {
+    same_stack_ssm        = var.same_stack_ssm
+    same_stack_asm        = var.same_stack_asm
+    ssm_query             = var.ssm_query
+    asm_query             = var.asm_query
+    ssm_raw_key           = var.ssm_raw_key
+    asm_raw_key           = var.asm_raw_key
+    template_read         = var.template_read
+    cold_start_default    = var.cold_start_default
+    cross_stack_ssm       = var.cross_stack_ssm
+    cross_stack_asm       = var.cross_stack_asm
+    cross_stack_ssm_query = var.cross_stack_ssm_query
+    cross_stack_template  = var.cross_stack_template
+  }
+}

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/stacks/consumer.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/stacks/consumer.yaml
@@ -1,0 +1,16 @@
+vars:
+  stage: consumer
+
+components:
+  terraform:
+    reader:
+      metadata:
+        component: output-demo
+      dependencies:
+        tools:
+          opentofu: "1.12.2"
+      vars:
+        cross_stack_ssm: !store outputs/ssm producer output-demo demo_id
+        cross_stack_asm: !store outputs/asm producer output-demo demo_id
+        cross_stack_ssm_query: !store outputs/ssm producer output-demo structured_config | query .endpoint
+        cross_stack_template: !template '{{ atmos.Store "outputs/asm" "producer" "output-demo" "demo_id" }}'

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/stacks/producer.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/stacks/producer.yaml
@@ -1,0 +1,44 @@
+vars:
+  stage: producer
+
+components:
+  terraform:
+    output-demo:
+      dependencies:
+        tools:
+          opentofu: "1.12.2"
+      hooks:
+        store-to-ssm:
+          events:
+            - after-terraform-apply
+          kind: store
+          name: outputs/ssm
+          outputs:
+            demo_id: .demo_id
+            structured_config: .structured_config
+            secret_like_value: .secret_like_value
+        store-to-secrets-manager:
+          events:
+            - after-terraform-apply
+          kind: store
+          name: outputs/asm
+          outputs:
+            demo_id: .demo_id
+            structured_config: .structured_config
+            secret_like_value: .secret_like_value
+
+    reader:
+      metadata:
+        component: output-demo
+      dependencies:
+        tools:
+          opentofu: "1.12.2"
+      vars:
+        same_stack_ssm: !store outputs/ssm output-demo demo_id
+        same_stack_asm: !store outputs/asm output-demo demo_id
+        ssm_query: !store outputs/ssm output-demo structured_config | query .nested.enabled
+        asm_query: !store outputs/asm output-demo structured_config | query .ports[0]
+        ssm_raw_key: !store.get outputs/ssm producer/output-demo/demo_id
+        asm_raw_key: !store.get outputs/asm producer/output-demo/demo_id
+        template_read: !template '{{ atmos.Store "outputs/ssm" "producer" "output-demo" "demo_id" }}'
+        cold_start_default: !store outputs/ssm output-demo missing_key | default "fallback-value"


### PR DESCRIPTION
## what

- Make the terraform after-apply `store-outputs` hook path inherit the run's auto-detected identity for
  stores that don't declare their own `identity`, matching the main terraform path.
- Add a new `internal/exec.HookStoreDefaultIdentity` helper (auto-detect the active identity from the
  auth manager's chain, normalize empty/`select`/`disabled` to `""`); `cmd/terraform`'s
  `injectHookStoreAuthResolver` now calls `SetAuthContextResolverWithDefaultIdentity` instead of the
  resolver-only variant.
- Fix an adjacent bug: `pkg/store.defaultIdentityForStore` was missing `*SecretsManagerStore`
  (`aws/asm`), so AWS Secrets Manager stores never inherited a default identity on **any** path. Added
  the case so `aws/asm` behaves like `aws/ssm`.
- Tests: `internal/exec.TestHookStoreDefaultIdentity` (new), `cmd/terraform`
  `TestInjectHookStoreAuthResolver_InheritsDefaultIdentity` (replaces `…_ResolverOnly`), updated
  `pkg/store` default-identity test so identity-less `aws/asm` asserts inheritance, and Floci E2E
  `TestAWSStoreHooks_InheritedIdentity_FlociE2E` with fixture `aws-store-hooks-floci-inherit`.
- Fix doc: `docs/fixes/2026-06-27-store-hook-inherit-default-identity.md`.

## why

- **Hook fix.** Under Atmos auth, `atmos terraform apply` on a component with a `store-outputs` hook
  applied successfully but then failed in the hook when the target store had no `identity`:

  ```text
  INFO  Running hooks event=after.terraform.apply status=success
  ✓ Fetching <output> from <component> in <stack>
  Error: failed to assume write role: … get identity: get credentials:
  failed to refresh cached credentials, no EC2 IMDS role found, … ec2imds: GetMetadata …
  ```

  Hooks run in a freshly-loaded config, so the apply-phase store registry (and its injected default
  identity) is gone. The hook re-injected the resolver but **no** default identity, so identity-less
  stores fell back to the default AWS SDK credential chain — empty under Atmos auth (credentials live
  in the keyring, not the environment) — and dropped to EC2 IMDS. The main terraform path and `!store`
  reads already inherit the run's identity; this removes a surprising asymmetry and completes the
  follow-up explicitly deferred in #2625 ("Component-identity inheritance for identity-less stores is
  intentionally left for a follow-up design decision").

- **ASM fix.** `defaultIdentityForStore` handled `*SSMStore`, `*AzureKeyVaultStore`, and `*GSMStore`
  but not `*SecretsManagerStore`, so `aws/asm` stores without an explicit `identity` could never
  inherit one. This was latent before (and was even codified by the old test); the hook fix's E2E
  surfaced it.

- **Backward compatible.** `HookStoreDefaultIdentity` returns `""` whenever no identity is resolved
  (no auth manager, or empty/`select`/`disabled`), and `SetAuthContextResolverWithDefaultIdentity("")`
  is a no-op for the default — so runs without Atmos auth keep their prior ambient/default-SDK
  credential behavior, and stores with an explicit `identity` are never overridden.

## references

- Follow-up to #2625 (AWS stores/secrets auth; deferred identity-less inheritance in the hook path).
- Related fix docs: `docs/fixes/2026-06-17-aws-stores-secrets-auth-and-gists.md`,
  `docs/fixes/2026-05-25-store-hook-missing-backend-role-assumption.md`.
