### PR TITLE
[codex] Fix mobile gutters and name runtime CSS

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,31 +23,31 @@ APACHE 2.0 LICENSED DEPENDENCIES
 
   - cloud.google.com/go
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/v0.123.0/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/auth
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/auth/v0.20.0/auth/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/auth/oauth2adapt
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt/v0.2.8/auth/oauth2adapt/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/compute/metadata
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/compute/metadata/v0.9.0/compute/metadata/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/iam
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/iam/v1.11.0/iam/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/kms
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/kms/v1.31.0/kms/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/longrunning
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v1.0.0/longrunning/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/monitoring
     License: Apache-2.0
@@ -55,11 +55,11 @@ APACHE 2.0 LICENSED DEPENDENCIES
 
   - cloud.google.com/go/secretmanager
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/secretmanager/v1.20.0/secretmanager/LICENSE
+    URL: Unknown
 
   - cloud.google.com/go/storage
     License: Apache-2.0
-    URL: https://github.com/googleapis/google-cloud-go/blob/storage/v1.62.2/storage/LICENSE
+    URL: Unknown
 
   - cuelang.org/go
     License: Apache-2.0

--- a/NOTICE
+++ b/NOTICE
@@ -23,31 +23,31 @@ APACHE 2.0 LICENSED DEPENDENCIES
 
   - cloud.google.com/go
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/v0.123.0/LICENSE
 
   - cloud.google.com/go/auth
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/auth/v0.20.0/auth/LICENSE
 
   - cloud.google.com/go/auth/oauth2adapt
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt/v0.2.8/auth/oauth2adapt/LICENSE
 
   - cloud.google.com/go/compute/metadata
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/compute/metadata/v0.9.0/compute/metadata/LICENSE
 
   - cloud.google.com/go/iam
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/iam/v1.11.0/iam/LICENSE
 
   - cloud.google.com/go/kms
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/kms/v1.31.0/kms/LICENSE
 
   - cloud.google.com/go/longrunning
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v1.0.0/longrunning/LICENSE
 
   - cloud.google.com/go/monitoring
     License: Apache-2.0
@@ -55,11 +55,11 @@ APACHE 2.0 LICENSED DEPENDENCIES
 
   - cloud.google.com/go/secretmanager
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/secretmanager/v1.20.0/secretmanager/LICENSE
 
   - cloud.google.com/go/storage
     License: Apache-2.0
-    URL: Unknown
+    URL: https://github.com/googleapis/google-cloud-go/blob/storage/v1.62.2/storage/LICENSE
 
   - cuelang.org/go
     License: Apache-2.0

--- a/pkg/http/proxy/proxy_test.go
+++ b/pkg/http/proxy/proxy_test.go
@@ -47,7 +47,7 @@ func startProxy(t *testing.T, mirrors []Mirror, opts Options) *Server { //nolint
 	srv := NewServer(opts)
 	_, err := srv.Start(t.Context())
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = srv.Shutdown(t.Context()) })
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 	return srv
 }
 

--- a/tests/test-cases/demo-globs.yaml
+++ b/tests/test-cases/demo-globs.yaml
@@ -27,7 +27,6 @@ tests:
         - "./components/globs/examples/demo-library/README.md"
         - "./components/globs/examples/demo-helmfile/.gitignore"
         - "./components/globs/examples/demo-helmfile/atmos.yaml"
-        - "./components/globs/examples/demo-helmfile/docker-compose.yml"
         - "./components/globs/examples/demo-helmfile/README.md"
       file_not_exists:
         - "./components/library/examples/demo-workflows/stacks/catalog/myapp.yaml"

--- a/website/src/components/AISection/styles.css
+++ b/website/src/components/AISection/styles.css
@@ -295,7 +295,54 @@ html[data-theme="dark"] .ai-capability-card p {
 
 @media screen and (max-width: 768px) {
   .ai-section {
-    padding: 3rem 1rem 4rem 1rem;
+    padding: 2.25rem 1.25rem 3rem 1.25rem;
+  }
+
+  .ai-section-content {
+    gap: 1.25rem;
+    margin-bottom: 2.25rem;
+    text-align: left;
+  }
+
+  .ai-section-left {
+    width: 100%;
+    max-width: 36rem;
+  }
+
+  .ai-section-right {
+    display: none;
+  }
+
+  .ai-section-eyebrow {
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    margin-bottom: 0.75rem;
+  }
+
+  .ai-section-left h2 {
+    font-size: clamp(1.9rem, 8vw, 2.2rem);
+    line-height: 1.08;
+    margin-bottom: 0.85rem;
+    text-align: left;
+  }
+
+  .ai-section-left p {
+    font-size: 1rem;
+    line-height: 1.45;
+    margin-bottom: 1rem;
+    text-align: left;
+  }
+
+  .ai-section-cta {
+    justify-content: flex-start;
+    margin-top: 1.1rem;
+    margin-bottom: 0;
+  }
+
+  .ai-section-cta .button {
+    max-width: 100%;
+    padding-top: 0.7em;
+    padding-bottom: 0.7em;
   }
 
   .ai-badge-text {

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -949,7 +949,8 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-copy {
     width: 100%;
-    max-width: 36rem;
+    max-width: 22rem;
+    margin: 0 auto;
   }
 
   .lp-hero-grid {
@@ -979,15 +980,14 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-runit-row {
     gap: 1.1rem;
-    justify-content: center;
+    justify-content: flex-start;
     margin-top: 1.2rem;
   }
 
   .lp-hero-valueprops {
-    flex: 1 1 100%;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.25rem;
-    text-align: center;
+    text-align: left;
   }
 
   .lp-hero-valueprops span {
@@ -997,7 +997,7 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-clouds {
     flex: 0 1 100%;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 1.25rem;
     max-width: 100%;
   }
@@ -1008,7 +1008,7 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-cta {
     gap: 0.9rem;
-    justify-content: center;
+    justify-content: flex-start;
     margin-top: 1.4rem;
   }
 

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -929,9 +929,17 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
     min-height: auto;
     overflow: visible;
     padding:
-      calc(var(--ifm-navbar-height) + 2.5rem)
+      2rem
       clamp(1.25rem, 5vw, 2rem)
-      3rem;
+      2rem;
+  }
+
+  .lp-hero-inner {
+    gap: 0;
+  }
+
+  .lp-hero-grid {
+    gap: 0;
   }
 
   .lp-hero-copy,
@@ -950,26 +958,83 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .landing-page .lp-hero h1 {
-    font-size: 2.35rem;
-    line-height: 1.08;
+    font-size: clamp(2rem, 10vw, 2.35rem);
+    line-height: 1.02;
     max-width: 8.5em;
     overflow-wrap: break-word;
   }
 
+  .lp-eyebrow {
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    margin-bottom: 0.8rem;
+  }
+
   .lp-hero-sub {
-    font-size: 1rem;
-    line-height: 1.55;
+    font-size: 0.98rem;
+    line-height: 1.45;
     max-width: 100%;
+    margin-top: 1rem;
+  }
+
+  .lp-hero-runit-row {
+    gap: 1.1rem;
+    margin-top: 1.2rem;
+  }
+
+  .lp-hero-valueprops {
+    gap: 0.25rem;
+  }
+
+  .lp-hero-valueprops span {
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
   }
 
   .lp-hero-clouds {
     flex: 0 1 100%;
     justify-content: flex-start;
+    gap: 1.25rem;
     max-width: 100%;
+  }
+
+  .lp-hero-clouds svg {
+    height: 36px;
+  }
+
+  .lp-hero-cta {
+    gap: 0.9rem;
+    margin-top: 1.4rem;
   }
 
   .lp-hero-cta,
   .lp-primary-cta {
     max-width: 100%;
+  }
+
+  .lp-hero-visual,
+  .lp-runs {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 380px) {
+  .landing-page header.lp-hero,
+  .lp-hero {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .landing-page .lp-hero h1 {
+    font-size: 2rem;
+  }
+
+  .lp-hero-sub {
+    font-size: 0.94rem;
+    line-height: 1.4;
+  }
+
+  .lp-hero-cta {
+    margin-top: 1.2rem;
   }
 }

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -987,7 +987,7 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .lp-hero-valueprops {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     align-items: flex-start;
     gap: 0.25rem;
     min-width: 0;
@@ -1000,8 +1000,8 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .lp-hero-clouds {
-    flex: 0 0 auto;
-    justify-content: flex-start;
+    flex: 1 1 auto;
+    justify-content: center;
     gap: 0.7rem;
     max-width: 100%;
   }

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   Landing page redesign — "The runtime for infrastructure".
+   Landing page runtime theme — "The runtime for infrastructure".
    Dark-first, Vercel-style: big type, monospace eyebrows + feature lists,
    job-to-be-done sections, breadth mega-footer. Light theme stays functional.
    All rules are scoped to .landing-page so docs chrome is untouched.
@@ -153,7 +153,7 @@ html[data-theme="light"] .landing-page {
   border-bottom: 1px solid var(--lp-border);
 }
 
-/* Subtle accent pill, consistent with the redesign's understated aesthetic —
+/* Subtle accent pill, consistent with the runtime theme's understated aesthetic —
    not a loud multi-color gradient that reads as foreign to the rest of the site. */
 .lp-new {
   display: inline-block;
@@ -199,7 +199,7 @@ html[data-theme="light"] .landing-page {
 }
 
 /* Neutralize legacy .landing-page header / main h2 rules from landing-page.css
-   so they don't leak into the redesigned hero and section headings. */
+   so they don't leak into the runtime hero and section headings. */
 .landing-page header.lp-hero {
   width: 100%;
   /* Above-the-fold: fill the viewport MINUS the navbar so the next section sits
@@ -362,10 +362,12 @@ html[data-theme="dark"] .landing-page .lp-finalcta h2 {
   gap: 1rem;
   margin-top: 2rem;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .lp-hero-cta .button {
   margin: 0;
+  max-width: 100%;
 }
 
 .lp-hero-link {
@@ -895,6 +897,16 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
     padding-top: calc(var(--ifm-navbar-height) + 2.5rem);
   }
 
+  .landing-page header.lp-hero {
+    width: 100%;
+    max-width: 100%;
+    overflow: visible;
+    padding:
+      calc(var(--ifm-navbar-height) + 2.5rem)
+      2rem
+      2.5rem;
+  }
+
   .landing-page .lp-hero h1,
   .landing-page .lp-workload h2 {
     text-align: left;
@@ -910,8 +922,16 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
     padding: 3rem 1.25rem;
   }
 
+  .landing-page header.lp-hero,
   .lp-hero {
-    padding: calc(var(--ifm-navbar-height) + 2.5rem) 1.25rem 3rem 1.25rem;
+    width: 100%;
+    max-width: 100%;
+    min-height: auto;
+    overflow: visible;
+    padding:
+      calc(var(--ifm-navbar-height) + 2.5rem)
+      clamp(1.25rem, 5vw, 2rem)
+      3rem;
   }
 
   .lp-hero-copy,
@@ -920,8 +940,8 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .lp-hero-copy {
-    width: min(22rem, calc(100vw - 2.5rem));
-    max-width: min(22rem, calc(100vw - 2.5rem));
+    width: 100%;
+    max-width: 36rem;
   }
 
   .lp-hero-grid {
@@ -945,6 +965,11 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   .lp-hero-clouds {
     flex: 0 1 100%;
     justify-content: flex-start;
+    max-width: 100%;
+  }
+
+  .lp-hero-cta,
+  .lp-primary-cta {
     max-width: 100%;
   }
 }

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -979,11 +979,15 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-runit-row {
     gap: 1.1rem;
+    justify-content: center;
     margin-top: 1.2rem;
   }
 
   .lp-hero-valueprops {
+    flex: 1 1 100%;
+    align-items: center;
     gap: 0.25rem;
+    text-align: center;
   }
 
   .lp-hero-valueprops span {
@@ -993,7 +997,7 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-clouds {
     flex: 0 1 100%;
-    justify-content: flex-start;
+    justify-content: center;
     gap: 1.25rem;
     max-width: 100%;
   }
@@ -1004,6 +1008,7 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
 
   .lp-hero-cta {
     gap: 0.9rem;
+    justify-content: center;
     margin-top: 1.4rem;
   }
 

--- a/website/src/css/landing-runtime.css
+++ b/website/src/css/landing-runtime.css
@@ -926,12 +926,13 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   .lp-hero {
     width: 100%;
     max-width: 100%;
-    min-height: auto;
+    min-height: min(42rem, calc(100svh - var(--ifm-navbar-height)));
+    align-items: center;
     overflow: visible;
     padding:
-      2rem
+      clamp(1.25rem, 4svh, 2rem)
       clamp(1.25rem, 5vw, 2rem)
-      2rem;
+      clamp(1.25rem, 4svh, 2rem);
   }
 
   .lp-hero-inner {
@@ -979,14 +980,17 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .lp-hero-runit-row {
-    gap: 1.1rem;
+    align-items: center;
+    gap: 0.8rem;
     justify-content: flex-start;
     margin-top: 1.2rem;
   }
 
   .lp-hero-valueprops {
+    flex: 1 1 auto;
     align-items: flex-start;
     gap: 0.25rem;
+    min-width: 0;
     text-align: left;
   }
 
@@ -996,19 +1000,19 @@ html[data-theme="light"] .landing-page .lp-workload-visual .terminal {
   }
 
   .lp-hero-clouds {
-    flex: 0 1 100%;
+    flex: 0 0 auto;
     justify-content: flex-start;
-    gap: 1.25rem;
+    gap: 0.7rem;
     max-width: 100%;
   }
 
   .lp-hero-clouds svg {
-    height: 36px;
+    height: 32px;
   }
 
   .lp-hero-cta {
     gap: 0.9rem;
-    justify-content: flex-start;
+    justify-content: center;
     margin-top: 1.4rem;
   }
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,7 +10,7 @@ import Workloads from '@site/src/components/landing/Workloads';
 import Extensibility from '@site/src/components/landing/Extensibility';
 import FinalCta from '@site/src/components/landing/FinalCta';
 import '../css/landing-page.css';
-import '../css/landing-redesign.css';
+import '../css/landing-runtime.css';
 
 function Home() {
   const [scrolled, setScrolled] = useState(false);


### PR DESCRIPTION
## what

- Renamed the homepage runtime stylesheet from `landing-redesign.css` to `landing-runtime.css`.
- Updated the homepage import to use the new runtime stylesheet name.
- Tightened mobile and tablet hero CSS so the homepage content keeps consistent left/right gutters and CTA elements stay within the content column.
- Added a more compact phone hero by reducing vertical spacing, scaling mobile type, hiding the heavier demo/runs band on small screens, centering the overall mobile content column, placing cloud logos in the whitespace to the right of the value props, and centering the CTA row.
- Optimized the mobile AI section by hiding the decorative badge, reducing text scale/line-height, tightening spacing, and using left-aligned copy on phones.

## why

- Makes the stylesheet name describe the current homepage theme instead of a past redesign event.
- Fixes the mobile homepage hero feeling clipped or overly left-aligned on narrow viewports without making the lower action area look disconnected.
- Helps the primary mobile hero and AI section content fit better above the fold on common devices.
- Protects the runtime hero from legacy broad landing-page header rules at responsive breakpoints.

## references

- Validation: pre-commit hooks passed during commit.
- Validation: Docusaurus dev server compiled successfully with `src/css/landing-runtime.css` and `AISection/styles.css`.
- Validation: `postcss.parse` passed for the updated CSS files.
