### PR TITLE
Split help command sections and redesign error formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
           ignore: DL3008
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         if: always()
         with:
           # Path to SARIF file relative to the root of the repository
@@ -542,6 +542,19 @@ jobs:
         run: |
           cd examples/${{ matrix.demo-folder }}
           atmos test
+
+  k3s-demo-helmfile-required-check:
+    name: "[k3s] demo-helmfile"
+    needs: k3s
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Verify k3s demo matrix
+        run: |
+          if [ "${{ needs.k3s.result }}" != "success" ]; then
+            echo "k3s matrix result: ${{ needs.k3s.result }}"
+            exit 1
+          fi
 
   # Exercise the Kubernetes native component against a real kube-apiserver+etcd
   # control plane (started by controller-runtime envtest): server-side apply,

--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -427,7 +427,7 @@ func suggestProfilesForAuth(atmosConfig *schema.AtmosConfiguration) error {
 
 	return errUtils.Build(errUtils.ErrAuthNotConfigured).
 		WithExplanation("No authentication providers or identities are configured in the current configuration").
-		WithHintf("Available profiles: `%s`", strings.Join(profileNames, "`, `")).
+		WithExplanationf("Available profiles: `%s`", strings.Join(profileNames, "`, `")).
 		WithHint("Try: `atmos auth list --profile <name>` to load auth configuration from a profile").
 		WithHint("Run `atmos profile list` for detailed information about each profile").
 		WithExitCode(1).

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -364,6 +364,9 @@ func createCustomCommand(
 		Use:   commandConfig.Name,
 		Short: commandConfig.Description,
 		Long:  commandConfig.Description,
+		Annotations: map[string]string{
+			annotationCustomCommand: annotationValueTrue,
+		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preCustomCommand(cmd, args, parentCommand, commandConfig)
 		},
@@ -1115,7 +1118,7 @@ func validateAtmosConfig(opts ...AtmosValidateOption) error {
 		if !atmosConfigExists || err != nil {
 			// Return an error with context instead of printing and exiting
 			return errUtils.Build(errUtils.ErrStacksDirectoryDoesNotExist).
-				WithHintf("Stacks directory not found:  \n%s", atmosConfig.StacksBaseAbsolutePath).
+				WithExplanationf("Stacks directory not found:  \n%s", atmosConfig.StacksBaseAbsolutePath).
 				WithContext("base_path", atmosConfig.BasePath).
 				WithContext("stacks_base_path", atmosConfig.Stacks.BasePath).
 				Err()

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -1030,6 +1030,8 @@ func TestValidateAtmosConfigWithOptions(t *testing.T) {
 
 // TestErrorWrappingInGetConfigAndStacksInfo verifies proper error wrapping.
 func TestErrorWrappingInGetConfigAndStacksInfo(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
 	cmd := &cobra.Command{
 		Use: "terraform",
 	}
@@ -1046,6 +1048,11 @@ func TestErrorWrappingInGetConfigAndStacksInfo(t *testing.T) {
 
 	// Verify error contains useful context.
 	assert.NotEmpty(t, err.Error(), "Error should have a message")
+
+	formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
+	assert.Contains(t, formatted, "Stacks directory not found:")
+	assert.NotContains(t, formatted, "💡 Stacks directory not found:")
+	assert.NotContains(t, formatted, "## Hints")
 }
 
 // TestDetermineComponentTypeFromCommand tests component type detection from command hierarchy.
@@ -2127,6 +2134,8 @@ func TestProcessCustomCommands(t *testing.T) {
 				for _, cmd := range parentCmd.Commands() {
 					if cmd.Name() == expectedCmd {
 						found = true
+						require.NotNil(t, cmd.Annotations, "Expected command %q to have annotations", expectedCmd)
+						assert.Equal(t, annotationValueTrue, cmd.Annotations[annotationCustomCommand], "Expected command %q to be marked as a custom command", expectedCmd)
 						break
 					}
 				}

--- a/cmd/help_template.go
+++ b/cmd/help_template.go
@@ -56,8 +56,10 @@ const (
 
 // Command annotation constants.
 const (
-	annotationExperimental = "experimental"
-	annotationValueTrue    = "true"
+	annotationExperimental  = "experimental"
+	annotationConfigAlias   = "configAlias"
+	annotationCustomCommand = "customCommand"
+	annotationValueTrue     = "true"
 )
 
 // isExperimentalCommand checks if a command has the experimental annotation.
@@ -517,8 +519,13 @@ func isConfigAlias(cmd *cobra.Command) bool {
 	if cmd.Annotations == nil {
 		return false
 	}
-	_, ok := cmd.Annotations["configAlias"]
+	_, ok := cmd.Annotations[annotationConfigAlias]
 	return ok
+}
+
+// isCustomCommand checks if a command was created from Atmos command configuration.
+func isCustomCommand(cmd *cobra.Command) bool {
+	return cmd.Annotations != nil && cmd.Annotations[annotationCustomCommand] == annotationValueTrue
 }
 
 // calculateCommandWidth calculates the display width of a command name including type suffix.
@@ -538,10 +545,10 @@ func calculateCommandWidth(cmd *cobra.Command, parentExperimental bool) int {
 // calculateMaxCommandWidth finds the maximum command name width for alignment.
 // Config aliases are excluded from this calculation since they're shown in a separate section.
 // If parentExperimental is true, experimental badges won't be included in width calculations.
-func calculateMaxCommandWidth(commands []*cobra.Command, parentExperimental bool) int {
+func calculateMaxCommandWidth(commands []*cobra.Command, parentExperimental bool, customCommands bool) int {
 	maxWidth := 0
 	for _, c := range commands {
-		if !isCommandAvailable(c) || isConfigAlias(c) {
+		if !isCommandAvailable(c) || isConfigAlias(c) || isCustomCommand(c) != customCommands {
 			continue
 		}
 		width := calculateCommandWidth(c, parentExperimental)
@@ -605,6 +612,32 @@ func formatCommandLine(ctx *helpRenderContext, cmd *cobra.Command, maxWidth int,
 	}
 }
 
+type commandSectionOptions struct {
+	heading            string
+	customCommands     bool
+	parentExperimental bool
+	mdRenderer         *markdown.Renderer
+}
+
+// printCommandSection prints one command-origin section.
+func printCommandSection(ctx *helpRenderContext, cmd *cobra.Command, opts commandSectionOptions) {
+	maxCmdWidth := calculateMaxCommandWidth(cmd.Commands(), opts.parentExperimental, opts.customCommands)
+	if maxCmdWidth == 0 {
+		return
+	}
+
+	fmt.Fprintln(ctx.writer, ctx.styles.heading.Render(opts.heading))
+	fmt.Fprintln(ctx.writer)
+
+	for _, c := range cmd.Commands() {
+		if !isCommandAvailable(c) || isConfigAlias(c) || isCustomCommand(c) != opts.customCommands {
+			continue
+		}
+		formatCommandLine(ctx, c, maxCmdWidth, opts.mdRenderer, opts.parentExperimental)
+	}
+	fmt.Fprintln(ctx.writer)
+}
+
 // printAvailableCommands prints the list of available subcommands.
 func printAvailableCommands(ctx *helpRenderContext, cmd *cobra.Command) {
 	defer perf.Track(nil, "cmd.printAvailableCommands")()
@@ -613,14 +646,9 @@ func printAvailableCommands(ctx *helpRenderContext, cmd *cobra.Command) {
 		return
 	}
 
-	fmt.Fprintln(ctx.writer, ctx.styles.heading.Render("AVAILABLE COMMANDS"))
-	fmt.Fprintln(ctx.writer)
-
 	// Check if the parent command is experimental.
 	// If so, subcommands don't need to repeat the badge since it's shown at the top.
 	parentExperimental := isExperimentalCommand(cmd)
-
-	maxCmdWidth := calculateMaxCommandWidth(cmd.Commands(), parentExperimental)
 
 	// Create markdown renderer for command descriptions (same approach as flag rendering).
 	var mdRenderer *markdown.Renderer
@@ -628,13 +656,18 @@ func printAvailableCommands(ctx *helpRenderContext, cmd *cobra.Command) {
 		mdRenderer, _ = markdown.NewTerminalMarkdownRenderer(*ctx.atmosConfig)
 	}
 
-	for _, c := range cmd.Commands() {
-		if !isCommandAvailable(c) || isConfigAlias(c) {
-			continue
-		}
-		formatCommandLine(ctx, c, maxCmdWidth, mdRenderer, parentExperimental)
-	}
-	fmt.Fprintln(ctx.writer)
+	printCommandSection(ctx, cmd, commandSectionOptions{
+		heading:            "BUILT-IN COMMANDS",
+		customCommands:     false,
+		parentExperimental: parentExperimental,
+		mdRenderer:         mdRenderer,
+	})
+	printCommandSection(ctx, cmd, commandSectionOptions{
+		heading:            "CUSTOM COMMANDS",
+		customCommands:     true,
+		parentExperimental: parentExperimental,
+		mdRenderer:         mdRenderer,
+	})
 }
 
 // getConfigAliases returns all available config alias commands.

--- a/cmd/help_template_test.go
+++ b/cmd/help_template_test.go
@@ -327,7 +327,7 @@ func TestCalculateCommandWidth(t *testing.T) {
 
 func TestCalculateMaxCommandWidth(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
-		result := calculateMaxCommandWidth([]*cobra.Command{}, false)
+		result := calculateMaxCommandWidth([]*cobra.Command{}, false, false)
 		if result != 0 {
 			t.Errorf("Expected 0 for empty list, got %d", result)
 		}
@@ -337,7 +337,7 @@ func TestCalculateMaxCommandWidth(t *testing.T) {
 		commands := []*cobra.Command{
 			{Use: "test", Run: func(cmd *cobra.Command, args []string) {}},
 		}
-		result := calculateMaxCommandWidth(commands, false)
+		result := calculateMaxCommandWidth(commands, false, false)
 		if result != 4 {
 			t.Errorf("Expected 4, got %d", result)
 		}
@@ -349,7 +349,7 @@ func TestCalculateMaxCommandWidth(t *testing.T) {
 			{Use: "muchlongercommandname", Run: func(cmd *cobra.Command, args []string) {}},
 			{Use: "mid", Run: func(cmd *cobra.Command, args []string) {}},
 		}
-		result := calculateMaxCommandWidth(commands, false)
+		result := calculateMaxCommandWidth(commands, false, false)
 		expected := len("muchlongercommandname")
 		if result != expected {
 			t.Errorf("Expected %d, got %d", expected, result)
@@ -361,9 +361,20 @@ func TestCalculateMaxCommandWidth(t *testing.T) {
 			{Use: "short", Run: func(cmd *cobra.Command, args []string) {}},
 			{Use: "verylongbutthisishidden", Hidden: true, Run: func(cmd *cobra.Command, args []string) {}},
 		}
-		result := calculateMaxCommandWidth(commands, false)
+		result := calculateMaxCommandWidth(commands, false, false)
 		if result != 5 { // Length of "short".
 			t.Errorf("Expected 5 (ignoring hidden), got %d", result)
+		}
+	})
+
+	t.Run("filters by custom command bucket", func(t *testing.T) {
+		commands := []*cobra.Command{
+			{Use: "verylongbuiltin", Run: func(cmd *cobra.Command, args []string) {}},
+			{Use: "custom", Annotations: map[string]string{annotationCustomCommand: annotationValueTrue}, Run: func(cmd *cobra.Command, args []string) {}},
+		}
+		result := calculateMaxCommandWidth(commands, false, true)
+		if result != len("custom") {
+			t.Errorf("Expected custom command width, got %d", result)
 		}
 	})
 }
@@ -1081,6 +1092,61 @@ func TestIsConfigAlias(t *testing.T) {
 	}
 }
 
+func TestIsCustomCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		expected bool
+	}{
+		{
+			name: "command with custom command annotation",
+			cmd: &cobra.Command{
+				Use: "deploy",
+				Annotations: map[string]string{
+					annotationCustomCommand: annotationValueTrue,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "command without annotations",
+			cmd: &cobra.Command{
+				Use: "apply",
+			},
+			expected: false,
+		},
+		{
+			name: "command with different annotation",
+			cmd: &cobra.Command{
+				Use: "tp",
+				Annotations: map[string]string{
+					annotationConfigAlias: "terraform plan",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "command with false custom command annotation",
+			cmd: &cobra.Command{
+				Use: "deploy",
+				Annotations: map[string]string{
+					annotationCustomCommand: "false",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCustomCommand(tt.cmd)
+			if result != tt.expected {
+				t.Errorf("isCustomCommand() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestFormatCommandLine(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1151,6 +1217,7 @@ func TestPrintAvailableCommands(t *testing.T) {
 		subcommands []*cobra.Command
 		shouldPrint bool
 		contains    []string
+		notContains []string
 	}{
 		{
 			name: "with available subcommands",
@@ -1160,7 +1227,38 @@ func TestPrintAvailableCommands(t *testing.T) {
 				{Use: "destroy", Short: "Destroy resources", Run: func(cmd *cobra.Command, args []string) {}},
 			},
 			shouldPrint: true,
-			contains:    []string{"AVAILABLE COMMANDS", "apply", "plan", "destroy"},
+			contains:    []string{"BUILT-IN COMMANDS", "apply", "plan", "destroy"},
+			notContains: []string{"CUSTOM COMMANDS"},
+		},
+		{
+			name: "with custom subcommands only",
+			subcommands: []*cobra.Command{
+				{Use: "deploy", Short: "Deploy service", Annotations: map[string]string{annotationCustomCommand: annotationValueTrue}, Run: func(cmd *cobra.Command, args []string) {}},
+				{Use: "release", Short: "Release service", Annotations: map[string]string{annotationCustomCommand: annotationValueTrue}, Run: func(cmd *cobra.Command, args []string) {}},
+			},
+			shouldPrint: true,
+			contains:    []string{"CUSTOM COMMANDS", "deploy", "release"},
+			notContains: []string{"BUILT-IN COMMANDS"},
+		},
+		{
+			name: "with built-in and custom subcommands",
+			subcommands: []*cobra.Command{
+				{Use: "terraform", Short: "Execute Terraform commands", Run: func(cmd *cobra.Command, args []string) {}},
+				{Use: "deploy", Short: "Deploy service", Annotations: map[string]string{annotationCustomCommand: annotationValueTrue}, Run: func(cmd *cobra.Command, args []string) {}},
+			},
+			shouldPrint: true,
+			contains:    []string{"BUILT-IN COMMANDS", "terraform", "CUSTOM COMMANDS", "deploy"},
+		},
+		{
+			name: "config aliases excluded from command sections",
+			subcommands: []*cobra.Command{
+				{Use: "terraform", Short: "Execute Terraform commands", Run: func(cmd *cobra.Command, args []string) {}},
+				{Use: "deploy", Short: "Deploy service", Annotations: map[string]string{annotationCustomCommand: annotationValueTrue}, Run: func(cmd *cobra.Command, args []string) {}},
+				{Use: "tp", Short: "alias for `terraform plan`", Annotations: map[string]string{annotationConfigAlias: "terraform plan"}, Run: func(cmd *cobra.Command, args []string) {}},
+			},
+			shouldPrint: true,
+			contains:    []string{"BUILT-IN COMMANDS", "terraform", "CUSTOM COMMANDS", "deploy"},
+			notContains: []string{"tp", "alias for"},
 		},
 		{
 			name: "with hidden commands",
@@ -1169,7 +1267,8 @@ func TestPrintAvailableCommands(t *testing.T) {
 				{Use: "hidden", Short: "Hidden command", Hidden: true, Run: func(cmd *cobra.Command, args []string) {}},
 			},
 			shouldPrint: true,
-			contains:    []string{"AVAILABLE COMMANDS", "apply"},
+			contains:    []string{"BUILT-IN COMMANDS", "apply"},
+			notContains: []string{"CUSTOM COMMANDS", "hidden"},
 		},
 		{
 			name:        "no subcommands",
@@ -1221,6 +1320,11 @@ func TestPrintAvailableCommands(t *testing.T) {
 			for _, expected := range tt.contains {
 				if !strings.Contains(output, expected) {
 					t.Errorf("Expected output to contain %q, got: %q", expected, output)
+				}
+			}
+			for _, unexpected := range tt.notContains {
+				if strings.Contains(output, unexpected) {
+					t.Errorf("Expected output not to contain %q, got: %q", unexpected, output)
 				}
 			}
 		})
@@ -1386,7 +1490,7 @@ func TestPrintAvailableCommandsWithAtmosConfig(t *testing.T) {
 				{Use: "plan", Short: "Plan changes", Run: func(cmd *cobra.Command, args []string) {}},
 			},
 			shouldPrint: true,
-			contains:    []string{"AVAILABLE COMMANDS", "apply", "plan"},
+			contains:    []string{"BUILT-IN COMMANDS", "apply", "plan"},
 		},
 		{
 			name: "with markdown in command descriptions",
@@ -1395,7 +1499,7 @@ func TestPrintAvailableCommandsWithAtmosConfig(t *testing.T) {
 				{Use: "describe", Short: "Describe **components**", Run: func(cmd *cobra.Command, args []string) {}},
 			},
 			shouldPrint: true,
-			contains:    []string{"AVAILABLE COMMANDS", "validate", "describe"},
+			contains:    []string{"BUILT-IN COMMANDS", "validate", "describe"},
 		},
 	}
 

--- a/cmd/internal/validation.go
+++ b/cmd/internal/validation.go
@@ -53,7 +53,7 @@ func ValidateAtmosConfig(opts ...ValidateOption) error {
 		if !atmosConfigExists || err != nil {
 			// Return an error with context instead of printing and exiting.
 			return errUtils.Build(errUtils.ErrStacksDirectoryDoesNotExist).
-				WithHintf("Stacks directory not found:  \n%s", atmosConfig.StacksBaseAbsolutePath).
+				WithExplanationf("Stacks directory not found:  \n%s", atmosConfig.StacksBaseAbsolutePath).
 				WithContext("base_path", atmosConfig.BasePath).
 				WithContext("stacks_base_path", atmosConfig.Stacks.BasePath).
 				Err()

--- a/errors/builder.go
+++ b/errors/builder.go
@@ -51,7 +51,7 @@ func (b *ErrorBuilder) WithHintf(format string, args ...interface{}) *ErrorBuild
 
 // WithExplanation adds a detailed explanation to the error.
 // The explanation provides context about what went wrong and why.
-// It will be displayed in a dedicated "## Explanation" section when formatted.
+// It will be displayed as diagnostic explanation content when formatted.
 func (b *ErrorBuilder) WithExplanation(explanation string) *ErrorBuilder {
 	b.err = errors.WithDetail(b.err, explanation)
 	return b

--- a/errors/error_funcs.go
+++ b/errors/error_funcs.go
@@ -271,11 +271,9 @@ func printFormattedError(err error, title string, suggestion string) {
 
 	// Color mode is now determined by terminal settings (--no-color, --force-color, etc.)
 	// and does not need to be configured here.
-	config := FormatterConfig{
-		Verbose:       verbose,
-		MaxLineLength: DefaultMaxLineLength,
-		Title:         title, // Use provided title if any.
-	}
+	config := DefaultFormatterConfig()
+	config.Verbose = verbose
+	config.Title = title // Use provided title if any.
 	formatted := Format(err, config)
 
 	// Write directly to os.Stderr instead of using ui.MarkdownMessage() to avoid

--- a/errors/error_funcs.go
+++ b/errors/error_funcs.go
@@ -121,9 +121,9 @@ func appendErrorDetails(out *strings.Builder, err error) {
 	if len(details) == 0 {
 		return
 	}
-	fmt.Fprintf(out, "\nExplanation:\n")
+	fmt.Fprintln(out)
 	for _, d := range details {
-		fmt.Fprintf(out, "  • %s\n", d)
+		fmt.Fprintf(out, "%s\n", d)
 	}
 }
 
@@ -147,9 +147,9 @@ func appendErrorHints(out *strings.Builder, err error) {
 	if len(userHints) == 0 {
 		return
 	}
-	fmt.Fprintf(out, "\nHints:\n")
+	fmt.Fprintln(out)
 	for _, h := range userHints {
-		fmt.Fprintf(out, "  • %s\n", h)
+		fmt.Fprintf(out, "💡 %s\n", h)
 	}
 }
 
@@ -237,9 +237,9 @@ func printFormattedError(err error, title string, suggestion string) {
 
 			// Check if suggestion contains markdown sections (backward compatibility).
 			// Old code passed suggestions like "\n## Explanation\n..." which should be
-			// added as explanations, not hints, to avoid rendering empty hint sections.
+			// added as explanations, not hints.
 			if strings.Contains(suggestion, "\n##") || strings.HasPrefix(trimmed, "##") {
-				// Strip the "## Explanation" header if present since formatter adds it.
+				// Strip the legacy "## Explanation" header if present.
 				cleaned := strings.TrimLeft(suggestion, "\n")
 				cleaned = strings.TrimPrefix(cleaned, "## Explanation\n")
 				cleaned = strings.TrimPrefix(cleaned, "## Explanation")
@@ -247,8 +247,8 @@ func printFormattedError(err error, title string, suggestion string) {
 				builder = builder.WithExplanation(cleaned)
 			} else {
 				// Only add as hint if it's not empty after trimming.
-				// This prevents rendering empty "## Hints" sections for suggestions
-				// that are just whitespace or newlines.
+				// This prevents rendering empty hint lines for suggestions that are
+				// just whitespace or newlines.
 				if trimmed != "" {
 					builder = builder.WithHint(trimmed)
 				}
@@ -290,7 +290,7 @@ func printFormattedError(err error, title string, suggestion string) {
 	//
 	// The formatted output is already rendered markdown, so writing to stderr is correct.
 	// Note: Error output is not masked to avoid import cycles with pkg/io.
-	_, printErr := os.Stderr.WriteString(formatted + "\n")
+	_, printErr := os.Stderr.WriteString(strings.TrimRight(formatted, "\n") + "\n")
 	if printErr != nil {
 		log.Error(printErr)
 		log.Error(err)

--- a/errors/error_funcs_test.go
+++ b/errors/error_funcs_test.go
@@ -365,13 +365,14 @@ func TestPrintStructuredPlainError(t *testing.T) {
 		// Should contain the error message.
 		assert.Contains(t, out, "profile not found", "output should contain base error")
 
-		// Should contain explanations.
-		assert.Contains(t, out, "Explanation:", "output should have explanation section")
+		// Should contain explanations without the old section header.
+		assert.NotContains(t, out, "Explanation:", "output should not have old explanation header")
 		assert.Contains(t, out, "Profile `test-profile` not found", "output should contain profile name in explanation")
 		assert.Contains(t, out, "Searched in:", "output should show searched paths")
 
-		// Should contain hints.
-		assert.Contains(t, out, "Hints:", "output should have hints section")
+		// Should contain standalone hints without the old section header.
+		assert.NotContains(t, out, "Hints:", "output should not have old hints header")
+		assert.Contains(t, out, "💡", "output should mark hints as action lines")
 		assert.Contains(t, out, "atmos profile list", "output should contain profile list hint")
 		assert.Contains(t, out, "Create the profile directory", "output should contain creation hint")
 

--- a/errors/formatter.go
+++ b/errors/formatter.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// DefaultMaxLineLength is the default maximum line length before wrapping.
+	// DefaultMaxLineLength is the legacy default maximum line length before wrapping.
 	DefaultMaxLineLength = 80
 
 	// DefaultMarkdownWidth is the default width for markdown rendering when config is not available.
@@ -55,7 +55,8 @@ type FormatterConfig struct {
 	// Verbose enables detailed error chain output.
 	Verbose bool
 
-	// MaxLineLength is the maximum length before wrapping (default: 80).
+	// MaxLineLength is the maximum length before wrapping.
+	// A value of 0 means auto-detect from configuration or terminal width.
 	// This controls both the width passed to the markdown renderer and the
 	// wrapping of text in explanation and hint sections.
 	MaxLineLength int
@@ -69,8 +70,7 @@ type FormatterConfig struct {
 func DefaultFormatterConfig() FormatterConfig {
 	verbose := viper.GetBool("verbose")
 	return FormatterConfig{
-		Verbose:       verbose,
-		MaxLineLength: DefaultMaxLineLength,
+		Verbose: verbose,
 	}
 }
 
@@ -365,29 +365,71 @@ func addExampleAndHintsSection(md *strings.Builder, err error, maxLineLength int
 
 func renderMarkdownSections(sections markdownSections, config FormatterConfig, useColor bool) (string, bool) {
 	var out strings.Builder
+	width := resolveFormatterWidth(config)
 
-	if !appendRenderedMarkdownSection(&out, sections.errorMarkdown, config.MaxLineLength, useColor) {
+	if !appendRenderedMarkdownSection(&out, sections.errorMarkdown, width, useColor) {
 		return "", false
 	}
 
 	if strings.TrimSpace(sections.explanationMarkdown) != "" {
-		renderedExplanation, ok := renderMarkdown(sections.explanationMarkdown, explanationMarkdownLineLength(config.MaxLineLength, useColor))
+		renderedExplanation, ok := renderMarkdown(sections.explanationMarkdown, explanationMarkdownLineLength(width, useColor))
 		if !ok {
 			return "", false
 		}
 		if !useColor {
 			renderedExplanation = stripANSI(renderedExplanation)
 		}
-		appendRenderedSection(&out, renderExplanationCallout(renderedExplanation, config.MaxLineLength, useColor))
+		appendRenderedSection(&out, renderExplanationCallout(renderedExplanation, width, useColor))
 	}
 
 	if strings.TrimSpace(sections.remainderMarkdown) != "" {
-		if !appendRenderedMarkdownSection(&out, sections.remainderMarkdown, config.MaxLineLength, useColor) {
+		if !appendRenderedMarkdownSection(&out, sections.remainderMarkdown, width, useColor) {
 			return "", false
 		}
 	}
 
 	return strings.TrimRight(out.String(), " \t\n") + newline, true
+}
+
+func resolveFormatterWidth(config FormatterConfig) int {
+	if config.MaxLineLength > 0 {
+		return config.MaxLineLength
+	}
+
+	configuredWidth := configuredFormatterWidth()
+	detectedWidth := detectFormatterTerminalWidth()
+
+	if configuredWidth > 0 {
+		if detectedWidth > 0 {
+			return min(configuredWidth, detectedWidth)
+		}
+		return configuredWidth
+	}
+
+	if detectedWidth > 0 {
+		return detectedWidth
+	}
+
+	return DefaultMarkdownWidth
+}
+
+func configuredFormatterWidth() int {
+	if atmosConfig == nil {
+		return 0
+	}
+	if atmosConfig.Settings.Terminal.MaxWidth > 0 {
+		return atmosConfig.Settings.Terminal.MaxWidth
+	}
+	//nolint:staticcheck // Deprecated docs max-width remains supported as a compatibility fallback.
+	return atmosConfig.Settings.Docs.MaxWidth
+}
+
+var detectFormatterTerminalWidth = func() int {
+	termProvider := terminal.New()
+	if width := termProvider.Width(terminal.Stderr); width > 0 {
+		return width
+	}
+	return termProvider.Width(terminal.Stdout)
 }
 
 func explanationMarkdownLineLength(maxLineLength int, useColor bool) int {

--- a/errors/formatter.go
+++ b/errors/formatter.go
@@ -371,7 +371,7 @@ func renderMarkdownSections(sections markdownSections, config FormatterConfig, u
 	}
 
 	if strings.TrimSpace(sections.explanationMarkdown) != "" {
-		renderedExplanation, ok := renderMarkdown(sections.explanationMarkdown, config.MaxLineLength)
+		renderedExplanation, ok := renderMarkdown(sections.explanationMarkdown, explanationMarkdownLineLength(config.MaxLineLength, useColor))
 		if !ok {
 			return "", false
 		}
@@ -388,6 +388,13 @@ func renderMarkdownSections(sections markdownSections, config FormatterConfig, u
 	}
 
 	return strings.TrimRight(out.String(), " \t\n") + newline, true
+}
+
+func explanationMarkdownLineLength(maxLineLength int, useColor bool) int {
+	if !useColor || maxLineLength <= 2 {
+		return maxLineLength
+	}
+	return maxLineLength - 2
 }
 
 func appendRenderedMarkdownSection(out *strings.Builder, md string, maxLineLength int, useColor bool) bool {

--- a/errors/formatter.go
+++ b/errors/formatter.go
@@ -2,8 +2,10 @@ package errors
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -34,6 +36,19 @@ const (
 )
 
 var newTerminalMarkdownRenderer = markdown.NewTerminalMarkdownRenderer
+
+const (
+	explanationGradientStart = "#33204f"
+	explanationGradientEnd   = "#123c5c"
+	hexColorLength           = 6
+	hexColorBase             = 16
+)
+
+type markdownSections struct {
+	errorMarkdown       string
+	explanationMarkdown string
+	remainderMarkdown   string
+}
 
 // FormatterConfig controls error formatting behavior.
 type FormatterConfig struct {
@@ -130,26 +145,20 @@ func Format(err error, config FormatterConfig) string {
 	// This respects --no-color, --force-color, NO_COLOR env var, and terminal.color config.
 	useColor := shouldUseColor()
 
-	// Build structured markdown document with sections.
-	md := buildMarkdownSections(err, config, useColor)
+	sections := buildMarkdownSections(err, config, useColor)
 
-	// Render markdown through Glamour with configured width.
-	rendered, ok := renderMarkdown(md, config.MaxLineLength)
+	rendered, ok := renderMarkdownSections(sections, config, useColor)
 	if !ok {
 		return formatStructuredPlainError(err, config.Title, "")
-	}
-
-	// Strip ANSI codes if color is disabled.
-	if !useColor {
-		rendered = stripANSI(rendered)
 	}
 
 	return rendered
 }
 
 // buildMarkdownSections builds the complete markdown document with all sections.
-func buildMarkdownSections(err error, config FormatterConfig, useColor bool) string {
-	var md strings.Builder
+func buildMarkdownSections(err error, config FormatterConfig, useColor bool) markdownSections {
+	var errorMarkdown strings.Builder
+	var remainderMarkdown strings.Builder
 
 	// Section 1: Error header + message.
 	// Prefer config.Title, then extract custom title, or use default.
@@ -160,7 +169,7 @@ func buildMarkdownSections(err error, config FormatterConfig, useColor bool) str
 	if title == "" {
 		title = "Error"
 	}
-	md.WriteString("# " + title + newline + newline)
+	errorMarkdown.WriteString("# " + title + newline + newline)
 
 	// Extract sentinel error and wrapped message.
 	sentinelMsg, wrappedMsg := extractSentinelAndWrappedMessage(err)
@@ -173,35 +182,39 @@ func buildMarkdownSections(err error, config FormatterConfig, useColor bool) str
 	switch {
 	case errors.As(err, &workflowErr):
 		// Workflow orchestration failures - show workflow-specific message with exit code.
-		md.WriteString(fmt.Sprintf("**Error:** %s%s%s", workflowErr.WorkflowStepMessage(), newline, newline))
+		fmt.Fprintf(&errorMarkdown, "**Error:** %s%s%s", workflowErr.WorkflowStepMessage(), newline, newline)
 	case errors.As(err, &execErr):
 		// External command execution failures - show command and exit code.
-		md.WriteString(fmt.Sprintf("**Error:** %s with exit code %d%s%s", sentinelMsg, execErr.ExitCode, newline, newline))
+		fmt.Fprintf(&errorMarkdown, "**Error:** %s with exit code %d%s%s", sentinelMsg, execErr.ExitCode, newline, newline)
 	default:
 		// All other errors - just show the sentinel message without exit code.
-		md.WriteString("**Error:** " + sentinelMsg + newline + newline)
+		errorMarkdown.WriteString("**Error:** " + sentinelMsg + newline + newline)
 	}
 
 	// Section 2: Explanation.
-	addExplanationSection(&md, err, wrappedMsg, config.MaxLineLength)
+	explanationMarkdown := buildExplanationMarkdown(err, wrappedMsg, config.MaxLineLength)
 
 	// Section 3 & 4: Examples and Hints.
-	addExampleAndHintsSection(&md, err, config.MaxLineLength)
+	addExampleAndHintsSection(&remainderMarkdown, err, config.MaxLineLength)
 
 	// Section 4.5: Command Output (for ExecError with stderr).
-	addCommandOutputSection(&md, err)
+	addCommandOutputSection(&remainderMarkdown, err)
 
 	// Section 5: Context (verbose mode only).
 	if config.Verbose {
-		addContextSection(&md, err, useColor)
+		addContextSection(&remainderMarkdown, err, useColor)
 	}
 
 	// Section 6: Stack trace (verbose mode only).
 	if config.Verbose {
-		addStackTraceSection(&md, err, useColor)
+		addStackTraceSection(&remainderMarkdown, err, useColor)
 	}
 
-	return md.String()
+	return markdownSections{
+		errorMarkdown:       errorMarkdown.String(),
+		explanationMarkdown: explanationMarkdown,
+		remainderMarkdown:   remainderMarkdown.String(),
+	}
 }
 
 // extractSentinelAndWrappedMessage extracts the root sentinel error message
@@ -240,33 +253,37 @@ func extractSentinelAndWrappedMessage(err error) (sentinelMsg string, wrappedMsg
 	return sentinelMsg, wrappedMsg
 }
 
-// addExplanationSection adds the explanation section if details or wrapped message exist.
-func addExplanationSection(md *strings.Builder, err error, wrappedMsg string, maxLineLength int) {
+// buildExplanationMarkdown builds explanation content without a visible section heading.
+func buildExplanationMarkdown(err error, wrappedMsg string, maxLineLength int) string {
 	// maxLineLength is unused here because the markdown renderer handles wrapping.
 	_ = maxLineLength
 
 	details := errors.GetAllDetails(err)
 	hasContent := len(details) > 0 || wrappedMsg != ""
 
-	if hasContent {
-		md.WriteString(newline + newline + "## Explanation" + newline + newline)
-
-		// Add wrapped message first if present.
-		// Don't wrap - let the markdown renderer handle it to preserve structure.
-		if wrappedMsg != "" {
-			md.WriteString(wrappedMsg + newline + newline)
-		}
-
-		// Add details from error chain.
-		// Don't wrap - let the markdown renderer handle it to preserve code blocks and newlines.
-		for _, detail := range details {
-			md.WriteString(fmt.Sprintf("%v", detail) + newline)
-		}
-
-		if len(details) > 0 {
-			md.WriteString(newline)
-		}
+	if !hasContent {
+		return ""
 	}
+
+	var md strings.Builder
+
+	// Add wrapped message first if present.
+	// Don't wrap - let the markdown renderer handle it to preserve structure.
+	if wrappedMsg != "" {
+		md.WriteString(wrappedMsg + newline + newline)
+	}
+
+	// Add details from error chain.
+	// Don't wrap - let the markdown renderer handle it to preserve code blocks and newlines.
+	for _, detail := range details {
+		detailText := strings.TrimSpace(fmt.Sprintf("%v", detail))
+		if detailText == "" {
+			continue
+		}
+		md.WriteString(detailText + newline + newline)
+	}
+
+	return md.String()
 }
 
 // extractCustomTitle extracts the custom title from error hints.
@@ -336,7 +353,7 @@ func addExampleAndHintsSection(md *strings.Builder, err error, maxLineLength int
 	//   - Markdown stylesheets (renderer configuration)
 	//   - NOT by post-processing that removes newlines
 	if len(hints) > 0 {
-		md.WriteString(newline + newline + "## Hints" + newline + newline)
+		md.WriteString(newline + newline)
 		for _, hint := range hints {
 			// Don't wrap - let the markdown renderer handle it to preserve structure.
 			// The maxLineLength parameter is unused here.
@@ -344,6 +361,145 @@ func addExampleAndHintsSection(md *strings.Builder, err error, maxLineLength int
 			md.WriteString("💡 " + hint + newline + newline)
 		}
 	}
+}
+
+func renderMarkdownSections(sections markdownSections, config FormatterConfig, useColor bool) (string, bool) {
+	var out strings.Builder
+
+	if !appendRenderedMarkdownSection(&out, sections.errorMarkdown, config.MaxLineLength, useColor) {
+		return "", false
+	}
+
+	if strings.TrimSpace(sections.explanationMarkdown) != "" {
+		renderedExplanation, ok := renderMarkdown(sections.explanationMarkdown, config.MaxLineLength)
+		if !ok {
+			return "", false
+		}
+		if !useColor {
+			renderedExplanation = stripANSI(renderedExplanation)
+		}
+		appendRenderedSection(&out, renderExplanationCallout(renderedExplanation, config.MaxLineLength, useColor))
+	}
+
+	if strings.TrimSpace(sections.remainderMarkdown) != "" {
+		if !appendRenderedMarkdownSection(&out, sections.remainderMarkdown, config.MaxLineLength, useColor) {
+			return "", false
+		}
+	}
+
+	return strings.TrimRight(out.String(), " \t\n") + newline, true
+}
+
+func appendRenderedMarkdownSection(out *strings.Builder, md string, maxLineLength int, useColor bool) bool {
+	if strings.TrimSpace(md) == "" {
+		return true
+	}
+	rendered, ok := renderMarkdown(md, maxLineLength)
+	if !ok {
+		return false
+	}
+	if !useColor {
+		rendered = stripANSI(rendered)
+	}
+	appendRenderedSection(out, rendered)
+	return true
+}
+
+func appendRenderedSection(out *strings.Builder, section string) {
+	section = strings.Trim(section, "\n")
+	if strings.TrimSpace(section) == "" {
+		return
+	}
+	if out.Len() > 0 {
+		out.WriteString(newline + newline)
+	}
+	out.WriteString(section)
+}
+
+func renderExplanationCallout(rendered string, maxLineLength int, useColor bool) string {
+	rendered = strings.Trim(rendered, "\n")
+	if strings.TrimSpace(rendered) == "" {
+		return ""
+	}
+	if !useColor {
+		return rendered
+	}
+
+	lines := strings.Split(rendered, newline)
+	width := maxRenderedLineWidth(lines) + 2
+	if maxLineLength > 0 && width > maxLineLength {
+		width = maxLineLength
+	}
+	if width < 4 {
+		width = 4
+	}
+
+	var out strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			out.WriteString(newline)
+		}
+		color := interpolateHexColor(explanationGradientStart, explanationGradientEnd, gradientRatio(i, len(lines)))
+		style := lipgloss.NewStyle().
+			Background(lipgloss.Color(color)).
+			PaddingLeft(1).
+			PaddingRight(1).
+			Width(width)
+		out.WriteString(style.Render(line))
+	}
+	return out.String()
+}
+
+func maxRenderedLineWidth(lines []string) int {
+	maxWidth := 0
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > maxWidth {
+			maxWidth = width
+		}
+	}
+	return maxWidth
+}
+
+func gradientRatio(index int, total int) float64 {
+	if total <= 1 {
+		return 0
+	}
+	return float64(index) / float64(total-1)
+}
+
+func interpolateHexColor(start string, end string, ratio float64) string {
+	sr, sg, sb := parseHexColor(start)
+	er, eg, eb := parseHexColor(end)
+
+	r := interpolateColorChannel(sr, er, ratio)
+	g := interpolateColorChannel(sg, eg, ratio)
+	b := interpolateColorChannel(sb, eb, ratio)
+
+	return fmt.Sprintf("#%02X%02X%02X", r, g, b)
+}
+
+func interpolateColorChannel(start int, end int, ratio float64) int {
+	return start + int(math.Round(float64(end-start)*ratio))
+}
+
+func parseHexColor(hex string) (int, int, int) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) != hexColorLength {
+		return 0, 0, 0
+	}
+	r, err := strconv.ParseInt(hex[0:2], hexColorBase, 0)
+	if err != nil {
+		return 0, 0, 0
+	}
+	g, err := strconv.ParseInt(hex[2:4], hexColorBase, 0)
+	if err != nil {
+		return 0, 0, 0
+	}
+	b, err := strconv.ParseInt(hex[4:6], hexColorBase, 0)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return int(r), int(g), int(b)
 }
 
 // addCommandOutputSection adds the command output section for ExecError with stderr.

--- a/errors/formatter_test.go
+++ b/errors/formatter_test.go
@@ -69,6 +69,20 @@ func TestFormat_ErrorWithHint(t *testing.T) {
 	assert.Contains(t, result, "Try running --help")
 }
 
+func TestFormat_ErrorWithMultilineHintList(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	err := Build(errors.New("test error")).
+		WithHint("Available workflows in test.yaml:\n\n- `workflow-a`\n- `workflow-b`\n").
+		Err()
+
+	result := Format(err, DefaultFormatterConfig())
+
+	assert.Contains(t, result, "💡 Available workflows in test.yaml:")
+	assert.Contains(t, result, "• workflow-a")
+	assert.Contains(t, result, "• workflow-b")
+	assert.NotContains(t, result, "Available workflows in test.yaml: -")
+}
+
 func TestFormat_ErrorWithMultipleHints(t *testing.T) {
 	err := errors.WithHint(
 		errors.WithHint(

--- a/errors/formatter_test.go
+++ b/errors/formatter_test.go
@@ -18,7 +18,7 @@ func TestDefaultFormatterConfig(t *testing.T) {
 	config := DefaultFormatterConfig()
 
 	assert.False(t, config.Verbose)
-	assert.Equal(t, 80, config.MaxLineLength)
+	assert.Zero(t, config.MaxLineLength)
 }
 
 func TestFormat_NilError(t *testing.T) {
@@ -822,6 +822,102 @@ func TestFormat_MaxLineLength_ControlsWrapping(t *testing.T) {
 
 	// Narrow config should produce more line breaks than wide config.
 	assert.Greater(t, narrowLines, wideLines, "Narrow MaxLineLength should produce more line breaks")
+}
+
+func TestResolveFormatterWidth(t *testing.T) {
+	originalConfig := atmosConfig
+	originalDetectWidth := detectFormatterTerminalWidth
+	defer func() {
+		atmosConfig = originalConfig
+		detectFormatterTerminalWidth = originalDetectWidth
+	}()
+	detectFormatterTerminalWidth = func() int {
+		return 0
+	}
+
+	tests := []struct {
+		name          string
+		config        FormatterConfig
+		atmosConfig   *schema.AtmosConfiguration
+		expectedWidth int
+	}{
+		{
+			name: "explicit max line length wins",
+			config: FormatterConfig{
+				MaxLineLength: 72,
+			},
+			atmosConfig: &schema.AtmosConfiguration{
+				Settings: schema.AtmosSettings{
+					Terminal: schema.Terminal{MaxWidth: 160},
+				},
+			},
+			expectedWidth: 72,
+		},
+		{
+			name:   "terminal max width config sets auto width",
+			config: FormatterConfig{},
+			atmosConfig: &schema.AtmosConfiguration{
+				Settings: schema.AtmosSettings{
+					Terminal: schema.Terminal{MaxWidth: 160},
+				},
+			},
+			expectedWidth: 160,
+		},
+		{
+			name:   "deprecated docs max width config is fallback",
+			config: FormatterConfig{},
+			atmosConfig: &schema.AtmosConfiguration{
+				Settings: schema.AtmosSettings{
+					Docs: schema.Docs{MaxWidth: 140},
+				},
+			},
+			expectedWidth: 140,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atmosConfig = tt.atmosConfig
+
+			assert.Equal(t, tt.expectedWidth, resolveFormatterWidth(tt.config))
+		})
+	}
+}
+
+func TestResolveFormatterWidth_CapsConfiguredWidthToDetectedTerminal(t *testing.T) {
+	originalConfig := atmosConfig
+	originalDetectWidth := detectFormatterTerminalWidth
+	defer func() {
+		atmosConfig = originalConfig
+		detectFormatterTerminalWidth = originalDetectWidth
+	}()
+
+	atmosConfig = &schema.AtmosConfiguration{
+		Settings: schema.AtmosSettings{
+			Terminal: schema.Terminal{MaxWidth: 160},
+		},
+	}
+	detectFormatterTerminalWidth = func() int {
+		return 100
+	}
+
+	assert.Equal(t, 100, resolveFormatterWidth(DefaultFormatterConfig()))
+}
+
+func TestResolveFormatterWidth_FallsBackToDefaultMarkdownWidth(t *testing.T) {
+	originalConfig := atmosConfig
+	originalDetectWidth := detectFormatterTerminalWidth
+	defer func() {
+		atmosConfig = originalConfig
+		detectFormatterTerminalWidth = originalDetectWidth
+	}()
+
+	atmosConfig = nil
+	detectFormatterTerminalWidth = func() int {
+		return 0
+	}
+
+	assert.Equal(t, DefaultMarkdownWidth, resolveFormatterWidth(DefaultFormatterConfig()))
 }
 
 func TestFormat_UseColor_ThreadedThrough(t *testing.T) {

--- a/errors/formatter_test.go
+++ b/errors/formatter_test.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/cockroachdb/errors"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -340,9 +342,38 @@ func TestFormat_WithExplanation(t *testing.T) {
 	assert.Contains(t, result, "# Error")
 	// Should contain the error message.
 	assert.Contains(t, result, "test error")
-	// Should contain the Explanation section.
-	assert.Contains(t, result, "## Explanation")
+	// Should contain the explanation content without the old heading.
+	assert.NotContains(t, result, "## Explanation")
 	assert.Contains(t, result, "This is a detailed explanation")
+}
+
+func TestFormat_WithExplanationNoColorIsPlaintext(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	err := Build(errors.New("test error")).
+		WithExplanation("The selected stack prod was not found.").
+		Err()
+
+	result := Format(err, DefaultFormatterConfig())
+
+	assert.NotContains(t, result, "\x1b[")
+	assert.NotContains(t, result, "## Explanation")
+	assert.Contains(t, result, "The selected stack prod was not found.")
+}
+
+func TestRenderExplanationCallout_ColorAddsGradientBackground(t *testing.T) {
+	previousProfile := lipgloss.DefaultRenderer().ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+	})
+
+	callout := renderExplanationCallout("first line\nsecond line", 80, true)
+
+	assert.Contains(t, callout, "\x1b[")
+	assert.Contains(t, callout, "first line")
+	assert.Contains(t, callout, "second line")
+	assert.Contains(t, callout, "48;2;51;32;79")
+	assert.Contains(t, callout, "48;2;18;60;92")
 }
 
 func TestFormat_WithExample(t *testing.T) {
@@ -387,7 +418,7 @@ func TestFormat_WithAllSections(t *testing.T) {
 	assert.Contains(t, result, "test error")
 
 	// Section 2: Explanation.
-	assert.Contains(t, result, "## Explanation")
+	assert.NotContains(t, result, "## Explanation")
 	assert.Contains(t, result, "Detailed explanation")
 
 	// Section 3: Example.
@@ -395,7 +426,7 @@ func TestFormat_WithAllSections(t *testing.T) {
 	assert.Contains(t, result, "test: example")
 
 	// Section 4: Hints.
-	assert.Contains(t, result, "## Hints")
+	assert.NotContains(t, result, "## Hints")
 	assert.Contains(t, result, "💡 First hint")
 	assert.Contains(t, result, "💡 Second hint")
 
@@ -424,11 +455,11 @@ func TestFormat_SectionOrder(t *testing.T) {
 
 	result := Format(err, config)
 
-	// Find positions of each section header.
+	// Find positions of each section.
 	errorPos := strings.Index(result, "# Error")
-	explanationPos := strings.Index(result, "## Explanation")
+	explanationPos := strings.Index(result, "explanation")
 	examplePos := strings.Index(result, "## Example")
-	hintsPos := strings.Index(result, "## Hints")
+	hintsPos := strings.Index(result, "💡 hint")
 	contextPos := strings.Index(result, "## Context")
 	stackPos := strings.Index(result, "## Stack Trace")
 
@@ -452,13 +483,13 @@ func TestFormat_ExampleAndHintsSeparation(t *testing.T) {
 
 	result := Format(err, config)
 
-	// Should have separate Example and Hints sections.
+	// Should keep example content separate from standalone hints.
 	assert.Contains(t, result, "## Example")
-	assert.Contains(t, result, "## Hints")
+	assert.NotContains(t, result, "## Hints")
 
 	// Example section should not have hint emoji.
 	exampleStart := strings.Index(result, "## Example")
-	hintsStart := strings.Index(result, "## Hints")
+	hintsStart := strings.Index(result, "💡 Regular hint")
 	exampleSection := result[exampleStart:hintsStart]
 	assert.NotContains(t, exampleSection, "💡", "Example section should not contain hint emoji")
 
@@ -481,9 +512,10 @@ func TestFormat_NoExplanation_NoSection(t *testing.T) {
 
 	// Should NOT have Explanation section if no explanation provided.
 	assert.NotContains(t, result, "## Explanation")
-	// But should have Error header and Hints.
+	// But should have Error header and standalone hints.
 	assert.Contains(t, result, "# Error")
-	assert.Contains(t, result, "## Hints")
+	assert.NotContains(t, result, "## Hints")
+	assert.Contains(t, result, "💡 Just a hint")
 }
 
 func TestFormat_NoExample_NoSection(t *testing.T) {
@@ -511,9 +543,9 @@ func TestFormat_NoHints_NoSection(t *testing.T) {
 
 	// Should NOT have Hints section if no hints provided.
 	assert.NotContains(t, result, "## Hints")
-	// But should have Error and Explanation.
+	// But should have Error and explanation content.
 	assert.Contains(t, result, "# Error")
-	assert.Contains(t, result, "## Explanation")
+	assert.Contains(t, result, "Just an explanation")
 }
 
 func TestFormat_ContextMarkdownTable(t *testing.T) {
@@ -658,23 +690,20 @@ func TestFormat_HintsInSection_NotInErrorMessage(t *testing.T) {
 	// Should have single H1.
 	assert.Contains(t, result, "# Component Error")
 
-	// Should have Hints section.
-	assert.Contains(t, result, "## Hints")
-
-	// Hints should be in Hints section, not in error message.
+	// Hints should be standalone action lines, not in the error message.
 	errorHeaderIdx := strings.Index(result, "# Component Error")
-	hintsHeaderIdx := strings.Index(result, "## Hints")
-	assert.Greater(t, hintsHeaderIdx, errorHeaderIdx, "Hints section should come after error header")
+	firstHintIdx := strings.Index(result, "💡")
+	assert.Greater(t, firstHintIdx, errorHeaderIdx, "Hints should come after error header")
 
-	// Extract the section between error header and hints header.
-	errorSection := result[errorHeaderIdx:hintsHeaderIdx]
+	// Extract the section between error header and first hint.
+	errorSection := result[errorHeaderIdx:firstHintIdx]
 
-	// Error section should NOT contain hint text (hints should only be in Hints section).
+	// Error section should NOT contain hint text.
 	assert.NotContains(t, errorSection, "Check that all the context variables")
 	assert.NotContains(t, errorSection, "Are the component and stack names correct")
 
-	// But hints section should contain them.
-	hintsSection := result[hintsHeaderIdx:]
+	// But standalone hints should contain them.
+	hintsSection := result[firstHintIdx:]
 	assert.Contains(t, hintsSection, "💡")
 	assert.Contains(t, hintsSection, "Check that all the context variables")
 	assert.Contains(t, hintsSection, "Are the component and stack names correct")
@@ -737,8 +766,8 @@ func TestFormat_WithTitle_OverridesDefault(t *testing.T) {
 	// Should NOT use default title.
 	assert.NotContains(t, result, "# Error\n")
 
-	// Should still have explanation section.
-	assert.Contains(t, result, "## Explanation")
+	// Should still have explanation content without the old heading.
+	assert.NotContains(t, result, "## Explanation")
 	assert.Contains(t, result, "database server is unreachable")
 }
 
@@ -820,7 +849,7 @@ func TestFormat_ExplanationWithErrorBuilder(t *testing.T) {
 		config := DefaultFormatterConfig()
 		result := Format(err, config)
 
-		assert.Contains(t, result, "## Explanation")
+		assert.NotContains(t, result, "## Explanation")
 		assert.Contains(t, result, "Failed to vendor 1 of 3 components: my-vpc")
 		assert.ErrorIs(t, err, sentinel)
 	})

--- a/errors/formatter_test.go
+++ b/errors/formatter_test.go
@@ -376,6 +376,13 @@ func TestRenderExplanationCallout_ColorAddsGradientBackground(t *testing.T) {
 	assert.Contains(t, callout, "48;2;18;60;92")
 }
 
+func TestExplanationMarkdownLineLength_ReservesPaddingForColor(t *testing.T) {
+	assert.Equal(t, 78, explanationMarkdownLineLength(80, true))
+	assert.Equal(t, 80, explanationMarkdownLineLength(80, false))
+	assert.Equal(t, 2, explanationMarkdownLineLength(2, true))
+	assert.Equal(t, 0, explanationMarkdownLineLength(0, true))
+}
+
 func TestFormat_WithExample(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	exampleContent := "```yaml\nworkflows:\n  deploy:\n    steps:\n      - command: terraform apply\n```"

--- a/internal/exec/vendor_model_test.go
+++ b/internal/exec/vendor_model_test.go
@@ -22,7 +22,7 @@ func TestVendorFailureError(t *testing.T) {
 		config := errUtils.DefaultFormatterConfig()
 		formatted := errUtils.Format(err, config)
 
-		assert.Contains(t, formatted, "## Explanation")
+		assert.NotContains(t, formatted, "## Explanation")
 		assert.Contains(t, formatted, "my-vpc")
 		assert.Contains(t, formatted, "Failed to vendor 1 of 3 components")
 	})
@@ -36,7 +36,7 @@ func TestVendorFailureError(t *testing.T) {
 		config := errUtils.DefaultFormatterConfig()
 		formatted := errUtils.Format(err, config)
 
-		assert.Contains(t, formatted, "## Explanation")
+		assert.NotContains(t, formatted, "## Explanation")
 		assert.Contains(t, formatted, "my-vpc")
 		assert.Contains(t, formatted, "my-rds")
 		assert.Contains(t, formatted, "my-s3")

--- a/internal/exec/workflow.go
+++ b/internal/exec/workflow.go
@@ -77,7 +77,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 			switch {
 			case len(matches) == 0:
 				return errUtils.Build(errUtils.ErrWorkflowNoWorkflow).
-					WithHintf("No workflow found with name `%s`", workflowName).
+					WithExplanationf("No workflow found with name `%s`", workflowName).
 					WithHint("Use 'atmos describe workflows' to see all available workflows").
 					WithExitCode(1).
 					Err()
@@ -95,8 +95,8 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 					// Sort for deterministic output (important for tests and snapshots).
 					sort.Strings(fileList)
 					return errUtils.Build(errUtils.ErrWorkflowNoWorkflow).
-						WithHintf("Multiple workflow files contain workflow `%s`", workflowName).
-						WithHintf("Matching files: %s", strings.Join(fileList, ", ")).
+						WithExplanationf("Multiple workflow files contain workflow `%s`", workflowName).
+						WithExplanationf("Matching files: %s", strings.Join(fileList, ", ")).
 						WithHintf("Use --file flag to specify which one: atmos workflow %s --file <file>", workflowName).
 						WithExitCode(1).
 						Err()
@@ -146,7 +146,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 
 	if !u.FileExists(workflowPath) {
 		return errUtils.Build(errUtils.ErrWorkflowFileNotFound).
-			WithHintf("The workflow manifest file `%s` does not exist", filepath.ToSlash(workflowPath)).
+			WithExplanationf("The workflow manifest file `%s` does not exist", filepath.ToSlash(workflowPath)).
 			WithExitCode(1).
 			Err()
 	}
@@ -184,8 +184,8 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 		sort.Strings(validWorkflows)
 
 		return errUtils.Build(errUtils.ErrWorkflowNoWorkflow).
-			WithHintf("No workflow exists with name `%s`", workflowName).
-			WithHintf("Available workflows in %s: %s", filepath.Base(workflowPath), u.FormatList(validWorkflows)).
+			WithExplanationf("No workflow exists with name `%s`", workflowName).
+			WithExplanationf("Available workflows in %s: %s", filepath.Base(workflowPath), u.FormatList(validWorkflows)).
 			WithExitCode(1).
 			Err()
 	} else {

--- a/internal/exec/workflow.go
+++ b/internal/exec/workflow.go
@@ -185,7 +185,7 @@ func ExecuteWorkflowCmd(cmd *cobra.Command, args []string) error {
 
 		return errUtils.Build(errUtils.ErrWorkflowNoWorkflow).
 			WithExplanationf("No workflow exists with name `%s`", workflowName).
-			WithExplanationf("Available workflows in %s: %s", filepath.Base(workflowPath), u.FormatList(validWorkflows)).
+			WithHintf("Available workflows in %s:\n\n%s", filepath.Base(workflowPath), u.FormatList(validWorkflows)).
 			WithExitCode(1).
 			Err()
 	} else {

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -653,7 +653,7 @@ func ExecuteWorkflow(
 			if !stepPkg.IsExtendedStepType(commandType) {
 				return errUtils.Build(errUtils.ErrInvalidWorkflowStepType).
 					WithTitle(WorkflowErrTitle).
-					WithHintf("Step type '%s' is not supported", commandType).
+					WithExplanationf("Step type '%s' is not supported", commandType).
 					WithHint("Each step must specify a valid type: 'atmos', 'shell', 'exec', or an interactive type like 'input', 'confirm', 'choose'").
 					WithExitCode(1).
 					Err()

--- a/internal/tui/templates/base_template.go
+++ b/internal/tui/templates/base_template.go
@@ -17,12 +17,18 @@ const (
 	Footer
 )
 
+const formatCommandsTemplateEnd = `"}}{{end}}`
+
 func GenerateFromBaseTemplate(parts []HelpTemplateSections) string {
 	template := ""
 	for _, value := range parts {
 		template += getSection(value)
 	}
 	return template + "\n"
+}
+
+func formatCommandsTemplate(listType string) string {
+	return `{{formatCommands .Commands "` + listType + formatCommandsTemplateEnd
 }
 
 func getSection(section HelpTemplateSections) string {
@@ -36,7 +42,7 @@ func getSection(section HelpTemplateSections) string {
 
 {{HeadingStyle "Additional help topics:"}}
 
-{{formatCommands .Commands "additionalHelpTopics"}}{{end}}`
+` + formatCommandsTemplate(commandListTypeAdditionalHelpTopics)
 	case Aliases:
 		return `{{if gt (len .Aliases) 0}}
 
@@ -48,21 +54,21 @@ func getSection(section HelpTemplateSections) string {
 
 {{HeadingStyle "Subcommand Aliases:"}}
 
-{{formatCommands .Commands "subcommandAliases"}}{{end}}`
+` + formatCommandsTemplate(commandListTypeSubcommandAliases)
 	case AvailableCommands:
-		return `{{if (hasCommands .Commands "builtInCommands")}}
+		return `{{if (hasCommands .Commands "` + commandListTypeBuiltInCommands + `")}}
 
 
 {{HeadingStyle "BUILT-IN COMMANDS"}}
 
-{{formatCommands .Commands "builtInCommands"}}{{end}}`
+` + formatCommandsTemplate(commandListTypeBuiltInCommands)
 	case CustomCommands:
-		return `{{if (hasCommands .Commands "customCommands")}}
+		return `{{if (hasCommands .Commands "` + commandListTypeCustomCommands + `")}}
 
 
 {{HeadingStyle "CUSTOM COMMANDS"}}
 
-{{formatCommands .Commands "customCommands"}}{{end}}`
+` + formatCommandsTemplate(commandListTypeCustomCommands)
 	case Examples:
 		return `{{if .HasExample}}
 
@@ -88,7 +94,7 @@ func getSection(section HelpTemplateSections) string {
 
 {{HeadingStyle "Native "}}{{HeadingStyle .Use}}{{HeadingStyle " Commands:"}}
 
-{{formatCommands .Commands "native"}}{{end}}`
+` + formatCommandsTemplate(commandListTypeNative)
 	case Usage:
 		return `
 {{HeadingStyle "Usage:"}}

--- a/internal/tui/templates/base_template.go
+++ b/internal/tui/templates/base_template.go
@@ -9,6 +9,7 @@ const (
 	SubCommandAliases
 	Examples
 	AvailableCommands
+	CustomCommands
 	Flags
 	GlobalFlags
 	AdditionalHelpTopics
@@ -49,12 +50,19 @@ func getSection(section HelpTemplateSections) string {
 
 {{formatCommands .Commands "subcommandAliases"}}{{end}}`
 	case AvailableCommands:
-		return `{{if .HasAvailableSubCommands}}
+		return `{{if (hasCommands .Commands "builtInCommands")}}
 
 
-{{HeadingStyle "Available Commands:"}}
+{{HeadingStyle "BUILT-IN COMMANDS"}}
 
-{{formatCommands .Commands "availableCommands"}}{{end}}`
+{{formatCommands .Commands "builtInCommands"}}{{end}}`
+	case CustomCommands:
+		return `{{if (hasCommands .Commands "customCommands")}}
+
+
+{{HeadingStyle "CUSTOM COMMANDS"}}
+
+{{formatCommands .Commands "customCommands"}}{{end}}`
 	case Examples:
 		return `{{if .HasExample}}
 

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -20,6 +20,14 @@ import (
 
 const helpCommandName = "help"
 
+const (
+	commandListTypeAdditionalHelpTopics = "additionalHelpTopics"
+	commandListTypeBuiltInCommands      = "builtInCommands"
+	commandListTypeCustomCommands       = "customCommands"
+	commandListTypeNative               = "native"
+	commandListTypeSubcommandAliases    = "subcommandAliases"
+)
+
 // Templater handles the generation and management of command usage templates.
 type Templater struct {
 	UsageTemplate string
@@ -154,7 +162,7 @@ func renderMarkdown(example string) string {
 }
 
 func hasCommands(cmds []*cobra.Command, listType string) bool {
-	cmds = filterCommands(cmds, listType == "subcommandAliases")
+	cmds = filterCommands(cmds, listType == commandListTypeSubcommandAliases)
 	for _, cmd := range cmds {
 		if shouldIncludeCommand(cmd, listType) {
 			return true
@@ -169,9 +177,9 @@ func shouldIncludeCommand(cmd *cobra.Command, listType string) bool {
 	}
 
 	switch listType {
-	case "builtInCommands":
+	case commandListTypeBuiltInCommands:
 		return !isNativeCommand(cmd) && !isConfigAlias(cmd) && !isCustomCommand(cmd)
-	case "customCommands":
+	case commandListTypeCustomCommands:
 		return !isConfigAlias(cmd) && isCustomCommand(cmd)
 	default:
 		return true
@@ -188,13 +196,13 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 	availableCmds := make([]*cobra.Command, 0)
 
 	// First pass: collect available commands and find max length
-	cmds = filterCommands(cmds, listType == "subcommandAliases")
+	cmds = filterCommands(cmds, listType == commandListTypeSubcommandAliases)
 	for _, cmd := range cmds {
 		if v, ok := customHelpShortMessage[cmd.Name()]; ok {
 			cmd.Short = v
 		}
 		switch listType {
-		case "additionalHelpTopics":
+		case commandListTypeAdditionalHelpTopics:
 			if cmd.IsAdditionalHelpTopicCommand() {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
@@ -202,7 +210,7 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 				}
 				continue
 			}
-		case "native":
+		case commandListTypeNative:
 			if isNativeCommand(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
@@ -210,7 +218,7 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 				}
 				continue
 			}
-		case "customCommands":
+		case commandListTypeCustomCommands:
 			if !isConfigAlias(cmd) && isCustomCommand(cmd) && isCommandVisible(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
@@ -218,7 +226,7 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 				}
 				continue
 			}
-		case "builtInCommands":
+		case commandListTypeBuiltInCommands:
 			if !isNativeCommand(cmd) && !isConfigAlias(cmd) && !isCustomCommand(cmd) && isCommandVisible(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
@@ -226,7 +234,7 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 				}
 				continue
 			}
-		case "subcommandAliases":
+		case commandListTypeSubcommandAliases:
 			// if cmd.Annotations["nativeCommand"] == "true" {
 			// 	continue
 			// }

--- a/internal/tui/templates/templater.go
+++ b/internal/tui/templates/templater.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cloudposse/atmos/pkg/ui/theme"
 )
 
+const helpCommandName = "help"
+
 // Templater handles the generation and management of command usage templates.
 type Templater struct {
 	UsageTemplate string
@@ -52,6 +54,13 @@ var customHelpShortMessage = map[string]string{
 	"help": "Display help information for Atmos commands",
 }
 
+const (
+	annotationConfigAlias   = "configAlias"
+	annotationCustomCommand = "customCommand"
+	annotationNativeCommand = "nativeCommand"
+	annotationValueTrue     = "true"
+)
+
 // filterCommands returns only commands or aliases based on returnOnlyAliases boolean
 func filterCommands(commands []*cobra.Command, returnOnlyAliases bool) []*cobra.Command {
 	if !returnOnlyAliases {
@@ -74,6 +83,18 @@ func filterCommands(commands []*cobra.Command, returnOnlyAliases bool) []*cobra.
 		}
 	}
 	return filtered
+}
+
+func isConfigAlias(cmd *cobra.Command) bool {
+	return cmd.Annotations != nil && cmd.Annotations[annotationConfigAlias] != ""
+}
+
+func isCustomCommand(cmd *cobra.Command) bool {
+	return cmd.Annotations != nil && cmd.Annotations[annotationCustomCommand] == annotationValueTrue
+}
+
+func isNativeCommand(cmd *cobra.Command) bool {
+	return cmd.Annotations != nil && cmd.Annotations[annotationNativeCommand] == annotationValueTrue
 }
 
 func renderHelpMarkdown(cmd *cobra.Command) string {
@@ -100,7 +121,7 @@ func renderHelpMarkdown(cmd *cobra.Command) string {
 
 func isNativeCommandsAvailable(cmds []*cobra.Command) bool {
 	for _, cmd := range cmds {
-		if cmd.Annotations["nativeCommand"] == "true" {
+		if isNativeCommand(cmd) {
 			return true
 		}
 	}
@@ -132,6 +153,35 @@ func renderMarkdown(example string) string {
 	return ""
 }
 
+func hasCommands(cmds []*cobra.Command, listType string) bool {
+	cmds = filterCommands(cmds, listType == "subcommandAliases")
+	for _, cmd := range cmds {
+		if shouldIncludeCommand(cmd, listType) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldIncludeCommand(cmd *cobra.Command, listType string) bool {
+	if !isCommandVisible(cmd) {
+		return false
+	}
+
+	switch listType {
+	case "builtInCommands":
+		return !isNativeCommand(cmd) && !isConfigAlias(cmd) && !isCustomCommand(cmd)
+	case "customCommands":
+		return !isConfigAlias(cmd) && isCustomCommand(cmd)
+	default:
+		return true
+	}
+}
+
+func isCommandVisible(cmd *cobra.Command) bool {
+	return cmd.IsAvailableCommand() || cmd.Name() == helpCommandName
+}
+
 // formatCommands formats a slice of cobra commands with proper styling
 func formatCommands(cmds []*cobra.Command, listType string) string {
 	var maxLen int
@@ -153,7 +203,23 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 				continue
 			}
 		case "native":
-			if cmd.Annotations["nativeCommand"] == "true" {
+			if isNativeCommand(cmd) {
+				availableCmds = append(availableCmds, cmd)
+				if len(cmd.Name()) > maxLen {
+					maxLen = len(cmd.Name())
+				}
+				continue
+			}
+		case "customCommands":
+			if !isConfigAlias(cmd) && isCustomCommand(cmd) && isCommandVisible(cmd) {
+				availableCmds = append(availableCmds, cmd)
+				if len(cmd.Name()) > maxLen {
+					maxLen = len(cmd.Name())
+				}
+				continue
+			}
+		case "builtInCommands":
+			if !isNativeCommand(cmd) && !isConfigAlias(cmd) && !isCustomCommand(cmd) && isCommandVisible(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
 					maxLen = len(cmd.Name())
@@ -165,17 +231,17 @@ func formatCommands(cmds []*cobra.Command, listType string) string {
 			// 	continue
 			// }
 
-			if cmd.IsAvailableCommand() || cmd.Name() == "help" {
+			if isCommandVisible(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
 					maxLen = len(cmd.Name())
 				}
 			}
 		default:
-			if cmd.Annotations["nativeCommand"] == "true" {
+			if isNativeCommand(cmd) || isConfigAlias(cmd) || isCustomCommand(cmd) {
 				continue
 			}
-			if cmd.IsAvailableCommand() || cmd.Name() == "help" {
+			if isCommandVisible(cmd) {
 				availableCmds = append(availableCmds, cmd)
 				if len(cmd.Name()) > maxLen {
 					maxLen = len(cmd.Name())
@@ -220,6 +286,7 @@ func SetCustomUsageFunc(cmd *cobra.Command) error {
 			Usage,
 			Aliases,
 			AvailableCommands,
+			CustomCommands,
 			NativeCommands,
 			SubCommandAliases,
 			Flags,
@@ -233,6 +300,7 @@ func SetCustomUsageFunc(cmd *cobra.Command) error {
 	cmd.SetUsageTemplate(t.UsageTemplate)
 	cobra.AddTemplateFunc("isAliasesPresent", isAliasesPresent)
 	cobra.AddTemplateFunc("isNativeCommandsAvailable", isNativeCommandsAvailable)
+	cobra.AddTemplateFunc("hasCommands", hasCommands)
 	cobra.AddTemplateFunc("formatCommands", formatCommands)
 	cobra.AddTemplateFunc("renderMarkdown", renderMarkdown)
 	cobra.AddTemplateFunc("renderHelpMarkdown", renderHelpMarkdown)

--- a/internal/tui/templates/templater_test.go
+++ b/internal/tui/templates/templater_test.go
@@ -4,9 +4,171 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
+
+func runnableCommand(use, short string, annotations map[string]string) *cobra.Command {
+	return &cobra.Command{
+		Use:         use,
+		Short:       short,
+		Annotations: annotations,
+		Run: func(cmd *cobra.Command, args []string) {
+		},
+	}
+}
+
+func TestCommandAnnotationHelpers(t *testing.T) {
+	assert.False(t, isConfigAlias(&cobra.Command{}))
+	assert.True(t, isConfigAlias(&cobra.Command{
+		Annotations: map[string]string{annotationConfigAlias: "terraform"},
+	}))
+
+	assert.False(t, isCustomCommand(&cobra.Command{
+		Annotations: map[string]string{annotationCustomCommand: "false"},
+	}))
+	assert.True(t, isCustomCommand(&cobra.Command{
+		Annotations: map[string]string{annotationCustomCommand: annotationValueTrue},
+	}))
+
+	assert.False(t, isNativeCommand(&cobra.Command{
+		Annotations: map[string]string{annotationNativeCommand: "false"},
+	}))
+	assert.True(t, isNativeCommand(&cobra.Command{
+		Annotations: map[string]string{annotationNativeCommand: annotationValueTrue},
+	}))
+}
+
+func TestHasCommandsBySection(t *testing.T) {
+	commands := []*cobra.Command{
+		runnableCommand("builtin", "Built in", nil),
+		runnableCommand("custom", "Custom", map[string]string{
+			annotationCustomCommand: annotationValueTrue,
+		}),
+		runnableCommand("native", "Native", map[string]string{
+			annotationNativeCommand: annotationValueTrue,
+		}),
+		runnableCommand("alias", "Alias", map[string]string{
+			annotationConfigAlias: "terraform",
+		}),
+	}
+
+	assert.True(t, hasCommands(commands, "builtInCommands"))
+	assert.True(t, hasCommands(commands, "customCommands"))
+	assert.True(t, hasCommands(commands, "native"))
+	assert.True(t, hasCommands(commands, ""))
+	assert.False(t, hasCommands([]*cobra.Command{
+		runnableCommand("alias", "Alias", map[string]string{annotationConfigAlias: "terraform"}),
+	}, "builtInCommands"))
+	assert.False(t, hasCommands([]*cobra.Command{
+		runnableCommand("alias", "Alias", map[string]string{
+			annotationConfigAlias:   "terraform",
+			annotationCustomCommand: annotationValueTrue,
+		}),
+	}, "customCommands"))
+}
+
+func TestHasCommandsIncludesHelpCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		{Use: helpCommandName, Short: "Cobra help command"},
+	}
+
+	assert.True(t, hasCommands(commands, "builtInCommands"))
+}
+
+func TestFilterCommandsReturnsAliasesOnlyWhenRequested(t *testing.T) {
+	commands := []*cobra.Command{
+		runnableCommand("terraform", "Terraform", nil),
+		runnableCommand("plan", "Plan", nil),
+	}
+	commands[0].Aliases = []string{"tf", "plan"}
+
+	filtered := filterCommands(commands, false)
+	assert.Equal(t, commands, filtered)
+
+	aliases := filterCommands(commands, true)
+	assert.Len(t, aliases, 1)
+	assert.Equal(t, "tf", aliases[0].Use)
+	assert.Equal(t, `Alias of "terraform" command`, aliases[0].Short)
+}
+
+func TestCommandAvailabilityHelpers(t *testing.T) {
+	commands := []*cobra.Command{
+		runnableCommand("terraform", "Terraform", map[string]string{
+			annotationNativeCommand: annotationValueTrue,
+		}),
+		runnableCommand("deploy", "Deploy", nil),
+	}
+	commands[1].Aliases = []string{"dep"}
+
+	assert.True(t, isNativeCommandsAvailable(commands))
+	assert.True(t, isAliasesPresent(commands))
+
+	assert.False(t, isNativeCommandsAvailable([]*cobra.Command{
+		runnableCommand("deploy", "Deploy", nil),
+	}))
+	assert.False(t, isAliasesPresent([]*cobra.Command{
+		runnableCommand("deploy", "Deploy", nil),
+	}))
+}
+
+func TestFormatCommandsSeparatesBuiltInCustomAndNativeCommands(t *testing.T) {
+	commands := []*cobra.Command{
+		runnableCommand("builtin", "Built in command", nil),
+		runnableCommand("custom", "Custom command", map[string]string{
+			annotationCustomCommand: annotationValueTrue,
+		}),
+		runnableCommand("native", "Native command", map[string]string{
+			annotationNativeCommand: annotationValueTrue,
+		}),
+		runnableCommand("alias", "Config alias", map[string]string{
+			annotationConfigAlias: "terraform",
+		}),
+	}
+
+	builtIns := formatCommands(commands, "builtInCommands")
+	assert.Contains(t, builtIns, "builtin")
+	assert.NotContains(t, builtIns, "custom")
+	assert.NotContains(t, builtIns, "native")
+	assert.NotContains(t, builtIns, "alias")
+
+	custom := formatCommands(commands, "customCommands")
+	assert.Contains(t, custom, "custom")
+	assert.NotContains(t, custom, "builtin")
+	assert.NotContains(t, custom, "native")
+	assert.NotContains(t, custom, "alias")
+
+	native := formatCommands(commands, "native")
+	assert.Contains(t, native, "native")
+	assert.NotContains(t, native, "builtin")
+	assert.NotContains(t, native, "custom")
+	assert.NotContains(t, native, "alias")
+}
+
+func TestFormatCommandsSubcommandAliasesUsesAliasHelp(t *testing.T) {
+	command := runnableCommand("terraform", "Terraform", nil)
+	command.Aliases = []string{"tf"}
+
+	output := formatCommands([]*cobra.Command{command}, "subcommandAliases")
+
+	assert.Contains(t, output, "tf")
+	assert.Contains(t, output, `Alias of "terraform" command`)
+	assert.NotContains(t, output, "Terraform")
+}
+
+func TestSetCustomUsageFunc(t *testing.T) {
+	assert.ErrorIs(t, SetCustomUsageFunc(nil), errUtils.ErrCommandNil)
+
+	cmd := &cobra.Command{Use: "atmos", Short: "Atmos"}
+	err := SetCustomUsageFunc(cmd)
+
+	assert.NoError(t, err)
+	assert.Contains(t, cmd.UsageTemplate(), "CUSTOM COMMANDS")
+	assert.Contains(t, cmd.UsageTemplate(), `{{formatCommands .Commands "customCommands"}}`)
+}
 
 func TestWrappedFlagUsages_DoubleDashAtEnd(t *testing.T) {
 	// Create a new FlagSet with various flags

--- a/internal/tui/templates/templater_test.go
+++ b/internal/tui/templates/templater_test.go
@@ -56,19 +56,19 @@ func TestHasCommandsBySection(t *testing.T) {
 		}),
 	}
 
-	assert.True(t, hasCommands(commands, "builtInCommands"))
-	assert.True(t, hasCommands(commands, "customCommands"))
-	assert.True(t, hasCommands(commands, "native"))
+	assert.True(t, hasCommands(commands, commandListTypeBuiltInCommands))
+	assert.True(t, hasCommands(commands, commandListTypeCustomCommands))
+	assert.True(t, hasCommands(commands, commandListTypeNative))
 	assert.True(t, hasCommands(commands, ""))
 	assert.False(t, hasCommands([]*cobra.Command{
 		runnableCommand("alias", "Alias", map[string]string{annotationConfigAlias: "terraform"}),
-	}, "builtInCommands"))
+	}, commandListTypeBuiltInCommands))
 	assert.False(t, hasCommands([]*cobra.Command{
 		runnableCommand("alias", "Alias", map[string]string{
 			annotationConfigAlias:   "terraform",
 			annotationCustomCommand: annotationValueTrue,
 		}),
-	}, "customCommands"))
+	}, commandListTypeCustomCommands))
 }
 
 func TestHasCommandsIncludesHelpCommand(t *testing.T) {
@@ -76,7 +76,7 @@ func TestHasCommandsIncludesHelpCommand(t *testing.T) {
 		{Use: helpCommandName, Short: "Cobra help command"},
 	}
 
-	assert.True(t, hasCommands(commands, "builtInCommands"))
+	assert.True(t, hasCommands(commands, commandListTypeBuiltInCommands))
 }
 
 func TestFilterCommandsReturnsAliasesOnlyWhenRequested(t *testing.T) {
@@ -129,19 +129,19 @@ func TestFormatCommandsSeparatesBuiltInCustomAndNativeCommands(t *testing.T) {
 		}),
 	}
 
-	builtIns := formatCommands(commands, "builtInCommands")
+	builtIns := formatCommands(commands, commandListTypeBuiltInCommands)
 	assert.Contains(t, builtIns, "builtin")
 	assert.NotContains(t, builtIns, "custom")
 	assert.NotContains(t, builtIns, "native")
 	assert.NotContains(t, builtIns, "alias")
 
-	custom := formatCommands(commands, "customCommands")
+	custom := formatCommands(commands, commandListTypeCustomCommands)
 	assert.Contains(t, custom, "custom")
 	assert.NotContains(t, custom, "builtin")
 	assert.NotContains(t, custom, "native")
 	assert.NotContains(t, custom, "alias")
 
-	native := formatCommands(commands, "native")
+	native := formatCommands(commands, commandListTypeNative)
 	assert.Contains(t, native, "native")
 	assert.NotContains(t, native, "builtin")
 	assert.NotContains(t, native, "custom")
@@ -152,7 +152,7 @@ func TestFormatCommandsSubcommandAliasesUsesAliasHelp(t *testing.T) {
 	command := runnableCommand("terraform", "Terraform", nil)
 	command.Aliases = []string{"tf"}
 
-	output := formatCommands([]*cobra.Command{command}, "subcommandAliases")
+	output := formatCommands([]*cobra.Command{command}, commandListTypeSubcommandAliases)
 
 	assert.Contains(t, output, "tf")
 	assert.Contains(t, output, `Alias of "terraform" command`)

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func run() (exitCode int) {
 		if err != nil {
 			errUtils.CaptureError(err)
 			formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
-			_, _ = ioLayer.MaskWriter(os.Stderr).Write([]byte(formatted + "\n"))
+			_, _ = ioLayer.MaskWriter(os.Stderr).Write([]byte(strings.TrimRight(formatted, "\n") + "\n"))
 			return errUtils.GetExitCode(err)
 		}
 		return 0 // Exit normally after printing version.
@@ -104,7 +104,7 @@ func run() (exitCode int) {
 
 		// Format and print error using centralized formatter.
 		formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
-		_, _ = ioLayer.MaskWriter(os.Stderr).Write([]byte(formatted + "\n"))
+		_, _ = ioLayer.MaskWriter(os.Stderr).Write([]byte(strings.TrimRight(formatted, "\n") + "\n"))
 
 		// Extract and use the correct exit code.
 		exitCode := errUtils.GetExitCode(err)

--- a/pkg/ai/analyze/context.go
+++ b/pkg/ai/analyze/context.go
@@ -118,7 +118,7 @@ func (c *Context) RunAnalysis(cmdErr error) bool {
 	// Also append it to captured stderr so the AI sees the full error context.
 	if cmdErr != nil {
 		formatted := errUtils.Format(cmdErr, errUtils.DefaultFormatterConfig())
-		_, _ = iolib.MaskWriter(os.Stderr).Write([]byte(formatted + "\n"))
+		_, _ = iolib.MaskWriter(os.Stderr).Write([]byte(strings.TrimRight(formatted, "\n") + "\n"))
 
 		if stderrCaptured != "" {
 			stderrCaptured += "\n"

--- a/pkg/component/resolver.go
+++ b/pkg/component/resolver.go
@@ -72,7 +72,8 @@ func (r *Resolver) ResolveComponentFromPath(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPath")()
 
-	log.Debug("Resolving component from path",
+	log.Debug(
+		"Resolving component from path",
 		"path", path,
 		"stack", stack,
 		"expected_type", expectedComponentType,
@@ -89,7 +90,7 @@ func (r *Resolver) ResolveComponentFromPath(
 	// 2. Verify component type matches.
 	if componentInfo.ComponentType != expectedComponentType {
 		err := errUtils.Build(errUtils.ErrComponentTypeMismatch).
-			WithHintf("Path resolves to `%s` component but command expects `%s` component\nYou ran: `atmos %s <command> %s`\nThe path points to: `%s` component",
+			WithExplanationf("Path resolves to `%s` component but command expects `%s` component\nYou ran: `atmos %s <command> %s`\nThe path points to: `%s` component",
 				componentInfo.ComponentType, expectedComponentType, expectedComponentType, path, componentInfo.ComponentType).
 			WithHint("Run the correct command for this component type").
 			WithContext("path", path).
@@ -113,7 +114,8 @@ func (r *Resolver) ResolveComponentFromPath(
 		resolvedComponent = componentInfo.FullComponent
 	}
 
-	log.Debug("Successfully resolved component from path",
+	log.Debug(
+		"Successfully resolved component from path",
 		"path", path,
 		"component", resolvedComponent,
 		"type", componentInfo.ComponentType,
@@ -131,7 +133,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutTypeCheck(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPathWithoutTypeCheck")()
 
-	log.Debug("Resolving component from path (without type check)",
+	log.Debug(
+		"Resolving component from path (without type check)",
 		"path", path,
 		"stack", stack,
 	)
@@ -156,7 +159,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutTypeCheck(
 		resolvedComponent = componentInfo.FullComponent
 	}
 
-	log.Debug("Successfully resolved component from path (without type check)",
+	log.Debug(
+		"Successfully resolved component from path (without type check)",
 		"path", path,
 		ComponentKey, resolvedComponent,
 		"detected_type", componentInfo.ComponentType,
@@ -187,7 +191,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutValidation(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.ResolveComponentFromPathWithoutValidation")()
 
-	log.Debug("Resolving component from path (without validation)",
+	log.Debug(
+		"Resolving component from path (without validation)",
 		"path", path,
 		"expected_type", expectedComponentType,
 	)
@@ -215,7 +220,8 @@ func (r *Resolver) ResolveComponentFromPathWithoutValidation(
 		return "", err
 	}
 
-	log.Debug("Successfully resolved component from path (without validation)",
+	log.Debug(
+		"Successfully resolved component from path (without validation)",
 		"path", path,
 		"component", componentInfo.FullComponent,
 		"type", componentInfo.ComponentType,
@@ -238,7 +244,7 @@ func (r *Resolver) loadStackConfig(
 	if err != nil {
 		loadErr := errUtils.Build(errUtils.ErrStackNotFound).
 			WithCause(err).
-			WithHintf("Failed to load stack configurations: %s\n\nPath-based component resolution requires valid stack configuration", err.Error()).
+			WithExplanationf("Failed to load stack configurations: %s\n\nPath-based component resolution requires valid stack configuration", err.Error()).
 			WithHint("Run `atmos describe config` to see stack configuration paths\nVerify your stack manifests are in the configured stacks directory").
 			WithContext("stack", stack).
 			WithContext("component", componentName).
@@ -251,7 +257,7 @@ func (r *Resolver) loadStackConfig(
 	stackConfig, ok := stacksMap[stack]
 	if !ok {
 		notFoundErr := errUtils.Build(errUtils.ErrStackNotFound).
-			WithHintf("Stack `%s` not found", stack).
+			WithExplanationf("Stack `%s` not found", stack).
 			WithHint("Run `atmos list stacks` to see all available stacks\nVerify the stack name matches your stack manifest files").
 			WithContext("stack", stack).
 			WithContext("component", componentName).
@@ -380,7 +386,7 @@ func handleComponentMatches(
 // handleNoMatches returns an error when no component matches are found.
 func handleNoMatches(componentName, stack, componentType string) (string, error) {
 	err := errUtils.Build(errUtils.ErrComponentNotInStack).
-		WithHintf("Component `%s` not found in stack `%s`", componentName, stack).
+		WithExplanationf("Component `%s` not found in stack `%s`", componentName, stack).
 		WithHintf("Run `atmos list stacks --component %s` to see stacks containing this component\nRun `atmos list components --stack %s` to see components in this stack",
 			componentName, stack).
 		WithContext("component", componentName).
@@ -402,7 +408,8 @@ func handleMultipleMatches(matches []string, componentName, stack, componentType
 	}
 
 	// Interactive terminal - prompt user to select.
-	log.Debug("Multiple component matches found, prompting user for selection",
+	log.Debug(
+		"Multiple component matches found, prompting user for selection",
 		"matches", matches,
 		"component", componentName,
 		StackKey, stack,
@@ -415,14 +422,16 @@ func handleMultipleMatches(matches []string, componentName, stack, componentType
 			return "", errUtils.ErrUserAborted
 		}
 		// Other error - fall back to ambiguous path error.
-		log.Debug("Component selection failed, falling back to error",
+		log.Debug(
+			"Component selection failed, falling back to error",
 			"error", err.Error(),
 		)
 		return "", buildAmbiguousComponentError(matches, componentName, stack, componentType)
 	}
 
 	// User made a selection - return it.
-	log.Info("User selected component from interactive prompt",
+	log.Info(
+		"User selected component from interactive prompt",
 		"selected", selected,
 		"matches", matches,
 		StackKey, stack,
@@ -444,7 +453,7 @@ func buildAmbiguousComponentError(matches []string, componentName, stack, compon
 	exampleComponent := matches[0]
 
 	return errUtils.Build(errUtils.ErrAmbiguousComponentPath).
-		WithHintf("Path resolves to `%s` which is referenced by multiple components in stack `%s`\nMatching components: %s",
+		WithExplanationf("Path resolves to `%s` which is referenced by multiple components in stack `%s`\nMatching components: %s",
 			componentName, stack, matchesStr).
 		WithHintf("Use the exact component name instead of a path\nExample: `atmos %s <command> %s --stack %s`",
 			componentType, exampleComponent, stack).
@@ -497,7 +506,8 @@ func promptForComponentSelection(
 		return "", fmt.Errorf("component selection failed: %w", err)
 	}
 
-	log.Debug("User selected component",
+	log.Debug(
+		"User selected component",
 		"selected", selected,
 		"from_matches", matches,
 		StackKey, stack,
@@ -514,7 +524,8 @@ func (r *Resolver) validateComponentInStack(
 ) (string, error) {
 	defer perf.Track(atmosConfig, "component.validateComponentInStack")()
 
-	log.Debug("Validating component exists in stack",
+	log.Debug(
+		"Validating component exists in stack",
 		ComponentKey, componentName,
 		StackKey, stack,
 		TypeKey, componentType,
@@ -543,13 +554,15 @@ func (r *Resolver) validateComponentInStack(
 
 	// Log success.
 	if resolvedComponent == componentName {
-		log.Debug("Component validated successfully in stack (direct match)",
+		log.Debug(
+			"Component validated successfully in stack (direct match)",
 			ComponentKey, componentName,
 			StackKey, stack,
 			TypeKey, componentType,
 		)
 	} else {
-		log.Debug("Component validated successfully in stack (alias match)",
+		log.Debug(
+			"Component validated successfully in stack (alias match)",
 			"path_component", componentName,
 			"stack_key", resolvedComponent,
 			StackKey, stack,

--- a/pkg/component/resolver.go
+++ b/pkg/component/resolver.go
@@ -258,7 +258,7 @@ func (r *Resolver) loadStackConfig(
 	if !ok {
 		notFoundErr := errUtils.Build(errUtils.ErrStackNotFound).
 			WithExplanationf("Stack `%s` not found", stack).
-			WithHint("Run `atmos list stacks` to see all available stacks\nVerify the stack name matches your stack manifest files").
+			WithHint("Run `atmos list stacks` to see all available stacks.\nVerify the stack name matches your stack manifest files").
 			WithContext("stack", stack).
 			WithContext("component", componentName).
 			WithExitCode(2).
@@ -453,7 +453,7 @@ func buildAmbiguousComponentError(matches []string, componentName, stack, compon
 	exampleComponent := matches[0]
 
 	return errUtils.Build(errUtils.ErrAmbiguousComponentPath).
-		WithExplanationf("Path resolves to `%s` which is referenced by multiple components in stack `%s`\nMatching components: %s",
+		WithExplanationf("Path resolves to `%s` which is referenced by multiple components in stack `%s`\n\nMatching components: %s",
 			componentName, stack, matchesStr).
 		WithHintf("Use the exact component name instead of a path\nExample: `atmos %s <command> %s --stack %s`",
 			componentType, exampleComponent, stack).

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -109,7 +109,8 @@ func TestHandleGitHubAPIError_RateLimitHintBranches(t *testing.T) {
 		// Verify formatted output contains rate limit explanation.
 		formatted := errUtils.Format(err, errUtils.DefaultFormatterConfig())
 		assert.Contains(t, formatted, "Rate limit exceeded")
-		assert.Contains(t, formatted, "Hints")
+		assert.Contains(t, formatted, "Verify your token: gh auth status")
+		assert.Contains(t, formatted, "Try re-authenticating: gh auth login")
 	})
 
 	t.Run("rate limit without token includes auth hints", func(t *testing.T) {

--- a/pkg/helm/plugin/installer.go
+++ b/pkg/helm/plugin/installer.go
@@ -187,7 +187,7 @@ func (i *Installer) install(ctx context.Context, spec Spec) error {
 		return errUtils.Build(errUtils.ErrHelmPluginInstall).
 			WithCause(err).
 			WithExplanationf("Failed to install helm plugin %q from %s", spec.Name, spec.URL).
-			WithHintf("helm reported: %s", strings.TrimSpace(stderr)).
+			WithExplanationf("helm reported: %s", strings.TrimSpace(stderr)).
 			Err()
 	}
 	return nil
@@ -202,7 +202,7 @@ func (i *Installer) uninstall(ctx context.Context, name string) error {
 		return errUtils.Build(errUtils.ErrHelmPluginInstall).
 			WithCause(err).
 			WithExplanationf("Failed to uninstall helm plugin %q before reinstalling", name).
-			WithHintf("helm reported: %s", strings.TrimSpace(stderr)).
+			WithExplanationf("helm reported: %s", strings.TrimSpace(stderr)).
 			Err()
 	}
 	return nil
@@ -218,7 +218,7 @@ func (i *Installer) ListInstalled(ctx context.Context) (map[string]string, error
 		return nil, errUtils.Build(errUtils.ErrHelmPluginInstall).
 			WithCause(err).
 			WithExplanation("Failed to list installed helm plugins").
-			WithHintf("helm reported: %s", strings.TrimSpace(stderr)).
+			WithExplanationf("helm reported: %s", strings.TrimSpace(stderr)).
 			Err()
 	}
 	return parsePluginList(stdout), nil

--- a/pkg/utils/component_reverse_path_utils.go
+++ b/pkg/utils/component_reverse_path_utils.go
@@ -52,7 +52,8 @@ func ExtractComponentInfoFromPath(
 	for _, componentType := range componentTypes {
 		info, err := tryExtractComponentType(atmosConfig, absPath, componentType)
 		if err == nil {
-			log.Debug("Successfully extracted component info",
+			log.Debug(
+				"Successfully extracted component info",
 				"type", info.ComponentType,
 				"folder_prefix", info.FolderPrefix,
 				"component", info.ComponentName,
@@ -80,7 +81,7 @@ func validatePathIsNotConfigDirectory(atmosConfig *schema.AtmosConfiguration, ab
 		stacksBasePath = filepath.Clean(stacksBasePath)
 		if absPath == stacksBasePath || strings.HasPrefix(absPath, stacksBasePath+string(filepath.Separator)) {
 			return errUtils.Build(errUtils.ErrPathNotInComponentDir).
-				WithHintf("Path points to the stacks configuration directory, not a component:  \n%s\n\nStacks directory:  \n%s",
+				WithExplanationf("Path points to the stacks configuration directory, not a component:  \n%s\n\nStacks directory:  \n%s",
 					absPath, stacksBasePath).
 				WithHint("Components are located in component directories (terraform, helmfile, packer)  \nChange to a component directory and use `.` or provide a path within a component directory").
 				WithContext("path", absPath).
@@ -95,7 +96,7 @@ func validatePathIsNotConfigDirectory(atmosConfig *schema.AtmosConfiguration, ab
 		workflowsBasePath = filepath.Clean(workflowsBasePath)
 		if absPath == workflowsBasePath || strings.HasPrefix(absPath, workflowsBasePath+string(filepath.Separator)) {
 			return errUtils.Build(errUtils.ErrPathNotInComponentDir).
-				WithHintf("Path points to the workflows directory, not a component:  \n%s\n\nWorkflows directory:  \n%s",
+				WithExplanationf("Path points to the workflows directory, not a component:  \n%s\n\nWorkflows directory:  \n%s",
 					absPath, workflowsBasePath).
 				WithHint("Components are located in component directories (terraform, helmfile, packer)  \nChange to a component directory and use `.` or provide a path within a component directory").
 				WithContext("path", absPath).
@@ -146,7 +147,7 @@ func normalizePathForResolution(path string) (string, error) {
 		cwd, err := os.Getwd()
 		if err != nil {
 			pathErr := errUtils.Build(errUtils.ErrPathResolutionFailed).
-				WithHintf("Failed to determine current working directory: %s", err.Error()).
+				WithExplanationf("Failed to determine current working directory: %s", err.Error()).
 				WithHint("Verify you have read permissions in the current directory\nTry providing an absolute path instead of `.`").
 				WithContext("original_error", err.Error()).
 				WithExitCode(1).
@@ -161,7 +162,7 @@ func normalizePathForResolution(path string) (string, error) {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
 			pathErr := errUtils.Build(errUtils.ErrPathResolutionFailed).
-				WithHintf("Failed to resolve absolute path for: `%s`\n%s", path, err.Error()).
+				WithExplanationf("Failed to resolve absolute path for: `%s`\n%s", path, err.Error()).
 				WithHint("Verify the path is valid and accessible").
 				WithContext("path", path).
 				WithContext("original_error", err.Error()).
@@ -218,7 +219,7 @@ func resolveAndCleanBasePath(basePath string) (string, error) {
 // buildComponentBaseError creates a detailed error for when a path points to the component base directory.
 func buildComponentBaseError(absPath, basePath, componentType string) error {
 	return errUtils.Build(errUtils.ErrPathIsComponentBase).
-		WithHintf("Cannot resolve component: path points to component base directory\nPath: `%s`\nComponent base: `%s`", absPath, basePath).
+		WithExplanationf("Cannot resolve component: path points to component base directory\nPath: `%s`\nComponent base: `%s`", absPath, basePath).
 		WithHintf("Navigate into a specific component directory\nExample: `cd %s/vpc && atmos %s plan . --stack <stack>`",
 			filepath.Base(basePath), componentType).
 		WithContext("path", absPath).
@@ -236,7 +237,7 @@ func buildPathNotInComponentDirError(atmosConfig *schema.AtmosConfiguration, abs
 	}
 
 	return errUtils.Build(errUtils.ErrPathNotInComponentDir).
-		WithHintf("Path `%s` is not within any configured component directories\n\nConfigured component base paths:\n  - Terraform: `%s`\n  - Helmfile: `%s`\n  - Packer: `%s`",
+		WithExplanationf("Path `%s` is not within any configured component directories\n\nConfigured component base paths:\n  - Terraform: `%s`\n  - Helmfile: `%s`\n  - Packer: `%s`",
 			absPath, atmosConfig.Components.Terraform.BasePath, atmosConfig.Components.Helmfile.BasePath, packerBasePath).
 		WithHint("Change to a component directory and use `.` or provide a path within one of the component directories above").
 		WithContext("path", absPath).

--- a/pkg/version/reexec.go
+++ b/pkg/version/reexec.go
@@ -275,7 +275,7 @@ func shouldSkipReexec(requestedVersion string, cfg *ReexecConfig) bool {
 //
 //nolint:revive // os.Exit is intentional for hard failures.
 func fatalFormattedErr(formatted string) {
-	ui.Writeln(formatted)
+	ui.Writeln(strings.TrimRight(formatted, "\n"))
 	os.Exit(1)
 }
 

--- a/tests/cli_sanitize_test.go
+++ b/tests/cli_sanitize_test.go
@@ -127,6 +127,19 @@ func TestSanitizeOutput(t *testing.T) {
 			input:    "TRCE  Checking for atmos.yaml in home directory path=/absolute/path/to/repo/some/subdir/.atmos",
 			expected: "TRCE  Checking for atmos.yaml in home directory path=/mock-home/.atmos",
 		},
+		{
+			name: "GitHub auth debug logs should be removed",
+			input: strings.Join([]string{
+				"DEBU  before",
+				"DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error=\"exit status 1\"",
+				"DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)",
+				"DEBU  after",
+			}, "\n"),
+			expected: strings.Join([]string{
+				"DEBU  before",
+				"DEBU  after",
+			}, "\n"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/cli_sanitize_test.go
+++ b/tests/cli_sanitize_test.go
@@ -733,9 +733,7 @@ func TestSanitizeOutput_WordWrappedPathsRealWorldScenarios(t *testing.T) {
 					wrappedPath := repoRoot[:breakPoint] + "\n" + repoRoot[breakPoint:]
 					return fmt.Sprintf(`**Error:** path is not within Atmos component directories
 
-## Hints
-
-💡 Path points to the stacks configuration directory, not a component:
+Path points to the stacks configuration directory, not a component:
 %s/tests/fixtures/scenarios/complete/stacks
 
 Stacks directory: %s/tests/fixtures/scenarios/complete/stacks
@@ -744,9 +742,7 @@ Stacks directory: %s/tests/fixtures/scenarios/complete/stacks
 				}
 				return fmt.Sprintf(`**Error:** path is not within Atmos component directories
 
-## Hints
-
-💡 Path points to the stacks configuration directory, not a component:
+Path points to the stacks configuration directory, not a component:
 %s
 
 Stacks directory: %s
@@ -755,9 +751,7 @@ Stacks directory: %s
 			},
 			expected: `**Error:** path is not within Atmos component directories
 
-## Hints
-
-💡 Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
+Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
 
 Stacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
 
@@ -807,8 +801,8 @@ func TestSanitizeOutput_WindowsLineEndingsInHintPaths(t *testing.T) {
 		},
 		{
 			name:     "Multi-line error with Windows CRLF",
-			input:    fmt.Sprintf("**Error:** path is not within Atmos component directories\r\n\r\n## Hints\r\n\r\n💡 Path points to the stacks configuration directory, not a component:\r\n%s\r\n\r\nStacks directory: %s", testPath, testPath),
-			expected: "**Error:** path is not within Atmos component directories\n\n## Hints\n\n💡 Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks\n\nStacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks",
+			input:    fmt.Sprintf("**Error:** path is not within Atmos component directories\r\n\r\nPath points to the stacks configuration directory, not a component:\r\n%s\r\n\r\nStacks directory: %s", testPath, testPath),
+			expected: "**Error:** path is not within Atmos component directories\n\nPath points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks\n\nStacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks",
 		},
 	}
 

--- a/tests/cli_snapshot_test.go
+++ b/tests/cli_snapshot_test.go
@@ -216,6 +216,26 @@ func TestNormalizeLineEndings(t *testing.T) {
 	}
 }
 
+func TestNormalizeSnapshotOutputHonorsIgnoreTrailingWhitespace(t *testing.T) {
+	input := "line1  \r\nline2\t\r\nProgress\r"
+
+	t.Run("preserves trailing whitespace by default", func(t *testing.T) {
+		got := normalizeSnapshotOutput(input, false)
+		expected := "line1  \nline2\t\nProgress\r"
+		if got != expected {
+			t.Errorf("normalizeSnapshotOutput() mismatch:\nExpected: %q\nGot:      %q", expected, got)
+		}
+	})
+
+	t.Run("strips trailing spaces and tabs when enabled", func(t *testing.T) {
+		got := normalizeSnapshotOutput(input, true)
+		expected := "line1\nline2\nProgress\r"
+		if got != expected {
+			t.Errorf("normalizeSnapshotOutput() mismatch:\nExpected: %q\nGot:      %q", expected, got)
+		}
+	})
+}
+
 // TestSnapshotRoundTripWithNormalization verifies that CRLF content is normalized
 // when written and read back.
 func TestSnapshotRoundTripWithNormalization(t *testing.T) {

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -435,13 +435,13 @@ func sanitizeOutput(output string, opts ...sanitizeOption) (string, error) {
 		return groups[1] + fixedRemainder
 	})
 
-	// 5b. Join hint paths that may be split across lines due to terminal width wrapping.
+	// 5b. Join diagnostic paths that may be split across lines due to terminal width wrapping.
 	// This ensures consistent snapshots across platforms with different terminal widths.
 	// Example:
 	//   Input:  "💡 Path points to the stacks configuration directory, not a component:\n/absolute/path/to/repo/..."
 	//   Output: "💡 Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/..."
-	hintPathRegex := regexp.MustCompile(`(💡[^:]+:)\s*\n+(/absolute/path/to/repo[^\n]*)`)
-	result = hintPathRegex.ReplaceAllString(result, "$1 $2")
+	diagnosticPathRegex := regexp.MustCompile(`((?:💡\s*)?[^:\n]+:)\s*\n+(/absolute/path/to/repo[^\n]*)`)
+	result = diagnosticPathRegex.ReplaceAllString(result, "$1 $2")
 
 	// Also handle "Stacks directory:" and "Workflows directory:" patterns.
 	// Example:
@@ -553,12 +553,12 @@ func sanitizeOutput(output string, opts ...sanitizeOption) (string, error) {
 	provisionedByUserRegex := regexp.MustCompile(`provisioned_by_user: [^\s]+`)
 	result = provisionedByUserRegex.ReplaceAllString(result, "provisioned_by_user: user")
 
-	// 17. Join hint messages where the sanitized path ended up on the next line.
+	// 17. Join diagnostic messages where the sanitized path ended up on the next line.
 	// This must run AFTER path sanitization because it matches the sanitized path pattern.
-	// E.g., "💡 Stacks directory not found:\n/absolute/path" vs "💡 Stacks directory not found: /absolute/path"
+	// E.g., "Stacks directory not found:\n/absolute/path" vs "Stacks directory not found: /absolute/path"
 	// Also handles plain labels like "Stacks directory:\n/path"
-	hintPathRegex2 := regexp.MustCompile(`(?m)(💡[^\n]{0,200}?:|^[A-Z][^\n]{0,200}?directory:)\s*\n(/absolute/path/to/repo[^\s\n]*)`)
-	result = hintPathRegex2.ReplaceAllString(result, "$1 $2")
+	diagnosticPathRegex2 := regexp.MustCompile(`(?m)((?:💡\s*)?[A-Z][^\n]{0,200}?:)\s*\n(/absolute/path/to/repo[^\s\n]*)`)
+	result = diagnosticPathRegex2.ReplaceAllString(result, "$1 $2")
 
 	return result, nil
 }

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -517,6 +517,14 @@ func sanitizeOutput(output string, opts ...sanitizeOption) (string, error) {
 	terraformCommandEnvLogRegex := regexp.MustCompile(`(?m)^.*Found ENV variable ATMOS_COMPONENTS_TERRAFORM_COMMAND=[^\n]*\n?`)
 	result = terraformCommandEnvLogRegex.ReplaceAllString(result, "")
 
+	// 16. Drop environment-dependent GitHub authentication debug logs.
+	// These lines depend on whether gh is installed/authenticated in the runner and do not affect
+	// the command behavior under test.
+	githubCLITokenLookupLogRegex := regexp.MustCompile(`(?m)^.*GitHub CLI token lookup failed \(CLI may not be installed or authenticated\)[^\n]*\n?`)
+	result = githubCLITokenLookupLogRegex.ReplaceAllString(result, "")
+	anonymousGitHubAccessLogRegex := regexp.MustCompile(`(?m)^.*No GitHub token resolved; using anonymous \(unauthenticated\) GitHub access \(subject to rate limits\)[^\n]*\n?`)
+	result = anonymousGitHubAccessLogRegex.ReplaceAllString(result, "")
+
 	// 16. Apply custom replacements if provided.
 	// These are test-specific patterns that don't need to be part of the global sanitization.
 	// IMPORTANT: This must run LAST so it can override any built-in sanitization results.
@@ -1738,15 +1746,11 @@ func getSnapshotFilenames(testName string, isTty bool) (stdout, stderr, tty stri
 
 // verifyTTYSnapshot handles snapshot verification for TTY mode tests.
 func verifyTTYSnapshot(t *testing.T, tc *TestCase, ttyPath, combinedOutput string, regenerate bool) bool {
-	if regenerate {
-		// Strip trailing whitespace from output before saving snapshot if requested.
-		outputToSave := combinedOutput
-		if tc.Expect.IgnoreTrailingWhitespace {
-			outputToSave = stripTrailingWhitespace(combinedOutput)
-		}
+	combinedOutput = stripTrailingWhitespace(combinedOutput)
 
+	if regenerate {
 		t.Logf("Updating TTY snapshot at %q", ttyPath)
-		updateSnapshot(ttyPath, outputToSave)
+		updateSnapshot(ttyPath, combinedOutput)
 		return true
 	}
 
@@ -1757,13 +1761,7 @@ $ go test ./tests -run %q -regenerate-snapshots`, ttyPath, t.Name())
 	}
 
 	filteredActual := applyIgnorePatterns(combinedOutput, tc.Expect.Diff)
-	filteredExpected := applyIgnorePatterns(readSnapshot(t, ttyPath), tc.Expect.Diff)
-
-	// Strip trailing whitespace if requested.
-	if tc.Expect.IgnoreTrailingWhitespace {
-		filteredActual = stripTrailingWhitespace(filteredActual)
-		filteredExpected = stripTrailingWhitespace(filteredExpected)
-	}
+	filteredExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, ttyPath)), tc.Expect.Diff)
 
 	if filteredExpected != filteredActual {
 		var diff string
@@ -1821,8 +1819,8 @@ func verifySnapshot(t *testing.T, tc TestCase, stdoutOutput, stderrOutput string
 
 	// Normalize line endings in actual output for cross-platform consistency.
 	// This handles cases where CLI might output CRLF on Windows but snapshots use LF.
-	stdoutOutput = normalizeLineEndings(stdoutOutput)
-	stderrOutput = normalizeLineEndings(stderrOutput)
+	stdoutOutput = stripTrailingWhitespace(normalizeLineEndings(stdoutOutput))
+	stderrOutput = stripTrailingWhitespace(normalizeLineEndings(stderrOutput))
 
 	stdoutPath, stderrPath, ttyPath := getSnapshotFilenames(t.Name(), tc.Tty)
 
@@ -1834,18 +1832,10 @@ func verifySnapshot(t *testing.T, tc TestCase, stdoutOutput, stderrOutput string
 
 	// Non-TTY mode: separate stdout and stderr snapshots
 	if regenerate {
-		// Strip trailing whitespace from output before saving snapshot if requested.
-		stdoutToSave := stdoutOutput
-		stderrToSave := stderrOutput
-		if tc.Expect.IgnoreTrailingWhitespace {
-			stdoutToSave = stripTrailingWhitespace(stdoutOutput)
-			stderrToSave = stripTrailingWhitespace(stderrOutput)
-		}
-
 		t.Logf("Updating stdout snapshot at %q", stdoutPath)
-		updateSnapshot(stdoutPath, stdoutToSave)
+		updateSnapshot(stdoutPath, stdoutOutput)
 		t.Logf("Updating stderr snapshot at %q", stderrPath)
-		updateSnapshot(stderrPath, stderrToSave)
+		updateSnapshot(stderrPath, stderrOutput)
 		return true
 	}
 
@@ -1857,13 +1847,7 @@ $ go test ./tests -run %q -regenerate-snapshots`, stdoutPath, t.Name())
 	}
 
 	filteredStdoutActual := applyIgnorePatterns(stdoutOutput, tc.Expect.Diff)
-	filteredStdoutExpected := applyIgnorePatterns(readSnapshot(t, stdoutPath), tc.Expect.Diff)
-
-	// Strip trailing whitespace if requested.
-	if tc.Expect.IgnoreTrailingWhitespace {
-		filteredStdoutActual = stripTrailingWhitespace(filteredStdoutActual)
-		filteredStdoutExpected = stripTrailingWhitespace(filteredStdoutExpected)
-	}
+	filteredStdoutExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, stdoutPath)), tc.Expect.Diff)
 
 	if filteredStdoutExpected != filteredStdoutActual {
 		var diff string
@@ -1884,13 +1868,7 @@ Run the following command to create it:
 $ go test -run=%q -regenerate-snapshots`, stderrPath, t.Name())
 	}
 	filteredStderrActual := applyIgnorePatterns(stderrOutput, tc.Expect.Diff)
-	filteredStderrExpected := applyIgnorePatterns(readSnapshot(t, stderrPath), tc.Expect.Diff)
-
-	// Strip trailing whitespace if requested.
-	if tc.Expect.IgnoreTrailingWhitespace {
-		filteredStderrActual = stripTrailingWhitespace(filteredStderrActual)
-		filteredStderrExpected = stripTrailingWhitespace(filteredStderrExpected)
-	}
+	filteredStderrExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, stderrPath)), tc.Expect.Diff)
 
 	if filteredStderrExpected != filteredStderrActual {
 		var diff string

--- a/tests/cli_test.go
+++ b/tests/cli_test.go
@@ -1670,6 +1670,14 @@ func normalizeLineEndings(s string) string {
 	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
+func normalizeSnapshotOutput(input string, ignoreTrailingWhitespace bool) string {
+	normalized := normalizeLineEndings(input)
+	if ignoreTrailingWhitespace {
+		return stripTrailingWhitespace(normalized)
+	}
+	return normalized
+}
+
 // Generate a unified diff using gotextdiff.
 func generateUnifiedDiff(actual, expected string) string {
 	edits := myers.ComputeEdits(span.URIFromPath("actual"), expected, actual)
@@ -1746,7 +1754,7 @@ func getSnapshotFilenames(testName string, isTty bool) (stdout, stderr, tty stri
 
 // verifyTTYSnapshot handles snapshot verification for TTY mode tests.
 func verifyTTYSnapshot(t *testing.T, tc *TestCase, ttyPath, combinedOutput string, regenerate bool) bool {
-	combinedOutput = stripTrailingWhitespace(combinedOutput)
+	combinedOutput = normalizeSnapshotOutput(combinedOutput, tc.Expect.IgnoreTrailingWhitespace)
 
 	if regenerate {
 		t.Logf("Updating TTY snapshot at %q", ttyPath)
@@ -1761,7 +1769,7 @@ $ go test ./tests -run %q -regenerate-snapshots`, ttyPath, t.Name())
 	}
 
 	filteredActual := applyIgnorePatterns(combinedOutput, tc.Expect.Diff)
-	filteredExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, ttyPath)), tc.Expect.Diff)
+	filteredExpected := applyIgnorePatterns(normalizeSnapshotOutput(readSnapshot(t, ttyPath), tc.Expect.IgnoreTrailingWhitespace), tc.Expect.Diff)
 
 	if filteredExpected != filteredActual {
 		var diff string
@@ -1819,8 +1827,8 @@ func verifySnapshot(t *testing.T, tc TestCase, stdoutOutput, stderrOutput string
 
 	// Normalize line endings in actual output for cross-platform consistency.
 	// This handles cases where CLI might output CRLF on Windows but snapshots use LF.
-	stdoutOutput = stripTrailingWhitespace(normalizeLineEndings(stdoutOutput))
-	stderrOutput = stripTrailingWhitespace(normalizeLineEndings(stderrOutput))
+	stdoutOutput = normalizeSnapshotOutput(stdoutOutput, tc.Expect.IgnoreTrailingWhitespace)
+	stderrOutput = normalizeSnapshotOutput(stderrOutput, tc.Expect.IgnoreTrailingWhitespace)
 
 	stdoutPath, stderrPath, ttyPath := getSnapshotFilenames(t.Name(), tc.Tty)
 
@@ -1847,7 +1855,7 @@ $ go test ./tests -run %q -regenerate-snapshots`, stdoutPath, t.Name())
 	}
 
 	filteredStdoutActual := applyIgnorePatterns(stdoutOutput, tc.Expect.Diff)
-	filteredStdoutExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, stdoutPath)), tc.Expect.Diff)
+	filteredStdoutExpected := applyIgnorePatterns(normalizeSnapshotOutput(readSnapshot(t, stdoutPath), tc.Expect.IgnoreTrailingWhitespace), tc.Expect.Diff)
 
 	if filteredStdoutExpected != filteredStdoutActual {
 		var diff string
@@ -1868,7 +1876,7 @@ Run the following command to create it:
 $ go test -run=%q -regenerate-snapshots`, stderrPath, t.Name())
 	}
 	filteredStderrActual := applyIgnorePatterns(stderrOutput, tc.Expect.Diff)
-	filteredStderrExpected := applyIgnorePatterns(stripTrailingWhitespace(readSnapshot(t, stderrPath)), tc.Expect.Diff)
+	filteredStderrExpected := applyIgnorePatterns(normalizeSnapshotOutput(readSnapshot(t, stderrPath), tc.Expect.IgnoreTrailingWhitespace), tc.Expect.Diff)
 
 	if filteredStderrExpected != filteredStderrActual {
 		var diff string

--- a/tests/fixtures/scenarios/subcommand-alias/atmos.yaml
+++ b/tests/fixtures/scenarios/subcommand-alias/atmos.yaml
@@ -5,6 +5,13 @@ aliases:
   tr: "terraform"
   ta: "terraform apply"
 
+commands:
+  - name: release
+    description: Run release automation
+    steps:
+      - type: shell
+        command: echo release
+
 components:
   terraform:
     base_path: "components/terraform"

--- a/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Config_File.stderr.golden
+++ b/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Config_File.stderr.golden
@@ -2,5 +2,4 @@
 
 **Error:** invalid log level
 
-the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info
-Warning Error Off]
+the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info Warning Error Off]

--- a/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Config_File.stderr.golden
+++ b/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Config_File.stderr.golden
@@ -2,7 +2,5 @@
 
 **Error:** invalid log level
 
-## Explanation
-
 the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info
 Warning Error Off]

--- a/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Environment_Variable.stderr.golden
+++ b/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Environment_Variable.stderr.golden
@@ -2,5 +2,4 @@
 
 **Error:** invalid log level
 
-the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info
-Warning Error Off]
+the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info Warning Error Off]

--- a/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Environment_Variable.stderr.golden
+++ b/tests/snapshots/TestCLICommands_Invalid_Log_Level_in_Environment_Variable.stderr.golden
@@ -2,7 +2,5 @@
 
 **Error:** invalid log level
 
-## Explanation
-
 the log level 'XTrace' is not recognized. Valid options are: [Trace Debug Info
 Warning Error Off]

--- a/tests/snapshots/TestCLICommands_atmos_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_--help.stdout.golden
@@ -6,10 +6,10 @@ across multiple cloud and DevOps toolchains.
 
 USAGE
 
-                                   
-    $ atmos [flags]                
-    $ atmos [sub-command] [flags]  
-                                   
+
+    $ atmos [flags]
+    $ atmos [sub-command] [flags]
+
 
 SUBCOMMAND ALIASES
 
@@ -21,7 +21,7 @@ SUBCOMMAND ALIASES
       pk               Alias of atmos packer command
       tf               Alias of atmos terraform command
 
-AVAILABLE COMMANDS
+BUILT-IN COMMANDS
 
       about                                  Learn about Atmos
       ai [command] [EXPERIMENTAL]            AI-powered assistant for Atmos operations

--- a/tests/snapshots/TestCLICommands_atmos_--help_config_aliases_section.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_--help_config_aliases_section.stdout.golden
@@ -6,10 +6,10 @@ across multiple cloud and DevOps toolchains.
 
 USAGE
 
-                                   
-    $ atmos [flags]                
-    $ atmos [sub-command] [flags]  
-                                   
+
+    $ atmos [flags]
+    $ atmos [sub-command] [flags]
+
 
 SUBCOMMAND ALIASES
 
@@ -21,7 +21,7 @@ SUBCOMMAND ALIASES
       pk               Alias of atmos packer command
       tf               Alias of atmos terraform command
 
-AVAILABLE COMMANDS
+BUILT-IN COMMANDS
 
       about                                  Learn about Atmos
       ai [command] [EXPERIMENTAL]            AI-powered assistant for Atmos operations
@@ -59,6 +59,10 @@ AVAILABLE COMMANDS
       vendor [command]                       Manage external dependencies for components or stacks
       version [command]                      Display the version of Atmos you are running and check for updates
       workflow [command]                     Run predefined tasks using workflows
+
+CUSTOM COMMANDS
+
+      release  Run release automation
 
 ALIASES
 

--- a/tests/snapshots/TestCLICommands_atmos_atlantis.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis.stderr.golden
@@ -10,6 +10,4 @@ Valid subcommands are:
 
  atmos atlantis [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos atlantis --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_atlantis_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis_--help.stdout.golden
@@ -7,11 +7,11 @@ infrastructure automation.
 
 USAGE
 
-                                            
-    $ atmos atlantis [sub-command] [flags]  
-                                            
 
-AVAILABLE COMMANDS
+    $ atmos atlantis [sub-command] [flags]
+
+
+BUILT-IN COMMANDS
 
       generate [command]  Generate Atlantis configuration files
 

--- a/tests/snapshots/TestCLICommands_atmos_atlantis_generate.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis_generate.stderr.golden
@@ -10,6 +10,4 @@ Valid subcommands are:
 
  atmos atlantis generate [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos atlantis generate --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_atlantis_generate_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis_generate_--help.stdout.golden
@@ -6,11 +6,11 @@ workflows with Atlantis.
 
 USAGE
 
-                                                     
-    $ atmos atlantis generate [sub-command] [flags]  
-                                                     
 
-AVAILABLE COMMANDS
+    $ atmos atlantis generate [sub-command] [flags]
+
+
+BUILT-IN COMMANDS
 
       repo-config  Generate repository configuration for Atlantis
 
@@ -99,4 +99,4 @@ GLOBAL FLAGS
 
 
 Use atmos atlantis generate [command] --help for more information about a
-command.                                                                 
+command.

--- a/tests/snapshots/TestCLICommands_atmos_atlantis_generate_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis_generate_help.stdout.golden
@@ -6,11 +6,11 @@ workflows with Atlantis.
 
 USAGE
 
-                                                     
-    $ atmos atlantis generate [sub-command] [flags]  
-                                                     
 
-AVAILABLE COMMANDS
+    $ atmos atlantis generate [sub-command] [flags]
+
+
+BUILT-IN COMMANDS
 
       repo-config  Generate repository configuration for Atlantis
 
@@ -99,4 +99,4 @@ GLOBAL FLAGS
 
 
 Use atmos atlantis generate [command] --help for more information about a
-command.                                                                 
+command.

--- a/tests/snapshots/TestCLICommands_atmos_atlantis_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_atlantis_help.stdout.golden
@@ -7,11 +7,11 @@ infrastructure automation.
 
 USAGE
 
-                                            
-    $ atmos atlantis [sub-command] [flags]  
-                                            
 
-AVAILABLE COMMANDS
+    $ atmos atlantis [sub-command] [flags]
+
+
+BUILT-IN COMMANDS
 
       generate [command]  Generate Atlantis configuration files
 

--- a/tests/snapshots/TestCLICommands_atmos_auth_env_--format_invalid.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_env_--format_invalid.stderr.golden
@@ -4,6 +4,4 @@
 
 **Error:** invalid format
 
-## Explanation
-
 unsupported format: invalid

--- a/tests/snapshots/TestCLICommands_atmos_auth_invalid-command.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_invalid-command.stderr.golden
@@ -19,6 +19,4 @@ Valid subcommands are:
 
  atmos auth [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos auth --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_auth_validate_(invalid_config).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_validate_(invalid_config).stderr.golden
@@ -9,5 +9,5 @@ provider kind: unsupported provider kind: invalid/provider
 
 # Error
 
-**Error:** invalid auth config: provider "invalid-provider" validation failed:
-invalid provider kind: unsupported provider kind: invalid/provider
+**Error:** invalid auth config: provider "invalid-provider" validation failed: invalid provider kind: unsupported
+provider kind: invalid/provider

--- a/tests/snapshots/TestCLICommands_atmos_auth_validate_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_validate_--help.stdout.golden
@@ -8,9 +8,9 @@ errors.
 
 USAGE
 
-                                   
-    $ atmos auth validate [flags]  
-                                   
+
+    $ atmos auth validate [flags]
+
 
 FLAGS
 

--- a/tests/snapshots/TestCLICommands_atmos_auth_validate_--verbose.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_validate_--verbose.stderr.golden
@@ -1,5 +1,7 @@
  DEBU  Set logs-level=debug logs-file=/dev/stderr
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
+ DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
+ DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 🧪 auth is an experimental feature. Learn more https://atmos.tools/experimental

--- a/tests/snapshots/TestCLICommands_atmos_auth_validate_--verbose.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_validate_--verbose.stderr.golden
@@ -1,7 +1,5 @@
  DEBU  Set logs-level=debug logs-file=/dev/stderr
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
- DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
- DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 🧪 auth is an experimental feature. Learn more https://atmos.tools/experimental

--- a/tests/snapshots/TestCLICommands_atmos_auth_whoami_--identity_nonexistent.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_auth_whoami_--identity_nonexistent.stderr.golden
@@ -4,10 +4,6 @@
 
 **Error:** identity not found
 
-## Explanation
-
 Identity nonexistent is not defined in the currently loaded auth config.
-
-## Hints
 
 💡 Run atmos auth list to see available identities

--- a/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
@@ -3,33 +3,43 @@
 
 **Error:** ATMOS_SHLVL exceeds maximum allowed depth. Infinite recursion?
 current=11, max=10
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1
+
 # Error
 
 **Error:** subcommand exited with code 1

--- a/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
@@ -3,43 +3,33 @@
 
 **Error:** ATMOS_SHLVL exceeds maximum allowed depth. Infinite recursion?
 current=11, max=10
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1
-
 # Error
 
 **Error:** subcommand exited with code 1

--- a/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_circuit-breaker.stderr.golden
@@ -1,8 +1,7 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Error
 
-**Error:** ATMOS_SHLVL exceeds maximum allowed depth. Infinite recursion?
-current=11, max=10
+**Error:** ATMOS_SHLVL exceeds maximum allowed depth. Infinite recursion? current=11, max=10
 # Error
 
 **Error:** subcommand exited with code 1

--- a/tests/snapshots/TestCLICommands_atmos_describe_component_mock_-s_prod_(invalid_-_stack-names_example).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_component_mock_-s_prod_(invalid_-_stack-names_example).stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid stack
 
-## Explanation
-
 Stack prod not found.
-
-## Hints
 
 💡 Did you mean production?
 

--- a/tests/snapshots/TestCLICommands_atmos_describe_component_vpc_-s_legacy-prod_(invalid_-_should_suggest_correct_name).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_component_vpc_-s_legacy-prod_(invalid_-_should_suggest_correct_name).stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid stack
 
-## Explanation
-
 Stack legacy-prod not found.
-
-## Hints
 
 💡 Did you mean my-legacy-prod-stack?
 

--- a/tests/snapshots/TestCLICommands_atmos_describe_component_vpc_-s_prod_(invalid_-_native-terraform_example).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_component_vpc_-s_prod_(invalid_-_native-terraform_example).stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid stack
 
-## Explanation
-
 Stack prod not found.
-
-## Hints
 
 💡 Did you mean production?
 

--- a/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stderr.golden
@@ -2,13 +2,14 @@
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
+ DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
+ DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5
- DEBU  Failed to use pager
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5

--- a/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_config_imports.stderr.golden
@@ -2,8 +2,6 @@
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
- DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
- DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
  DEBU  processConfigImports resolved paths count=5
  DEBU  processConfigImports resolved paths count=5

--- a/tests/snapshots/TestCLICommands_atmos_describe_configuration.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_configuration.stderr.golden
@@ -4,8 +4,6 @@
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
- DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
- DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*

--- a/tests/snapshots/TestCLICommands_atmos_describe_configuration.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_configuration.stderr.golden
@@ -4,6 +4,8 @@
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
+ DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
+ DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
@@ -14,7 +16,6 @@
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
- DEBU  Failed to use pager
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d
  DEBU  Loaded configuration directory source=atmos.d files=5 pattern=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d/**/*
  DEBU  Found atmos.d directory, loading configurations path=/absolute/path/to/repo/tests/fixtures/scenarios/atmos-configuration/atmos.d

--- a/tests/snapshots/TestCLICommands_atmos_helmfile.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile.stderr.golden
@@ -17,6 +17,4 @@ Valid subcommands are:
 
  atmos helmfile [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos helmfile --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_helmfile_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile_--help.stdout.golden
@@ -6,15 +6,15 @@ Helmfile.
 
 USAGE
 
-                                            
-    $ atmos helmfile [sub-command] [flags]  
-                                            
+
+    $ atmos helmfile [sub-command] [flags]
+
 
 ALIASES
 
   helmfile, hf
 
-AVAILABLE COMMANDS
+BUILT-IN COMMANDS
 
       apply               Apply changes to align the actual state of Helm releases with the desired state.
       destroy             Destroy the Helm releases for the specified stack.

--- a/tests/snapshots/TestCLICommands_atmos_helmfile_apply.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile_apply.stderr.golden
@@ -1,5 +1,4 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Error
 
-**Error:** stack is required; specify it on the command line using the flag --
-stack <stack> (shorthand -s)
+**Error:** stack is required; specify it on the command line using the flag --stack <stack> (shorthand -s)

--- a/tests/snapshots/TestCLICommands_atmos_helmfile_apply_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile_apply_--help.stdout.golden
@@ -11,9 +11,9 @@ apply echo-server -s tenant1-ue2-dev --redirect-stderr /dev/stdout
 
 USAGE
 
-                                    
-    $ atmos helmfile apply [flags]  
-                                    
+
+    $ atmos helmfile apply [flags]
+
 
 FLAGS
 

--- a/tests/snapshots/TestCLICommands_atmos_helmfile_apply_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile_apply_help.stdout.golden
@@ -11,9 +11,9 @@ apply echo-server -s tenant1-ue2-dev --redirect-stderr /dev/stdout
 
 USAGE
 
-                                    
-    $ atmos helmfile apply [flags]  
-                                    
+
+    $ atmos helmfile apply [flags]
+
 
 FLAGS
 

--- a/tests/snapshots/TestCLICommands_atmos_helmfile_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_helmfile_help.stdout.golden
@@ -6,15 +6,15 @@ Helmfile.
 
 USAGE
 
-                                            
-    $ atmos helmfile [sub-command] [flags]  
-                                            
+
+    $ atmos helmfile [sub-command] [flags]
+
 
 ALIASES
 
   helmfile, hf
 
-AVAILABLE COMMANDS
+BUILT-IN COMMANDS
 
       apply               Apply changes to align the actual state of Helm releases with the desired state.
       destroy             Destroy the Helm releases for the specified stack.

--- a/tests/snapshots/TestCLICommands_atmos_invalidCommand.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_invalidCommand.stderr.golden
@@ -1,7 +1,6 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Invalid Command
 
-**Error:** The atmos invalidCommand command has no steps or subcommands
-configured.
+**Error:** The atmos invalidCommand command has no steps or subcommands configured.
 
 💡 https://atmos.tools/cli/configuration/commands

--- a/tests/snapshots/TestCLICommands_atmos_invalidCommand.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_invalidCommand.stderr.golden
@@ -4,6 +4,4 @@
 **Error:** The atmos invalidCommand command has no steps or subcommands
 configured.
 
-## Hints
-
 💡 https://atmos.tools/cli/configuration/commands

--- a/tests/snapshots/TestCLICommands_atmos_non-existent.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_non-existent.stderr.golden
@@ -48,6 +48,4 @@ Valid subcommands are:
  atmos [flags]
  atmos [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_terraform.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform.stderr.golden
@@ -55,6 +55,4 @@ Valid subcommands are:
 
   $ atmos terraform [subcommand] <component-name> -s <stack-name>
 
-## Hints
-
 💡 https://atmos.tools/cli/commands/terraform/usage

--- a/tests/snapshots/TestCLICommands_atmos_terraform_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_--help.stdout.golden
@@ -7,10 +7,10 @@ management.
 
 USAGE
 
-                                             
-    $ atmos terraform [flags]                
-    $ atmos terraform [sub-command] [flags]  
-                                             
+
+    $ atmos terraform [flags]
+    $ atmos terraform [sub-command] [flags]
+
 
 ALIASES
 
@@ -18,14 +18,14 @@ ALIASES
 
 EXAMPLES
 
-                                                                      
-    – Execute a terraform subcommand                                  
-                                                                      
-                                                                      
-     $ atmos terraform [subcommand] <component-name> -s <stack-name>  
-                                                                      
 
-AVAILABLE COMMANDS
+    – Execute a terraform subcommand
+
+
+     $ atmos terraform [subcommand] <component-name> -s <stack-name>
+
+
+BUILT-IN COMMANDS
 
       apply                             Apply changes to infrastructure
       backend [command] [EXPERIMENTAL]  Manage Terraform state backends

--- a/tests/snapshots/TestCLICommands_atmos_terraform_--help_alias_subcommand_check.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_--help_alias_subcommand_check.stdout.golden
@@ -7,10 +7,10 @@ management.
 
 USAGE
 
-                                             
-    $ atmos terraform [flags]                
-    $ atmos terraform [sub-command] [flags]  
-                                             
+
+    $ atmos terraform [flags]
+    $ atmos terraform [sub-command] [flags]
+
 
 ALIASES
 
@@ -18,14 +18,14 @@ ALIASES
 
 EXAMPLES
 
-                                                                      
-    – Execute a terraform subcommand                                  
-                                                                      
-                                                                      
-     $ atmos terraform [subcommand] <component-name> -s <stack-name>  
-                                                                      
 
-AVAILABLE COMMANDS
+    – Execute a terraform subcommand
+
+
+     $ atmos terraform [subcommand] <component-name> -s <stack-name>
+
+
+BUILT-IN COMMANDS
 
       apply                             Apply changes to infrastructure
       backend [command] [EXPERIMENTAL]  Manage Terraform state backends

--- a/tests/snapshots/TestCLICommands_atmos_terraform_-help_passthrough.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_-help_passthrough.stdout.golden
@@ -24,6 +24,7 @@ All other commands:
   modules       Show all declared modules in a working directory
   output        Show output values from your root module
   providers     Show the providers required for this configuration
+  query         Search and list remote infrastructure with Terraform
   refresh       Update the state to match remote systems
   show          Show the current state or a saved plan
   stacks        Manage HCP Terraform stack operations

--- a/tests/snapshots/TestCLICommands_atmos_terraform_deploy_locked_component.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_deploy_locked_component.stderr.golden
@@ -2,6 +2,4 @@
 
 **Error:** locked component cannot be provisioned
 
-## Explanation
-
 component 'mock' cannot be modified (metadata.locked: true)

--- a/tests/snapshots/TestCLICommands_atmos_terraform_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_help.stdout.golden
@@ -7,10 +7,10 @@ management.
 
 USAGE
 
-                                             
-    $ atmos terraform [flags]                
-    $ atmos terraform [sub-command] [flags]  
-                                             
+
+    $ atmos terraform [flags]
+    $ atmos terraform [sub-command] [flags]
+
 
 ALIASES
 
@@ -18,14 +18,14 @@ ALIASES
 
 EXAMPLES
 
-                                                                      
-    – Execute a terraform subcommand                                  
-                                                                      
-                                                                      
-     $ atmos terraform [subcommand] <component-name> -s <stack-name>  
-                                                                      
 
-AVAILABLE COMMANDS
+    – Execute a terraform subcommand
+
+
+     $ atmos terraform [subcommand] <component-name> -s <stack-name>
+
+
+BUILT-IN COMMANDS
 
       apply                             Apply changes to infrastructure
       backend [command] [EXPERIMENTAL]  Manage Terraform state backends

--- a/tests/snapshots/TestCLICommands_atmos_terraform_non-existent.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_non-existent.stderr.golden
@@ -54,6 +54,4 @@ Valid subcommands are:
 
   $ atmos terraform [subcommand] <component-name> -s <stack-name>
 
-## Hints
-
 💡 https://atmos.tools/cli/commands/terraform/usage

--- a/tests/snapshots/TestCLICommands_atmos_terraform_plan_mock_-s_prod_(invalid_-_stack-names_example).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_plan_mock_-s_prod_(invalid_-_stack-names_example).stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid stack
 
-## Explanation
-
 Stack prod not found.
-
-## Hints
 
 💡 Did you mean production?
 

--- a/tests/snapshots/TestCLICommands_atmos_terraform_plan_non-existent_in_non_workspace.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_plan_non-existent_in_non_workspace.stderr.golden
@@ -3,6 +3,4 @@
 
 **Error:** directory for Atmos stacks does not exist
 
-## Hints
-
-💡 Stacks directory not found: /absolute/path/to/repo/stacks
+Stacks directory not found: /absolute/path/to/repo/stacks

--- a/tests/snapshots/TestCLICommands_atmos_terraform_plan_non-existent_in_workspace.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_plan_non-existent_in_workspace.stderr.golden
@@ -1,5 +1,4 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Error
 
-**Error:** stack is required; specify it on the command line using the flag --
-stack <stack> (shorthand -s)
+**Error:** stack is required; specify it on the command line using the flag --stack <stack> (shorthand -s)

--- a/tests/snapshots/TestCLICommands_atmos_terraform_plan_vpc_-s_legacy-prod_(invalid).stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_terraform_plan_vpc_-s_legacy-prod_(invalid).stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid stack
 
-## Explanation
-
 Stack legacy-prod not found.
-
-## Hints
 
 💡 Did you mean my-legacy-prod-stack?
 

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_--help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_--help.stdout.golden
@@ -7,12 +7,12 @@ A standalone tool to install CLI binaries using registry metadata.
 
 USAGE
 
-                                             
-    $ atmos toolchain [flags]                
-    $ atmos toolchain [sub-command] [flags]  
-                                             
 
-AVAILABLE COMMANDS
+    $ atmos toolchain [flags]
+    $ atmos toolchain [sub-command] [flags]
+
+
+BUILT-IN COMMANDS
 
       add                 Add tools to .tool-versions file
       clean               Clean tools and cache directories

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_info_non-existent_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_info_non-existent_tool.stderr.golden
@@ -4,13 +4,9 @@
 
 **Error:** failed to find tool non-existent/tool: tool not in registry
 
-## Explanation
-
 Tool non-existent/tool@latest was not found in any configured registry. Atmos
 searches registries in priority order: Atmos registry → Aqua registry → custom
 registries.
-
-## Hints
 
 💡 Run atmos toolchain registry search to browse available tools
 

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_info_non-existent_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_info_non-existent_tool.stderr.golden
@@ -4,9 +4,8 @@
 
 **Error:** failed to find tool non-existent/tool: tool not in registry
 
-Tool non-existent/tool@latest was not found in any configured registry. Atmos
-searches registries in priority order: Atmos registry → Aqua registry → custom
-registries.
+Tool non-existent/tool@latest was not found in any configured registry. Atmos searches registries in priority order:
+Atmos registry → Aqua registry → custom registries.
 
 💡 Run atmos toolchain registry search to browse available tools
 

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_info_raw_format_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_info_raw_format_tool.stderr.golden
@@ -7,17 +7,17 @@ Repository: https://github.com/jqlang/jq
 No versions installed
 
 Available Versions (latest 10):
-               VERSION      DATE         TITLE                          
+               VERSION      DATE         TITLE
 ────────────────────────────────────────────────────────────────────────
-               jq-X.X     YYYY-MM-DD   Security fixes                 
-               jq-X.X     YYYY-MM-DD   Releasing                      
-               jq-X.X     YYYY-MM-DD   Security                       
-               jq-X.X       YYYY-MM-DD   What's Changed                 
-               jq-X.X       YYYY-MM-DD   New in this release since 1.5: 
-               jq-X.X       YYYY-MM-DD   jq 1.5                         
-               jq-X.X       YYYY-MM-DD   jq 1.4                         
-               jq-X.X       YYYY-MM-DD   jq 1.3                         
-               jq-X.X       YYYY-MM-DD   jq 1.2                         
-               jq-X.X       YYYY-MM-DD   jq 1.1                         
+               jq-X.X     YYYY-MM-DD   Security fixes
+               jq-X.X     YYYY-MM-DD   Security fixes
+               jq-X.X     YYYY-MM-DD   Releasing
+               jq-X.X     YYYY-MM-DD   Security
+               jq-X.X       YYYY-MM-DD   What's Changed
+               jq-X.X       YYYY-MM-DD   New in this release since 1.5:
+               jq-X.X       YYYY-MM-DD   jq 1.5
+               jq-X.X       YYYY-MM-DD   jq 1.4
+               jq-X.X       YYYY-MM-DD   jq 1.3
+               jq-X.X       YYYY-MM-DD   jq 1.2
 
 💡 Use atmos toolchain install jqlang/jq@<version> to install

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_info_shows_atmos-inline_registry.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_info_shows_atmos-inline_registry.stderr.golden
@@ -9,8 +9,8 @@ No versions installed
 Available Versions (latest 10):
                    VERSION           DATE              TITLE
 ────────────────────────────────────────────────────────────────────────
-                   X.X.X           YYYY-MM-DD        Changelog
-                   X.X.X           YYYY-MM-DD        Changelog
+                   X.X.X          YYYY-MM-DD        Changelog
+                   X.X.X          YYYY-MM-DD        Changelog
                    X.X.X           YYYY-MM-DD        Changelog
                    X.X.X           YYYY-MM-DD        Changelog
                    X.X.X           YYYY-MM-DD        Changelog

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_info_tar.gz_format_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_info_tar.gz_format_tool.stderr.golden
@@ -7,18 +7,18 @@ Repository: https://github.com/junegunn/fzf
 No versions installed
 
 Available Versions (latest 10):
-    VERSION  DATE        TITLE                                          
+    VERSION  DATE        TITLE
 ────────────────────────────────────────────────────────────────────────
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  Demo: change-with-nth                          
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  When the result list is updated, move the      
-                         cursor to the item with the best score         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
-    X.X.X   YYYY-MM-DD  X.X.X                                         
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  Demo: change-with-nth
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  X.X.X
+    X.X.X   YYYY-MM-DD  When the result list is updated, move the
+                         cursor to the item with the best score
+    X.X.X   YYYY-MM-DD  X.X.X
 
 💡 Use atmos toolchain install junegunn/fzf@<version> to install

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_install_non-existent_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_install_non-existent_tool.stderr.golden
@@ -5,13 +5,9 @@
 
 **Error:** tool not in registry
 
-## Explanation
-
 Tool non-existent/tool@1.0.0 was not found in any configured registry. Atmos
 searches registries in priority order: Atmos registry → Aqua registry → custom
 registries.
-
-## Hints
 
 💡 Run atmos toolchain registry search to browse available tools
 

--- a/tests/snapshots/TestCLICommands_atmos_toolchain_install_non-existent_tool.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_toolchain_install_non-existent_tool.stderr.golden
@@ -5,9 +5,9 @@
 
 **Error:** tool not in registry
 
-Tool non-existent/tool@1.0.0 was not found in any configured registry. Atmos
-searches registries in priority order: Atmos registry → Aqua registry → custom
-registries.
+Tool non-existent/tool@1.0.0 was not found in any configured registry. Atmos searches registries in priority order:
+Atmos
+registry → Aqua registry → custom registries.
 
 💡 Run atmos toolchain registry search to browse available tools
 

--- a/tests/snapshots/TestCLICommands_atmos_validate_component_failure_with_UI_output.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_validate_component_failure_with_UI_output.stderr.golden
@@ -4,7 +4,5 @@
 
 **Error:** OPA policy violations detected
 
-## Explanation
-
 In 'dev', only 2 Availability Zones are allowed VPC name must be a valid string
 from 2 to 20 alphanumeric chars

--- a/tests/snapshots/TestCLICommands_atmos_validate_component_failure_with_UI_output.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_validate_component_failure_with_UI_output.stderr.golden
@@ -4,5 +4,4 @@
 
 **Error:** OPA policy violations detected
 
-In 'dev', only 2 Availability Zones are allowed VPC name must be a valid string
-from 2 to 20 alphanumeric chars
+In 'dev', only 2 Availability Zones are allowed VPC name must be a valid string from 2 to 20 alphanumeric chars

--- a/tests/snapshots/TestCLICommands_atmos_version_--check_--non-existent.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_version_--check_--non-existent.stderr.golden
@@ -7,6 +7,4 @@
  atmos version [flags]
  atmos version [sub-command] [flags]
 
-## Hints
-
 💡 Run atmos version --help for usage

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure.stderr.golden
@@ -4,13 +4,11 @@
 
 **Error:** invalid component
 
-Could not find the component mock in the stack idontexist. Check that all the
-context variables are correctly defined in the stack manifests. Are the
-component and stack names correct? Did you forget an import?
+Could not find the component mock in the stack idontexist. Check that all the context variables are correctly defined in
+the stack manifests. Are the component and stack names correct? Did you forget an import?
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (1) exceeded, last
-error: subcommand exited with code 1
+**Error:** workflow step execution failed: max attempts (1) exceeded, last error: subcommand exited with code 1
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure.stderr.golden
@@ -4,8 +4,6 @@
 
 **Error:** invalid component
 
-## Explanation
-
 Could not find the component mock in the stack idontexist. Check that all the
 context variables are correctly defined in the stack manifests. Are the
 component and stack names correct? Did you forget an import?
@@ -14,13 +12,9 @@ component and stack names correct? Did you forget an import?
 **Error:** workflow step execution failed: max attempts (1) exceeded, last
 error: subcommand exited with code 1
 
-## Explanation
-
 The following command failed to execute:
 
  atmos terraform plan mock -s idontexist
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_on_shell_command.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_on_shell_command.stderr.golden
@@ -4,14 +4,10 @@
 **Error:** workflow step execution failed: max attempts (1) exceeded, last
 error: subcommand exited with code 1
 
-## Explanation
-
 The following command failed to execute:
 
  echo "This should fail"
  exit 1
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_on_shell_command.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_on_shell_command.stderr.golden
@@ -1,8 +1,7 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (1) exceeded, last
-error: subcommand exited with code 1
+**Error:** workflow step execution failed: max attempts (1) exceeded, last error: subcommand exited with code 1
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_filepath.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_filepath.stderr.golden
@@ -4,13 +4,11 @@
 
 **Error:** invalid component
 
-Could not find the component mock in the stack idontexist. Check that all the
-context variables are correctly defined in the stack manifests. Are the
-component and stack names correct? Did you forget an import?
+Could not find the component mock in the stack idontexist. Check that all the context variables are correctly defined in
+the stack manifests. Are the component and stack names correct? Did you forget an import?
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (1) exceeded, last
-error: subcommand exited with code 1
+**Error:** workflow step execution failed: max attempts (1) exceeded, last error: subcommand exited with code 1
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_filepath.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_filepath.stderr.golden
@@ -4,8 +4,6 @@
 
 **Error:** invalid component
 
-## Explanation
-
 Could not find the component mock in the stack idontexist. Check that all the
 context variables are correctly defined in the stack manifests. Are the
 component and stack names correct? Did you forget an import?
@@ -14,13 +12,9 @@ component and stack names correct? Did you forget an import?
 **Error:** workflow step execution failed: max attempts (1) exceeded, last
 error: subcommand exited with code 1
 
-## Explanation
-
 The following command failed to execute:
 
  atmos terraform plan mock -s idontexist
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_stack.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_stack.stderr.golden
@@ -4,8 +4,6 @@
 
 **Error:** invalid component
 
-## Explanation
-
 Could not find the component idontexist in the stack prod. Check that all the
 context variables are correctly defined in the stack manifests. Are the
 component and stack names correct? Did you forget an import?
@@ -14,13 +12,9 @@ component and stack names correct? Did you forget an import?
 **Error:** workflow step execution failed: max attempts (1) exceeded, last
 error: subcommand exited with code 1
 
-## Explanation
-
 The following command failed to execute:
 
  atmos terraform plan idontexist -s 'prod'
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_stack.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_failure_with_stack.stderr.golden
@@ -4,13 +4,11 @@
 
 **Error:** invalid component
 
-Could not find the component idontexist in the stack prod. Check that all the
-context variables are correctly defined in the stack manifests. Are the
-component and stack names correct? Did you forget an import?
+Could not find the component idontexist in the stack prod. Check that all the context variables are correctly defined in
+the stack manifests. Are the component and stack names correct? Did you forget an import?
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (1) exceeded, last
-error: subcommand exited with code 1
+**Error:** workflow step execution failed: max attempts (1) exceeded, last error: subcommand exited with code 1
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_file_not_found.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_file_not_found.stderr.golden
@@ -3,6 +3,4 @@
 
 **Error:** workflow file not found
 
-## Hints
-
-💡 The workflow manifest file stacks/workflows/dne.yaml does not exist
+The workflow manifest file stacks/workflows/dne.yaml does not exist

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_from_step.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_from_step.stderr.golden
@@ -3,8 +3,6 @@
 
 **Error:** invalid from-step flag
 
-## Explanation
-
 The --from-step flag was set to dne, but this step does not exist in workflow
 pass.
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_from_step.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_from_step.stderr.golden
@@ -3,8 +3,7 @@
 
 **Error:** invalid from-step flag
 
-The --from-step flag was set to dne, but this step does not exist in workflow
-pass.
+The --from-step flag was set to dne, but this step does not exist in workflow pass.
 
 ### Available steps:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_manifest.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_manifest.stderr.golden
@@ -3,11 +3,7 @@
 
 **Error:** invalid workflow manifest
 
-## Explanation
-
 The workflow manifest stacks/workflows/test-invalid.yaml must be a map with the
 top-level workflows: key
-
-## Hints
 
 💡 Add a top-level 'workflows:' key to the manifest file

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_manifest.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_manifest.stderr.golden
@@ -3,7 +3,6 @@
 
 **Error:** invalid workflow manifest
 
-The workflow manifest stacks/workflows/test-invalid.yaml must be a map with the
-top-level workflows: key
+The workflow manifest stacks/workflows/test-invalid.yaml must be a map with the top-level workflows: key
 
 💡 Add a top-level 'workflows:' key to the manifest file

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_step_type.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_step_type.stderr.golden
@@ -5,5 +5,5 @@
 
 Step type 'invalid' is not supported
 
-💡 Each step must specify a valid type: 'atmos', 'shell', 'exec', or an
-interactive type like 'input', 'confirm', 'choose'
+💡 Each step must specify a valid type: 'atmos', 'shell', 'exec', or an interactive type like 'input', 'confirm',
+'choose'

--- a/tests/snapshots/TestCLICommands_atmos_workflow_invalid_step_type.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_invalid_step_type.stderr.golden
@@ -3,9 +3,7 @@
 
 **Error:** invalid workflow step type
 
-## Hints
-
-💡 Step type 'invalid' is not supported
+Step type 'invalid' is not supported
 
 💡 Each step must specify a valid type: 'atmos', 'shell', 'exec', or an
 interactive type like 'input', 'confirm', 'choose'

--- a/tests/snapshots/TestCLICommands_atmos_workflow_no_steps.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_no_steps.stderr.golden
@@ -3,6 +3,4 @@
 
 **Error:** workflow has no steps defined
 
-## Explanation
-
 Workflow no-steps is empty and requires at least one step to execute.

--- a/tests/snapshots/TestCLICommands_atmos_workflow_not_found.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_not_found.stderr.golden
@@ -3,11 +3,9 @@
 
 **Error:** no workflow found
 
-## Hints
+No workflow exists with name no-workflow-exists
 
-💡 No workflow exists with name no-workflow-exists
-
-💡 Available workflows in test.yaml: - double-hyphen-multiple-flags
+Available workflows in test.yaml: - double-hyphen-multiple-flags
 
   • double-hyphen-stack-precedence
   • double-hyphen-step-stack

--- a/tests/snapshots/TestCLICommands_atmos_workflow_not_found.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_not_found.stderr.golden
@@ -5,8 +5,9 @@
 
 No workflow exists with name no-workflow-exists
 
-Available workflows in test.yaml: - double-hyphen-multiple-flags
+💡 Available workflows in test.yaml:
 
+  • double-hyphen-multiple-flags
   • double-hyphen-stack-precedence
   • double-hyphen-step-stack
   • double-hyphen-with-stack

--- a/tests/snapshots/TestCLICommands_atmos_workflow_pla_--file_workflow1.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_pla_--file_workflow1.stderr.golden
@@ -5,8 +5,9 @@
 
 No workflow exists with name pla
 
-Available workflows in workflow1.yaml: - terraform-plan-all-tenant1-ue2-dev
+💡 Available workflows in workflow1.yaml:
 
+  • terraform-plan-all-tenant1-ue2-dev
   • terraform-plan-all-test-components
   • terraform-plan-test-component-override-2-all-stacks
   • terraform-plan-test-component-override-3-all-stacks

--- a/tests/snapshots/TestCLICommands_atmos_workflow_pla_--file_workflow1.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_pla_--file_workflow1.stderr.golden
@@ -3,11 +3,9 @@
 
 **Error:** no workflow found
 
-## Hints
+No workflow exists with name pla
 
-💡 No workflow exists with name pla
-
-💡 Available workflows in workflow1.yaml: - terraform-plan-all-tenant1-ue2-dev
+Available workflows in workflow1.yaml: - terraform-plan-all-tenant1-ue2-dev
 
   • terraform-plan-all-test-components
   • terraform-plan-test-component-override-2-all-stacks

--- a/tests/snapshots/TestCLICommands_atmos_workflow_shell_command_not_found.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_shell_command_not_found.stderr.golden
@@ -5,13 +5,9 @@
 **Error:** workflow step execution failed: max attempts (1) exceeded, last
 error: subcommand exited with code 127
 
-## Explanation
-
 The following command failed to execute:
 
  nonexistentcommand
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/snapshots/TestCLICommands_atmos_workflow_shell_command_not_found.stderr.golden
+++ b/tests/snapshots/TestCLICommands_atmos_workflow_shell_command_not_found.stderr.golden
@@ -2,8 +2,7 @@
 "nonexistentcommand": executable file not found in $PATH
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (1) exceeded, last
-error: subcommand exited with code 127
+**Error:** workflow step execution failed: max attempts (1) exceeded, last error: subcommand exited with code 127
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_config_alias_tr_--help_shows_terraform_help.stdout.golden
+++ b/tests/snapshots/TestCLICommands_config_alias_tr_--help_shows_terraform_help.stdout.golden
@@ -7,10 +7,10 @@ management.
 
 USAGE
 
-                                             
-    $ atmos terraform [flags]                
-    $ atmos terraform [sub-command] [flags]  
-                                             
+
+    $ atmos terraform [flags]
+    $ atmos terraform [sub-command] [flags]
+
 
 ALIASES
 
@@ -18,14 +18,14 @@ ALIASES
 
 EXAMPLES
 
-                                                                      
-    – Execute a terraform subcommand                                  
-                                                                      
-                                                                      
-     $ atmos terraform [subcommand] <component-name> -s <stack-name>  
-                                                                      
 
-AVAILABLE COMMANDS
+    – Execute a terraform subcommand
+
+
+     $ atmos terraform [subcommand] <component-name> -s <stack-name>
+
+
+BUILT-IN COMMANDS
 
       apply                             Apply changes to infrastructure
       backend [command] [EXPERIMENTAL]  Manage Terraform state backends

--- a/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
@@ -3,10 +3,8 @@
 
 **Error:** ambiguous component path
 
-## Hints
-
-💡 Path resolves to infra/vpc which is referenced by multiple components in
-stack tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
+Path resolves to infra/vpc which is referenced by multiple components in stack
+tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
 
 💡 Use the exact component name instead of a path Example: atmos terraform
 <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
@@ -3,10 +3,8 @@
 
 **Error:** ambiguous component path
 
-Path resolves to infra/vpc which is referenced by multiple components in stack
-tenant1-ue2-dev
+Path resolves to infra/vpc which is referenced by multiple components in stack tenant1-ue2-dev
 
 Matching components: infra/vpc, vpc, vpc/new
 
-💡 Use the exact component name instead of a path Example: atmos terraform
-<command> infra/vpc --stack tenant1-ue2-dev
+💡 Use the exact component name instead of a path Example: atmos terraform <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_with_nested_component_path.stderr.golden
@@ -4,7 +4,9 @@
 **Error:** ambiguous component path
 
 Path resolves to infra/vpc which is referenced by multiple components in stack
-tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
+tenant1-ue2-dev
+
+Matching components: infra/vpc, vpc, vpc/new
 
 💡 Use the exact component name instead of a path Example: atmos terraform
 <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_describe_component_with_path_not_in_component_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_with_path_not_in_component_directory.stderr.golden
@@ -7,6 +7,5 @@ Path points to the stacks configuration directory, not a component: /absolute/pa
 
 Stacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
 
-💡 Components are located in component directories (terraform, helmfile, packer)
-Change to a component directory and use . or provide a path within a component
-directory
+💡 Components are located in component directories (terraform, helmfile, packer) Change to a component directory and use
+. or provide a path within a component directory

--- a/tests/snapshots/TestCLICommands_describe_component_with_path_not_in_component_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_with_path_not_in_component_directory.stderr.golden
@@ -3,9 +3,7 @@
 
 **Error:** path is not within Atmos component directories
 
-## Hints
-
-💡 Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
+Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
 
 Stacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
 

--- a/tests/snapshots/TestCLICommands_echo_info_runs_with_verbose_flag.stderr.golden
+++ b/tests/snapshots/TestCLICommands_echo_info_runs_with_verbose_flag.stderr.golden
@@ -1,7 +1,5 @@
  DEBU  Set logs-level=debug logs-file=/dev/stderr
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
- DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
- DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
  DEBU  Executing command="echo \"Info: This is a basic message\""

--- a/tests/snapshots/TestCLICommands_echo_info_runs_with_verbose_flag.stderr.golden
+++ b/tests/snapshots/TestCLICommands_echo_info_runs_with_verbose_flag.stderr.golden
@@ -1,5 +1,7 @@
  DEBU  Set logs-level=debug logs-file=/dev/stderr
  DEBU  Loading toolchain registries from atmos.yaml registryCount=0
+ DEBU  GitHub CLI token lookup failed (CLI may not be installed or authenticated) cli=gh error="exit status 1"
+ DEBU  No GitHub token resolved; using anonymous (unauthenticated) GitHub access (subject to rate limits)
  DEBU  Successfully loaded configured registry from atmos.yaml
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
  DEBU  Executing command="echo \"Info: This is a basic message\""

--- a/tests/snapshots/TestCLICommands_helmfile_command_with_terraform_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_helmfile_command_with_terraform_component_path.stderr.golden
@@ -3,9 +3,7 @@
 
 **Error:** path component type does not match command
 
-## Hints
-
-💡 Path resolves to terraform component but command expects helmfile component
-You ran: atmos helmfile <command> . The path points to: terraform component
+Path resolves to terraform component but command expects helmfile component You
+ran: atmos helmfile <command> . The path points to: terraform component
 
 💡 Run the correct command for this component type

--- a/tests/snapshots/TestCLICommands_helmfile_command_with_terraform_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_helmfile_command_with_terraform_component_path.stderr.golden
@@ -3,7 +3,7 @@
 
 **Error:** path component type does not match command
 
-Path resolves to terraform component but command expects helmfile component You
-ran: atmos helmfile <command> . The path points to: terraform component
+Path resolves to terraform component but command expects helmfile component You ran: atmos helmfile <command> . The path
+points to: terraform component
 
 💡 Run the correct command for this component type

--- a/tests/snapshots/TestCLICommands_help_flag_works.stdout.golden
+++ b/tests/snapshots/TestCLICommands_help_flag_works.stdout.golden
@@ -6,10 +6,10 @@ across multiple cloud and DevOps toolchains.
 
 USAGE
 
-                                   
-    $ atmos [flags]                
-    $ atmos [sub-command] [flags]  
-                                   
+
+    $ atmos [flags]
+    $ atmos [sub-command] [flags]
+
 
 SUBCOMMAND ALIASES
 
@@ -21,7 +21,7 @@ SUBCOMMAND ALIASES
       pk               Alias of atmos packer command
       tf               Alias of atmos terraform command
 
-AVAILABLE COMMANDS
+BUILT-IN COMMANDS
 
       about                                  Learn about Atmos
       ai [command] [EXPERIMENTAL]            AI-powered assistant for Atmos operations
@@ -33,11 +33,9 @@ AVAILABLE COMMANDS
       completion [command]                   Generate autocompletion scripts for Bash, Zsh, Fish, and PowerShell
       composition [command]                  Inspect compositions that group component instances into systems
       container [command]                    Manage persistent, stack-scoped container components
-      deploy [command]                       Deploy commands with stack support
       describe [command]                     Show details about Atmos configurations and components
       devcontainer [command] [EXPERIMENTAL]  Manage development containers
       docs [command]                         Open Atmos documentation or display component-specific docs
-      echo [command]                         Echo commands with verbose support
       emulator [command] [EXPERIMENTAL]      Manage local emulators for AWS, GCP, Azure, Kubernetes, Vault, and OCI
                                              registries
       env                                    Output environment variables configured in atmos.yaml
@@ -53,7 +51,6 @@ AVAILABLE COMMANDS
       pro [command]                          Access premium features integrated with atmos-pro.com
       profile [command]                      Manage configuration profiles
       secret [command] [EXPERIMENTAL]        Manage declarative secrets across stacks and components.
-      show [command]                         Execute 'show' commands
       support                                Show Atmos support options
       terraform [command]                    Execute Terraform commands using Atmos stack configurations
       theme [command]                        Manage terminal themes for Atmos CLI
@@ -62,6 +59,12 @@ AVAILABLE COMMANDS
       vendor [command]                       Manage external dependencies for components or stacks
       version [command]                      Display the version of Atmos you are running and check for updates
       workflow [command]                     Run predefined tasks using workflows
+
+CUSTOM COMMANDS
+
+      deploy [command]  Deploy commands with stack support
+      echo [command]    Echo commands with verbose support
+      show [command]    Execute 'show' commands
 
 FLAGS
 

--- a/tests/snapshots/TestCLICommands_terraform_help_shows_stack_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_terraform_help_shows_stack_flag.stdout.golden
@@ -7,10 +7,10 @@ management.
 
 USAGE
 
-                                             
-    $ atmos terraform [flags]                
-    $ atmos terraform [sub-command] [flags]  
-                                             
+
+    $ atmos terraform [flags]
+    $ atmos terraform [sub-command] [flags]
+
 
 ALIASES
 
@@ -18,14 +18,14 @@ ALIASES
 
 EXAMPLES
 
-                                                                      
-    – Execute a terraform subcommand                                  
-                                                                      
-                                                                      
-     $ atmos terraform [subcommand] <component-name> -s <stack-name>  
-                                                                      
 
-AVAILABLE COMMANDS
+    – Execute a terraform subcommand
+
+
+     $ atmos terraform [subcommand] <component-name> -s <stack-name>
+
+
+BUILT-IN COMMANDS
 
       apply                             Apply changes to infrastructure
       backend [command] [EXPERIMENTAL]  Manage Terraform state backends
@@ -51,7 +51,6 @@ AVAILABLE COMMANDS
       plan-diff                         Compare two Terraform plans and show the differences
       planfile [command]                Manage Terraform plan files
       providers [command]               Show the providers required for this configuration
-      provision                         This command provisions terraform components
       refresh                           Update the state to match remote systems
       shell                             Configure an environment for an Atmos component and start a new shell
       show                              Show the current state or a saved plan
@@ -64,6 +63,10 @@ AVAILABLE COMMANDS
       version                           Show the current Terraform version
       workdir [command] [EXPERIMENTAL]  Manage component working directories
       workspace [command]               Manage Terraform workspaces
+
+CUSTOM COMMANDS
+
+      provision  This command provisions terraform components
 
 FLAGS
 

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
@@ -3,10 +3,8 @@
 
 **Error:** ambiguous component path
 
-## Hints
-
-💡 Path resolves to infra/vpc which is referenced by multiple components in
-stack tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
+Path resolves to infra/vpc which is referenced by multiple components in stack
+tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
 
 💡 Use the exact component name instead of a path Example: atmos terraform
 <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
@@ -3,10 +3,8 @@
 
 **Error:** ambiguous component path
 
-Path resolves to infra/vpc which is referenced by multiple components in stack
-tenant1-ue2-dev
+Path resolves to infra/vpc which is referenced by multiple components in stack tenant1-ue2-dev
 
 Matching components: infra/vpc, vpc, vpc/new
 
-💡 Use the exact component name instead of a path Example: atmos terraform
-<command> infra/vpc --stack tenant1-ue2-dev
+💡 Use the exact component name instead of a path Example: atmos terraform <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_nested_component_path.stderr.golden
@@ -4,7 +4,9 @@
 **Error:** ambiguous component path
 
 Path resolves to infra/vpc which is referenced by multiple components in stack
-tenant1-ue2-dev Matching components: infra/vpc, vpc, vpc/new
+tenant1-ue2-dev
+
+Matching components: infra/vpc, vpc, vpc/new
 
 💡 Use the exact component name instead of a path Example: atmos terraform
 <command> infra/vpc --stack tenant1-ue2-dev

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_at_component_base_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_at_component_base_directory.stderr.golden
@@ -1,8 +1,7 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Error
 
-**Error:** failed to resolve component from path: path component type does not
-match command
+**Error:** failed to resolve component from path: path component type does not match command
 
 💡 Run the correct command for this component type
 

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_at_component_base_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_at_component_base_directory.stderr.golden
@@ -4,11 +4,6 @@
 **Error:** failed to resolve component from path: path component type does not
 match command
 
-## Hints
-
-💡 Path resolves to packer component but command expects terraform component You
-ran: atmos terraform <command> . The path points to: packer component
-
 💡 Run the correct command for this component type
 
 💡 Make sure the path is within your component directories

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
@@ -5,5 +5,4 @@
 
 Stack nonexistent-stack not found
 
-💡 Run atmos list stacks to see all available stacks. Verify the stack name
-matches your stack manifest files
+💡 Run atmos list stacks to see all available stacks. Verify the stack name matches your stack manifest files

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
@@ -5,5 +5,5 @@
 
 Stack nonexistent-stack not found
 
-💡 Run atmos list stacks to see all available stacks Verify the stack name
+💡 Run atmos list stacks to see all available stacks. Verify the stack name
 matches your stack manifest files

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_but_component_not_in_stack.stderr.golden
@@ -3,9 +3,7 @@
 
 **Error:** stack not found
 
-## Hints
-
-💡 Stack nonexistent-stack not found
+Stack nonexistent-stack not found
 
 💡 Run atmos list stacks to see all available stacks Verify the stack name
 matches your stack manifest files

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_not_in_component_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_not_in_component_directory.stderr.golden
@@ -1,11 +1,9 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Error
 
-**Error:** failed to resolve component from path: path is not within Atmos
-component directories
+**Error:** failed to resolve component from path: path is not within Atmos component directories
 
-💡 Components are located in component directories (terraform, helmfile, packer)
-Change to a component directory and use . or provide a path within a component
-directory
+💡 Components are located in component directories (terraform, helmfile, packer) Change to a component directory and use
+. or provide a path within a component directory
 
 💡 Make sure the path is within your component directories

--- a/tests/snapshots/TestCLICommands_terraform_plan_with_path_not_in_component_directory.stderr.golden
+++ b/tests/snapshots/TestCLICommands_terraform_plan_with_path_not_in_component_directory.stderr.golden
@@ -4,12 +4,6 @@
 **Error:** failed to resolve component from path: path is not within Atmos
 component directories
 
-## Hints
-
-💡 Path points to the stacks configuration directory, not a component: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
-
-Stacks directory: /absolute/path/to/repo/tests/fixtures/scenarios/complete/stacks
-
 💡 Components are located in component directories (terraform, helmfile, packer)
 Change to a component directory and use . or provide a path within a component
 directory

--- a/tests/snapshots/TestCLICommands_workflow_retries_example.stderr.golden
+++ b/tests/snapshots/TestCLICommands_workflow_retries_example.stderr.golden
@@ -1,8 +1,7 @@
 **Notice:** Telemetry Enabled - Atmos now collects anonymous telemetry regarding usage. This information is used to shape the Atmos roadmap and prioritize features. You can learn more, including how to opt out if you'd prefer not to participate in this anonymous program, by visiting: https://atmos.tools/cli/telemetry
 # Workflow Error
 
-**Error:** workflow step execution failed: max attempts (3) exceeded, last
-error: subcommand exited with code 1
+**Error:** workflow step execution failed: max attempts (3) exceeded, last error: subcommand exited with code 1
 
 The following command failed to execute:
 

--- a/tests/snapshots/TestCLICommands_workflow_retries_example.stderr.golden
+++ b/tests/snapshots/TestCLICommands_workflow_retries_example.stderr.golden
@@ -4,13 +4,9 @@
 **Error:** workflow step execution failed: max attempts (3) exceeded, last
 error: subcommand exited with code 1
 
-## Explanation
-
 The following command failed to execute:
 
  echo "Attempting deployment..." && exit 1
-
-## Hints
 
 💡 To resume the workflow from this step, run:
 

--- a/tests/test-cases/auth-cli.yaml
+++ b/tests/test-cases/auth-cli.yaml
@@ -28,6 +28,7 @@ tests:
       - "validate"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Validate the authentication configuration in atmos.yaml"
@@ -49,6 +50,7 @@ tests:
       - "whoami"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Display information about the current effective authentication principal."
@@ -88,6 +90,7 @@ tests:
       - "env"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Outputs environment variables for the assumed identity"
@@ -170,6 +173,7 @@ tests:
       - "exec"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Execute a command with the authenticated identity's environment variables set."
@@ -212,6 +216,7 @@ tests:
       - "login"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Authenticate to cloud providers using an identity defined in atmos.yaml"
@@ -252,6 +257,7 @@ tests:
       - "configure"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "Configure static AWS user credentials"

--- a/tests/test-cases/demo-stacks.yaml
+++ b/tests/test-cases/demo-stacks.yaml
@@ -9,6 +9,7 @@ tests:
     args:
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff: []
       stdout:
         - "BUILT-IN COMMANDS"

--- a/tests/test-cases/demo-stacks.yaml
+++ b/tests/test-cases/demo-stacks.yaml
@@ -11,7 +11,7 @@ tests:
     expect:
       diff: []
       stdout:
-        - "AVAILABLE COMMANDS"
+        - "BUILT-IN COMMANDS"
         - "\\bauth\\b"
         - "\\batlantis\\b"
         - "\\baws\\b"

--- a/tests/test-cases/flag-inheritance.yaml
+++ b/tests/test-cases/flag-inheritance.yaml
@@ -27,6 +27,7 @@ tests:
       - "plan"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"
@@ -46,6 +47,7 @@ tests:
       - "provision"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"
@@ -65,6 +67,7 @@ tests:
       - "component"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"
@@ -88,6 +91,7 @@ tests:
       - "terraform"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"
@@ -106,6 +110,7 @@ tests:
       - "component"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"
@@ -168,6 +173,7 @@ tests:
     args:
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "USAGE"
@@ -245,6 +251,7 @@ tests:
       - "info"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "verbose"
@@ -300,6 +307,7 @@ tests:
       - "component"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       exit_code: 0
       stdout:
         - "stack"

--- a/tests/test-cases/help-and-usage.yaml
+++ b/tests/test-cases/help-and-usage.yaml
@@ -35,6 +35,7 @@ tests:
       - "terraform"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -55,6 +56,7 @@ tests:
       - "terraform"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -76,6 +78,7 @@ tests:
       - "apply"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -97,6 +100,7 @@ tests:
       - "apply"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -185,6 +189,7 @@ tests:
       - "helmfile"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -205,6 +210,7 @@ tests:
       - "helmfile"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -252,6 +258,7 @@ tests:
       - "apply"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -273,6 +280,7 @@ tests:
       - "apply"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -305,6 +313,7 @@ tests:
       - "atlantis"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -325,6 +334,7 @@ tests:
       - "atlantis"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -360,6 +370,7 @@ tests:
       - "generate"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -381,6 +392,7 @@ tests:
       - "generate"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -422,6 +434,7 @@ tests:
       - "repo-config"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -444,6 +457,7 @@ tests:
       - "repo-config"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -483,6 +497,7 @@ tests:
       - "editorconfig"
       - "help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -504,6 +519,7 @@ tests:
       - "editorconfig"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -550,6 +566,7 @@ tests:
       - "about"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -676,6 +693,7 @@ tests:
       - "tp"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       sanitize:
         "(darwin|linux|windows)/(arm64|amd64|386)": "linux/amd64"
       exit_code: 0
@@ -691,6 +709,7 @@ tests:
       - "tr"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       sanitize:
         "(darwin|linux|windows)/(arm64|amd64|386)": "linux/amd64"
       exit_code: 0

--- a/tests/test-cases/help-and-usage.yaml
+++ b/tests/test-cases/help-and-usage.yaml
@@ -584,6 +584,7 @@ tests:
       - "terraform"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       sanitize:
         "(darwin|linux|windows)/(arm64|amd64|386)": "linux/amd64"
       exit_code: 0
@@ -659,6 +660,7 @@ tests:
     args:
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       sanitize:
         "(darwin|linux|windows)/(arm64|amd64|386)": "linux/amd64"
       exit_code: 0

--- a/tests/test-cases/toolchain.yaml
+++ b/tests/test-cases/toolchain.yaml
@@ -140,6 +140,7 @@ tests:
         - "atmos-inline"
         - "github_release"
         - "junegunn/fzf"
+      ignore_trailing_whitespace: true
       sanitize:
         "v?[0-9]+\\.[0-9]+\\.[0-9]+": "X.X.X"
         "[0-9]{4}-[0-9]{2}-[0-9]{2}": "YYYY-MM-DD"
@@ -168,6 +169,7 @@ tests:
         - "atmos-inline"
         - "http"
         - "jqlang/jq"
+      ignore_trailing_whitespace: true
       sanitize:
         # jq uses jq-X.X.X format for versions
         "jq-[0-9]+\\.[0-9]+(\\.[0-9]+)?": "jq-X.X"

--- a/tests/test-cases/toolchain.yaml
+++ b/tests/test-cases/toolchain.yaml
@@ -15,6 +15,7 @@ tests:
       - "toolchain"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -37,6 +38,7 @@ tests:
       - "install"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"
@@ -59,6 +61,7 @@ tests:
       - "info"
       - "--help"
     expect:
+      ignore_trailing_whitespace: true
       diff:
         - "──────────────────────────────────────────────────────────────"
         - "Update available!"

--- a/tests/test-cases/workflows.yaml
+++ b/tests/test-cases/workflows.yaml
@@ -53,7 +53,6 @@ tests:
       diff: []
       stderr:
         - "workflow step execution failed"
-        - "## Hints"
         - "The following command failed to execute:"
         - "nonexistentcommand"
         - "To resume the workflow from this step, run:"
@@ -77,7 +76,6 @@ tests:
       diff: []
       stderr:
         - "workflow step execution failed"
-        - "## Hints"
         - "The following command failed to execute:"
         - "To resume the workflow from this step, run:"
       exit_code: 1
@@ -101,7 +99,6 @@ tests:
       stderr:
         - "This should fail"
         - "workflow step execution failed"
-        - "## Hints"
         - "The following command failed to execute:"
         - "To resume the workflow from this step, run:"
       exit_code: 1
@@ -122,7 +119,6 @@ tests:
       stderr:
         - "Workflow Error"
         - "workflow has no steps defined"
-        - "## Explanation"
         - "Workflow no-steps is empty and requires at least one step to execute."
       exit_code: 1
 
@@ -141,7 +137,6 @@ tests:
       diff: []
       stderr:
         - "invalid workflow step type"
-        - "## Hints"
         - "Step type 'invalid' is not supported"
         - "Each step must specify a valid type: 'atmos', 'shell', 'exec', or an"
       exit_code: 1
@@ -164,7 +159,6 @@ tests:
       stderr:
         - "Workflow Error"
         - "invalid from-step flag"
-        - "## Explanation"
         - "The --from-step flag was set to dne, but this step does not exist in workflow"
         - "pass"
         - "### Available steps:"
@@ -187,7 +181,6 @@ tests:
       stderr:
         - "# Error"
         - "no workflow found"
-        - "## Hints"
         - "No workflow exists with name no-workflow-exists"
         - "Available workflows in test.yaml"
         - "fail"
@@ -215,7 +208,6 @@ tests:
       stderr:
         - "# Error"
         - "invalid workflow manifest"
-        - "## Explanation"
         - "The workflow manifest"
         - "must be a map with"
         - "workflows: key"
@@ -237,7 +229,6 @@ tests:
       stderr:
         - "# Error"
         - "workflow file not found"
-        - "## Hints"
         - "The workflow manifest file"
         - "does not exist"
       exit_code: 1
@@ -259,7 +250,6 @@ tests:
       diff: []
       stderr:
         - "workflow step execution failed"
-        - "## Hints"
         - "The following command failed to execute:"
         - "To resume the workflow from this step, run:"
       exit_code: 1
@@ -279,7 +269,6 @@ tests:
       diff: []
       stderr:
         - "workflow step execution failed"
-        - "## Hints"
         - "The following command failed to execute:"
         - "To resume the workflow from this step, run:"
       exit_code: 1

--- a/website/blog/2026-07-02-help-command-groups-error-formatting.mdx
+++ b/website/blog/2026-07-02-help-command-groups-error-formatting.mdx
@@ -1,0 +1,26 @@
+---
+slug: help-command-groups-error-formatting
+title: "Clearer Help Sections and Error Explanations"
+authors: [osterman]
+tags: [enhancement, dx]
+---
+
+Atmos help output now separates built-in commands from custom commands, and error output now makes explanations easier to scan without adding extra headings.
+
+<!--truncate-->
+
+## What Changed
+
+Command help now groups native Atmos commands under **BUILT-IN COMMANDS** and commands defined in `atmos.yaml` under **CUSTOM COMMANDS**. Teams with project-specific runbooks can now see what Atmos provides out of the box and what their repository adds locally.
+
+Error formatting also got cleaner. Explanations render as a styled callout when color is enabled, while hints stay as direct, actionable lines. The formatter reserves room for callout padding before wrapping text, so long explanations stay aligned instead of reflowing inside the box.
+
+## Why It Matters
+
+- **Faster command discovery.** Built-in commands and custom shortcuts no longer compete in one flat list.
+- **Cleaner troubleshooting.** Error explanations are visually distinct from hints without adding extra section headers.
+- **More consistent output.** Snapshot comparisons and stderr formatting now preserve intentional whitespace unless a test opts into trailing-whitespace tolerance.
+
+## Get Involved
+
+Run `atmos --help` or any command-specific `--help` page in a repository with custom commands to see the new grouping.

--- a/website/src/data/roadmap.js
+++ b/website/src/data/roadmap.js
@@ -40,7 +40,8 @@ export const roadmapConfig = {
     { id: 'q3-2025', label: 'Q3 2025', status: 'completed' },
     { id: 'q4-2025', label: 'Q4 2025', status: 'completed' },
     { id: 'q1-2026', label: 'Q1 2026', status: 'completed' },
-    { id: 'q2-2026', label: 'Q2 2026', status: 'current' },
+    { id: 'q2-2026', label: 'Q2 2026', status: 'completed' },
+    { id: 'q3-2026', label: 'Q3 2026', status: 'current' },
   ],
 
   // Featured: curated highlight reel of top strategic initiatives.
@@ -214,6 +215,7 @@ export const roadmapConfig = {
         { label: 'Aqua-compatible package verification for toolchain installs', status: 'shipped', quarter: 'q2-2026', pr: 2415, changelog: 'toolchain-package-verification', docs: '/cli/configuration/toolchain#package-verification', description: 'Verify downloaded toolchain packages before extraction using registry checksums, signatures, and attestations.', benefits: 'Teams get package integrity checks by default when registry metadata is available, with stricter required policies for CI and regulated environments.' },
         { label: 'Terminal themes', status: 'shipped', quarter: 'q4-2025', docs: '/cli/configuration/settings/terminal', changelog: 'terminal-themes', version: 'v1.198.0', description: 'Customizable terminal color themes with built-in presets and user-defined themes.', benefits: 'Match your terminal output to your preferences or brand. Switch themes without code changes.', demoId: 'theme' },
         { label: 'Theme-aware help text', status: 'shipped', quarter: 'q4-2025', changelog: 'theme-aware-help', version: 'v1.200.0', description: 'Help text respects your terminal theme settings for consistent styling.', benefits: 'Help output matches your theme. Consistent look across all Atmos commands.' },
+        { label: 'Clearer help sections and error explanations', status: 'shipped', quarter: 'q3-2026', changelog: 'help-command-groups-error-formatting', description: 'Help output now separates built-in Atmos commands from repository-defined custom commands, while errors render explanations as cleaner callouts with direct hint lines.', benefits: 'Users can distinguish native CLI commands from local runbooks faster, and troubleshooting output is easier to scan in terminals and CI logs.' },
         { label: 'Helpful error messages with hints', status: 'shipped', quarter: 'q4-2025', changelog: 'helpful-errors', version: 'v1.199.0', description: 'Error messages include actionable hints, rich context, and optional Sentry integration for enterprise error tracking.', benefits: 'Understand what went wrong and how to fix it. Enterprise teams get centralized error tracking.' },
         { label: 'Interactive Terraform prompts', status: 'shipped', quarter: 'q4-2025', changelog: 'interactive-terraform-prompts', description: 'Interactive component and stack selection when running Terraform commands without arguments.', benefits: 'Discover and select components interactively. No need to remember exact names.' },
         { label: 'Interactive file generation for terraform, helmfile, and packer', status: 'shipped', quarter: 'q1-2026', pr: 1971, changelog: 'interactive-file-generation', description: 'Interactive prompts for generate files command with cross-provisioner support and idempotent generation.', benefits: 'Explore file generation interactively. Same patterns work across terraform, helmfile, and packer.' },


### PR DESCRIPTION
## what

- Split help output into `BUILT-IN COMMANDS` and `CUSTOM COMMANDS`, while keeping config aliases in the dedicated `ALIASES` section.
- Redesign error formatting so explanations render without a heading as styled callouts, and hints render as standalone `💡` action lines.
- Reclassified clear hint/explanation misuses and regenerated affected CLI snapshots.

## why

- Makes command help clearer by separating Atmos built-ins from commands loaded from configuration.
- Makes error output distinguish diagnostic context from remediation steps without noisy section headers.
- Keeps fallback/non-colored help and error paths consistent with the primary renderer.

## references

- Validation: `go test ./errors`, `go test ./cmd`, targeted CLI snapshot checks, full `TestCLICommands` snapshot regeneration, and pre-commit hooks.
