### PR TITLE
Fix native CI dogfood regressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -545,6 +545,19 @@ jobs:
           cd examples/${{ matrix.demo-folder }}
           atmos test
 
+  k3s-required:
+    name: "[k3s] demo-helmfile"
+    needs: k3s
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Check k3s matrix result
+        run: |
+          if [ "${{ needs.k3s.result }}" != "success" ]; then
+            echo "k3s matrix result was '${{ needs.k3s.result }}'"
+            exit 1
+          fi
+
   # Exercise the Kubernetes native component against a real kube-apiserver+etcd
   # control plane (started by controller-runtime envtest): server-side apply,
   # dry-run diff, delete, server-side validate, and a CRD round-trip. The

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
           ignore: DL3008
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always()
         with:
           # Path to SARIF file relative to the root of the repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -468,6 +468,8 @@ jobs:
     runs-on: ${{ matrix.flavor.os }}
     env:
       ATMOS_LOGS_LEVEL: Debug
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -478,7 +480,7 @@ jobs:
           - demo-helmfile
           - helm
 
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 RUN set -ex; \
     # Update the package list
     apt-get update; \
-    # Install curl and git
-    apt-get -y install  --no-install-recommends curl git ca-certificates; \
+    # Install runtime dependencies required by Atmos-managed tools.
+    apt-get -y install  --no-install-recommends curl git ca-certificates python3; \
     # Install the Cloud Posse Debian repository
     curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/bash.deb.sh' | bash -x; \
     # Install OpenTofu

--- a/actions/cache/action.yml
+++ b/actions/cache/action.yml
@@ -28,6 +28,20 @@ runs:
     - id: meta
       shell: bash
       run: atmos ci cache paths --format=github
+    - id: validate
+      shell: bash
+      env:
+        ATMOS_CACHE_KEY: ${{ steps.meta.outputs.key }}
+        ATMOS_CACHE_PATH: ${{ steps.meta.outputs.path }}
+      run: |
+        if [ -z "${ATMOS_CACHE_KEY}" ]; then
+          echo "::error::Atmos cache metadata did not include a cache key. Check the previous 'atmos ci cache paths --format=github' step output."
+          exit 1
+        fi
+        if [ -z "${ATMOS_CACHE_PATH}" ]; then
+          echo "::error::Atmos cache metadata did not include any cache paths. Check ci.cache configuration and the previous metadata step output."
+          exit 1
+        fi
     - id: cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:

--- a/cmd/docker_and_action_regression_test.go
+++ b/cmd/docker_and_action_regression_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerfileInstallsPython3Runtime(t *testing.T) {
+	content, err := os.ReadFile("../Dockerfile")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "--no-install-recommends curl git ca-certificates python3")
+	assert.NotContains(t, string(content), "python3-pip")
+	assert.NotContains(t, string(content), "python3-venv")
+}
+
+func TestAtmosCacheActionValidatesMetadataBeforeActionsCache(t *testing.T) {
+	content, err := os.ReadFile("../actions/cache/action.yml")
+	require.NoError(t, err)
+	action := string(content)
+
+	assert.Contains(t, action, "steps.meta.outputs.key")
+	assert.Contains(t, action, "steps.meta.outputs.path")
+	assert.Contains(t, action, "Atmos cache metadata did not include a cache key")
+	assert.Contains(t, action, "Atmos cache metadata did not include any cache paths")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -456,6 +456,9 @@ var RootCmd = &cobra.Command{
 				if !isHelpRequested {
 					log.Warn(err.Error())
 				}
+			} else if isCIGitCloneBootstrapRequested() {
+				tmpConfig.CI.Enabled = true
+				log.Debug("CLI configuration error (continuing for CI git clone bootstrap)", "error", err)
 			} else if isVersionCommand() {
 				// Version command should always work, even with invalid config.
 				// Log config error but allow version command to proceed.
@@ -1440,6 +1443,12 @@ func handleConfigInitError(initErr error, atmosConfig *schema.AtmosConfiguration
 		return nil
 	}
 
+	if isCIGitCloneBootstrapRequested() {
+		atmosConfig.CI.Enabled = true
+		log.Debug("Warning: CLI configuration error (continuing for CI git clone bootstrap)", "error", initErr)
+		return nil
+	}
+
 	if errors.Is(initErr, cfg.NotFound) {
 		// Config not found is acceptable for some commands.
 		return nil
@@ -1467,6 +1476,117 @@ func handleConfigInitError(initErr error, atmosConfig *schema.AtmosConfiguration
 
 	// Return other errors as-is.
 	return initErr
+}
+
+func isCIGitCloneBootstrapRequested() bool {
+	return ci.Detect() != nil && argsRequestNoArgGitClone(os.Args[1:])
+}
+
+const (
+	rootFlagChdirShort       = "-C"
+	rootFlagChdirShortPrefix = "-C="
+)
+
+var (
+	gitCloneBootstrapValueFlags = map[string]struct{}{
+		"--repo-uri":       {},
+		"-r":               {},
+		"--branch":         {},
+		"-b":               {},
+		"--remote":         {},
+		"--workdir":        {},
+		"--filter":         {},
+		"--depth":          {},
+		rootFlagChdirShort: {},
+	}
+	rootBootstrapValueFlags = map[string]struct{}{
+		"--chdir":          {},
+		rootFlagChdirShort: {},
+		"--profile":        {},
+		"--config":         {},
+		"--config-path":    {},
+		"--base-path":      {},
+		"--logs-level":     {},
+		"--logs-file":      {},
+		"--use-version":    {},
+	}
+)
+
+func argsRequestNoArgGitClone(args []string) bool {
+	args = stripRootFlagsForBootstrapCheck(args)
+	if len(args) < 2 || args[0] != "git" || args[1] != "clone" {
+		return false
+	}
+	return gitCloneArgsAllowBootstrap(args[2:])
+}
+
+type bootstrapArgAction int
+
+const (
+	bootstrapArgAllow bootstrapArgAction = iota
+	bootstrapArgConsumeNext
+	bootstrapArgReject
+)
+
+func gitCloneArgsAllowBootstrap(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		switch gitCloneBootstrapArgAction(args[i]) {
+		case bootstrapArgReject:
+			return false
+		case bootstrapArgConsumeNext:
+			i++
+		}
+	}
+	return true
+}
+
+func gitCloneBootstrapArgAction(arg string) bootstrapArgAction {
+	switch {
+	case arg == "--" || arg == "--all":
+		return bootstrapArgReject
+	case flagTakesSeparateValue(arg, gitCloneBootstrapValueFlags):
+		return bootstrapArgConsumeNext
+	case flagHasInlineValue(arg, gitCloneBootstrapValueFlags), shortChdirHasInlineValue(arg), strings.HasPrefix(arg, "-"):
+		return bootstrapArgAllow
+	default:
+		return bootstrapArgReject
+	}
+}
+
+func stripRootFlagsForBootstrapCheck(args []string) []string {
+	for len(args) > 0 {
+		arg := args[0]
+		switch {
+		case flagTakesSeparateValue(arg, rootBootstrapValueFlags):
+			if len(args) < 2 {
+				return nil
+			}
+			args = args[2:]
+		case flagHasInlineValue(arg, rootBootstrapValueFlags):
+			args = args[1:]
+		default:
+			return args
+		}
+	}
+	return args
+}
+
+func flagTakesSeparateValue(arg string, flags map[string]struct{}) bool {
+	_, ok := flags[arg]
+	return ok
+}
+
+func flagHasInlineValue(arg string, flags map[string]struct{}) bool {
+	for flag := range flags {
+		if strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func shortChdirHasInlineValue(arg string) bool {
+	return strings.HasPrefix(arg, rootFlagChdirShort) && len(arg) > len(rootFlagChdirShort)
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -129,6 +129,59 @@ func TestInitFunction(t *testing.T) {
 	}
 }
 
+func TestArgsRequestNoArgGitClone(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "no arg git clone",
+			args: []string{"git", "clone"},
+			want: true,
+		},
+		{
+			name: "global profile flag is ignored for bootstrap detection",
+			args: []string{"--profile", "github", "git", "clone", "--depth", "1", "--filter=blob:none"},
+			want: true,
+		},
+		{
+			name: "positional repository is not CI bootstrap",
+			args: []string{"git", "clone", "repo"},
+			want: false,
+		},
+		{
+			name: "native git args imply explicit clone",
+			args: []string{"git", "clone", "--", "--no-tags"},
+			want: false,
+		},
+		{
+			name: "all flag is not CI bootstrap",
+			args: []string{"git", "clone", "--all"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, argsRequestNoArgGitClone(tt.args))
+		})
+	}
+}
+
+func TestHandleConfigInitError_AllowsCIGitCloneBootstrap(t *testing.T) {
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"atmos", "--profile", "github", "git", "clone"}
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	cfg := &schema.AtmosConfiguration{}
+	err := handleConfigInitError(assert.AnError, cfg)
+
+	assert.NoError(t, err)
+	assert.True(t, cfg.CI.Enabled, "CI clone bootstrap must enable the no-arg CI checkout path without repo-local config")
+}
+
 func TestSetupLogger_TraceLevel(t *testing.T) {
 	// Save original state.
 	originalLevel := log.GetLevel()

--- a/internal/terraform_backend/terraform_backend_local.go
+++ b/internal/terraform_backend/terraform_backend_local.go
@@ -35,7 +35,12 @@ func ReadTerraformBackendLocal(
 	componentPath := resolveLocalBackendComponentPath(atmosConfig, componentSections)
 
 	var tfStateFilePath string
-	if workspace == "" || workspace == "default" {
+	if backendPath := configuredLocalBackendPath(componentSections); backendPath != "" {
+		tfStateFilePath = backendPath
+		if !filepath.IsAbs(tfStateFilePath) {
+			tfStateFilePath = filepath.Join(componentPath, tfStateFilePath)
+		}
+	} else if workspace == "" || workspace == "default" {
 		// Default workspace: state is stored directly at terraform.tfstate.
 		tfStateFilePath = filepath.Join(componentPath, "terraform.tfstate")
 	} else {
@@ -62,6 +67,20 @@ func ReadTerraformBackendLocal(
 	}
 
 	return content, nil
+}
+
+func configuredLocalBackendPath(sections *map[string]any) string {
+	backend := GetComponentBackend(sections)
+	if backend == nil {
+		return ""
+	}
+	if path := GetBackendAttribute(&backend, "path"); path != "" {
+		return path
+	}
+	if localBackend, ok := backend["local"].(map[string]any); ok {
+		return GetBackendAttribute(&localBackend, "path")
+	}
+	return ""
 }
 
 // resolveLocalBackendComponentPath returns the directory that contains the local

--- a/internal/terraform_backend/terraform_backend_local_test.go
+++ b/internal/terraform_backend/terraform_backend_local_test.go
@@ -216,6 +216,84 @@ func TestReadTerraformBackendLocal_DefaultWorkspace_WrongLocation(t *testing.T) 
 	assert.Nil(t, content, "Should not find state file in terraform.tfstate.d/default/ for default workspace")
 }
 
+func TestReadTerraformBackendLocal_ConfiguredBackendPath(t *testing.T) {
+	const stateJSON = `{
+		"version": 4,
+		"terraform_version": "1.0.0",
+		"outputs": {
+			"id": {
+				"value": "from-configured-backend-path",
+				"type": "string"
+			}
+		}
+	}`
+
+	t.Run("relative path resolves from component directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		componentDir := filepath.Join(tempDir, "components", "terraform", "producer")
+		statePath := filepath.Join(componentDir, ".context", "tfstate", "producer.tfstate")
+		require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0o755))
+		require.NoError(t, os.WriteFile(statePath, []byte(stateJSON), 0o644))
+
+		config := &schema.AtmosConfiguration{
+			TerraformDirAbsolutePath: filepath.Join(tempDir, "components", "terraform"),
+		}
+		sections := map[string]any{
+			"component":    "producer",
+			"workspace":    "default",
+			"backend_type": "local",
+			"backend": map[string]any{
+				"path": filepath.Join(".context", "tfstate", "producer.tfstate"),
+			},
+		}
+
+		content, err := tb.ReadTerraformBackendLocal(config, &sections, nil)
+		require.NoError(t, err)
+		require.NotNil(t, content)
+
+		result, err := tb.ProcessTerraformStateFile(content)
+		require.NoError(t, err)
+		assert.Equal(t, "from-configured-backend-path", result["id"])
+	})
+
+	t.Run("workdir component uses backend path relative to workdir", func(t *testing.T) {
+		tempDir := t.TempDir()
+		workdirPath := filepath.Join(tempDir, ".workdir", "terraform", "test-producer")
+		statePath := filepath.Join(workdirPath, ".context", "tfstate", "producer.tfstate")
+		require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0o755))
+		require.NoError(t, os.WriteFile(statePath, []byte(stateJSON), 0o644))
+
+		config := &schema.AtmosConfiguration{
+			BasePath:                 tempDir,
+			TerraformDirAbsolutePath: filepath.Join(tempDir, "components", "terraform"),
+		}
+		sections := map[string]any{
+			"component":       "producer",
+			"atmos_component": "producer",
+			"atmos_stack":     "test",
+			"workspace":       "default",
+			"backend_type":    "local",
+			"backend": map[string]any{
+				"local": map[string]any{
+					"path": filepath.Join(".context", "tfstate", "producer.tfstate"),
+				},
+			},
+			"provision": map[string]any{
+				"workdir": map[string]any{"enabled": true},
+			},
+			"_workdir_path": workdirPath,
+		}
+
+		content, err := tb.ReadTerraformBackendLocal(config, &sections, nil)
+		require.NoError(t, err)
+		require.NotNil(t, content)
+
+		result, err := tb.ProcessTerraformStateFile(content)
+		require.NoError(t, err)
+		assert.Equal(t, "from-configured-backend-path", result["id"])
+	})
+}
+
 // TestReadTerraformBackendLocal_JITWorkdir verifies that ReadTerraformBackendLocal
 // resolves the correct path for components with provision.workdir.enabled: true.
 // Regression test for https://github.com/cloudposse/atmos/issues/2167.

--- a/pkg/container/common.go
+++ b/pkg/container/common.go
@@ -33,11 +33,27 @@ func buildCreateArgs(config *CreateConfig) []string {
 	args := []string{"create", "--name", config.Name, "-it"}
 
 	args = addRuntimeFlags(args, config)
+	args = addNetworkFlags(args, config.Networks)
 	args = addHealthAndRestart(args, config)
 	args = addMetadata(args, config)
 	args = addResourceBindings(args, config)
 	args = addImageAndCommand(args, config)
 
+	return args
+}
+
+func addNetworkFlags(args []string, networks []NetworkAttachment) []string {
+	for _, network := range networks {
+		if network.Name == "" {
+			continue
+		}
+		args = append(args, "--network", network.Name)
+		for _, alias := range network.Aliases {
+			if alias != "" {
+				args = append(args, "--network-alias", alias)
+			}
+		}
+	}
 	return args
 }
 

--- a/pkg/container/common_test.go
+++ b/pkg/container/common_test.go
@@ -123,6 +123,23 @@ func TestBuildCreateArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "config with networks and aliases",
+			config: &CreateConfig{
+				Name:  "test-container",
+				Image: "ubuntu:22.04",
+				Networks: []NetworkAttachment{
+					{Name: "github_network_123", Aliases: []string{"aws", "localstack"}},
+				},
+			},
+			expected: []string{
+				"create", "--name", "test-container", "-it",
+				"--network", "github_network_123",
+				"--network-alias", "aws",
+				"--network-alias", "localstack",
+				"ubuntu:22.04",
+			},
+		},
+		{
 			name: "config with user and workspace",
 			config: &CreateConfig{
 				Name:            "test-container",

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -208,6 +208,7 @@ func (d *DockerRuntime) parseInspectData(data map[string]interface{}) *Info {
 
 	// Parse labels.
 	info.Labels = getLabelsFromInspect(data)
+	info.Networks = getNetworksFromInspect(data)
 
 	return info
 }
@@ -252,6 +253,25 @@ func getLabelsFromInspect(data map[string]interface{}) map[string]string {
 	for k, v := range labels {
 		if s, ok := v.(string); ok {
 			result[k] = s
+		}
+	}
+	return result
+}
+
+func getNetworksFromInspect(data map[string]interface{}) []string {
+	settings, ok := data["NetworkSettings"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	networks, ok := settings["Networks"].(map[string]interface{})
+	if !ok || len(networks) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(networks))
+	for name := range networks {
+		if name != "" {
+			result = append(result, name)
 		}
 	}
 	return result

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -274,6 +275,7 @@ func getNetworksFromInspect(data map[string]interface{}) []string {
 			result = append(result, name)
 		}
 	}
+	sort.Strings(result)
 	return result
 }
 

--- a/pkg/container/docker_unit_test.go
+++ b/pkg/container/docker_unit_test.go
@@ -667,5 +667,5 @@ func TestGetNetworksFromInspect(t *testing.T) {
 
 	got := getNetworksFromInspect(data)
 
-	assert.ElementsMatch(t, []string{"github_network_123", "bridge"}, got)
+	assert.Equal(t, []string{"bridge", "github_network_123"}, got)
 }

--- a/pkg/container/docker_unit_test.go
+++ b/pkg/container/docker_unit_test.go
@@ -654,3 +654,18 @@ func TestParseDockerPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNetworksFromInspect(t *testing.T) {
+	data := map[string]interface{}{
+		"NetworkSettings": map[string]interface{}{
+			"Networks": map[string]interface{}{
+				"github_network_123": map[string]interface{}{},
+				"bridge":             map[string]interface{}{},
+			},
+		},
+	}
+
+	got := getNetworksFromInspect(data)
+
+	assert.ElementsMatch(t, []string{"github_network_123", "bridge"}, got)
+}

--- a/pkg/container/lifecycle.go
+++ b/pkg/container/lifecycle.go
@@ -28,6 +28,7 @@ type NamedConfig struct {
 	Image       string
 	Command     []string
 	Ports       []PortBinding
+	Networks    []NetworkAttachment
 	Mounts      []Mount
 	Env         map[string]string
 	User        string
@@ -195,6 +196,7 @@ func buildNamedCreateConfig(config *NamedConfig, name string) *CreateConfig {
 		Command:     config.Command,
 		Mounts:      config.Mounts,
 		Ports:       config.Ports,
+		Networks:    config.Networks,
 		Env:         config.Env,
 		User:        config.User,
 		Labels:      labels,

--- a/pkg/container/podman.go
+++ b/pkg/container/podman.go
@@ -257,8 +257,34 @@ func parsePodmanContainer(containerJSON map[string]interface{}) Info {
 	if raw, ok := containerJSON["Ports"]; ok {
 		info.Ports = parsePodmanPorts(raw)
 	}
+	if networks := parsePodmanNetworks(containerJSON["Networks"]); len(networks) > 0 {
+		info.Networks = networks
+	}
 
 	return info
+}
+
+func parsePodmanNetworks(raw interface{}) []string {
+	switch v := raw.(type) {
+	case []interface{}:
+		networks := make([]string, 0, len(v))
+		for _, item := range v {
+			if name, ok := item.(string); ok && name != "" {
+				networks = append(networks, name)
+			}
+		}
+		return networks
+	case map[string]interface{}:
+		networks := make([]string, 0, len(v))
+		for name := range v {
+			if name != "" {
+				networks = append(networks, name)
+			}
+		}
+		return networks
+	default:
+		return nil
+	}
 }
 
 // parsePodmanPorts extracts published port bindings from a podman `ps --format json`

--- a/pkg/container/podman.go
+++ b/pkg/container/podman.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -273,6 +274,7 @@ func parsePodmanNetworks(raw interface{}) []string {
 				networks = append(networks, name)
 			}
 		}
+		sort.Strings(networks)
 		return networks
 	case map[string]interface{}:
 		networks := make([]string, 0, len(v))
@@ -281,6 +283,7 @@ func parsePodmanNetworks(raw interface{}) []string {
 				networks = append(networks, name)
 			}
 		}
+		sort.Strings(networks)
 		return networks
 	default:
 		return nil

--- a/pkg/container/podman_test.go
+++ b/pkg/container/podman_test.go
@@ -1073,8 +1073,8 @@ func TestParsePodmanPorts(t *testing.T) {
 }
 
 func TestParsePodmanNetworks(t *testing.T) {
-	assert.Equal(t, []string{"github_network_123", "bridge"}, parsePodmanNetworks([]interface{}{"github_network_123", "bridge"}))
-	assert.ElementsMatch(t, []string{"github_network_123", "bridge"}, parsePodmanNetworks(map[string]interface{}{
+	assert.Equal(t, []string{"bridge", "github_network_123"}, parsePodmanNetworks([]interface{}{"github_network_123", "bridge"}))
+	assert.Equal(t, []string{"bridge", "github_network_123"}, parsePodmanNetworks(map[string]interface{}{
 		"github_network_123": map[string]interface{}{},
 		"bridge":             map[string]interface{}{},
 	}))

--- a/pkg/container/podman_test.go
+++ b/pkg/container/podman_test.go
@@ -1072,6 +1072,15 @@ func TestParsePodmanPorts(t *testing.T) {
 	}
 }
 
+func TestParsePodmanNetworks(t *testing.T) {
+	assert.Equal(t, []string{"github_network_123", "bridge"}, parsePodmanNetworks([]interface{}{"github_network_123", "bridge"}))
+	assert.ElementsMatch(t, []string{"github_network_123", "bridge"}, parsePodmanNetworks(map[string]interface{}{
+		"github_network_123": map[string]interface{}{},
+		"bridge":             map[string]interface{}{},
+	}))
+	assert.Empty(t, parsePodmanNetworks("not-networks"))
+}
+
 func TestParsePodmanPort(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/container/runtime.go
+++ b/pkg/container/runtime.go
@@ -112,6 +112,7 @@ type CreateConfig struct {
 	WorkspaceFolder string
 	Mounts          []Mount
 	Ports           []PortBinding
+	Networks        []NetworkAttachment
 	Env             map[string]string
 	User            string
 	Labels          map[string]string
@@ -164,16 +165,24 @@ type PortBinding struct {
 	Protocol      string // tcp, udp
 }
 
+// NetworkAttachment describes a container network membership created at
+// container-create time, including DNS aliases scoped to that network.
+type NetworkAttachment struct {
+	Name    string
+	Aliases []string
+}
+
 // Info represents container state information.
 type Info struct {
-	ID      string
-	Name    string
-	Image   string
-	Status  string // running, stopped, exited, etc.
-	Health  string // healthy, unhealthy, starting, or "" when no healthcheck.
-	Created time.Time
-	Ports   []PortBinding
-	Labels  map[string]string
+	ID       string
+	Name     string
+	Image    string
+	Status   string // running, stopped, exited, etc.
+	Health   string // healthy, unhealthy, starting, or "" when no healthcheck.
+	Created  time.Time
+	Ports    []PortBinding
+	Networks []string
+	Labels   map[string]string
 }
 
 // ExecOptions represents options for executing commands in containers.

--- a/pkg/emulator/endpoint_host.go
+++ b/pkg/emulator/endpoint_host.go
@@ -1,0 +1,146 @@
+package emulator
+
+import (
+	"context"
+	"encoding/hex"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/cloudposse/atmos/pkg/container"
+	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/spf13/viper"
+)
+
+const (
+	envEmulatorEndpointHost               = "ATMOS_EMULATOR_ENDPOINT_HOST"
+	envEmulatorUseCurrentContainerNetwork = "ATMOS_EMULATOR_USE_CURRENT_CONTAINER_NETWORK"
+	linuxRouteGatewayBase                 = 16
+	linuxRouteGatewayBytes                = 4
+)
+
+var (
+	processRunsInContainer = defaultProcessRunsInContainer
+	readProcFile           = os.ReadFile
+)
+
+func reachableHostForPublishedPorts() string {
+	defer perf.Track(nil, "emulator.reachableHostForPublishedPorts")()
+
+	if host := strings.TrimSpace(envString(envEmulatorEndpointHost)); host != "" {
+		return host
+	}
+	if !processRunsInContainer() {
+		return "localhost"
+	}
+	if gateway := linuxDefaultGateway(); gateway != "" {
+		return gateway
+	}
+	return "localhost"
+}
+
+func currentContainerNetwork(ctx context.Context, runtime container.Runtime) string {
+	defer perf.Track(nil, "emulator.currentContainerNetwork")()
+
+	if !useCurrentContainerNetwork() || runtime == nil {
+		return ""
+	}
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		return ""
+	}
+	info, err := runtime.Inspect(ctx, hostname)
+	if err != nil || info == nil {
+		return ""
+	}
+	return firstReachableNetwork(info.Networks)
+}
+
+func useCurrentContainerNetwork() bool {
+	defer perf.Track(nil, "emulator.useCurrentContainerNetwork")()
+
+	switch strings.ToLower(strings.TrimSpace(envString(envEmulatorUseCurrentContainerNetwork))) {
+	case "1", "true", "yes", "on":
+		return processRunsInContainer()
+	case "0", "false", "no", "off":
+		return false
+	}
+	return envString("GITHUB_ACTIONS") == "true" && processRunsInContainer()
+}
+
+func envString(name string) string {
+	defer perf.Track(nil, "emulator.envString")()
+
+	_ = viper.BindEnv(name, name)
+	return viper.GetString(name)
+}
+
+func firstReachableNetwork(networks []string) string {
+	defer perf.Track(nil, "emulator.firstReachableNetwork")()
+
+	for _, network := range networks {
+		switch network {
+		case "", "host", "none":
+			continue
+		default:
+			return network
+		}
+	}
+	return ""
+}
+
+func defaultProcessRunsInContainer() bool {
+	defer perf.Track(nil, "emulator.defaultProcessRunsInContainer")()
+
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+
+	data, err := readProcFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	cgroup := string(data)
+	for _, marker := range []string{"docker", "containerd", "kubepods", "libpod"} {
+		if strings.Contains(cgroup, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func linuxDefaultGateway() string {
+	defer perf.Track(nil, "emulator.linuxDefaultGateway")()
+
+	data, err := readProcFile("/proc/net/route")
+	if err != nil {
+		return ""
+	}
+	return parseLinuxDefaultGateway(string(data))
+}
+
+func parseLinuxDefaultGateway(routeTable string) string {
+	defer perf.Track(nil, "emulator.parseLinuxDefaultGateway")()
+
+	for _, line := range strings.Split(routeTable, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[1] != "00000000" {
+			continue
+		}
+		gateway, err := hex.DecodeString(fields[2])
+		if err != nil || len(gateway) != linuxRouteGatewayBytes || isZeroIPv4(gateway) {
+			continue
+		}
+		return net.IPv4(gateway[3], gateway[2], gateway[1], gateway[0]).String()
+	}
+	return ""
+}
+
+func isZeroIPv4(ip []byte) bool {
+	defer perf.Track(nil, "emulator.isZeroIPv4")()
+
+	return len(ip) == linuxRouteGatewayBytes && ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0
+}

--- a/pkg/emulator/endpoint_host.go
+++ b/pkg/emulator/endpoint_host.go
@@ -7,15 +7,15 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/viper"
+
 	"github.com/cloudposse/atmos/pkg/container"
 	"github.com/cloudposse/atmos/pkg/perf"
-	"github.com/spf13/viper"
 )
 
 const (
 	envEmulatorEndpointHost               = "ATMOS_EMULATOR_ENDPOINT_HOST"
 	envEmulatorUseCurrentContainerNetwork = "ATMOS_EMULATOR_USE_CURRENT_CONTAINER_NETWORK"
-	linuxRouteGatewayBase                 = 16
 	linuxRouteGatewayBytes                = 4
 )
 

--- a/pkg/emulator/endpoint_host_test.go
+++ b/pkg/emulator/endpoint_host_test.go
@@ -1,0 +1,113 @@
+package emulator
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/cloudposse/atmos/pkg/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReachableHostForPublishedPorts_HostNativeUsesLocalhost(t *testing.T) {
+	t.Setenv(envEmulatorEndpointHost, "")
+	restore := stubEndpointHostDetection(t, false, "")
+
+	got := reachableHostForPublishedPorts()
+
+	assert.Equal(t, "localhost", got)
+	restore()
+}
+
+func TestReachableHostForPublishedPorts_ContainerUsesDefaultGateway(t *testing.T) {
+	t.Setenv(envEmulatorEndpointHost, "")
+	restore := stubEndpointHostDetection(t, true, "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\neth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0\n")
+
+	got := reachableHostForPublishedPorts()
+
+	assert.Equal(t, "172.17.0.1", got)
+	restore()
+}
+
+func TestReachableHostForPublishedPorts_OverrideWins(t *testing.T) {
+	t.Setenv(envEmulatorEndpointHost, "host.docker.internal")
+	restore := stubEndpointHostDetection(t, false, "")
+
+	got := reachableHostForPublishedPorts()
+
+	assert.Equal(t, "host.docker.internal", got)
+	restore()
+}
+
+func TestFirstReachableNetwork(t *testing.T) {
+	assert.Equal(t, "github_network_123", firstReachableNetwork([]string{"", "none", "host", "github_network_123"}))
+	assert.Empty(t, firstReachableNetwork([]string{"", "none", "host"}))
+}
+
+func TestUseCurrentContainerNetworkRequiresActionsOrOverride(t *testing.T) {
+	restore := stubEndpointHostDetection(t, true, "")
+	defer restore()
+
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "")
+	assert.False(t, useCurrentContainerNetwork())
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	assert.True(t, useCurrentContainerNetwork())
+
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "false")
+	assert.False(t, useCurrentContainerNetwork())
+
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "true")
+	assert.True(t, useCurrentContainerNetwork())
+}
+
+func TestParseLinuxDefaultGateway(t *testing.T) {
+	routeTable := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"eth0\t00000000\t0102A8C0\t0003\t0\t0\t0\t00000000\t0\t0\t0\n"
+
+	assert.Equal(t, "192.168.2.1", parseLinuxDefaultGateway(routeTable))
+	assert.Empty(t, parseLinuxDefaultGateway("Iface Destination Gateway\neth0 00000001 0102A8C0\n"))
+}
+
+type staticInspectRuntime struct {
+	container.Runtime
+	info *container.Info
+}
+
+func (r staticInspectRuntime) Inspect(context.Context, string) (*container.Info, error) {
+	return r.info, nil
+}
+
+func TestCurrentContainerNetwork(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "")
+	restore := stubEndpointHostDetection(t, true, "")
+	defer restore()
+
+	got := currentContainerNetwork(context.Background(), staticInspectRuntime{
+		info: &container.Info{Networks: []string{"none", "github_network_123"}},
+	})
+
+	assert.Equal(t, "github_network_123", got)
+}
+
+func stubEndpointHostDetection(t *testing.T, inContainer bool, routeTable string) func() {
+	t.Helper()
+
+	origProcessRunsInContainer := processRunsInContainer
+	origReadProcFile := readProcFile
+
+	processRunsInContainer = func() bool { return inContainer }
+	readProcFile = func(name string) ([]byte, error) {
+		if name == "/proc/net/route" {
+			return []byte(routeTable), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	return func() {
+		processRunsInContainer = origProcessRunsInContainer
+		readProcFile = origReadProcFile
+	}
+}

--- a/pkg/emulator/endpoint_host_test.go
+++ b/pkg/emulator/endpoint_host_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudposse/atmos/pkg/container"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudposse/atmos/pkg/container"
 )
 
 func TestReachableHostForPublishedPorts_HostNativeUsesLocalhost(t *testing.T) {

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -254,8 +254,8 @@ func emulatorNetworkName(stack string) string {
 	return "atmos-emulator-" + sanitizeNetworkToken(stack)
 }
 
-func emulatorNetworkAlias(name string) string {
-	return sanitizeNetworkToken(name)
+func emulatorNetworkAlias(stack, name string) string {
+	return sanitizeNetworkToken(stack + "-" + name)
 }
 
 // sanitizeNetworkToken reduces a stack name to characters valid in a docker/podman
@@ -284,7 +284,7 @@ func sanitizeNetworkToken(s string) string {
 func (m *Manager) attachSharedNetwork(ctx context.Context, runtime container.Runtime, namedConfig *container.NamedConfig, stack, name string) {
 	defer perf.Track(nil, "emulator.Manager.attachSharedNetwork")()
 
-	alias := emulatorNetworkAlias(name)
+	alias := emulatorNetworkAlias(stack, name)
 	if network := currentContainerNetwork(ctx, runtime); network != "" {
 		namedConfig.Networks = append(namedConfig.Networks, container.NetworkAttachment{
 			Name:    network,
@@ -440,7 +440,7 @@ func (m *Manager) endpoint(ctx context.Context, runtime container.Runtime, spec 
 		if ok {
 			return Endpoint{
 				Target:   target,
-				Host:     emulatorNetworkAlias(name),
+				Host:     emulatorNetworkAlias(stack, name),
 				Ports:    ports,
 				Region:   spec.Region,
 				Project:  spec.Project,

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -254,6 +254,10 @@ func emulatorNetworkName(stack string) string {
 	return "atmos-emulator-" + sanitizeNetworkToken(stack)
 }
 
+func emulatorNetworkAlias(name string) string {
+	return sanitizeNetworkToken(name)
+}
+
 // sanitizeNetworkToken reduces a stack name to characters valid in a docker/podman
 // network name ([a-zA-Z0-9_.-]); any other rune becomes '-'.
 func sanitizeNetworkToken(s string) string {
@@ -280,6 +284,15 @@ func sanitizeNetworkToken(s string) string {
 func (m *Manager) attachSharedNetwork(ctx context.Context, runtime container.Runtime, namedConfig *container.NamedConfig, stack, name string) {
 	defer perf.Track(nil, "emulator.Manager.attachSharedNetwork")()
 
+	alias := emulatorNetworkAlias(name)
+	if network := currentContainerNetwork(ctx, runtime); network != "" {
+		namedConfig.Networks = append(namedConfig.Networks, container.NetworkAttachment{
+			Name:    network,
+			Aliases: []string{alias},
+		})
+		return
+	}
+
 	ensurer, ok := runtime.(container.NetworkEnsurer)
 	if !ok {
 		return
@@ -290,7 +303,10 @@ func (m *Manager) attachSharedNetwork(ctx context.Context, runtime container.Run
 			"network", network, "error", err)
 		return
 	}
-	namedConfig.RunArgs = append(namedConfig.RunArgs, "--network", network, "--network-alias", name)
+	namedConfig.Networks = append(namedConfig.Networks, container.NetworkAttachment{
+		Name:    network,
+		Aliases: []string{alias},
+	})
 }
 
 // resolveRootlessRun applies the driver's rootless override under a rootless
@@ -419,6 +435,22 @@ func (m *Manager) endpoint(ctx context.Context, runtime container.Runtime, spec 
 	if err != nil {
 		return Endpoint{}, err
 	}
+	if network := currentContainerNetwork(ctx, runtime); network != "" {
+		ports, ok := containerPorts(spec)
+		if ok {
+			return Endpoint{
+				Target:   target,
+				Host:     emulatorNetworkAlias(name),
+				Ports:    ports,
+				Region:   spec.Region,
+				Project:  spec.Project,
+				Services: spec.Services,
+			}, nil
+		}
+		log.Debug("emulator current container network detected but container ports are unavailable; falling back to published host ports",
+			"network", network, "component", name)
+	}
+
 	ports := make(map[int]int, len(info.Ports))
 	for _, binding := range info.Ports {
 		if binding.HostPort != 0 {
@@ -427,12 +459,28 @@ func (m *Manager) endpoint(ctx context.Context, runtime container.Runtime, spec 
 	}
 	return Endpoint{
 		Target:   target,
-		Host:     "localhost",
+		Host:     reachableHostForPublishedPorts(),
 		Ports:    ports,
 		Region:   spec.Region,
 		Project:  spec.Project,
 		Services: spec.Services,
 	}, nil
+}
+
+func containerPorts(spec *Spec) (map[int]int, bool) {
+	defer perf.Track(nil, "emulator.containerPorts")()
+
+	specPorts, err := spec.ContainerPorts()
+	if err != nil || len(specPorts) == 0 {
+		return nil, false
+	}
+	ports := make(map[int]int, len(specPorts))
+	for _, binding := range specPorts {
+		if binding.Container != 0 {
+			ports[binding.Container] = binding.Container
+		}
+	}
+	return ports, len(ports) > 0
 }
 
 // Down stops and removes the emulator's container.

--- a/pkg/emulator/manager_more_test.go
+++ b/pkg/emulator/manager_more_test.go
@@ -100,6 +100,37 @@ func TestManager_Up_CreatesAndStartsContainer(t *testing.T) {
 	assert.Equal(t, 40001, endpoint.Ports[4566])
 }
 
+func TestManager_Up_GitHubJobContainerAttachesCurrentNetworkAlias(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "")
+	restore := stubEndpointHostDetection(t, true, "")
+	defer restore()
+
+	ctrl := gomock.NewController(t)
+	runtime := NewMockRuntime(ctrl)
+	gomock.InOrder(
+		runtime.EXPECT().Inspect(gomock.Any(), gomock.Any()).Return(&container.Info{Networks: []string{"github_network_123"}}, nil),
+		runtime.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil),
+		runtime.EXPECT().Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, create *container.CreateConfig) (string, error) {
+				require.Len(t, create.Networks, 1)
+				assert.Equal(t, "github_network_123", create.Networks[0].Name)
+				assert.Equal(t, []string{"aws"}, create.Networks[0].Aliases)
+				return "new-id", nil
+			}),
+		runtime.EXPECT().Start(gomock.Any(), "new-id").Return(nil),
+		runtime.EXPECT().List(gomock.Any(), gomock.Any()).
+			Return([]container.Info{runningEmulatorInfo(40001)}, nil),
+		runtime.EXPECT().Inspect(gomock.Any(), gomock.Any()).Return(&container.Info{Networks: []string{"github_network_123"}}, nil),
+	)
+
+	m := newManagerWithRuntime(runtime)
+	endpoint, err := m.Up(context.Background(), &Spec{Driver: testDriverName}, "dev", "aws", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "aws", endpoint.Host)
+	assert.Equal(t, 4566, endpoint.Ports[4566])
+}
+
 func TestManager_Up_UpWithRuntimeError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runtime := NewMockRuntime(ctrl)

--- a/pkg/emulator/manager_more_test.go
+++ b/pkg/emulator/manager_more_test.go
@@ -115,7 +115,7 @@ func TestManager_Up_GitHubJobContainerAttachesCurrentNetworkAlias(t *testing.T) 
 			DoAndReturn(func(_ context.Context, create *container.CreateConfig) (string, error) {
 				require.Len(t, create.Networks, 1)
 				assert.Equal(t, "github_network_123", create.Networks[0].Name)
-				assert.Equal(t, []string{"aws"}, create.Networks[0].Aliases)
+				assert.Equal(t, []string{"dev-aws"}, create.Networks[0].Aliases)
 				return "new-id", nil
 			}),
 		runtime.EXPECT().Start(gomock.Any(), "new-id").Return(nil),
@@ -127,7 +127,7 @@ func TestManager_Up_GitHubJobContainerAttachesCurrentNetworkAlias(t *testing.T) 
 	m := newManagerWithRuntime(runtime)
 	endpoint, err := m.Up(context.Background(), &Spec{Driver: testDriverName}, "dev", "aws", nil)
 	require.NoError(t, err)
-	assert.Equal(t, "aws", endpoint.Host)
+	assert.Equal(t, "dev-aws", endpoint.Host)
 	assert.Equal(t, 4566, endpoint.Ports[4566])
 }
 

--- a/pkg/emulator/manager_test.go
+++ b/pkg/emulator/manager_test.go
@@ -45,6 +45,28 @@ func TestManager_Resolve_Running(t *testing.T) {
 	assert.Equal(t, true, profile.Provider["test_flag"], "manager returns the resolved driver's provider fragment")
 }
 
+func TestManager_Resolve_GitHubJobContainerUsesNetworkAliasEndpoint(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv(envEmulatorUseCurrentContainerNetwork, "")
+	restore := stubEndpointHostDetection(t, true, "")
+	defer restore()
+
+	ctrl := gomock.NewController(t)
+	runtime := NewMockRuntime(ctrl)
+	gomock.InOrder(
+		runtime.EXPECT().List(gomock.Any(), gomock.Any()).Return([]container.Info{runningEmulatorInfo(54321)}, nil),
+		runtime.EXPECT().Inspect(gomock.Any(), gomock.Any()).Return(&container.Info{Networks: []string{"github_network_123"}}, nil),
+	)
+
+	m := newManagerWithRuntime(runtime)
+	endpoint, profile, err := m.Resolve(context.Background(), &Spec{Driver: testDriverName}, "dev", "aws")
+	require.NoError(t, err)
+
+	assert.Equal(t, "aws", endpoint.Host)
+	assert.Equal(t, 4566, endpoint.Ports[4566])
+	assert.Equal(t, "http://aws:4566", profile.Env["AWS_ENDPOINT_URL"])
+}
+
 func TestManager_Resolve_NotRunning(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runtime := NewMockRuntime(ctrl)

--- a/pkg/emulator/manager_test.go
+++ b/pkg/emulator/manager_test.go
@@ -62,9 +62,9 @@ func TestManager_Resolve_GitHubJobContainerUsesNetworkAliasEndpoint(t *testing.T
 	endpoint, profile, err := m.Resolve(context.Background(), &Spec{Driver: testDriverName}, "dev", "aws")
 	require.NoError(t, err)
 
-	assert.Equal(t, "aws", endpoint.Host)
+	assert.Equal(t, "dev-aws", endpoint.Host)
 	assert.Equal(t, 4566, endpoint.Ports[4566])
-	assert.Equal(t, "http://aws:4566", profile.Env["AWS_ENDPOINT_URL"])
+	assert.Equal(t, "http://dev-aws:4566", profile.Env["AWS_ENDPOINT_URL"])
 }
 
 func TestManager_Resolve_NotRunning(t *testing.T) {

--- a/pkg/emulator/network_test.go
+++ b/pkg/emulator/network_test.go
@@ -24,3 +24,8 @@ func TestSanitizeNetworkToken(t *testing.T) {
 	assert.Equal(t, "x--y", sanitizeNetworkToken("x/?y"))
 	assert.Equal(t, "default", sanitizeNetworkToken(""))
 }
+
+func TestEmulatorNetworkAliasScopesByStack(t *testing.T) {
+	assert.Equal(t, "dev-aws", emulatorNetworkAlias("dev", "aws"))
+	assert.Equal(t, "deploy-prod-aws", emulatorNetworkAlias("deploy/prod", "aws"))
+}

--- a/pkg/provisioner/lock/lock_hook.go
+++ b/pkg/provisioner/lock/lock_hook.go
@@ -143,6 +143,14 @@ func persistDir(componentConfig map[string]any, workingDir string) string {
 			log.Debug("Skipping per-instance lock persist: workdir source unknown", "workdir", wp)
 			return ""
 		}
+		if md.SourceType == workdir.SourceTypeRemote {
+			log.Debug("Skipping per-instance lock persist: remote workdir source is not a local directory", "workdir", wp, "source", md.Source)
+			return ""
+		}
+		if info, statErr := os.Stat(md.Source); statErr != nil || !info.IsDir() {
+			log.Debug("Skipping per-instance lock persist: workdir source is not an existing local directory", "workdir", wp, "source", md.Source, "error", statErr)
+			return ""
+		}
 		return md.Source
 	}
 	if _, ok := componentConfig["source"]; ok {

--- a/pkg/provisioner/lock/lock_hook_test.go
+++ b/pkg/provisioner/lock/lock_hook_test.go
@@ -84,6 +84,7 @@ func TestAutoLockProviders_PersistsForSourceComponent(t *testing.T) {
 
 func TestAutoLockProviders_SkipsRemoteWorkdirSource(t *testing.T) {
 	dir := t.TempDir()
+	t.Chdir(dir)
 	workdirPath := filepath.Join(dir, ".workdir", "terraform", "dev-vpc")
 	require.NoError(t, os.MkdirAll(workdirPath, 0o755))
 	require.NoError(t, provWorkdir.WriteMetadata(workdirPath, &provWorkdir.WorkdirMetadata{

--- a/pkg/provisioner/lock/lock_hook_test.go
+++ b/pkg/provisioner/lock/lock_hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/provisioner"
+	provWorkdir "github.com/cloudposse/atmos/pkg/provisioner/workdir"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -79,6 +80,32 @@ func TestAutoLockProviders_PersistsForSourceComponent(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dir, provisioner.InstanceLockFilename(cc)))
 	require.NoError(t, err)
 	assert.Equal(t, "locked\n", string(got))
+}
+
+func TestAutoLockProviders_SkipsRemoteWorkdirSource(t *testing.T) {
+	dir := t.TempDir()
+	workdirPath := filepath.Join(dir, ".workdir", "terraform", "dev-vpc")
+	require.NoError(t, os.MkdirAll(workdirPath, 0o755))
+	require.NoError(t, provWorkdir.WriteMetadata(workdirPath, &provWorkdir.WorkdirMetadata{
+		Component:  "vpc",
+		Stack:      "dev",
+		SourceType: provWorkdir.SourceTypeRemote,
+		Source:     "github.com/cloudposse/terraform-aws-vpc//src",
+	}))
+
+	var calls [][]string
+	cfg := cfgWith([]string{"linux_amd64", "darwin_arm64"}, true, false)
+	cc := map[string]any{
+		"atmos_stack":              "dev",
+		"atmos_component":          "vpc",
+		provWorkdir.WorkdirPathKey: workdirPath,
+	}
+
+	require.NoError(t, autoLockProviders(context.Background(), cfg, cc, nil, recordingExecCtx(workdirPath, &calls)))
+	require.Len(t, calls, 1)
+
+	_, err := os.Stat(filepath.Join("github.com", "cloudposse", "terraform-aws-vpc", "src", provisioner.InstanceLockFilename(cc)))
+	assert.True(t, os.IsNotExist(err), "remote source identifiers must not be treated as local persistence paths")
 }
 
 func TestAutoLockProviders_Skips(t *testing.T) {

--- a/pkg/toolchain/registry/aqua/aqua.go
+++ b/pkg/toolchain/registry/aqua/aqua.go
@@ -62,6 +62,7 @@ type AquaRegistry struct {
 	client          httpClient.Client
 	cache           *RegistryCache
 	cacheStore      cache.Store
+	githubToken     string
 	githubBaseURL   string
 	registryBaseURL string // Base URL of the aqua-registry repo (raw content). See defaultAquaRegistryBaseURL.
 	lastSearchTotal int    // Total number of search results before pagination.
@@ -127,14 +128,16 @@ func NewAquaRegistry(opts ...RegistryOption) *AquaRegistry {
 		cacheBaseDir = filepath.Join(os.TempDir(), "atmos-toolchain-cache")
 	}
 
+	githubToken := github.GetGitHubToken()
 	ar := &AquaRegistry{
 		client: httpClient.NewDefaultClient(
-			httpClient.WithGitHubToken(github.GetGitHubToken()),
+			httpClient.WithGitHubToken(githubToken),
 		),
 		cache: &RegistryCache{
 			baseDir: filepath.Join(cacheBaseDir, "registry"),
 		},
 		cacheStore:      cache.NewFileStore(cacheBaseDir),
+		githubToken:     githubToken,
 		githubBaseURL:   "https://api.github.com", // default
 		registryBaseURL: defaultAquaRegistryBaseURL,
 	}
@@ -160,7 +163,19 @@ func (ar *AquaRegistry) get(url string) (*http.Response, error) {
 		return nil, err
 	}
 
+	if ar.shouldRetryUnauthenticated(url, resp) {
+		resp.Body.Close()
+		return httpClient.NewDefaultClient().Do(req)
+	}
+
 	return resp, nil
+}
+
+func (ar *AquaRegistry) shouldRetryUnauthenticated(url string, resp *http.Response) bool {
+	if resp == nil || resp.StatusCode != http.StatusForbidden || ar.githubToken == "" {
+		return false
+	}
+	return strings.HasPrefix(url, strings.TrimRight(ar.githubBaseURL, "/")+"/")
 }
 
 // LoadLocalConfig is deprecated and no-op for compatibility.

--- a/pkg/toolchain/registry/aqua/aqua_test.go
+++ b/pkg/toolchain/registry/aqua/aqua_test.go
@@ -500,6 +500,30 @@ func TestAquaRegistry_GetLatestVersion(t *testing.T) {
 	assert.Equal(t, "1.5.0", version) // Should skip draft v1.6.0 and prerelease v2.0.0-beta
 }
 
+func TestAquaRegistry_GetLatestVersion_RetriesUnauthenticatedAfterForbidden(t *testing.T) {
+	releases := []releaseInfo{{TagName: "v1.5.0", Prerelease: false, Draft: false}}
+	var calls int
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	ar := NewAquaRegistry(WithGitHubBaseURL(ts.URL))
+	ar.githubToken = "github-actions-installation-token"
+
+	version, err := ar.GetLatestVersion("aquasecurity", "trivy")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.5.0", version)
+	assert.Equal(t, 2, calls)
+}
+
 func TestAquaRegistry_GetLatestVersion_NoVersionPrefixPreservesTag(t *testing.T) {
 	const packageYAML = `packages:
   - type: github_release


### PR DESCRIPTION
## what

- Fix native CI bootstrap so `atmos git clone` can run before repo-local profile/config files exist, and make the cache action fail fast when Atmos cache metadata is missing.
- Add regressions and fixes for local backend `path` state reads, remote source-provisioned lock persistence, Docker `python3`, Aqua latest lookup fallback, and emulator job-container networking.
- Attach emulator containers to the current GitHub job container network with aliases so Terraform can reach emulator endpoints without a nested `docker run --network host` wrapper.

## why

- Dogfooding Atmos native CI exposed release gaps across checkout bootstrap, cache setup, Terraform fixture state reads, source-provisioned workdirs, inherited toolchain installs, and emulator endpoint resolution.
- These changes let GitHub Actions run the Atmos image as the job container while still using the host Docker socket for emulator-backed Terraform tests.

## references

- Dogfood PR: https://github.com/cloudposse-examples/atmos-native-ci/pull/49
