### PR TITLE
Fix GitHub artifact signed URL download

### DIFF
--- a/pkg/ci/artifact/github/store.go
+++ b/pkg/ci/artifact/github/store.go
@@ -681,8 +681,9 @@ func (s *Store) downloadViaRuntime(ctx context.Context, key string) (io.ReadClos
 	return extractFromZip(zipData)
 }
 
-// fetchBlob downloads the bytes at a pre-signed blob URL. The URL carries its
-// own authentication, so it is fetched with a plain client (no GitHub token).
+// fetchBlob downloads the bytes at a GitHub-issued signed blob URL. Runtime
+// artifact URLs and REST artifact redirect URLs carry their own authentication,
+// so they must be fetched with a plain client (no GitHub token).
 func (s *Store) fetchBlob(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -690,7 +691,7 @@ func (s *Store) fetchBlob(ctx context.Context, url string) ([]byte, error) {
 	}
 
 	client := &http.Client{Timeout: httpTimeout}
-	resp, err := client.Do(req) //nolint:gosec // G704: url is a GitHub-issued, pre-signed blob URL from the runtime API.
+	resp, err := client.Do(req) //nolint:gosec // G704: url is a GitHub-issued signed blob URL.
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to download artifact blob: %w", errUtils.ErrArtifactDownloadFailed, err)
 	}
@@ -729,20 +730,9 @@ func (s *Store) downloadArtifactContent(ctx context.Context, artifactID int64) (
 		return nil, fmt.Errorf("%w: failed to get artifact download URL: %w", errUtils.ErrArtifactDownloadFailed, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to create download request: %w", errUtils.ErrArtifactDownloadFailed, err)
-	}
-
-	resp, err := s.httpClient.Do(req)
+	zipData, err := s.fetchBlob(ctx, downloadURL)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to download artifact: %w", errUtils.ErrArtifactDownloadFailed, err)
-	}
-	defer resp.Body.Close()
-
-	zipData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to read artifact content: %w", errUtils.ErrArtifactDownloadFailed, err)
 	}
 
 	return zipData, nil

--- a/pkg/ci/artifact/github/store_test.go
+++ b/pkg/ci/artifact/github/store_test.go
@@ -1984,8 +1984,17 @@ func TestStore_DownloadViaRuntime(t *testing.T) {
 			archiveFilename: []byte("rest tar content"),
 		})
 
-		// Blob server for the REST redirect target.
-		blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Blob server for the REST redirect target. GitHub/Azure signed blob
+		// URLs reject an extra GitHub Authorization header, so this catches
+		// regressions where the authenticated API client is reused for the blob.
+		var blobAuthHeader string
+		blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			blobAuthHeader = r.Header.Get("Authorization")
+			if blobAuthHeader != "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`<Error><Code>InvalidAuthenticationInfo</Code></Error>`))
+				return
+			}
 			_, _ = w.Write(zipData)
 		}))
 		defer blob.Close()
@@ -2013,7 +2022,12 @@ func TestStore_DownloadViaRuntime(t *testing.T) {
 		}
 
 		store := &Store{
-			httpClient: api.Client(),
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					r.Header.Set("Authorization", "Bearer test-token")
+					return http.DefaultTransport.RoundTrip(r)
+				}),
+			},
 			baseURL:    api.URL,
 			prefix:     "planfile",
 			owner:      "testowner",
@@ -2030,6 +2044,7 @@ func TestStore_DownloadViaRuntime(t *testing.T) {
 		content, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		assert.Equal(t, "rest tar content", string(content))
+		assert.Empty(t, blobAuthHeader)
 	})
 
 	t.Run("invalid runtime token returns download error", func(t *testing.T) {
@@ -2149,6 +2164,7 @@ func TestStore_FetchBlob(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, errUtils.ErrArtifactDownloadFailed)
 		assert.Contains(t, err.Error(), "status 403")
+		assert.Contains(t, err.Error(), "access denied")
 	})
 
 	t.Run("transport error returns download error", func(t *testing.T) {


### PR DESCRIPTION
## what

- Fetch GitHub artifact REST redirect signed blob URLs with the unauthenticated blob client instead of the OAuth-backed GitHub API client.
- Reuse the signed blob status/body handling before zip extraction for both runtime and REST artifact download paths.
- Add regression coverage for REST fallback downloads where a signed blob endpoint rejects requests carrying an `Authorization` header.

## why

- GitHub's REST artifact download endpoint redirects to a signed blob URL that can reject extra GitHub authorization headers and return non-zip XML.
- This fixes completed-run planfile downloads so deploy verification receives the uploaded artifact zip instead of passing an error response to the zip reader.

## references

- Closes #2680
