### PR TITLE
fix(docs-generate): apply terraform-docs section settings + migration skill

### DIFF
--- a/agent-skills/AGENTS.md
+++ b/agent-skills/AGENTS.md
@@ -129,7 +129,7 @@ When a task involves Atmos, activate the matching skill for detailed guidance.
 | AWS ECR: registry login, ECR auth integrations, Docker credential writes                                          | `atmos-aws-ecr`         | `agent-skills/skills/atmos-aws-ecr/SKILL.md`         |
 | AWS compliance: Security Hub standards, compliance reports, CIS AWS, PCI DSS, SOC2, HIPAA, NIST                   | `atmos-aws-compliance`  | `agent-skills/skills/atmos-aws-compliance/SKILL.md`  |
 | AWS security: analyze findings, map to components/stacks, structured remediation                                  | `atmos-aws-security`    | `agent-skills/skills/atmos-aws-security/SKILL.md`    |
-| Migrating to Atmos from native Terraform/OpenTofu or Terraform Workspaces: layout, workspace mapping, remote-state bridge | `atmos-migration`       | `agent-skills/skills/atmos-migration/SKILL.md`       |
+| Migrating to Atmos from native Terraform/OpenTofu, Terraform Workspaces, or standalone terraform-docs: layout, workspace mapping, remote-state bridge, docs generation | `atmos-migration`       | `agent-skills/skills/atmos-migration/SKILL.md`       |
 | Atmos Modernization: replace deprecated patterns with current Atmos naming, CI, Pro, auth, secrets, and dependencies | `atmos-modernization`   | `agent-skills/skills/atmos-modernization/SKILL.md`   |
 
 ## Common Patterns

--- a/agent-skills/skills/atmos-migration/SKILL.md
+++ b/agent-skills/skills/atmos-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atmos-migration
-description: "Migrating to Atmos from existing IaC: techniques, tactics, and design patterns for native Terraform and Terraform Workspaces — minimum-disruption paths, file-layout options, workspace mapping, and the remote-state bridge for progressive migration"
+description: "Migrating to Atmos from existing IaC: techniques, tactics, and design patterns for native Terraform and Terraform Workspaces — minimum-disruption paths, file-layout options, workspace mapping, and the remote-state bridge for progressive migration; also migrating standalone terraform-docs README generation to atmos docs generate"
 metadata:
   copyright: Copyright Cloud Posse, LLC 2026
   version: "1.0.0"
@@ -8,6 +8,7 @@ references:
   - references/from-native-terraform.md
   - references/from-terraform-workspaces.md
   - references/remote-state-bridge.md
+  - references/from-terraform-docs.md
 ---
 
 # Migrating to Atmos
@@ -73,6 +74,7 @@ different reference:
 | Multiple TF root modules in scattered dirs                           | [from-native-terraform.md](references/from-native-terraform.md) |
 | `terraform.workspace`-driven environments with shared state backend  | [from-terraform-workspaces.md](references/from-terraform-workspaces.md) |
 | Need to read outputs from un-migrated TF (legacy or another repo)    | [remote-state-bridge.md](references/remote-state-bridge.md) |
+| Standalone `terraform-docs` CLI + `.terraform-docs.yml` generating READMEs | [from-terraform-docs.md](references/from-terraform-docs.md) |
 
 The remote-state-bridge pattern is what makes **progressive, component-by-component migration**
 possible. Without it, a team is forced into a big-bang cutover. Cover it any time the user has
@@ -186,3 +188,5 @@ Things to push back on if a user (or another agent) proposes them during migrati
   workspaces to stacks without losing state
 - [References/remote-state-bridge.md](references/remote-state-bridge.md) -- the dummy-component
   and abstract-component patterns for reading state from un-migrated or external Terraform
+- [References/from-terraform-docs.md](references/from-terraform-docs.md) -- replacing a standalone
+  `terraform-docs` CLI setup with `atmos docs generate`

--- a/agent-skills/skills/atmos-migration/references/from-terraform-docs.md
+++ b/agent-skills/skills/atmos-migration/references/from-terraform-docs.md
@@ -1,0 +1,109 @@
+# Migrating from terraform-docs
+
+This reference covers replacing a standalone [terraform-docs](https://terraform-docs.io) CLI setup
+(`.terraform-docs.yml` plus a manual invocation, Makefile target, or pre-commit hook) with
+`atmos docs generate`. This is not a lossy swap: `atmos docs generate` imports
+`github.com/terraform-docs/terraform-docs` directly as a Go module (a direct dependency in `go.mod`,
+not a shelled-out binary) and uses it to render the same Terraform documentation, merged into a
+Gomplate-templated document alongside any other YAML input. See
+[atmos.tools/cli/configuration/docs](https://atmos.tools/cli/configuration/docs) and
+[atmos.tools/cli/commands/docs/generate](https://atmos.tools/cli/commands/docs/generate) for the
+full user-facing docs.
+
+## Identifying the User's Shape
+
+| Shape                                                                          | Notes |
+|---------------------------------------------------------------------------------|-------|
+| Single module, `.terraform-docs.yml` + manual/Makefile `terraform-docs` invocation | Direct swap — see Recipe below |
+| Pre-commit hook running the `terraform-docs` binary                             | Same swap; replace the hook's command, see Recipe step 4 |
+| Multi-module repo relying on `terraform-docs`' `recursive.enabled` module discovery | Gap — no Atmos equivalent; see Common Gotchas |
+
+## Recipe
+
+1. **Map `.terraform-docs.yml` settings into `docs.generate.<name>.terraform` in `atmos.yaml`:**
+
+   | `.terraform-docs.yml`              | `docs.generate.<name>.terraform` | Notes |
+   |-------------------------------------|-----------------------------------|-------|
+   | `formatter:`                        | `format:`                         | Atmos supports `markdown table`, `markdown`, `tfvars hcl`, `tfvars json` — not the full upstream set (no `asciidoc`, `json`, `pretty`, `toml`, `xml`, `yaml`) |
+   | `sort.by:`                          | `sort_by:`                        | Sort is implicitly enabled whenever `sort_by` is non-empty; there's no separate `sort.enabled` field |
+   | `sections.show`/`sections.hide` for `inputs`, `outputs`, `providers` | `show_inputs:` / `show_outputs:` / `show_providers:` (booleans) | Only these three sections are controllable; `header`, `footer`, `requirements`, `resources`, `data-sources`, `modules` have no Atmos equivalent |
+   | (module root directory)             | `source:` (relative to `base-dir`) | |
+   | `.terraform-docs.yml` file itself   | the `terraform:` block             | No separate config file — it's inline in `atmos.yaml` |
+
+   ```yaml
+   # atmos.yaml
+   docs:
+     generate:
+       readme:
+         base-dir: .
+         input:
+           - "./README.yaml"
+         template: "./README.md.gotmpl"
+         output: "./README.md"
+         terraform:
+           source: src/
+           enabled: true
+           format: "markdown table"
+           show_inputs: true
+           show_outputs: true
+           show_providers: false
+           sort_by: "name"
+   ```
+
+2. **Add a Go template that renders the `terraform_docs` data key.** `atmos docs generate` injects
+   the rendered Terraform docs into the merged template data under `terraform_docs`:
+
+   ```gotmpl
+   {{- $data := (ds "config") -}}
+   # {{ $data.name | default "Project Title" }}
+
+   {{ $data.description | default "No description provided." }}
+
+   {{ if has $data "terraform_docs" }}
+   ## Terraform Documentation
+
+   {{ $data.terraform_docs }}
+   {{ end }}
+   ```
+
+3. **Run `atmos docs generate <name>` and diff the output** against the README the standalone
+   `terraform-docs` binary produced, to confirm parity before removing the old tooling.
+
+4. **Replace the CI/pre-commit step.** A pre-commit hook or CI step that runs
+   `terraform-docs markdown table ./module > README.md` becomes a step that runs
+   `atmos docs generate <name>`.
+
+5. **Remove the standalone setup**: delete `.terraform-docs.yml`, and drop the `terraform-docs`
+   binary from `dependencies.tools`/`.tool-versions` (if toolchain-managed) or from CI setup steps,
+   once the generated output is verified equivalent.
+
+## Common Gotchas
+
+### No recursive multi-module scan
+
+`docs.generate.<name>.terraform.source` targets exactly one Terraform module directory per named
+generator. Standalone `terraform-docs`' `recursive.enabled` (scanning a `modules/` tree and writing a
+README per submodule) has no direct equivalent — a multi-module repo needs one
+`docs.generate.<name>` block (and one `atmos docs generate <name>` invocation) per module, not a
+single recursive pass.
+
+### Running both tools at once
+
+Don't leave the standalone `terraform-docs` binary wired into CI/pre-commit alongside
+`atmos docs generate` — both write into the same `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->`
+markers (or overwrite the whole file, depending on template), so running both produces
+duplicate or conflicting content.
+
+### Hand-edited content inside generated sections
+
+Content between the generated markers (or the whole output file, depending on template design) is
+overwritten on every `atmos docs generate` run, same as with standalone `terraform-docs`. Put
+hand-written prose in the `input` YAML or outside the generated section, not inside it.
+
+## What to NOT Do
+
+- Do not keep the standalone `terraform-docs` binary installed "just in case" once
+  `atmos docs generate` output is verified equivalent for every module.
+- Do not hand-roll a shell wrapper or Makefile target around the `terraform-docs` binary when
+  `docs.generate` already covers the need — that reintroduces the exact tool sprawl this migration
+  removes.

--- a/agent-skills/skills/atmos-migration/references/from-terraform-docs.md
+++ b/agent-skills/skills/atmos-migration/references/from-terraform-docs.md
@@ -4,8 +4,10 @@ This reference covers replacing a standalone [terraform-docs](https://terraform-
 (`.terraform-docs.yml` plus a manual invocation, Makefile target, or pre-commit hook) with
 `atmos docs generate`. This is not a lossy swap: `atmos docs generate` imports
 `github.com/terraform-docs/terraform-docs` directly as a Go module (a direct dependency in `go.mod`,
-not a shelled-out binary) and uses it to render the same Terraform documentation, merged into a
-Gomplate-templated document alongside any other YAML input. See
+not a shelled-out binary) and uses it to render equivalent supported Terraform documentation, merged
+into a Gomplate-templated document alongside any other YAML input — "equivalent supported" because
+Atmos exposes a subset of terraform-docs' formats and settings and has no recursive multi-module scan
+(see Common Gotchas below). See
 [atmos.tools/cli/configuration/docs](https://atmos.tools/cli/configuration/docs) and
 [atmos.tools/cli/commands/docs/generate](https://atmos.tools/cli/commands/docs/generate) for the
 full user-facing docs.
@@ -27,6 +29,8 @@ full user-facing docs.
    | `formatter:`                        | `format:`                         | Atmos supports `markdown table`, `markdown`, `tfvars hcl`, `tfvars json` — not the full upstream set (no `asciidoc`, `json`, `pretty`, `toml`, `xml`, `yaml`) |
    | `sort.by:`                          | `sort_by:`                        | Sort is implicitly enabled whenever `sort_by` is non-empty; there's no separate `sort.enabled` field |
    | `sections.show`/`sections.hide` for `inputs`, `outputs`, `providers` | `show_inputs:` / `show_outputs:` / `show_providers:` (booleans) | Only these three sections are controllable; `header`, `footer`, `requirements`, `resources`, `data-sources`, `modules` have no Atmos equivalent |
+   | `settings.hide-empty:`              | `hide_empty:`                     | Suppresses both the heading and the "No X." placeholder for an empty section |
+   | `settings.indent:`                  | `indent_level:`                   | Base Markdown heading depth (e.g. `2` renders `##`); only applied when greater than `0` |
    | (module root directory)             | `source:` (relative to `base-dir`) | |
    | `.terraform-docs.yml` file itself   | the `terraform:` block             | No separate config file — it's inline in `atmos.yaml` |
 
@@ -48,6 +52,8 @@ full user-facing docs.
            show_outputs: true
            show_providers: false
            sort_by: "name"
+           hide_empty: false
+           indent_level: 2
    ```
 
 2. **Add a Go template that renders the `terraform_docs` data key.** `atmos docs generate` injects
@@ -90,9 +96,11 @@ single recursive pass.
 ### Running both tools at once
 
 Don't leave the standalone `terraform-docs` binary wired into CI/pre-commit alongside
-`atmos docs generate` — both write into the same `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->`
-markers (or overwrite the whole file, depending on template), so running both produces
-duplicate or conflicting content.
+`atmos docs generate` if both target the same output file or generated section — whichever runs
+last wins, producing duplicate or conflicting content. This applies even without
+`<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers: `atmos docs generate` always renders and
+writes the whole configured `output` file from its template, it doesn't do terraform-docs' marker-based
+partial injection. Those markers only matter if your own template happens to include them.
 
 ### Hand-edited content inside generated sections
 

--- a/docs/fixes/2026-07-11-docs-generate-terraform-section-settings-fix.md
+++ b/docs/fixes/2026-07-11-docs-generate-terraform-section-settings-fix.md
@@ -1,0 +1,95 @@
+# `atmos docs generate` — terraform-docs section settings silently ignored
+
+**Date:** 2026-07-11
+**Branch:** `osterman/tf-docs-to-atmos-docs-skill`
+**Found while:** authoring the `atmos-migration` skill's `from-terraform-docs.md` reference,
+which required verifying every documented `docs.generate.<name>.terraform.*` field actually
+works before writing migration guidance for it.
+
+---
+
+## What the Bug Was
+
+`docs.generate.<name>.terraform.show_inputs`, `show_outputs`, `show_providers`, and
+`hide_empty` had **no effect** on the Terraform documentation rendered by
+`atmos docs generate`. Setting `show_inputs: false` still rendered the Inputs section;
+`hide_empty: true` still rendered "No providers." placeholders for empty sections.
+`indent_level` was never read at all.
+
+`sort_by` was **not** affected — it worked correctly (see Root Cause).
+
+## Root Cause
+
+**File:** `internal/exec/docs_generate.go`, `runTerraformDocs`
+
+The function built a `print.Config` from the atmos.yaml `terraform.*` settings:
+
+```go
+config := tfdocsPrint.DefaultConfig()
+config.Sections.Providers = settings.ShowProviders
+config.Sections.Inputs = settings.ShowInputs
+config.Sections.Outputs = settings.ShowOutputs
+```
+
+This `config` was passed to `tfdocsTf.LoadWithOptions(config)` to load the module, but the
+**formatter** — the code that actually renders section headings and tables via Go templates
+(`{{- if .Config.Sections.Inputs -}}` etc., in the vendored
+`terraform-docs/terraform-docs` templates) — was constructed with a **separate, fresh**
+`tfdocsPrint.DefaultConfig()` instead of the customized `config`:
+
+```go
+formatter = tfdocsFormat.NewMarkdownTable(tfdocsPrint.DefaultConfig())  // wrong: not `config`
+```
+
+`tfdocsPrint.DefaultConfig()` defaults `Sections.Inputs/Outputs/Providers` to `true` and
+`Settings.HideEmpty` to `false`, so the formatter always rendered every section regardless of
+what the user configured. `Settings.Indent` was never touched by either config, so
+`indent_level` was dead configuration.
+
+`sort_by` was unaffected because sorting happens during module *loading*
+(`tfdocsTf.LoadWithOptions` → `sortItems(module, config)`), which correctly used the
+customized `config` — the bug was specific to section visibility settings consumed only by
+the formatter's own config, and to settings (`hide_empty`, `indent_level`) that were never
+wired into any config at all.
+
+## Fix
+
+Reuse the same `config` for both the module loader and the formatter, and wire `HideEmpty`
+and `IndentLevel` into it:
+
+```go
+config.Settings.HideEmpty = settings.HideEmpty
+if settings.IndentLevel > 0 {
+    config.Settings.Indent = settings.IndentLevel
+}
+...
+formatter = tfdocsFormat.NewMarkdownTable(config)  // reuse config, not a fresh DefaultConfig()
+```
+
+`IndentLevel` is only applied when greater than zero, since the schema's Go zero value (`0`
+when unset in `atmos.yaml`) would otherwise silently override terraform-docs' own default
+indent of `2`.
+
+## Tests
+
+**File:** `internal/exec/docs_generate_test.go`
+
+- `TestRunTerraformDocs_SectionsRespected` — builds a minimal real Terraform module (one
+  variable, one output, one resource implying one provider), runs `runTerraformDocs` with
+  `ShowInputs: false, ShowOutputs: true, ShowProviders: false`, and asserts the rendered
+  output omits the input/provider content and includes the output. Repeats with the flags
+  flipped to confirm the reverse. Written first against the unfixed code to confirm it failed
+  before applying the fix (per the repo's bug-fixing workflow).
+- `TestRunTerraformDocs_HideEmptyRespected` — a module with an empty Inputs section; asserts
+  the `"No inputs."` placeholder renders when `HideEmpty: false` and is fully suppressed
+  (heading and placeholder both) when `HideEmpty: true`.
+
+Both tests failed against the pre-fix code and pass after the fix. Full `internal/exec`
+suite passes with no regressions.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/exec/docs_generate.go` | `runTerraformDocs` reuses `config` for the formatter instead of a fresh `DefaultConfig()`; wires `HideEmpty`/`IndentLevel` |
+| `internal/exec/docs_generate_test.go` | `TestRunTerraformDocs_SectionsRespected`, `TestRunTerraformDocs_HideEmptyRespected` |

--- a/internal/exec/docs_generate.go
+++ b/internal/exec/docs_generate.go
@@ -284,6 +284,10 @@ func runTerraformDocs(dir string, settings *schema.TerraformDocsReadmeSettings) 
 	config.Sections.Providers = settings.ShowProviders
 	config.Sections.Inputs = settings.ShowInputs
 	config.Sections.Outputs = settings.ShowOutputs
+	config.Settings.HideEmpty = settings.HideEmpty
+	if settings.IndentLevel > 0 {
+		config.Settings.Indent = settings.IndentLevel
+	}
 
 	if settings.SortBy != "" {
 		config.Sort.Enabled = true
@@ -297,18 +301,20 @@ func runTerraformDocs(dir string, settings *schema.TerraformDocsReadmeSettings) 
 
 	var formatter Formatter
 
-	// Assign the correct formatter based on settings.Format.
+	// Reuse the same config the module was loaded with so Sections/Settings/Sort (derived from
+	// the user's atmos.yaml terraform.* settings) actually reach the formatter. A fresh
+	// DefaultConfig() here would silently discard those settings.
 	switch settings.Format {
 	case "markdown table":
-		formatter = tfdocsFormat.NewMarkdownTable(tfdocsPrint.DefaultConfig())
+		formatter = tfdocsFormat.NewMarkdownTable(config)
 	case "markdown":
-		formatter = tfdocsFormat.NewMarkdownDocument(tfdocsPrint.DefaultConfig())
+		formatter = tfdocsFormat.NewMarkdownDocument(config)
 	case "tfvars hcl":
-		formatter = tfdocsFormat.NewTfvarsHCL(tfdocsPrint.DefaultConfig())
+		formatter = tfdocsFormat.NewTfvarsHCL(config)
 	case "tfvars json":
-		formatter = tfdocsFormat.NewTfvarsJSON(tfdocsPrint.DefaultConfig())
+		formatter = tfdocsFormat.NewTfvarsJSON(config)
 	default:
-		formatter = tfdocsFormat.NewMarkdownTable(tfdocsPrint.DefaultConfig())
+		formatter = tfdocsFormat.NewMarkdownTable(config)
 	}
 
 	// Generate content and return it.

--- a/internal/exec/docs_generate_test.go
+++ b/internal/exec/docs_generate_test.go
@@ -380,6 +380,123 @@ func TestRunTerraformDocs_Error(t *testing.T) {
 	}
 }
 
+// writeTerraformDocsFixture writes a minimal module with one input, one output, and one
+// resource (which implies one provider) so section-visibility settings are observable.
+func writeTerraformDocsFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `
+variable "example_input" {
+  type        = string
+  description = "An example input"
+}
+
+output "example_output" {
+  value       = var.example_input
+  description = "An example output"
+}
+
+resource "null_resource" "example" {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(content), defaultFilePermissions); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return dir
+}
+
+// TestRunTerraformDocs_SectionsRespected verifies that ShowInputs, ShowOutputs, and
+// ShowProviders actually control which sections appear in the rendered output. The
+// runTerraformDocs function builds a print.Config with these settings applied, but must pass
+// that same config to the formatter -- constructing the formatter with a fresh, uncustomized
+// config silently ignores the settings.
+func TestRunTerraformDocs_SectionsRespected(t *testing.T) {
+	dir := writeTerraformDocsFixture(t)
+
+	out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:       true,
+		Format:        "markdown table",
+		ShowInputs:    false,
+		ShowOutputs:   true,
+		ShowProviders: false,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+
+	if strings.Contains(out, "example_input") {
+		t.Errorf("expected Inputs section to be hidden (ShowInputs=false), got output containing it:\n%s", out)
+	}
+	if strings.Contains(out, "Providers") {
+		t.Errorf("expected Providers section to be hidden (ShowProviders=false), got output containing it:\n%s", out)
+	}
+	if !strings.Contains(out, "example_output") {
+		t.Errorf("expected Outputs section to be shown (ShowOutputs=true), got output missing it:\n%s", out)
+	}
+
+	// Flip every flag and confirm the output flips too.
+	out, err = runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:       true,
+		Format:        "markdown table",
+		ShowInputs:    true,
+		ShowOutputs:   false,
+		ShowProviders: true,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+	if !strings.Contains(out, "example_input") {
+		t.Errorf("expected Inputs section to be shown (ShowInputs=true), got output missing it:\n%s", out)
+	}
+	if !strings.Contains(out, "Providers") {
+		t.Errorf("expected Providers section to be shown (ShowProviders=true), got output missing it:\n%s", out)
+	}
+	if strings.Contains(out, "example_output") {
+		t.Errorf("expected Outputs section to be hidden (ShowOutputs=false), got output containing it:\n%s", out)
+	}
+}
+
+// TestRunTerraformDocs_HideEmptyRespected verifies that HideEmpty suppresses the heading and
+// "No inputs." placeholder for a section with no content, instead of always rendering it.
+func TestRunTerraformDocs_HideEmptyRespected(t *testing.T) {
+	dir := t.TempDir()
+	// No variables defined, so the Inputs section is empty.
+	content := `
+output "example_output" {
+  value       = "x"
+  description = "An example output"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(content), defaultFilePermissions); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:    true,
+		Format:     "markdown table",
+		ShowInputs: true,
+		HideEmpty:  false,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+	if !strings.Contains(out, "No inputs.") {
+		t.Errorf("expected empty Inputs section to render the placeholder when HideEmpty=false, got:\n%s", out)
+	}
+
+	out, err = runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:    true,
+		Format:     "markdown table",
+		ShowInputs: true,
+		HideEmpty:  true,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+	if strings.Contains(out, "Inputs") || strings.Contains(out, "No inputs.") {
+		t.Errorf("expected empty Inputs section to be fully suppressed when HideEmpty=true, got:\n%s", out)
+	}
+}
+
 // TestResolvePath tests the resolvePath function with various path types.
 func TestResolvePath(t *testing.T) {
 	tests := []struct {

--- a/internal/exec/docs_generate_test.go
+++ b/internal/exec/docs_generate_test.go
@@ -2,6 +2,7 @@
 package exec
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -495,6 +496,109 @@ output "example_output" {
 	if strings.Contains(out, "Inputs") || strings.Contains(out, "No inputs.") {
 		t.Errorf("expected empty Inputs section to be fully suppressed when HideEmpty=true, got:\n%s", out)
 	}
+}
+
+// TestRunTerraformDocs_IndentLevelRespected verifies that IndentLevel controls the heading depth
+// of rendered sections, confirming it reaches the formatter instead of being silently dropped.
+func TestRunTerraformDocs_IndentLevelRespected(t *testing.T) {
+	dir := writeTerraformDocsFixture(t)
+
+	out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:    true,
+		Format:     "markdown table",
+		ShowInputs: true,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+	if !strings.Contains(out, "## Inputs") {
+		t.Errorf("expected default IndentLevel to render a level-2 (##) Inputs heading, got:\n%s", out)
+	}
+
+	out, err = runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+		Enabled:     true,
+		Format:      "markdown table",
+		ShowInputs:  true,
+		IndentLevel: 3,
+	})
+	if err != nil {
+		t.Fatalf("runTerraformDocs failed: %v", err)
+	}
+	if !strings.Contains(out, "### Inputs") {
+		t.Errorf("expected IndentLevel=3 to render a level-3 (###) Inputs heading, got:\n%s", out)
+	}
+	// "## Inputs" is a substring of "### Inputs", so anchor on a preceding newline to check for
+	// an actual level-2 heading line rather than matching inside the level-3 one.
+	if strings.Contains(out, "\n## Inputs") {
+		t.Errorf("expected IndentLevel=3 to replace the level-2 (##) heading, got:\n%s", out)
+	}
+}
+
+// TestRunTerraformDocs_FormatVariants covers the "markdown", "tfvars hcl", and "tfvars json"
+// formatters (in addition to "markdown table" and the default, covered elsewhere), verifying each
+// produces format-appropriate content now that they all receive the customized config.
+func TestRunTerraformDocs_FormatVariants(t *testing.T) {
+	dir := writeTerraformDocsFixture(t)
+
+	t.Run("markdown", func(t *testing.T) {
+		out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+			Enabled:    true,
+			Format:     "markdown",
+			ShowInputs: true,
+		})
+		if err != nil {
+			t.Fatalf("runTerraformDocs failed: %v", err)
+		}
+		if !strings.Contains(out, "## Required Inputs") {
+			t.Errorf("expected markdown (non-table) format to render a 'Required Inputs' subsection, got:\n%s", out)
+		}
+	})
+
+	t.Run("tfvars hcl", func(t *testing.T) {
+		out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+			Enabled:    true,
+			Format:     "tfvars hcl",
+			ShowInputs: true,
+		})
+		if err != nil {
+			t.Fatalf("runTerraformDocs failed: %v", err)
+		}
+		if !strings.Contains(out, "example_input") {
+			t.Errorf("expected tfvars hcl output to assign example_input, got:\n%s", out)
+		}
+	})
+
+	t.Run("tfvars json", func(t *testing.T) {
+		out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+			Enabled:    true,
+			Format:     "tfvars json",
+			ShowInputs: true,
+		})
+		if err != nil {
+			t.Fatalf("runTerraformDocs failed: %v", err)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Fatalf("expected valid JSON, got error %v for output:\n%s", err, out)
+		}
+		if _, ok := parsed["example_input"]; !ok {
+			t.Errorf("expected tfvars json output to contain key example_input, got:\n%s", out)
+		}
+	})
+
+	t.Run("unrecognized format falls back to markdown table", func(t *testing.T) {
+		out, err := runTerraformDocs(dir, &schema.TerraformDocsReadmeSettings{
+			Enabled:    true,
+			Format:     "not-a-real-format",
+			ShowInputs: true,
+		})
+		if err != nil {
+			t.Fatalf("runTerraformDocs failed: %v", err)
+		}
+		if !strings.Contains(out, "| Name | Description | Type | Default | Required |") {
+			t.Errorf("expected unrecognized format to fall back to markdown table output, got:\n%s", out)
+		}
+	})
 }
 
 // TestResolvePath tests the resolvePath function with various path types.

--- a/tests/test-cases/docs-generate.yaml
+++ b/tests/test-cases/docs-generate.yaml
@@ -20,7 +20,8 @@ tests:
       file_contains:
         "README.md":
           - "## Requirements"
-          - "## Providers" 
+          - "## Outputs"
+          - !not "## Providers"
 
   - name: "atmos docs generate with remote template"
     enabled: true


### PR DESCRIPTION
## what

- Fixes `atmos docs generate`: `docs.generate.<name>.terraform.show_inputs`, `show_outputs`, `show_providers`, and `hide_empty` were silently ignored because the formatter was built with a fresh, uncustomized `print.Config` instead of the config that actually carried the user's settings; `indent_level` was never wired into any config at all. All four now work as documented.
- Adds two tests (`TestRunTerraformDocs_SectionsRespected`, `TestRunTerraformDocs_HideEmptyRespected`) built against a real Terraform module that reproduce the bug and verify the fix.
- Adds a `docs/fixes/` writeup documenting the root cause, fix, and verification.
- Adds a `references/from-terraform-docs.md` guide to the `atmos-migration` skill covering how to replace a standalone `terraform-docs` CLI setup (`.terraform-docs.yml` + manual/CI invocation) with `atmos docs generate`, and wires it into the skill's frontmatter, shape-decision table, and `agent-skills/AGENTS.md` skill index.

## why

- `atmos docs generate` already wraps `github.com/terraform-docs/terraform-docs` directly as a Go module, so it's a genuine (not lossy) replacement for a standalone `terraform-docs` CLI — but there was no migration guidance pointing users at it, and while writing that guidance the documented `terraform.*` settings turned out not to actually work, which would have made the guide inaccurate.
- Fixing the underlying bug first makes the new migration guide trustworthy, and gives every existing user of `docs.generate.<name>.terraform` correct section-visibility/hide-empty behavior going forward.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Terraform documentation generation now correctly respects section visibility, hides empty sections when configured, and applies indentation settings.
  - Generated READMEs no longer include disabled sections (for example, Providers when turned off).
- **Documentation**
  - Expanded the Terraform migration guidance to cover replacing standalone `terraform-docs` README generation with `atmos docs generate`, including new reference material and scenario updates.
  - Added a documentation note explaining the prior settings-ignoring issue and the fix.
- **Tests**
  - Expanded and updated Terraform docs generation test coverage and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->