### PR TITLE
fix(toolchain): repair dangling onedir symlink entrypoints (node)

### DIFF
--- a/pkg/toolchain/installer/onedir_fs.go
+++ b/pkg/toolchain/installer/onedir_fs.go
@@ -44,6 +44,7 @@ func createValidatedSymlinkForOS(root, linkPath, linkname, goos string) error {
 	if linkname == "" || filepath.IsAbs(linkname) {
 		return fmt.Errorf("%w: illegal symlink target: %s -> %q", ErrFileOperation, linkPath, linkname)
 	}
+	// resolved is used only for the containment check and the Windows fallback.
 	resolved := filepath.Clean(filepath.Join(filepath.Dir(cleanLinkPath), linkname))
 	if resolved != cleanRoot && !strings.HasPrefix(resolved, cleanRoot+string(os.PathSeparator)) {
 		return fmt.Errorf("%w: symlink target escapes root: %s -> %q", ErrFileOperation, linkPath, linkname)
@@ -54,7 +55,8 @@ func createValidatedSymlinkForOS(root, linkPath, linkname, goos string) error {
 	}
 	_ = os.Remove(cleanLinkPath)
 
-	if err := symlinkFunc(resolved, cleanLinkPath); err == nil {
+	// Symlink to the archive's relative target so it resolves from the link's own directory.
+	if err := symlinkFunc(linkname, cleanLinkPath); err == nil {
 		return nil
 	} else if goos != "windows" {
 		return fmt.Errorf("%w: failed to create symlink %s: %w", ErrFileOperation, linkPath, err)

--- a/pkg/toolchain/installer/onedir_test.go
+++ b/pkg/toolchain/installer/onedir_test.go
@@ -629,7 +629,7 @@ func TestCreateValidatedSymlink(t *testing.T) {
 		t.Skip("symlink creation requires privilege on Windows; onedir Windows support is tracked separately")
 	}
 
-	t.Run("creates a symlink with a guarded absolute in-tree target", func(t *testing.T) {
+	t.Run("creates a symlink reproducing the archive's relative target", func(t *testing.T) {
 		dest := t.TempDir()
 		link := filepath.Join(dest, "bin", "npm")
 		require.NoError(t, createValidatedSymlink(dest, link, "../lib/npm-cli.js"))
@@ -637,13 +637,15 @@ func TestCreateValidatedSymlink(t *testing.T) {
 		info, err := os.Lstat(link)
 		require.NoError(t, err)
 		require.NotZero(t, info.Mode()&os.ModeSymlink)
-		// The link target is the guarded ABSOLUTE path (the value the sink's
-		// containment check validates); onedir trees are pinned to their version
-		// dir rather than relocatable.
 		target, err := os.Readlink(link)
 		require.NoError(t, err)
-		assert.True(t, filepath.IsAbs(target), "target must be absolute, got %q", target)
-		assert.Equal(t, filepath.Join(dest, "lib", "npm-cli.js"), target)
+		assert.False(t, filepath.IsAbs(target), "target must be relative, got %q", target)
+		assert.Equal(t, filepath.FromSlash("../lib/npm-cli.js"), target)
+		// The link resolves to the real file once that file exists.
+		writeFileUnder(t, dest, "lib/npm-cli.js", "NPM")
+		got, err := os.ReadFile(link)
+		require.NoError(t, err)
+		assert.Equal(t, "NPM", string(got))
 	})
 
 	t.Run("rejects a relative target that escapes dest", func(t *testing.T) {
@@ -680,7 +682,7 @@ func TestCreateValidatedSymlink(t *testing.T) {
 // sink's containment guards (what CodeQL flags as "arbitrary file write via
 // archive symlinks"). The rejection cases return before any filesystem
 // mutation, so they run on every platform (no symlink privilege needed); the
-// success cases assert the guarded ABSOLUTE target and are Unix-only.
+// success cases assert the reproduced RELATIVE archive target and are Unix-only.
 func TestCreateValidatedSymlink_Validation(t *testing.T) {
 	t.Run("rejects an empty target", func(t *testing.T) {
 		root := t.TempDir()
@@ -720,7 +722,7 @@ func TestCreateValidatedSymlink_Validation(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr), "no link may be created outside root")
 	})
 
-	t.Run("creates an absolute in-root link for a valid target", func(t *testing.T) {
+	t.Run("creates a relative in-root link for a valid target", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("symlink creation requires privilege on Windows")
 		}
@@ -729,19 +731,20 @@ func TestCreateValidatedSymlink_Validation(t *testing.T) {
 		require.NoError(t, createValidatedSymlink(root, link, "../lib/npm-cli.js"))
 		got, err := os.Readlink(link)
 		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(root, "node", "lib", "npm-cli.js"), got)
+		assert.Equal(t, filepath.FromSlash("../lib/npm-cli.js"), got)
 	})
 
-	t.Run("cleans a redundant in-root target", func(t *testing.T) {
+	t.Run("reproduces a redundant archive target verbatim", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("symlink creation requires privilege on Windows")
 		}
 		root := t.TempDir()
 		link := filepath.Join(root, "node", "bin", "npm")
+		// The archive target is reproduced verbatim, not cleaned or rewritten.
 		require.NoError(t, createValidatedSymlink(root, link, "./sub/../other"))
 		got, err := os.Readlink(link)
 		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(root, "node", "bin", "other"), got)
+		assert.Equal(t, filepath.FromSlash("./sub/../other"), got)
 	})
 }
 
@@ -1168,6 +1171,69 @@ func TestExtractZip_Onedir_RecreatesSymlinkEntrypoint(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(versionDir, manifest.Entrypoints["tool"]))
 	require.NoError(t, err)
 	assert.Equal(t, "TOOL-BINARY", string(got))
+}
+
+// A onedir package whose first entrypoint is a symlink into a sibling tree (as
+// nodejs/node ships corepack/npm/npx) must install so the entrypoint resolves
+// to a real, executable file, including when the install path is relative.
+func TestExtractAndInstall_Onedir_RelativeInstallPath_LeadingSymlinkEntrypoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("in-archive symlink entrypoints require symlink privilege on Windows; onedir Windows support is tracked separately")
+	}
+
+	base := t.TempDir()
+	t.Chdir(base)
+
+	archive := filepath.Join(base, "node.tar.gz")
+	writeTarGzTree(t, archive, []tarEntry{
+		{name: "node-v1/bin/corepack", link: "../lib/node_modules/corepack/dist/corepack.js"},
+		{name: "node-v1/bin/npm", link: "../lib/node_modules/npm/bin/npm-cli.js"},
+		{name: "node-v1/bin/node", content: "NODE-BINARY", mode: 0o755},
+		{name: "node-v1/lib/node_modules/corepack/dist/corepack.js", content: "COREPACK", mode: 0o644},
+		{name: "node-v1/lib/node_modules/npm/bin/npm-cli.js", content: "NPM-CLI", mode: 0o644},
+	})
+
+	// A relative binDir (resolved against cwd) is the case under test.
+	inst := &Installer{binDir: filepath.Join(".tools", "bin")}
+	tool := &registry.Tool{
+		RepoOwner: "nodejs",
+		RepoName:  "node",
+		// corepack (a symlink) leads files[], so it is the resolved primary.
+		Files: []registry.File{
+			{Name: "corepack", Src: "node-v1/bin/corepack"},
+			{Name: "npm", Src: "node-v1/bin/npm"},
+			{Name: "node", Src: "node-v1/bin/node"},
+		},
+	}
+
+	resolved, err := inst.extractAndInstall(tool, archive, "20.19.6")
+	require.NoError(t, err)
+
+	// chmod and Stat follow the symlink, so the entrypoint must resolve to a real file.
+	require.NoError(t, os.Chmod(resolved, 0o755))
+
+	info, err := os.Stat(resolved)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	payload, err := os.ReadFile(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, "COREPACK", string(payload))
+
+	target, err := os.Readlink(resolved)
+	require.NoError(t, err)
+	assert.False(t, filepath.IsAbs(target), "symlink target must be relative, got %q", target)
+	assert.Equal(t, filepath.FromSlash("../lib/node_modules/corepack/dist/corepack.js"), target)
+
+	// Each entrypoint resolves through the manifest to a real file (npm via its symlink).
+	npm := inst.GetBinaryPath("nodejs", "node", "20.19.6", "npm")
+	npmPayload, err := os.ReadFile(npm)
+	require.NoError(t, err)
+	assert.Equal(t, "NPM-CLI", string(npmPayload))
+
+	node := inst.GetBinaryPath("nodejs", "node", "20.19.6", "node")
+	nodePayload, err := os.ReadFile(node)
+	require.NoError(t, err)
+	assert.Equal(t, "NODE-BINARY", string(nodePayload))
 }
 
 // TestExtractAndInstall_CleansUpOnFailure verifies that a failed extraction of a

--- a/website/docs/cli/commands/toolchain/toolchain-install.mdx
+++ b/website/docs/cli/commands/toolchain/toolchain-install.mdx
@@ -97,10 +97,11 @@ itself ships (for example Node's `npm`, which the archive links relatively as
 `../lib/node_modules/...` on Unix). Atmos recreates each such link inside the
 preserved `.pkg` tree after extraction, through a single validated step, so the
 tool functions identically to how it would if installed from its original
-archive; the links are never created by Atmos's exposure logic. Each recreated
-link resolves to its target's absolute location inside that tree, so a onedir
-install is **pinned to its install path** — reinstall a tool rather than moving
-or copying its version directory to a different absolute path.
+archive; the links are never created by Atmos's exposure logic. Each link is
+reproduced with the archive's **original relative target**, so it resolves
+relative to the link's own directory and works regardless of whether the
+install path is absolute or relative (such as `.tools`). The link's resolved
+target is still validated to stay inside the `.pkg` tree.
 
 On Windows, where creating a symlink normally requires Developer Mode or
 elevated privilege, an archive's own **file** symlink is reproduced as a hard


### PR DESCRIPTION
## what

- onedir (multi-file) installs now recreate an archive's internal **symlink entrypoints** using the archive's **original relative target** (e.g. `../lib/node_modules/corepack/dist/corepack.js`) instead of a root-rebased path.
- Fixes `nodejs/node`, whose `corepack`/`npm`/`npx` entrypoints are symlinks into a sibling `../lib/` tree:
  - `node@<=24.10.0` (whose `files:` list leads with `corepack`) no longer fails the install with `chmod .../bin/corepack: no such file or directory`.
  - `node@24.18.0` no longer reports success while leaving `npm`/`npx` dangling.
  - After install, `node`, `npm`, `npx`, and `corepack` all resolve to real files and run.
- Adds a regression test that installs a leading-symlink onedir package under a **relative** `install_path` (the real-world default, e.g. `install_path: .tools`) and asserts the entrypoint resolves via `os.Stat` (follows the link) and is `chmod`-able — the exact operation that failed.
- Updates the symlink-target unit assertions to expect the archive-relative target, and corrects the onedir docs note that claimed targets are "recreated absolute."

## why

- `createValidatedSymlinkForOS` wrote the containment-validated `resolved` path as the symlink target. `resolved` is the target rebased onto the toolchain root, so with a **relative** install root (the default `.tools`) it became a cwd-relative path. A symlink is interpreted relative to **its own directory**, so `.../bin/corepack -> .tools/bin/.../lib/...` resolved to `.../bin/.tools/bin/.../lib/...` and dangled. This reproduced independently of `install_path`.
- Writing the archive's original relative `linkname` reproduces the upstream archive exactly and resolves correctly whether the install root is absolute or relative.
- `resolved` is still used for the security containment check and the Windows copy/hard-link fallback, and absolute targets are still rejected — no change to the archive-symlink "arbitrary file write" protection.
- Note: this is a POSIX-only change (macOS/Linux). Windows onedir installs don't create symlinks — an archive's file symlink is reproduced as a hard link/copy via that unchanged `resolved`-based fallback, and `nodejs/node` ships `.cmd` shims there — so Windows behavior is unaffected.

## references

- Follow-up to #2750 (multi-file / "onedir" installs), which shipped the onedir install path but left `nodejs/node`'s internal symlink entrypoints dangling.
- Testing: `go test ./pkg/toolchain/... ./cmd/toolchain/...` passes; the new regression test fails on the pre-fix code with the exact `chmod ... corepack: no such file or directory` error. Also exercised on a GitHub-hosted `windows-latest` runner (`pkg/toolchain/installer` package green; symlink-privilege tests self-skip on Windows, Windows hard-link/copy fallback covered).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onedir installations so archived relative symlinks resolve correctly when using absolute or relative install paths.
  * Ensured symlink-based entry points correctly resolve to their target executables.

* **Documentation**
  * Clarified that archived symlinks retain their relative targets while remaining safely within the installation package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->