### PR TITLE
fix(toolchain): expose onedir command-dependency tools on step PATH

### DIFF
--- a/pkg/dependencies/environment.go
+++ b/pkg/dependencies/environment.go
@@ -165,6 +165,7 @@ type envConfig struct {
 	ensureTools    func(deps map[string]string) error
 	resolveFunc    func(tool string) (owner, repo string, err error)
 	findBinaryPath func(owner, repo, version string, binaryName ...string) (string, error)
+	entrypointDirs func(owner, repo, version string) []string
 	buildPATH      func(atmosConfig *schema.AtmosConfiguration, deps map[string]string) (string, error)
 }
 
@@ -189,6 +190,15 @@ func withResolveFunc(fn func(tool string) (owner, repo string, err error)) envOp
 func withFindBinaryPath(fn func(owner, repo, version string, binaryName ...string) (string, error)) envOption {
 	return func(c *envConfig) {
 		c.findBinaryPath = fn
+	}
+}
+
+// withEntrypointDirs overrides onedir-aware entrypoint directory resolution.
+// Returning nil for a tool makes newEnvironment fall back to the primary
+// binary's directory.
+func withEntrypointDirs(fn func(owner, repo, version string) []string) envOption {
+	return func(c *envConfig) {
+		c.entrypointDirs = fn
 	}
 }
 
@@ -221,6 +231,10 @@ func withProvisioner(p ToolProvisioner) envOption {
 		c.resolveFunc = p.ResolveToolName
 		c.findBinaryPath = p.FindBinaryPath
 		c.buildPATH = p.BuildPATH
+		// ToolProvisioner does not enumerate onedir entrypoints; return nil so
+		// env.dirs falls back to each resolved primary's directory. This keeps
+		// mock-driven environments hermetic (no real installer is constructed).
+		c.entrypointDirs = func(_, _, _ string) []string { return nil }
 	}
 }
 
@@ -272,25 +286,16 @@ func newEnvironment(atmosConfig *schema.AtmosConfiguration, deps map[string]stri
 		env.path = toolchainPATH
 	}
 
-	// Extract unique toolchain bin dirs from resolved paths for PrependToPath().
-	seen := make(map[string]bool)
-	for _, p := range env.resolved {
-		dir := filepath.Dir(p)
-		if !seen[dir] {
-			seen[dir] = true
-			env.dirs = append(env.dirs, dir)
-		}
-	}
-
 	return env, nil
 }
 
 // resolveBinaryPaths resolves each dependency to an absolute binary path
-// and populates env.resolved. Errors are logged and skipped.
+// and populates env.resolved and env.dirs. Errors are logged and skipped.
 func resolveBinaryPaths(env *ToolchainEnvironment, cfg *envConfig, deps map[string]string) {
 	resolveFunc := cfg.resolveFunc
 	findBinaryPath := cfg.findBinaryPath
-	if resolveFunc == nil || findBinaryPath == nil {
+	entrypointDirsFunc := cfg.entrypointDirs
+	if resolveFunc == nil || findBinaryPath == nil || entrypointDirsFunc == nil {
 		tcInstaller := toolchain.NewInstaller()
 		if resolveFunc == nil {
 			resolver := tcInstaller.GetResolver()
@@ -299,8 +304,17 @@ func resolveBinaryPaths(env *ToolchainEnvironment, cfg *envConfig, deps map[stri
 		if findBinaryPath == nil {
 			findBinaryPath = tcInstaller.FindBinaryPath
 		}
+		if entrypointDirsFunc == nil {
+			// Onedir-aware directory resolution — the same source of truth as
+			// `atmos toolchain env` — so multi-file packages expose every
+			// entrypoint directory, not just the primary binary's.
+			entrypointDirsFunc = func(owner, repo, version string) []string {
+				return toolchain.EntrypointDirsForVersion(tcInstaller, owner, repo, version, false)
+			}
+		}
 	}
 
+	seenDir := make(map[string]struct{})
 	for tool, version := range deps {
 		owner, repo, err := resolveFunc(tool)
 		if err != nil {
@@ -328,5 +342,33 @@ func resolveBinaryPaths(env *ToolchainEnvironment, cfg *envConfig, deps map[stri
 		base := filepath.Base(binaryPath)
 		key := strings.TrimSuffix(base, filepath.Ext(base))
 		env.resolved[key] = binaryPath
+
+		// Record every entrypoint directory for PrependToPath()/ToolchainDirs().
+		// A onedir (multi-file) package exposes commands that may live in more than
+		// one directory; a flat install (or a not-installed fallback) contributes
+		// only the primary binary's directory.
+		addEntrypointDirs(env, seenDir, entrypointDirsFunc(owner, repo, version), binaryPath)
+	}
+}
+
+// addEntrypointDirs appends the unique, absolute entrypoint directories for a
+// resolved dependency to env.dirs. When dirs is empty (a flat install, or a
+// locator that could not enumerate entrypoints) it falls back to the primary
+// binary's directory.
+func addEntrypointDirs(env *ToolchainEnvironment, seen map[string]struct{}, dirs []string, primaryBinaryPath string) {
+	if len(dirs) == 0 {
+		dirs = []string{filepath.Dir(primaryBinaryPath)}
+	}
+	for _, dir := range dirs {
+		if !filepath.IsAbs(dir) {
+			if abs, err := filepath.Abs(dir); err == nil {
+				dir = abs
+			}
+		}
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		env.dirs = append(env.dirs, dir)
 	}
 }

--- a/pkg/dependencies/environment_test.go
+++ b/pkg/dependencies/environment_test.go
@@ -250,7 +250,8 @@ func TestNewEnvironment_EnsureToolsFailure(t *testing.T) {
 
 	deps := map[string]string{"terraform": "1.10.0"}
 
-	env, err := newEnvironment(atmosConfig, deps,
+	env, err := newEnvironment(
+		atmosConfig, deps,
 		withEnsureTools(func(_ map[string]string) error {
 			return errors.New("install failed")
 		}),
@@ -276,7 +277,8 @@ func TestNewEnvironment_BuildPATHFailure(t *testing.T) {
 
 	deps := map[string]string{"terraform": "1.10.0"}
 
-	env, err := newEnvironment(atmosConfig, deps,
+	env, err := newEnvironment(
+		atmosConfig, deps,
 		withEnsureTools(func(_ map[string]string) error { return nil }),
 		withResolveFunc(func(tool string) (string, string, error) {
 			return "hashicorp", "terraform", nil
@@ -314,7 +316,8 @@ func TestNewEnvironment_SuccessfulResolution(t *testing.T) {
 
 	expectedPATH := filepath.Join(tempDir, "bin") + string(os.PathListSeparator) + filepath.Join("usr", "bin")
 
-	env, err := newEnvironment(atmosConfig, deps,
+	env, err := newEnvironment(
+		atmosConfig, deps,
 		withEnsureTools(func(_ map[string]string) error { return nil }),
 		withResolveFunc(func(tool string) (string, string, error) {
 			switch tool {
@@ -344,11 +347,13 @@ func TestNewEnvironment_SuccessfulResolution(t *testing.T) {
 	require.NotNil(t, env)
 
 	// Verify resolved map has entries keyed by binary basename.
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		filepath.Join(tempDir, "bin", "hashicorp", "terraform", "1.10.0", "terraform"),
 		env.resolved["terraform"],
 	)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		filepath.Join(tempDir, "bin", "opentofu", "opentofu", "1.8.0", "tofu"),
 		env.resolved["tofu"],
 	)
@@ -357,7 +362,8 @@ func TestNewEnvironment_SuccessfulResolution(t *testing.T) {
 	assert.Equal(t, expectedPATH, env.path)
 
 	// Verify Resolve uses the resolved map.
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		filepath.Join(tempDir, "bin", "opentofu", "opentofu", "1.8.0", "tofu"),
 		env.Resolve("tofu"),
 	)
@@ -384,7 +390,8 @@ func TestNewEnvironment_ResolveError(t *testing.T) {
 	deps := map[string]string{"unknown-tool": "1.0.0"}
 	expectedPATH := "/some/path"
 
-	env, err := newEnvironment(atmosConfig, deps,
+	env, err := newEnvironment(
+		atmosConfig, deps,
 		withEnsureTools(func(_ map[string]string) error { return nil }),
 		withResolveFunc(func(_ string) (string, string, error) {
 			return "", "", errors.New("unknown tool")
@@ -418,7 +425,8 @@ func TestNewEnvironment_FindBinaryPathError(t *testing.T) {
 	deps := map[string]string{"terraform": "1.10.0"}
 	expectedPATH := "/some/path"
 
-	env, err := newEnvironment(atmosConfig, deps,
+	env, err := newEnvironment(
+		atmosConfig, deps,
 		withEnsureTools(func(_ map[string]string) error { return nil }),
 		withResolveFunc(func(_ string) (string, string, error) {
 			return "hashicorp", "terraform", nil
@@ -604,4 +612,101 @@ func TestForComponent_WithDepsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, tenv)
 	assert.Contains(t, err.Error(), "failed to resolve component dependencies")
+}
+
+// TestNewEnvironment_OnedirDirs verifies that env.dirs (exposed via ToolchainDirs
+// and PrependToPath) includes every entrypoint directory of a onedir (multi-file)
+// tool, and falls back to the primary binary's directory when no entrypoint
+// directories are enumerated.
+func TestNewEnvironment_OnedirDirs(t *testing.T) {
+	tempDir := t.TempDir()
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath: tempDir,
+		Toolchain: schema.Toolchain{
+			InstallPath: filepath.Join(tempDir, ".atmos", "tools"),
+		},
+	}
+
+	origConfig := toolchain.GetAtmosConfig()
+	t.Cleanup(func() { toolchain.SetAtmosConfig(origConfig) })
+
+	nodeBinDir := filepath.Join(tempDir, "bin", "nodejs", "node", "24.18.0", ".pkg", "bin")
+	npmBinDir := filepath.Join(tempDir, "bin", "nodejs", "node", "24.18.0", ".pkg", "lib", "npm", "bin")
+
+	t.Run("onedir exposes every entrypoint directory", func(t *testing.T) {
+		env, err := newEnvironment(
+			atmosConfig, map[string]string{"nodejs/node": "24.18.0"},
+			withEnsureTools(func(_ map[string]string) error { return nil }),
+			withResolveFunc(func(string) (string, string, error) { return "nodejs", "node", nil }),
+			withFindBinaryPath(func(_, _, _ string, _ ...string) (string, error) {
+				return filepath.Join(nodeBinDir, "node"), nil
+			}),
+			withEntrypointDirs(func(_, _, _ string) []string {
+				return []string{nodeBinDir, npmBinDir}
+			}),
+			withBuildPATH(func(_ *schema.AtmosConfiguration, _ map[string]string) (string, error) {
+				return "", nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		assert.ElementsMatch(t, []string{nodeBinDir, npmBinDir}, env.ToolchainDirs(),
+			"both onedir entrypoint directories must be exposed")
+
+		prepended := env.PrependToPath(filepath.FromSlash("/usr/bin"))
+		assert.Contains(t, prepended, nodeBinDir)
+		assert.Contains(t, prepended, npmBinDir)
+	})
+
+	t.Run("falls back to the primary binary directory", func(t *testing.T) {
+		primaryDir := filepath.Join(tempDir, "bin", "kubernetes", "kubectl", "1.31.0")
+		env, err := newEnvironment(
+			atmosConfig, map[string]string{"kubernetes/kubectl": "1.31.0"},
+			withEnsureTools(func(_ map[string]string) error { return nil }),
+			withResolveFunc(func(string) (string, string, error) { return "kubernetes", "kubectl", nil }),
+			withFindBinaryPath(func(_, _, _ string, _ ...string) (string, error) {
+				return filepath.Join(primaryDir, "kubectl"), nil
+			}),
+			withEntrypointDirs(func(_, _, _ string) []string { return nil }),
+			withBuildPATH(func(_ *schema.AtmosConfiguration, _ map[string]string) (string, error) {
+				return "", nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		assert.Equal(t, []string{primaryDir}, env.ToolchainDirs(),
+			"a nil entrypoint-dir result must fall back to the primary binary's directory")
+	})
+
+	t.Run("deduplicates and absolutizes entrypoint directories", func(t *testing.T) {
+		relDir := filepath.Join("rel", "tools", "bin")
+		absExpected, err := filepath.Abs(relDir)
+		require.NoError(t, err)
+
+		absDir := filepath.Join(tempDir, "bin", "acme", "cli", "1.0.0", ".pkg", "bin")
+
+		env, err := newEnvironment(
+			atmosConfig, map[string]string{"acme/cli": "1.0.0"},
+			withEnsureTools(func(_ map[string]string) error { return nil }),
+			withResolveFunc(func(string) (string, string, error) { return "acme", "cli", nil }),
+			withFindBinaryPath(func(_, _, _ string, _ ...string) (string, error) {
+				return filepath.Join(absDir, "cli"), nil
+			}),
+			withEntrypointDirs(func(_, _, _ string) []string {
+				// A relative dir (must be absolutized) plus a duplicate absolute dir
+				// (must be collapsed).
+				return []string{relDir, absDir, absDir}
+			}),
+			withBuildPATH(func(_ *schema.AtmosConfiguration, _ map[string]string) (string, error) {
+				return "", nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		assert.Equal(t, []string{absExpected, absDir}, env.ToolchainDirs(),
+			"relative dirs are absolutized and duplicates collapsed, order preserved")
+	})
 }

--- a/pkg/dependencies/installer.go
+++ b/pkg/dependencies/installer.go
@@ -552,6 +552,14 @@ func getPathFromEnv() string {
 // BuildToolchainPATH constructs a PATH string with toolchain binaries prepended.
 // This function does NOT modify the global environment - it returns the PATH string
 // which should be added to ComponentEnvList for subprocess execution.
+//
+// Onedir (multi-file) tools such as nodejs/node or aws-cli keep their executables
+// nested inside a preserved .pkg tree (described by .atmos-onedir.json), not at the
+// bare version-dir root. PATH entries are therefore resolved through the same
+// onedir-aware helper as `atmos toolchain env` (toolchain.EntrypointDirsForVersion),
+// so every installed entrypoint is reachable; flat installs still contribute their
+// single version directory. A tool that is not installed falls back to its bare
+// version directory to preserve backward compatibility.
 func BuildToolchainPATH(atmosConfig *schema.AtmosConfiguration, dependencies map[string]string) (string, error) {
 	defer perf.Track(atmosConfig, "dependencies.BuildToolchainPATH")()
 
@@ -566,29 +574,14 @@ func BuildToolchainPATH(atmosConfig *schema.AtmosConfiguration, dependencies map
 	if atmosConfig != nil && atmosConfig.Toolchain.InstallPath != "" {
 		toolsDir = atmosConfig.Toolchain.InstallPath
 	}
+	binDir := filepath.Join(toolsDir, "bin")
 
-	// Get the resolver from toolchain package for alias and registry resolution.
-	tcInstaller := toolchain.NewInstaller()
-	resolver := tcInstaller.GetResolver()
+	// Bind a locator to the resolved bin dir so onedir manifest lookups
+	// (FindBinaryPath/GetBinaryPaths) target where the tools were installed.
+	locator := toolchain.NewInstallerWithBinDir(binDir)
+	resolver := locator.GetResolver()
 
-	var paths []string
-	for tool, version := range dependencies {
-		// Resolve tool to owner/repo using the shared resolver.
-		owner, repo, err := resolver.Resolve(tool)
-		if err != nil {
-			continue // Skip invalid tools.
-		}
-
-		// Add versioned bin directory to PATH.
-		binPath := filepath.Join(toolsDir, "bin", owner, repo, version)
-
-		// Convert to absolute path to avoid Go 1.19+ exec.LookPath security issues.
-		// Go 1.19+ rejects executables found via relative PATH entries.
-		// Note: filepath.Abs rarely fails in practice; we trust it to succeed here.
-		absBinPath, _ := filepath.Abs(binPath)
-
-		paths = append(paths, absBinPath)
-	}
+	paths := collectToolchainDirs(locator, resolver, binDir, dependencies)
 
 	// Prepend toolchain paths to existing PATH.
 	currentPath := getPathFromEnv()
@@ -598,6 +591,45 @@ func BuildToolchainPATH(atmosConfig *schema.AtmosConfiguration, dependencies map
 
 	newPath := strings.Join(append(paths, currentPath), string(os.PathListSeparator))
 	return newPath, nil
+}
+
+// collectToolchainDirs resolves the deduplicated, absolute PATH directories for a
+// set of resolved dependencies. Onedir tools contribute each nested entrypoint
+// directory; flat tools contribute their version directory. A tool that cannot be
+// located on disk falls back to its bare version directory.
+func collectToolchainDirs(locator *toolchain.Installer, resolver toolchain.ToolResolver, binDir string, dependencies map[string]string) []string {
+	defer perf.Track(nil, "dependencies.collectToolchainDirs")()
+
+	var paths []string
+	seen := make(map[string]struct{})
+	for tool, version := range dependencies {
+		// Resolve tool to owner/repo using the shared resolver.
+		owner, repo, err := resolver.Resolve(tool)
+		if err != nil {
+			continue // Skip invalid tools.
+		}
+
+		dirs := toolchain.EntrypointDirsForVersion(locator, owner, repo, version, false)
+		if len(dirs) == 0 {
+			// Not installed (or unusual layout): prepend the bare version directory
+			// so callers still get a usable entry. Convert to absolute to avoid
+			// Go 1.19+ exec.LookPath rejection of relative PATH entries.
+			absBinPath, absErr := filepath.Abs(filepath.Join(binDir, owner, repo, version))
+			if absErr != nil {
+				absBinPath = filepath.Join(binDir, owner, repo, version)
+			}
+			dirs = []string{absBinPath}
+		}
+
+		for _, dir := range dirs {
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			paths = append(paths, dir)
+		}
+	}
+	return paths
 }
 
 // UpdatePathForTools updates PATH environment variable to include tool binaries.

--- a/pkg/dependencies/installer.go
+++ b/pkg/dependencies/installer.go
@@ -589,8 +589,13 @@ func BuildToolchainPATH(atmosConfig *schema.AtmosConfiguration, dependencies map
 		return currentPath, nil
 	}
 
-	newPath := strings.Join(append(paths, currentPath), string(os.PathListSeparator))
-	return newPath, nil
+	// Append currentPath only when non-empty: a trailing list separator is
+	// interpreted as "." by exec lookups, which would run binaries from the
+	// working directory.
+	if currentPath != "" {
+		paths = append(paths, currentPath)
+	}
+	return strings.Join(paths, string(os.PathListSeparator)), nil
 }
 
 // collectToolchainDirs resolves the deduplicated, absolute PATH directories for a

--- a/pkg/dependencies/installer_test.go
+++ b/pkg/dependencies/installer_test.go
@@ -1789,3 +1789,29 @@ func TestBuildToolchainPATH_Onedir(t *testing.T) {
 	require.NoError(t, err, "kubectl must still be resolvable on the built PATH")
 	assert.Equal(t, kubectlBinPath, resolvedKubectl)
 }
+
+// TestBuildToolchainPATH_EmptyPATHNoTrailingSeparator verifies that when the
+// current PATH is empty, the built PATH does not end with a list separator and
+// contains no empty component. A trailing separator is interpreted as "." by
+// exec lookups, which would allow running a binary from the working directory.
+func TestBuildToolchainPATH_EmptyPATHNoTrailingSeparator(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	config := &schema.AtmosConfiguration{
+		Toolchain: schema.Toolchain{InstallPath: t.TempDir()},
+	}
+
+	// terraform is not installed here, so it falls back to the bare version dir;
+	// the point is that `paths` is non-empty while the current PATH is empty.
+	result, err := BuildToolchainPATH(config, map[string]string{
+		"hashicorp/terraform": "1.10.0",
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, result)
+	assert.NotEqual(t, string(os.PathListSeparator), result[len(result)-1:],
+		"built PATH must not end with a list separator")
+	for _, entry := range strings.Split(result, string(os.PathListSeparator)) {
+		assert.NotEmpty(t, entry, "built PATH must not contain an empty component")
+	}
+}

--- a/pkg/dependencies/installer_test.go
+++ b/pkg/dependencies/installer_test.go
@@ -1,9 +1,11 @@
 package dependencies
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -87,7 +89,8 @@ func TestNewInstaller(t *testing.T) {
 		mockInstall := func(string, bool, bool, bool, bool) error { return nil }
 		mockFileExists := func(string) bool { return true }
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(mockRes),
 			WithInstallFunc(mockInstall),
 			WithFileExistsFunc(mockFileExists),
@@ -402,7 +405,8 @@ func TestIsToolInstalled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver, finder := tt.setupMock()
 
-			inst := NewInstaller(tt.config,
+			inst := NewInstaller(
+				tt.config,
 				WithResolver(resolver),
 				WithBinaryPathFinder(finder),
 			)
@@ -693,7 +697,8 @@ func runDuplicateInstallTest(t *testing.T, tc *duplicateInstallTestCase) {
 		Toolchain: schema.Toolchain{InstallPath: toolsDir},
 	}
 
-	inst := NewInstaller(config,
+	inst := NewInstaller(
+		config,
 		WithResolver(resolver),
 		WithBatchInstallFunc(batchInstallFunc),
 		WithBinaryPathFinder(finder),
@@ -728,7 +733,8 @@ func TestEnsureTool(t *testing.T) {
 			},
 		}
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(resolver),
 			WithInstallFunc(installFunc),
 			WithBinaryPathFinder(finder),
@@ -757,7 +763,8 @@ func TestEnsureTool(t *testing.T) {
 			},
 		}
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(resolver),
 			WithInstallFunc(installFunc),
 			WithBinaryPathFinder(finder),
@@ -786,7 +793,8 @@ func TestEnsureTool(t *testing.T) {
 			},
 		}
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(resolver),
 			WithInstallFunc(installFunc),
 			WithBinaryPathFinder(finder),
@@ -984,7 +992,8 @@ func TestBuildToolchainPATH_SkipsInvalidTools(t *testing.T) {
 
 func TestResolveExecutablePath(t *testing.T) {
 	t.Run("returns absolute path unchanged", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{}),
 			WithBinaryPathFinder(&mockBinaryPathFinder{}),
 		)
@@ -993,7 +1002,8 @@ func TestResolveExecutablePath(t *testing.T) {
 	})
 
 	t.Run("resolves bare executable from toolchain", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					if toolName == "opentofu" {
@@ -1018,7 +1028,8 @@ func TestResolveExecutablePath(t *testing.T) {
 	})
 
 	t.Run("returns original name when not found in toolchain or PATH", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "opentofu", "opentofu", nil
@@ -1037,7 +1048,8 @@ func TestResolveExecutablePath(t *testing.T) {
 	})
 
 	t.Run("skips deps with resolver errors", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "", "", errInvalidTool
@@ -1052,7 +1064,8 @@ func TestResolveExecutablePath(t *testing.T) {
 	})
 
 	t.Run("no-op with empty deps", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{}),
 			WithBinaryPathFinder(&mockBinaryPathFinder{}),
 		)
@@ -1065,7 +1078,8 @@ func TestResolveExecutablePath(t *testing.T) {
 	t.Run("matches binary with platform extension against bare executable name", func(t *testing.T) {
 		// On Windows, FindBinaryPath returns a path like /path/tofu.exe but the
 		// executable is specified as bare "tofu". The comparison should still match.
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					if toolName == "opentofu" {
@@ -1390,7 +1404,8 @@ func TestFindInstalledMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver, lister, finder := tt.setupMock()
 
-			inst := NewInstaller(nil,
+			inst := NewInstaller(
+				nil,
 				WithResolver(resolver),
 				WithInstalledVersionLister(lister),
 				WithBinaryPathFinder(finder),
@@ -1411,7 +1426,8 @@ func TestResolveConstraints(t *testing.T) {
 			"opentofu/opentofu":   "1.8.0",
 		}
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{}),
 		)
 
@@ -1427,7 +1443,8 @@ func TestResolveConstraints(t *testing.T) {
 		}
 
 		versionListerCalled := false
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "hashicorp", "terraform", nil
@@ -1463,7 +1480,8 @@ func TestResolveConstraints(t *testing.T) {
 			"cloudposse/atmos":    "1.0.0", // Concrete, should not change.
 		}
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					parts := strings.Split(toolName, "/")
@@ -1498,7 +1516,8 @@ func TestResolveConstraints(t *testing.T) {
 // TestResolveOneConstraint tests the resolveOneConstraint method.
 func TestResolveOneConstraint(t *testing.T) {
 	t.Run("invalid constraint returns error", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{}),
 		)
 
@@ -1508,7 +1527,8 @@ func TestResolveOneConstraint(t *testing.T) {
 	})
 
 	t.Run("resolver error returns error", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "", "", errToolNotFound
@@ -1522,7 +1542,8 @@ func TestResolveOneConstraint(t *testing.T) {
 	})
 
 	t.Run("happy path resolves highest matching version", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "hashicorp", "terraform", nil
@@ -1541,7 +1562,8 @@ func TestResolveOneConstraint(t *testing.T) {
 	})
 
 	t.Run("no matching version returns error", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "hashicorp", "terraform", nil
@@ -1560,7 +1582,8 @@ func TestResolveOneConstraint(t *testing.T) {
 	})
 
 	t.Run("version lister error returns error", func(t *testing.T) {
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "hashicorp", "terraform", nil
@@ -1583,7 +1606,8 @@ func TestResolveOneConstraint(t *testing.T) {
 func TestFetchAvailableVersionsWithRetry(t *testing.T) {
 	t.Run("success on first attempt", func(t *testing.T) {
 		expected := []string{"1.10.0", "1.10.3"}
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithVersionLister(&mockVersionLister{
 				getAvailableVersionsFunc: func(owner, repo string) ([]string, error) {
 					return expected, nil
@@ -1598,7 +1622,8 @@ func TestFetchAvailableVersionsWithRetry(t *testing.T) {
 
 	t.Run("non-retryable error fails immediately", func(t *testing.T) {
 		callCount := int32(0)
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithVersionLister(&mockVersionLister{
 				getAvailableVersionsFunc: func(owner, repo string) ([]string, error) {
 					atomic.AddInt32(&callCount, 1)
@@ -1617,7 +1642,8 @@ func TestFetchAvailableVersionsWithRetry(t *testing.T) {
 
 	t.Run("HTTP 404 not retried", func(t *testing.T) {
 		callCount := int32(0)
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithVersionLister(&mockVersionLister{
 				getAvailableVersionsFunc: func(owner, repo string) ([]string, error) {
 					atomic.AddInt32(&callCount, 1)
@@ -1637,7 +1663,8 @@ func TestEnsureTools_WithConstraints(t *testing.T) {
 	t.Run("constraint resolved and installed", func(t *testing.T) {
 		var installedSpecs []string
 
-		inst := NewInstaller(nil,
+		inst := NewInstaller(
+			nil,
 			WithResolver(&mockResolver{
 				resolveFunc: func(toolName string) (string, string, error) {
 					return "hashicorp", "terraform", nil
@@ -1675,4 +1702,90 @@ func TestEnsureTools_WithConstraints(t *testing.T) {
 		require.Len(t, installedSpecs, 1)
 		assert.Equal(t, "hashicorp/terraform@1.10.3", installedSpecs[0])
 	})
+}
+
+// TestBuildToolchainPATH_Onedir verifies that a onedir (multi-file) tool's nested
+// entrypoint directory is placed on PATH (so its executable is resolvable), while a
+// flat single-binary tool still contributes its version directory. This exercises
+// the onedir-aware resolution shared with `atmos toolchain env`.
+func TestBuildToolchainPATH_Onedir(t *testing.T) {
+	// Isolate PATH to a non-existent directory so LookPath resolves only via the
+	// toolchain directories we build (no system node/kubectl can mask the result).
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "empty-base"))
+
+	toolsDir := t.TempDir()
+	binDir := filepath.Join(toolsDir, "bin")
+
+	exe := func(name string) string {
+		if runtime.GOOS == "windows" {
+			return name + ".exe"
+		}
+		return name
+	}
+
+	// Fake onedir install: nodejs/node with the executable nested under .pkg, its
+	// real location recorded in the .atmos-onedir.json manifest.
+	nodeVersionDir := filepath.Join(binDir, "nodejs", "node", "24.18.0")
+	pkgName := fmt.Sprintf("node-v24.18.0-%s-%s", runtime.GOOS, runtime.GOARCH)
+	nodeRel := filepath.Join(".pkg", pkgName, "bin", exe("node"))
+	nodeBinPath := filepath.Join(nodeVersionDir, nodeRel)
+	// npm ships in the same nested bin directory as node; two entrypoints resolving
+	// to one directory must collapse to a single PATH entry.
+	npmRel := filepath.Join(".pkg", pkgName, "bin", exe("npm"))
+	npmBinPath := filepath.Join(nodeVersionDir, npmRel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(nodeBinPath), 0o755))
+	require.NoError(t, os.WriteFile(nodeBinPath, []byte("#!/bin/sh\necho v24.18.0\n"), 0o755))
+	require.NoError(t, os.WriteFile(npmBinPath, []byte("#!/bin/sh\necho npm\n"), 0o755))
+	manifest, err := json.Marshal(map[string]any{
+		"entrypoints": map[string]string{"node": nodeRel, "npm": npmRel},
+		"primary":     "node",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(nodeVersionDir, ".atmos-onedir.json"), manifest, 0o644))
+
+	// Fake flat install: kubernetes/kubectl with the binary directly in the version dir.
+	kubectlVersionDir := filepath.Join(binDir, "kubernetes", "kubectl", "1.31.0")
+	kubectlBinPath := filepath.Join(kubectlVersionDir, exe("kubectl"))
+	require.NoError(t, os.MkdirAll(kubectlVersionDir, 0o755))
+	require.NoError(t, os.WriteFile(kubectlBinPath, []byte("#!/bin/sh\necho kubectl\n"), 0o755))
+
+	config := &schema.AtmosConfiguration{
+		Toolchain: schema.Toolchain{InstallPath: toolsDir},
+	}
+
+	result, err := BuildToolchainPATH(config, map[string]string{
+		"nodejs/node":        "24.18.0",
+		"kubernetes/kubectl": "1.31.0",
+	})
+	require.NoError(t, err)
+
+	entries := strings.Split(result, string(os.PathListSeparator))
+
+	// The onedir node executable's NESTED directory must be on PATH, not the bare
+	// version directory (which holds no executable).
+	assert.Contains(t, entries, filepath.Dir(nodeBinPath), "onedir node entrypoint dir must be on PATH")
+	assert.NotContains(t, entries, nodeVersionDir, "bare version dir must not be the node PATH entry")
+
+	// node and npm share a directory, so it must appear exactly once (deduplicated).
+	nodeDirCount := 0
+	for _, e := range entries {
+		if e == filepath.Dir(nodeBinPath) {
+			nodeDirCount++
+		}
+	}
+	assert.Equal(t, 1, nodeDirCount, "shared onedir entrypoint directory must be deduplicated")
+
+	// The flat kubectl tool still contributes its version directory.
+	assert.Contains(t, entries, kubectlVersionDir, "flat kubectl version dir must be on PATH")
+
+	// The built PATH must actually resolve both executables.
+	t.Setenv("PATH", result)
+
+	resolvedNode, err := osexec.LookPath("node")
+	require.NoError(t, err, "node must be resolvable on the built PATH")
+	assert.Equal(t, nodeBinPath, resolvedNode)
+
+	resolvedKubectl, err := osexec.LookPath("kubectl")
+	require.NoError(t, err, "kubectl must still be resolvable on the built PATH")
+	assert.Equal(t, kubectlBinPath, resolvedKubectl)
 }

--- a/pkg/toolchain/path_helpers.go
+++ b/pkg/toolchain/path_helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/perf"
 )
 
 // ToolPath represents a tool with its version and path.
@@ -59,6 +60,29 @@ func entrypointDirs(binaryPaths []string, relativeFlag bool) []string {
 		dirs = append(dirs, dir)
 	}
 	return dirs
+}
+
+// EntrypointDirsForVersion returns the directories that must be on PATH to expose
+// an installed tool version's entrypoints, using the same onedir-aware resolution
+// as `atmos toolchain env`. For a onedir (multi-file) package it returns each
+// directory holding a resolved manifest entrypoint (e.g. the nested .pkg/.../bin);
+// for a flat install it returns the single version directory. It returns one entry
+// per resolved entrypoint (callers deduplicate), and nil when the tool version is
+// not installed, letting the caller fall back to a bare version-dir guess for
+// backward compatibility.
+//
+// When relativeFlag is true the directories are relative to the locator's bin
+// dir; otherwise they are absolute (the common case for building a subprocess
+// PATH).
+func EntrypointDirsForVersion(locator InstallLocator, owner, repo, version string, relativeFlag bool) []string {
+	defer perf.Track(nil, "toolchain.EntrypointDirsForVersion")()
+
+	binaryPath, err := locator.FindBinaryPath(owner, repo, version)
+	if err != nil {
+		// Tool not installed (or unusual layout): let the caller decide the fallback.
+		return nil
+	}
+	return entrypointDirs(entrypointBinaryPaths(locator, owner, repo, version, binaryPath), relativeFlag)
 }
 
 // appendUniqueDirs appends dirs not already in seen to pathEntries.

--- a/pkg/toolchain/path_helpers.go
+++ b/pkg/toolchain/path_helpers.go
@@ -71,9 +71,10 @@ func entrypointDirs(binaryPaths []string, relativeFlag bool) []string {
 // not installed, letting the caller fall back to a bare version-dir guess for
 // backward compatibility.
 //
-// When relativeFlag is true the directories are relative to the locator's bin
-// dir; otherwise they are absolute (the common case for building a subprocess
-// PATH).
+// When relativeFlag is true the locator-provided path form is preserved (paths
+// are not absolutized, so they stay relative only when the locator's bin dir is
+// relative); when false the directories are absolutized — the common case for
+// building a subprocess PATH.
 func EntrypointDirsForVersion(locator InstallLocator, owner, repo, version string, relativeFlag bool) []string {
 	defer perf.Track(nil, "toolchain.EntrypointDirsForVersion")()
 

--- a/pkg/toolchain/path_helpers_test.go
+++ b/pkg/toolchain/path_helpers_test.go
@@ -460,6 +460,7 @@ type fakePathsLocator struct {
 	owner, repo string
 	primary     string
 	all         []string
+	findErr     error // When set, FindBinaryPath returns this error (simulates a not-installed tool).
 }
 
 func (f *fakePathsLocator) ParseToolSpec(string) (string, string, error) {
@@ -467,6 +468,9 @@ func (f *fakePathsLocator) ParseToolSpec(string) (string, string, error) {
 }
 
 func (f *fakePathsLocator) FindBinaryPath(_, _, _ string, _ ...string) (string, error) {
+	if f.findErr != nil {
+		return "", f.findErr
+	}
 	return f.primary, nil
 }
 
@@ -518,4 +522,55 @@ func TestBuildPathEntriesWithLocator_OnedirSameDirDeduped(t *testing.T) {
 	pathEntries, _, err := buildPathEntriesWithLocator(toolVersions, loc, true)
 	require.NoError(t, err)
 	assert.Len(t, pathEntries, 1, "entrypoints in the same directory collapse to one PATH entry")
+}
+
+// TestEntrypointDirsForVersion_OnedirMultipleDirs verifies that a onedir
+// package's entrypoints resolve to each of their (distinct) directories.
+func TestEntrypointDirsForVersion_OnedirMultipleDirs(t *testing.T) {
+	loc := &fakePathsLocator{
+		owner:   "nodejs",
+		repo:    "node",
+		primary: filepath.FromSlash("/tools/nodejs/node/24.18.0/.pkg/bin/node"),
+		all: []string{
+			filepath.FromSlash("/tools/nodejs/node/24.18.0/.pkg/bin/node"),
+			filepath.FromSlash("/tools/nodejs/node/24.18.0/.pkg/lib/node_modules/npm/bin/npm"),
+		},
+	}
+
+	dirs := EntrypointDirsForVersion(loc, "nodejs", "node", "24.18.0", true)
+
+	assert.ElementsMatch(t, []string{
+		filepath.FromSlash("/tools/nodejs/node/24.18.0/.pkg/bin"),
+		filepath.FromSlash("/tools/nodejs/node/24.18.0/.pkg/lib/node_modules/npm/bin"),
+	}, dirs, "each onedir entrypoint directory must be returned")
+}
+
+// TestEntrypointDirsForVersion_Flat verifies that a flat install (no onedir
+// manifest, so GetBinaryPaths returns nothing) resolves to the single directory
+// containing its primary binary.
+func TestEntrypointDirsForVersion_Flat(t *testing.T) {
+	loc := &fakePathsLocator{
+		owner:   "kubernetes",
+		repo:    "kubectl",
+		primary: filepath.FromSlash("/tools/kubernetes/kubectl/1.31.0/kubectl"),
+		all:     nil, // No manifest entrypoints => flat install.
+	}
+
+	dirs := EntrypointDirsForVersion(loc, "kubernetes", "kubectl", "1.31.0", true)
+
+	assert.Equal(t, []string{filepath.FromSlash("/tools/kubernetes/kubectl/1.31.0")}, dirs)
+}
+
+// TestEntrypointDirsForVersion_NotInstalled verifies that a tool whose binary
+// cannot be located returns nil, letting callers apply their own fallback.
+func TestEntrypointDirsForVersion_NotInstalled(t *testing.T) {
+	loc := &fakePathsLocator{
+		owner:   "nodejs",
+		repo:    "node",
+		findErr: errors.New("not installed"),
+	}
+
+	dirs := EntrypointDirsForVersion(loc, "nodejs", "node", "24.18.0", true)
+
+	assert.Nil(t, dirs)
 }


### PR DESCRIPTION
## what

- Fix onedir (multi-file) tools declared in a custom command's `dependencies.tools` (e.g. `nodejs/node`, `npm/cli`, `aws-cli`) not being reachable from the command's `steps` — they previously failed with `executable file not found in $PATH` (exit 127).
- `BuildToolchainPATH` now resolves each dependency's PATH entries through the same onedir-aware logic as `atmos toolchain env`, adding the nested `.pkg/.../bin` directory(ies) recorded in `.atmos-onedir.json` instead of the bare version directory.
- Add `toolchain.EntrypointDirsForVersion` as the single source of truth for onedir entrypoint-directory resolution, shared by `atmos toolchain env`, the dependency PATH builder (custom commands, hooks, terraform/helmfile/packer, ansible), and `ToolchainEnvironment`.
- Make `ToolchainEnvironment` dirs (`ToolchainDirs()` / `PrependToPath()`) onedir-complete — every entrypoint directory, not just the primary binary's.
- Flat single-binary tools are unchanged (still their version dir); a not-installed tool falls back to the bare version dir (preserves existing behavior).

## why

- Onedir installs (#2750) keep executables nested under `.pkg/.../bin` per `.atmos-onedir.json`, but the command-dependency PATH builder still prepended the bare version dir, so node/npm/aws-cli were never on PATH for steps.
- `atmos toolchain env` already resolved these correctly; the command-dependency path simply wasn't reusing that resolution. Unifying both behind one helper makes onedir tools generally usable as command/hook/component dependencies.
- This is the remaining gap after #2750 (onedir installs) and #2754 (onedir symlink materialization); this change is solely about how onedir command-dependency tools are exposed on PATH.

## references

- Builds on #2750 (multi-file "onedir" installs) and #2754 (onedir symlink entrypoints).
- Repro: a custom command with `dependencies.tools: { nodejs/node: v24.18.0 }` whose step runs `node --version` now succeeds; a single-binary control (`kubectl`) keeps resolving.

<details><summary>Testing</summary>

- New unit tests, with all net-new code covered (`EntrypointDirsForVersion` 100%, `BuildToolchainPATH` 100%, `collectToolchainDirs` 94.7%, `addEntrypointDirs` 100%):
  - `TestEntrypointDirsForVersion_*` (pkg/toolchain): onedir multi-dir, flat, not-installed.
  - `TestBuildToolchainPATH_Onedir` (pkg/dependencies): asserts `exec.LookPath` resolves the nested onedir entrypoint, flat `kubectl` still resolves, and a shared onedir dir is deduplicated. Verified this **fails on pre-fix code** and passes after.
  - `TestNewEnvironment_OnedirDirs` (pkg/dependencies): `env.dirs` onedir-complete, dedup + absolutize, primary-dir fallback.
- `go build ./...`, `go vet`, custom `golangci-lint` (patch-scoped), and `gofumpt` are clean; consumer packages (hooks, ansible, helm, terraform/output) pass.
- Cross-platform: `.exe` handling + `filepath.Join`. A Windows acceptance subset for `./pkg/toolchain/...` and `./pkg/dependencies/...` passed, including `TestBuildToolchainPATH_Onedir`, `TestEntrypointDirsForVersion_*`, and `TestNewEnvironment_OnedirDirs`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tool discovery for onedir-style installations.
  * Automatically prepends required entrypoint directories to the toolchain `PATH`, deduplicated and normalized (absolute, order preserved).
  * Preserves flat-install behavior by falling back to the tool’s primary binary directory.
* **Bug Fixes**
  * Ensures executable resolution from onedir layouts works reliably; returns `PATH` unchanged when no resolved directories are available (including for empty `PATH` input).
* **Tests**
  * Added coverage for onedir entrypoint directory behavior and `BuildToolchainPATH` edge cases (empty `PATH` handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->