### PR TITLE
fix(ci): prevent broken GitHub Action symlinks

### DIFF
--- a/.atmos.d/build.yaml
+++ b/.atmos.d/build.yaml
@@ -2,12 +2,7 @@ commands:
   - name: build
     description: Build and documentation commands for Atmos development
     default: binary
-    # No working_directory here (unlike other custom commands): this command
-    # bootstraps the very first build using a pinned, possibly-older atmos
-    # release (see .github/workflows/version-tracker.yaml's
-    # ATMOS_BOOTSTRAP_VERSION), so it must not depend on YAML tags newer than
-    # that pin (e.g. !repo-root). Each step below resolves the repo root
-    # itself via `git rev-parse --show-toplevel` instead.
+    working_directory: !repo-root .
     env: &build_env
       - key: GOTOOLCHAIN
         value: auto
@@ -40,11 +35,12 @@ commands:
     commands:
       - name: deps
         description: Download Go module dependencies, retrying on transient network failures
+        working_directory: !repo-root .
         env:
           - key: GOTOOLCHAIN
             value: auto
         steps:
-          - command: cd "$(git rev-parse --show-toplevel)" && go mod download
+          - command: go mod download
             type: shell
             retry:
               max_attempts: 5
@@ -54,6 +50,7 @@ commands:
 
       - name: binary
         description: Build the Atmos binary
+        working_directory: !repo-root .
         env: *build_env
         flags:
           - name: target
@@ -72,6 +69,7 @@ commands:
 
       - name: version
         description: Print the version from an already-built Atmos binary
+        working_directory: !repo-root .
         env:
           - key: ATMOS_BUILD_TARGET
             value: "{{ .Flags.target }}"
@@ -82,7 +80,6 @@ commands:
         steps:
           - |
             set -eu
-            cd "$(git rev-parse --show-toplevel)"
 
             target="${ATMOS_BUILD_TARGET:-default}"
 
@@ -103,12 +100,12 @@ commands:
 
       - name: readme
         description: Regenerate README.md from README.yaml
+        working_directory: !repo-root .
         env:
           - key: GOTOOLCHAIN
             value: auto
         steps:
           - |
             set -eu
-            cd "$(git rev-parse --show-toplevel)"
             atmos build
             ./build/atmos docs generate readme

--- a/.atmos.d/dev.yaml
+++ b/.atmos.d/dev.yaml
@@ -59,14 +59,13 @@ commands:
 
       - name: shell
         description: Start a development shell with build/ first on PATH
+        working_directory: !repo-root .
         steps:
           - type: exec
             command: |
               set -eu
-              root="$(git rev-parse --show-toplevel)"
-              cd "$root"
               export ATMOS_DEV_SHELL=1
-              export PATH="$root/build:$PATH"
+              export PATH="$PWD/build:$PATH"
               exec "${SHELL:-/bin/sh}"
 
       - name: validate
@@ -123,16 +122,12 @@ commands:
         commands:
           - name: notices
             description: Regenerate NOTICE from Go dependency licenses
-            # No working_directory here: scripts/generate-notice.sh already
-            # resolves the repo root itself via its own script path. Avoiding
-            # the !repo-root tag also keeps this file parseable by the older
-            # bootstrap atmos binary used to self-host CI's first build (see
-            # .atmos.d/build.yaml for the same constraint).
+            working_directory: !repo-root .
             env: *go_auto_env
             steps:
               - type: spin
                 title: Generating NOTICE from Go dependency licenses
-                command: cd "$(git rev-parse --show-toplevel)" && ./scripts/generate-notice.sh
+                command: ./scripts/generate-notice.sh
                 timeout: 10m
               - type: toast
                 level: success
@@ -147,8 +142,7 @@ commands:
 
           - name: snapshots
             description: Regenerate CLI golden snapshots
-            # No working_directory here (see the "notices" command above for
-            # why): cd's to the repo root inline in the step below instead.
+            working_directory: !repo-root .
             env:
               - key: GOTOOLCHAIN
                 value: auto
@@ -167,7 +161,6 @@ commands:
               - type: shell
                 command: |
                   set -eu
-                  cd "$(git rev-parse --show-toplevel)"
                   filter="${ATMOS_SNAPSHOT_FILTER:-}"
 
                   selected=0
@@ -189,7 +182,7 @@ commands:
 
           - name: schema
             description: Regenerate the atmos-manifest JSON Schema website copy from the embedded schema
-            # No working_directory here (see the "notices" command above for why).
+            working_directory: !repo-root .
             env:
               <<: *go_auto_env
               # go run . builds the whole atmos binary graph, which pulls in cgo-linked

--- a/.atmos.d/fix.yaml
+++ b/.atmos.d/fix.yaml
@@ -46,11 +46,10 @@ commands:
     commands:
       - name: symlinks
         description: Verify that every Git-tracked symbolic link resolves
+        working_directory: !repo-root .
         steps:
           - type: shell
-            # Keep this bootstrap-compatible: CI first loads custom commands with
-            # the pinned Atmos 1.222.0 release, which predates the !repo-root tag.
-            command: cd "$(git rev-parse --show-toplevel)" && scripts/check-symlinks.sh
+            command: scripts/check-symlinks.sh
 
       - name: sync
         description: |

--- a/.atmos.d/fix.yaml
+++ b/.atmos.d/fix.yaml
@@ -46,10 +46,11 @@ commands:
     commands:
       - name: symlinks
         description: Verify that every Git-tracked symbolic link resolves
-        working_directory: !repo-root .
         steps:
           - type: shell
-            command: scripts/check-symlinks.sh
+            # Keep this bootstrap-compatible: CI first loads custom commands with
+            # the pinned Atmos 1.222.0 release, which predates the !repo-root tag.
+            command: cd "$(git rev-parse --show-toplevel)" && scripts/check-symlinks.sh
 
       - name: sync
         description: |

--- a/.atmos.d/fix.yaml
+++ b/.atmos.d/fix.yaml
@@ -44,6 +44,13 @@ commands:
         content: "atmos fix --all complete."
 
     commands:
+      - name: symlinks
+        description: Verify that every Git-tracked symbolic link resolves
+        working_directory: !repo-root .
+        steps:
+          - type: shell
+            command: scripts/check-symlinks.sh
+
       - name: sync
         description: |
           Update the PR against origin/main if behind (GitHub-side, via `gh pr update-branch`),

--- a/.claude/skills/atmos-gitops
+++ b/.claude/skills/atmos-gitops
@@ -1,1 +1,0 @@
-../../agent-skills/skills/atmos-gitops

--- a/.github/workflows/landing-demos.yaml
+++ b/.github/workflows/landing-demos.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'landing-demos'
     runs-on: ubuntu-latest
     env:
-      ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+      ATMOS_BOOTSTRAP_VERSION: "1.223.0"
       TERM: xterm-256color
       COLORTERM: truecolor
       LANG: en_US.UTF-8

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -30,7 +30,7 @@ permissions:
   statuses: write
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
   ATMOS_NATIVE_CI_WORKDIR: tests/fixtures/scenarios/native-ci-e2e
   ATMOS_VERSION_CHECK_ENABLED: "false"
   NATIVE_CI_TRIVY_VERSION: "0.70.0"

--- a/.github/workflows/planfile-artifacts-e2e.yml
+++ b/.github/workflows/planfile-artifacts-e2e.yml
@@ -43,7 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
   # Pin the SHA so the plan upload and the apply download derive the identical
   # planfile key across both jobs.
   ATMOS_CI_SHA: ${{ github.sha }}

--- a/.github/workflows/planfile-verify-e2e.yml
+++ b/.github/workflows/planfile-verify-e2e.yml
@@ -48,7 +48,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
   # Pin the SHA so the plan upload and the deploy download derive the identical
   # planfile key across jobs.
   ATMOS_CI_SHA: ${{ github.sha }}

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -10,7 +10,7 @@ on:
     - cron: "35 0 * * *"
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
 
 jobs:
   cache-warmup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ permissions:
   pull-requests: read
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
   OPEN_TOFU_VERSION: "1.12.2"
   HELM_VERSION: "v3.19.2"
   HELMFILE_VERSION: "v1.1.0"

--- a/.github/workflows/verify-symlinks.yml
+++ b/.github/workflows/verify-symlinks.yml
@@ -1,0 +1,22 @@
+name: Verify Repository Symlinks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-symlinks:
+    name: Verify tracked symlinks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify tracked symlinks resolve
+        run: scripts/check-symlinks.sh

--- a/.github/workflows/version-tracker.yaml
+++ b/.github/workflows/version-tracker.yaml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  ATMOS_BOOTSTRAP_VERSION: "1.222.0"
+  ATMOS_BOOTSTRAP_VERSION: "1.223.0"
 
 jobs:
   demo:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,14 @@ repos:
         files: ^(CLAUDE\.md|\.conductor/.*/CLAUDE\.md)$
         pass_filenames: false
 
+      - id: tracked-symlinks-check
+        name: Verify tracked symlinks
+        description: Ensure every Git-tracked symbolic link resolves
+        entry: scripts/check-symlinks.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
 
   # General file hygiene
   # NOTE: trailing-whitespace, end-of-file-fixer, and check-added-large-files hardcode

--- a/scripts/build-atmos.sh
+++ b/scripts/build-atmos.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 set -eu
 
-# Run from the repo (or worktree) root regardless of the caller's cwd. Resolved
-# via git rather than atmos's !repo-root YAML tag so this script has no
-# dependency on the atmos version invoking it -- the "build" custom command is
-# also used to self-host the very first build with an older bootstrap binary
-# that may predate newer YAML tags.
+# Run from the repo (or worktree) root regardless of the caller's cwd. This is
+# a standalone script as well as an Atmos custom-command entrypoint, so it
+# resolves its own working directory.
 cd "$(git rev-parse --show-toplevel)"
 
 target="${1:-${ATMOS_BUILD_TARGET:-default}}"

--- a/scripts/check-symlinks.sh
+++ b/scripts/check-symlinks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Verify that every symbolic link tracked by Git resolves in this checkout.
+
+set -euo pipefail
+
+errors=0
+links=0
+
+while IFS= read -r -d '' entry; do
+    metadata=${entry%%$'\t'*}
+    path=${entry#*$'\t'}
+    mode=${metadata%% *}
+
+    if [[ "$mode" != "120000" ]]; then
+        continue
+    fi
+
+    links=$((links + 1))
+    if [[ -e "$path" ]]; then
+        continue
+    fi
+
+    target=$(readlink "$path" 2>/dev/null || printf '<unreadable>')
+    message="Broken tracked symlink: $path -> $target"
+    printf '::error file=%s::%s\n' "$path" "$message"
+    printf '%s\n' "$message" >&2
+    errors=$((errors + 1))
+done < <(git ls-files -s -z)
+
+if ((errors > 0)); then
+    printf 'Found %d broken tracked symlink(s).\n' "$errors" >&2
+    exit 1
+fi
+
+printf 'All %d tracked symlink(s) resolve.\n' "$links"


### PR DESCRIPTION
## what

- Remove the stale `atmos-gitops` Claude skill symlink.
- Add a repository-wide verifier for Git-tracked symlinks, run in PR/main CI and pre-commit.
- Add `atmos fix symlinks` to run the verifier from any repository subdirectory.
- Standardize repository-root custom commands on `working_directory: !repo-root .`.
- Upgrade every CI bootstrap pin to Atmos 1.223.0, which supports that YAML tag.
- Require the verifier status on `main`.

## why

- A dangling symlink prevented GitHub Actions from staging the Atmos action repository before `atmos plan` could start.
- Checking all tracked symlinks protects every action consumer from the same class of packaging failure.
- A consistent, supported working-directory mechanism avoids duplicated shell root-resolution and lets every CI workflow load the custom-command configuration.

It caused problems like this:

```
Download action repository 'actions/checkout@v6' (SHA:df4cb1c069e1874edd31b4311f1884172cec0e10)
Download action repository 'cloudposse/atmos@v1' (SHA:1c00575b4be0393764fd202c4f0fb8efaf2411a0)
Error: Could not find file '/home/runner/_work/_actions/_temp_abab9a8a-faa8-41be-b57a-2d057d929d26/_staging/atmos-1c00575b4be0393764fd202c4f0fb8efaf2411a0/.claude/skills/atmos-gitops'.
```

## references

- No issue; fixes the broken `cloudposse/atmos@v1` action staging path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added checks to verify that tracked symbolic links resolve correctly.
  - Added an `atmos fix symlinks` command for manually running the validation.
  - Added automatic validation during commits and continuous integration checks.

- **Improvements**
  - Standardized repository-root execution for development and build commands.
  - Updated automated workflows to use Atmos bootstrap version 1.223.0.
  - Clarified build script usage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->