### PR TITLE
fix(toolchain): fail incomplete parallel installs

### DIFF
--- a/pkg/toolchain/install.go
+++ b/pkg/toolchain/install.go
@@ -654,24 +654,30 @@ func rightAlignInstallProgress(left string, downloaded, total int64, terminalWid
 func installToolListConcurrently(toolList []toolInfo, reinstallFlag, showHint bool, maxConcurrency int) error {
 	events := startBatchInstallWorkers(toolList, reinstallFlag, maxConcurrency)
 	display := newBatchDisplay(len(toolList))
+	counts := collectBatchInstallEvents(events, display, len(toolList))
+	display.clear()
+	return counts.finish(len(toolList), showHint)
+}
+
+func collectBatchInstallEvents(events <-chan batchEvent, display *batchDisplay, total int) batchInstallCounts {
 	ticker := time.NewTicker(80 * time.Millisecond)
 	defer ticker.Stop()
 
 	var counts batchInstallCounts
-	for counts.completed < len(toolList) {
+	for counts.completed < total {
 		select {
 		case event, ok := <-events:
 			if !ok {
-				counts.completed = len(toolList)
+				counts.failed += total - counts.completed
+				counts.completed = total
 				break
 			}
-			counts.handle(&event, display, len(toolList))
+			counts.handle(&event, display, total)
 		case <-ticker.C:
 			display.tick()
 		}
 	}
-	display.clear()
-	return counts.finish(len(toolList), showHint)
+	return counts
 }
 
 func startBatchInstallWorkers(toolList []toolInfo, reinstallFlag bool, maxConcurrency int) <-chan batchEvent {

--- a/pkg/toolchain/install_test.go
+++ b/pkg/toolchain/install_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -71,6 +72,25 @@ func TestBatchRendererMarksCompletedDownloadAsVerifying(t *testing.T) {
 	renderer.updateProgress(tool, downloadProgress{downloaded: 100, total: 100})
 
 	assert.Equal(t, "Verifying", renderer.active[0].phase)
+}
+
+func TestCollectBatchInstallEventsFailsForMissingTerminalResults(t *testing.T) {
+	setupTestIO(t)
+	events := make(chan batchEvent, 1)
+	events <- batchEvent{
+		tool:   toolInfo{owner: "owner", repo: "installed", version: "v1.0.0"},
+		result: resultInstalled,
+	}
+	close(events)
+
+	counts := collectBatchInstallEvents(events, &batchDisplay{renderer: &batchRenderer{total: 2}}, 2)
+	err := counts.finish(2, false)
+
+	assert.Equal(t, 1, counts.installed)
+	assert.Equal(t, 1, counts.failed)
+	assert.Equal(t, 2, counts.completed)
+	assert.ErrorIs(t, err, errUtils.ErrToolInstall)
+	assert.Contains(t, err.Error(), "1 tool installation(s) failed")
 }
 
 func TestInstallResolvesAliasFromToolVersions(t *testing.T) {


### PR DESCRIPTION
## what

- Treat missing terminal results in parallel toolchain installs as failures.
- Add regression coverage for a prematurely closed event channel.

## why

- Prevents incomplete parallel installs from reporting a successful command.

## references

- Closes #2767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch tool installation reporting when one or more installations do not return a final result.
  * Failed installations are now counted accurately, and the reported error includes the number of failures.
* **Tests**
  * Added coverage for incomplete batch installation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->