### PR TITLE
fix(auth): normalize component default markers

### DIFF
--- a/docs/fixes/2026-07-21-component-auth-default-markers.md
+++ b/docs/fixes/2026-07-21-component-auth-default-markers.md
@@ -1,0 +1,73 @@
+# Fix: Component Auth Default-Only Markers
+
+**Date:** 2026-07-21
+
+**Status:** Implemented
+
+## Summary
+
+A component-level `auth.identities.<name>.default: false` entry is intended to
+demote an identity for that component. When the active global/profile auth
+configuration does not define `<name>`, the component-auth deep merge currently
+creates an identity with an empty `kind`. Auth-manager initialization validates
+that unintended identity and fails.
+
+The fix treats an undefined false-only entry as a default marker rather than
+an identity declaration.
+
+## Reproduction
+
+```yaml
+# Active global/profile auth configuration
+auth:
+  identities:
+    deploy:
+      kind: aws/assume-role
+      default: true
+```
+
+```yaml
+# Resolved component auth configuration
+auth:
+  identities:
+    deploy:
+      default: true
+    audit:
+      default: false
+```
+
+Today, the component merge adds `audit` to the effective auth configuration
+without a `kind`, and initialization reports that `audit` is not configured.
+
+## Root Cause
+
+`pkg/auth/config_helpers.go:MergeComponentAuthConfig` deep-merges all entries
+from the component `auth.identities` map into global auth. It has no distinction
+between a default-selection marker and an identity declaration. The resulting
+`schema.Identity` for an undefined false-only entry has `Default: false` and an
+empty `Kind`; `manager.initializeIdentities` correctly rejects that incomplete
+identity.
+
+## Intended Behavior
+
+- An undefined entry whose only field is `default: false` is removed before
+  the component/global auth merge. It has no runtime identity and does not
+  cause an error.
+- A false-only entry for an existing global identity remains an override of
+  that identity's default state.
+- An undefined entry whose only field is `default: true` fails early with
+  `ErrInvalidIdentityConfig` and an actionable message, because it attempts to
+  select an identity that cannot be used.
+- Entries containing `kind` or any field besides `default` remain identity
+  declarations and retain normal merge and validation behavior.
+
+See [Default Auth Behavior PRD](../prd/default-auth-behavior.md) for the full
+behavioral contract and acceptance criteria.
+
+## Regression Coverage
+
+`TestMergeComponentAuthFromConfig_DefaultOnlyUndefinedIdentityIsIgnored`
+asserts that an undefined false-only marker is removed and initialization
+succeeds. Companion unit tests cover existing false-only and true-only
+markers, an undefined true-only marker that returns `ErrInvalidIdentityConfig`
+without mutating global defaults, and incomplete non-marker declarations.

--- a/docs/prd/default-auth-behavior.md
+++ b/docs/prd/default-auth-behavior.md
@@ -1,0 +1,128 @@
+# PRD: Default Auth Behavior
+
+## Problem
+
+Component stack configuration can use `auth.identities.<name>.default` to choose
+or demote the identity used for that component. Atmos currently deep-merges the
+entire component identity map into the active global auth configuration. As a
+result, an entry containing only `default: false` for an identity absent from
+the active profile becomes a new identity with no `kind`. Auth-manager
+initialization then fails because every merged identity must have a `kind`.
+
+This makes a harmless default-selection marker behave as an incomplete identity
+declaration. Shared component mixins consequently force every profile to add
+dummy identities solely to make the merged configuration valid.
+
+## Goals
+
+- Let a component demote an identity it does not define without requiring a
+  placeholder identity in every active profile.
+- Preserve field-by-field merging for real component identity definitions and
+  for identities supplied by the active global auth configuration.
+- Fail early and clearly when a component selects an identity that does not
+  exist.
+
+## Non-Goals
+
+- Change the schema or syntax of `auth.identities`.
+- Change identity-selection precedence, profile loading, or stack import
+  semantics.
+- Treat entries with identity configuration beyond `default: false` as markers.
+
+## Desired Behavior
+
+Before merging component auth into global auth, Atmos must classify each entry
+in the component's resolved `auth.identities` map.
+
+| Component entry | Global identity exists | Result |
+| --- | --- | --- |
+| Only `default: false` | Yes | Merge it; the global identity remains complete and is not default. |
+| Only `default: false` | No | Drop it. Do not create an identity and do not return an error. |
+| Only `default: true` | Yes | Merge it and make the existing identity the component default. |
+| Only `default: true` | No | Return `ErrInvalidIdentityConfig` explaining that the component default references an undefined identity. |
+| Contains `kind` or any identity field besides `default` | Either | Treat it as an identity declaration and retain the existing deep-merge and validation behavior. |
+
+An empty identity map (`name: {}`), `required: true` without a `kind`, or any
+other incomplete declaration is **not** a marker and must retain the existing
+validation failure. The special treatment applies only when the entry has
+exactly one field, `default`, whose value is `false` or `true`.
+
+### Example
+
+Given an active profile with one real identity:
+
+```yaml
+auth:
+  identities:
+    deploy:
+      kind: aws/assume-role
+      default: true
+```
+
+and a shared component mixin:
+
+```yaml
+auth:
+  identities:
+    deploy:
+      default: true
+    audit:
+      default: false
+```
+
+the resulting component auth configuration contains only the complete
+`deploy` identity. `audit` is ignored because it is a false-only marker for an
+identity not defined by the active profile.
+
+If the mixin instead sets `audit.default: true`, Atmos must fail before
+authentication with an error that names `audit` and tells the user to define it
+in global/profile auth or select an existing identity.
+
+## Implementation
+
+Apply this normalization in `MergeComponentAuthConfig`, after the component
+configuration has been fully resolved from its stack imports and before global
+defaults are cleared or the maps are deep-merged.
+
+- Work on a copy of the component auth section so callers' component
+  configuration is not mutated.
+- Determine whether an identity exists from the copied global auth config using
+  the same name representation currently used by component auth merging; this
+  change must not alter existing identity-name or case-handling behavior.
+- Remove false-only entries that have no matching global identity.
+- Detect true-only entries that have no matching global identity and return an
+  `ErrInvalidIdentityConfig` error from the merge helper. Include the identity
+  name and an actionable hint to define it in active global/profile auth.
+- Run the existing `componentAuthHasDefault` check only after this validation,
+  so an invalid undefined `default: true` marker cannot clear an otherwise
+  valid global default.
+- Deep-merge all remaining entries exactly as today. Existing identity and
+  factory validation remains responsible for invalid real declarations.
+
+No public API or configuration-schema changes are required.
+
+## Compatibility
+
+Existing fully defined identities, including intentionally configured
+`aws/ambient` identities, retain their current behavior. Placeholder identities
+used only to support absent `default: false` entries become unnecessary but
+remain valid configuration. An undefined `default: true` currently leads to a
+later unusable or incomplete auth configuration; it will instead receive an
+earlier, targeted validation error.
+
+## Acceptance Tests
+
+- A false-only component entry for an undefined identity is absent from the
+  merged auth config and auth-manager initialization succeeds.
+- A false-only component entry for an existing identity updates its default
+  state without losing that identity's fields.
+- A true-only component entry for an existing identity selects it as default.
+- A true-only component entry for an undefined identity returns
+  `ErrInvalidIdentityConfig`, names the identity, and does not mutate or clear
+  the input global defaults.
+- Entries with any fields besides `default` continue through normal deep merge
+  and existing identity validation.
+- Existing tests continue to verify that merge inputs are not mutated.
+
+Regression coverage asserts that a false-only undefined marker is removed and
+initialization succeeds, rather than preserving the prior failure.

--- a/pkg/auth/config_helpers.go
+++ b/pkg/auth/config_helpers.go
@@ -93,11 +93,18 @@ func MergeComponentAuthConfig(
 	// makes MergeComponentAuthConfig safe for any future direct caller too.
 	workingGlobalAuth := CopyGlobalAuthConfig(globalAuthConfig)
 
+	// Normalize default-only component identity markers before they can be
+	// materialized as incomplete identities by the deep merge.
+	normalizedComponentAuth, err := normalizeComponentIdentityDefaultMarkers(workingGlobalAuth, componentAuthSection)
+	if err != nil {
+		return nil, err
+	}
+
 	// If the component declares its own default identity, clear any existing
 	// defaults from the working copy so the component-level default wins.
 	// This matches the precedence pattern used by MergeStackAuthDefaults in
 	// pkg/config/stack_auth_loader.go.
-	if componentAuthHasDefault(componentAuthSection) {
+	if componentAuthHasDefault(normalizedComponentAuth) {
 		clearExistingIdentityDefaults(workingGlobalAuth)
 	}
 
@@ -109,7 +116,7 @@ func MergeComponentAuthConfig(
 
 	// Deep merge global and component auth configs.
 	// Component config takes precedence and can override parts of identities/providers (not just whole objects).
-	mergedMap, err := merge.Merge(atmosConfig, []map[string]any{globalAuthMap, componentAuthSection})
+	mergedMap, err := merge.Merge(atmosConfig, []map[string]any{globalAuthMap, normalizedComponentAuth})
 	if err != nil {
 		return nil, fmt.Errorf("%w: global and component auth configs: %w", errUtils.ErrMerge, err)
 	}
@@ -143,6 +150,65 @@ func MergeComponentAuthConfig(
 	}
 
 	return &finalAuthConfig, nil
+}
+
+// normalizeComponentIdentityDefaultMarkers removes component identity entries that are only
+// `default: false` markers for identities absent from the active global auth configuration.
+// It also rejects undefined `default: true` markers because they select an identity that cannot
+// be authenticated. All other entries remain identity declarations and continue through the
+// existing deep-merge and validation flow.
+func normalizeComponentIdentityDefaultMarkers(
+	globalAuth *schema.AuthConfig,
+	componentAuth map[string]any,
+) (map[string]any, error) {
+	// Copy the top-level map and the identities map before filtering so callers' resolved component
+	// configuration remains unchanged.
+	normalized := make(map[string]any, len(componentAuth))
+	for key, value := range componentAuth {
+		normalized[key] = value
+	}
+
+	identities, ok := componentAuth["identities"].(map[string]any)
+	if !ok {
+		return normalized, nil
+	}
+
+	normalizedIdentities := make(map[string]any, len(identities))
+	for identityName, rawIdentity := range identities {
+		identity, isIdentityMap := rawIdentity.(map[string]any)
+		defaultValue, hasDefault := identity["default"]
+		isDefault, isBooleanDefault := defaultValue.(bool)
+
+		// Entries are markers only when they contain exactly one boolean `default` field.
+		if !isIdentityMap || len(identity) != 1 || !hasDefault || !isBooleanDefault {
+			normalizedIdentities[identityName] = rawIdentity
+			continue
+		}
+
+		existsInGlobalAuth := globalAuth != nil
+		if existsInGlobalAuth {
+			_, existsInGlobalAuth = globalAuth.Identities[identityName]
+		}
+		if existsInGlobalAuth {
+			normalizedIdentities[identityName] = rawIdentity
+			continue
+		}
+
+		if !isDefault {
+			// An undefined false-only marker has no identity to override and must not create one.
+			continue
+		}
+
+		return nil, errUtils.Build(errUtils.ErrInvalidIdentityConfig).
+			WithExplanationf("Component default identity %q is not defined in the active global auth configuration", identityName).
+			WithHint("Define the identity in atmos.yaml or the active profile, or select an existing identity").
+			WithContext("identity", identityName).
+			WithExitCode(1).
+			Err()
+	}
+
+	normalized["identities"] = normalizedIdentities
+	return normalized, nil
 }
 
 // MergeComponentAuthFromConfig merges component-specific auth config from component configuration

--- a/pkg/auth/config_helpers_test.go
+++ b/pkg/auth/config_helpers_test.go
@@ -3,9 +3,12 @@ package auth
 import (
 	"testing"
 
+	cockroachErrors "github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/auth/types"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
@@ -278,6 +281,142 @@ func TestMergeComponentAuthFromConfig(t *testing.T) {
 			tt.verify(t, result, err)
 		})
 	}
+}
+
+func TestMergeComponentAuthFromConfig_DefaultOnlyUndefinedIdentityIsIgnored(t *testing.T) {
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"selected": {
+				Kind:    "mock",
+				Default: true,
+			},
+		},
+	}
+	componentConfig := map[string]any{
+		cfg.AuthSectionName: map[string]any{
+			"identities": map[string]any{
+				"selected": map[string]any{
+					"default": true,
+				},
+				"unavailable": map[string]any{
+					"default": false,
+				},
+			},
+		},
+	}
+
+	mergedAuth, err := MergeComponentAuthFromConfig(globalAuth, componentConfig, &schema.AtmosConfiguration{}, cfg.AuthSectionName)
+	require.NoError(t, err)
+	assert.NotContains(t, mergedAuth.Identities, "unavailable")
+	assert.Contains(t, componentConfig[cfg.AuthSectionName].(map[string]any)["identities"].(map[string]any), "unavailable",
+		"normalizing markers must not mutate the resolved component configuration")
+
+	m := &manager{
+		config:     mergedAuth,
+		identities: make(map[string]types.Identity),
+		stackInfo:  &schema.ConfigAndStacksInfo{ProfilesFromArg: []string{"test"}},
+	}
+
+	err = m.initializeIdentities()
+	assert.NoError(t, err)
+}
+
+func TestMergeComponentAuthFromConfig_DefaultOnlyFalseMarkerOverridesExistingIdentity(t *testing.T) {
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"selected": {Kind: "mock", Default: true},
+		},
+	}
+	componentConfig := map[string]any{
+		cfg.AuthSectionName: map[string]any{
+			"identities": map[string]any{
+				"selected": map[string]any{"default": false},
+			},
+		},
+	}
+
+	mergedAuth, err := MergeComponentAuthFromConfig(globalAuth, componentConfig, &schema.AtmosConfiguration{}, cfg.AuthSectionName)
+	require.NoError(t, err)
+	assert.Equal(t, "mock", mergedAuth.Identities["selected"].Kind)
+	assert.False(t, mergedAuth.Identities["selected"].Default)
+}
+
+func TestMergeComponentAuthFromConfig_DefaultOnlyTrueMarkerSelectsExistingIdentity(t *testing.T) {
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"selected": {Kind: "mock", Default: false},
+			"fallback": {Kind: "mock", Default: true},
+		},
+	}
+	componentConfig := map[string]any{
+		cfg.AuthSectionName: map[string]any{
+			"identities": map[string]any{
+				"selected": map[string]any{"default": true},
+			},
+		},
+	}
+
+	mergedAuth, err := MergeComponentAuthFromConfig(globalAuth, componentConfig, &schema.AtmosConfiguration{}, cfg.AuthSectionName)
+	require.NoError(t, err)
+	assert.True(t, mergedAuth.Identities["selected"].Default)
+	assert.False(t, mergedAuth.Identities["fallback"].Default)
+}
+
+func TestMergeComponentAuthFromConfig_DefaultOnlyTrueUndefinedIdentityFailsWithoutMutatingGlobalAuth(t *testing.T) {
+	globalAuth := &schema.AuthConfig{
+		Identities: map[string]schema.Identity{
+			"fallback": {Kind: "mock", Default: true},
+		},
+	}
+	componentConfig := map[string]any{
+		cfg.AuthSectionName: map[string]any{
+			"identities": map[string]any{
+				"unavailable": map[string]any{"default": true},
+			},
+		},
+	}
+
+	mergedAuth, err := MergeComponentAuthFromConfig(globalAuth, componentConfig, &schema.AtmosConfiguration{}, cfg.AuthSectionName)
+	require.Error(t, err)
+	assert.Nil(t, mergedAuth)
+	assert.ErrorIs(t, err, errUtils.ErrInvalidIdentityConfig)
+	details := cockroachErrors.GetAllDetails(err)
+	require.NotEmpty(t, details)
+	assert.Contains(t, details[0], "unavailable")
+	assert.Contains(t, details[0], "active global auth configuration")
+	assert.True(t, globalAuth.Identities["fallback"].Default,
+		"an invalid component default must not clear the caller's global default")
+}
+
+func TestMergeComponentAuthFromConfig_IncompleteIdentityDeclarationStillFailsValidation(t *testing.T) {
+	componentConfig := map[string]any{
+		cfg.AuthSectionName: map[string]any{
+			"identities": map[string]any{
+				"incomplete": map[string]any{
+					"default": false,
+					"alias":   "not-a-marker",
+				},
+			},
+		},
+	}
+
+	mergedAuth, err := MergeComponentAuthFromConfig(&schema.AuthConfig{}, componentConfig, &schema.AtmosConfiguration{}, cfg.AuthSectionName)
+	require.NoError(t, err)
+	require.Contains(t, mergedAuth.Identities, "incomplete")
+
+	m := &manager{
+		config:     mergedAuth,
+		identities: make(map[string]types.Identity),
+		stackInfo:  &schema.ConfigAndStacksInfo{ProfilesFromArg: []string{"test"}},
+	}
+
+	err = m.initializeIdentities()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrInvalidIdentityConfig)
+	details := cockroachErrors.GetAllDetails(err)
+	require.NotEmpty(t, details)
+	assert.Contains(t, details[0], "incomplete")
+	assert.Contains(t, details[0], "is not configured")
 }
 
 func TestMergeComponentAuthFromConfig_NilGlobalAuth(t *testing.T) {
@@ -644,6 +783,7 @@ func TestMergeComponentAuthConfig_DoesNotMutateInput(t *testing.T) {
 	globalAuth := &schema.AuthConfig{
 		Identities: map[string]schema.Identity{
 			"global-default": {Kind: "aws/assume-role", Default: true},
+			"comp-default":   {Kind: "aws/assume-role", Default: false},
 		},
 	}
 


### PR DESCRIPTION
## what

- Normalize component auth default-only identity markers before merging with active global/profile auth.
- Ignore undefined `default: false` markers and reject undefined `default: true` markers with a targeted configuration error.
- Add regression coverage plus the Default Auth Behavior PRD and fix log.

## why

- Prevent a harmless false-only marker from becoming an incomplete runtime identity that fails authentication initialization.
- Preserve real component identity definitions and deterministic default selection.

## references

- [Default Auth Behavior PRD](docs/prd/default-auth-behavior.md)
- [Component Auth Default-Only Markers fix log](docs/fixes/2026-07-21-component-auth-default-markers.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component authentication configuration merging for identity default markers.
  * Prevented undefined `default: false` markers from creating invalid identities or causing initialization failures.
  * Added validation for undefined `default: true` markers with clearer configuration errors.
  * Preserved existing behavior for complete identity declarations and valid global identities.
  * Ensured invalid configurations do not modify existing global authentication settings.

* **Documentation**
  * Added guidance covering default-marker behavior, validation rules, and expected configuration outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->