### PR TITLE
fix(yaml): accept non-whitespace boundaries after YAML function tags

### DIFF
--- a/internal/exec/yaml_func_tag_processing_test.go
+++ b/internal/exec/yaml_func_tag_processing_test.go
@@ -500,10 +500,12 @@ func TestProcessNodes_TemplateTagNoSeparator(t *testing.T) {
 	atmosConfig := &schema.AtmosConfiguration{}
 
 	data := map[string]any{
-		"generated": `!template["one","two"]`,
+		"generated":     `!template["one","two"]`,
+		"generated_map": `!template{"key":"value"}`,
 	}
 
 	result, err := processNodes(atmosConfig, data, "test-stack", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{"one", "two"}, result["generated"])
+	assert.Equal(t, map[string]interface{}{"key": "value"}, result["generated_map"])
 }

--- a/internal/exec/yaml_func_tag_processing_test.go
+++ b/internal/exec/yaml_func_tag_processing_test.go
@@ -461,3 +461,49 @@ func TestProcessTagTemplate_JSONHandling(t *testing.T) {
 		})
 	}
 }
+
+// TestMatchesTag_NonWhitespaceSeparators covers cloudposse/atmos#2778: a tag
+// value with no whitespace between the tag name and its content (e.g. produced
+// when a Go template `{{-` trim marker eats the separating newline) must still
+// be recognized, as long as the following character isn't a valid tag-name
+// continuation character.
+func TestMatchesTag_NonWhitespaceSeparators(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		prefix   string
+		expected bool
+	}{
+		{"space separator", "!template {}", "!template", true},
+		{"tab separator", "!template\t{}", "!template", true},
+		{"newline separator", "!template\n{}", "!template", true},
+		{"no separator before bracket", `!template["one","two"]`, "!template", true},
+		{"no separator before brace", `!template{"a":1}`, "!template", true},
+		{"no separator before quote", `!template"hello"`, "!template", true},
+		{"exact match, no content", "!template", "!template", true},
+		{"unrelated longer tag name not matched", "!templated", "!template", false},
+		{"no match at all", "!env FOO", "!template", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchesTag(tt.input, tt.prefix))
+		})
+	}
+}
+
+// TestProcessNodes_TemplateTagNoSeparator covers cloudposse/atmos#2778: when Go
+// template rendering trims the whitespace between the !template tag and its
+// content (e.g. via a `{{-` trim marker), processNodes must still decode the
+// resulting value instead of leaving it as a literal string.
+func TestProcessNodes_TemplateTagNoSeparator(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	data := map[string]any{
+		"generated": `!template["one","two"]`,
+	}
+
+	result, err := processNodes(atmosConfig, data, "test-stack", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []interface{}{"one", "two"}, result["generated"])
+}

--- a/internal/exec/yaml_func_utils.go
+++ b/internal/exec/yaml_func_utils.go
@@ -233,12 +233,24 @@ func processCustomTags(
 }
 
 // matchesTag reports whether input starts with prefix as a complete YAML tag.
+// Any character that could extend the tag name (letters, digits, '.', '-', '_')
+// disqualifies the match; anything else (whitespace, but also punctuation like
+// '[', '{', '"' that unambiguously starts a value) is a valid boundary. The
+// whitespace-only check this replaced broke values whose Go template rendering
+// trims the separator (e.g. a `{{-` marker), producing `!template[...]` with no
+// space before the content.
 func matchesTag(input, prefix string) bool {
 	if !strings.HasPrefix(input, prefix) {
 		return false
 	}
 	rest := strings.TrimPrefix(input, prefix)
-	return rest == "" || rest[0] == ' ' || rest[0] == '\t' || rest[0] == '\n'
+	if rest == "" {
+		return true
+	}
+	c := rest[0]
+	isNameContinuation := c == '.' || c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+	return !isNameContinuation
 }
 
 // matchesPrefix checks if input has the given tag prefix and the function is not skipped.


### PR DESCRIPTION
## what

- `matchesTag` in `internal/exec/yaml_func_utils.go` now accepts any character that can't extend a tag name (not just whitespace) as a valid boundary after a YAML function tag.

## why

- Regression introduced in the unsupported-YAML-tag validation work (#1515): `matchesTag` only treated space/tab/newline as a valid separator after a tag name.
- When Go template rendering trims the separating whitespace (e.g. a `{{-` trim marker eating the newline after `!template`), the rendered value becomes `!template["one","two"]` with no separator. The tag no longer matched and the value silently fell through as a literal string instead of being decoded, breaking `!template` (and any other YAML function hitting the same boundary) for anyone whose templates produce output flush against the tag.

## references

- Closes #2778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML `!template` tag recognition when the tag is directly adjacent to its content (no whitespace separator).
  * Prevented incorrect tag matches by tightening boundary detection, including correct behavior around punctuation.
* **Tests**
  * Added unit coverage for `!template` handling with no-separator formats (e.g., inline array/object forms) and for positive/negative tag matching cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->