### PR TITLE
Prevent sensitive YAML function value leaks

### DIFF
--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -42,8 +42,10 @@ The pre-pass now uses Atmos's tag-aware YAML decoder, which reconstructs custom 
 expression reaches final configuration. Other raw YAML parsing in stack processing is
 either node-only diagnostics or display-only inspection; normal stack configuration
 decoding already uses the tag-aware decoder. Controlled `1.221.0` and `1.223.0` runs took
-a simpler route and therefore resolved correctly; the faulty structured pre-pass was
-introduced after those releases.
+a simpler route and therefore resolved correctly. This was not introduced by YAML
+function validation: commit `c1fd583de7` added the structured pre-pass on 2026-07-08,
+after those releases. That commit is the change that made a raw explicit tag pass through
+plain map decoding before the normal tag-aware stack decoder.
 
 ## Changes
 

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -19,29 +19,31 @@ was declared sensitive.
 
 A local, real-state reproduction confirmed the sensitive JSON leak in both Atmos
 `1.221.0` and `1.223.0`. The original report that opened this fix also showed the
-separate raw-argument symptom. The controlled fixture did not recreate that exact path:
-both versions preserved the explicit tag and resolved the state value correctly.
+separate raw-argument symptom. The direct source path that produces that symptom is now
+identified and covered by regression tests.
 
-### Hypothesis: how raw function arguments could become a Terraform value
+### Root cause: template preprocessing discarded explicit tags
 
 An explicit YAML scalar has two distinct parts after YAML parsing: its tag
 (`!terraform.state`) and its scalar value (`producer ".fields.PRIVATE_KEY"`). The
 runtime resolver only runs when it receives the reconstructed complete expression:
 `!terraform.state producer ".fields.PRIVATE_KEY"`.
 
-The observed raw-argument value is therefore consistent with a tag-preservation failure
-at a decode or validation boundary: if that boundary clears or drops the explicit tag
-without rebuilding `tag + " " + value`, the runtime sees only
-`producer ".fields.PRIVATE_KEY"`. It is then an ordinary string, not a recognized YAML
-function, and can be serialized unchanged as a Terraform input. Graceful degradation
-does not explain that symptom; it substitutes `(computed)`, not the function arguments.
+The execution-critical structured template pre-processing path decoded raw YAML into an
+untyped Go map with plain `yaml.Unmarshal` and then re-rendered it. Plain decoding
+preserves the scalar value but drops its explicit tag, so it transformed `!terraform.state producer
+".fields.PRIVATE_KEY"` into `producer ".fields.PRIVATE_KEY"`. The final function
+processor consequently received an ordinary string and correctly did not invoke the
+state resolver; Terraform was handed the raw arguments. Graceful degradation was not
+involved: it emits `(computed)`, never function arguments.
 
-The exact decode or validation boundary that dropped the tag in the original incident
-was not isolated from the available configuration. Controlled `1.221.0` and `1.223.0`
-runs both preserved the explicit tag and resolved the real state value. The regression
-tests added by this fix assert preservation in mapping and list values and assert that
-`TF_VAR_*` receives only the resolved value, so the reported failure mode is now covered
-even though its original environmental trigger remains unconfirmed.
+The pre-pass now uses Atmos's tag-aware YAML decoder, which reconstructs custom tags as
+`tag + " " + value`. The regression test follows that route and verifies that the complete
+expression reaches final configuration. Other raw YAML parsing in stack processing is
+either node-only diagnostics or display-only inspection; normal stack configuration
+decoding already uses the tag-aware decoder. Controlled `1.221.0` and `1.223.0` runs took
+a simpler route and therefore resolved correctly; the faulty structured pre-pass was
+introduced after those releases.
 
 ## Changes
 
@@ -54,6 +56,8 @@ even though its original environmental trigger remains unconfirmed.
 - Add function-aware debug logging for lenient YAML-function degradation.
 - Add a neutral producer/consumer regression fixture and coverage for explicit-tag decoding,
   state resolution, JSON exclusion, and `TF_VAR_*` transport.
+- Preserve explicit YAML function tags through the context/import template pre-processing
+  path that previously stripped them.
 
 ## Validation
 

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -6,7 +6,9 @@
 
 Terraform inputs declared with `sensitive = true` are now excluded from generated
 `*.terraform.tfvars.json` files while masking is enabled. Resolved values are supplied
-to Terraform only through `TF_VAR_<name>` environment variables.
+to Terraform only through `TF_VAR_<name>` environment variables. This fix was opened
+after an explicit YAML function's raw arguments appeared in a generated varfile instead
+of its resolved value; the tests now protect that tag-preservation boundary as well.
 
 ## Context
 
@@ -15,9 +17,31 @@ masker. A value resolved by `!terraform.state` from a source that was not regist
 a secret therefore bypassed that partition, even when the consumer Terraform variable
 was declared sensitive.
 
-A local, real-state reproduction confirmed the JSON leak in both Atmos `1.221.0` and
-`1.223.0`. The same fixture resolved the explicit `!terraform.state` tag correctly in
-both releases; the separately reported literal-argument symptom was not reproduced.
+A local, real-state reproduction confirmed the sensitive JSON leak in both Atmos
+`1.221.0` and `1.223.0`. The original report that opened this fix also showed the
+separate raw-argument symptom. The controlled fixture did not recreate that exact path:
+both versions preserved the explicit tag and resolved the state value correctly.
+
+### Hypothesis: how raw function arguments could become a Terraform value
+
+An explicit YAML scalar has two distinct parts after YAML parsing: its tag
+(`!terraform.state`) and its scalar value (`producer ".fields.PRIVATE_KEY"`). The
+runtime resolver only runs when it receives the reconstructed complete expression:
+`!terraform.state producer ".fields.PRIVATE_KEY"`.
+
+The observed raw-argument value is therefore consistent with a tag-preservation failure
+at a decode or validation boundary: if that boundary clears or drops the explicit tag
+without rebuilding `tag + " " + value`, the runtime sees only
+`producer ".fields.PRIVATE_KEY"`. It is then an ordinary string, not a recognized YAML
+function, and can be serialized unchanged as a Terraform input. Graceful degradation
+does not explain that symptom; it substitutes `(computed)`, not the function arguments.
+
+The exact decode or validation boundary that dropped the tag in the original incident
+was not isolated from the available configuration. Controlled `1.221.0` and `1.223.0`
+runs both preserved the explicit tag and resolved the real state value. The regression
+tests added by this fix assert preservation in mapping and list values and assert that
+`TF_VAR_*` receives only the resolved value, so the reported failure mode is now covered
+even though its original environmental trigger remains unconfirmed.
 
 ## Changes
 

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -1,0 +1,43 @@
+# Fix: Sensitive YAML-function values no longer leak into Terraform varfiles
+
+**Date:** 2026-07-22
+
+## Summary
+
+Terraform inputs declared with `sensitive = true` are now excluded from generated
+`*.terraform.tfvars.json` files while masking is enabled. Resolved values are supplied
+to Terraform only through `TF_VAR_<name>` environment variables.
+
+## Context
+
+The previous secret partition relied only on values that had been registered with the
+masker. A value resolved by `!terraform.state` from a source that was not registered as
+a secret therefore bypassed that partition, even when the consumer Terraform variable
+was declared sensitive.
+
+A local, real-state reproduction confirmed the JSON leak in both Atmos `1.221.0` and
+`1.223.0`. The same fixture resolved the explicit `!terraform.state` tag correctly in
+both releases; the separately reported literal-argument symptom was not reproduced.
+
+## Changes
+
+- Inspect the component's Terraform module metadata and treat supplied `sensitive = true`
+  variables as secret-bearing inputs when masking is enabled.
+- Exclude those inputs from normal and `--with-secrets` JSON varfile output, while retaining
+  the `--mask=false` typed-JSON compatibility behavior.
+- Pass secret-bearing inputs through `TF_VAR_*`, and reject degraded `(computed)` values
+  before Terraform varfile, execution, or shell handoff.
+- Add function-aware debug logging for lenient YAML-function degradation.
+- Add a neutral producer/consumer regression fixture and coverage for explicit-tag decoding,
+  state resolution, JSON exclusion, and `TF_VAR_*` transport.
+
+## Validation
+
+- `go test ./internal/exec ./pkg/utils -count=1`
+- Repository pre-commit hooks: go-fumpt, Go build, `go mod tidy`, and golangci-lint.
+- Manual local-state reproduction with `atmos --use-version=1.221.0` and
+  `atmos --use-version=1.223.0`.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -47,6 +47,16 @@ function validation: commit `c1fd583de7` added the structured pre-pass on 2026-0
 after those releases. That commit is the change that made a raw explicit tag pass through
 plain map decoding before the normal tag-aware stack decoder.
 
+### Why existing coverage missed it
+
+Existing YAML-function coverage exercised normal stack decoding, where the tag-aware
+decoder preserves explicit tags. Template coverage exercised rendering and context
+substitution, but did not combine an explicit YAML function with a non-empty import or
+template context. The new structured pre-pass only runs for that combination, so neither
+suite traversed the raw decode-to-map-to-YAML transformation that discarded the tag.
+Because the resulting arguments formed a valid ordinary string, the resolver and
+Terraform had no syntax error to expose the loss early.
+
 ## Changes
 
 - Inspect the component's Terraform module metadata and treat supplied `sensitive = true`
@@ -60,6 +70,8 @@ plain map decoding before the normal tag-aware stack decoder.
   state resolution, JSON exclusion, and `TF_VAR_*` transport.
 - Preserve explicit YAML function tags through the context/import template pre-processing
   path that previously stripped them.
+- Add regression coverage for the previously untested combination of explicit YAML
+  functions and non-empty template/import context.
 
 ## Validation
 

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -57,6 +57,15 @@ suite traversed the raw decode-to-map-to-YAML transformation that discarded the 
 Because the resulting arguments formed a valid ordinary string, the resolver and
 Terraform had no syntax error to expose the loss early.
 
+### Why the blast radius was limited
+
+The unsafe map conversion ran only when stack processing had a non-empty template/import
+context. Ordinary stack decoding, YAML functions without that context, and template files
+without context bypassed it and continued through the normal tag-aware decoder. Context
+can come from an import or from file-scoped values such as locals, settings, vars, or env,
+so the affected set is narrower than all YAML-function users but broader than explicitly
+templated files alone.
+
 ## Changes
 
 - Inspect the component's Terraform module metadata and treat supplied `sensitive = true`

--- a/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
+++ b/docs/fixes/2026-07-22-sensitive-yaml-function-varfiles.md
@@ -59,12 +59,13 @@ Terraform had no syntax error to expose the loss early.
 
 ### Why the blast radius was limited
 
-The unsafe map conversion ran only when stack processing had a non-empty template/import
+The unsafe map conversion ran only when stack processing had a non-empty in-memory
 context. Ordinary stack decoding, YAML functions without that context, and template files
 without context bypassed it and continued through the normal tag-aware decoder. Context
-can come from an import or from file-scoped values such as locals, settings, vars, or env,
-so the affected set is narrower than all YAML-function users but broader than explicitly
-templated files alone.
+can be supplied by an import's `context:` map or created by a file-scoped `locals:` section
+(including an empty locals map); settings, vars, and env consume that context but do not
+independently create it. The affected set is therefore narrower than all YAML-function
+users and does not require a `.tmpl` file.
 
 ## Changes
 
@@ -85,6 +86,8 @@ templated files alone.
 ## Validation
 
 - `go test ./internal/exec ./pkg/utils -count=1`
+- `atmos lint --changed`
+- `go build ./... && atmos test`
 - Repository pre-commit hooks: go-fumpt, Go build, `go mod tidy`, and golangci-lint.
 - Manual local-state reproduction with `atmos --use-version=1.221.0` and
   `atmos --use-version=1.223.0`.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -641,6 +641,7 @@ var (
 	ErrInvalidTerraformDependencies       = errors.New("invalid terraform dependencies section")
 	ErrInvalidTerraformSource             = errors.New("invalid terraform source section")
 	ErrInvalidTerraformProvision          = errors.New("invalid terraform provision section")
+	ErrUnresolvedComputedTerraformVar     = errors.New("terraform variable contains an unresolved computed value")
 
 	// Helmfile-specific subsection errors.
 	ErrInvalidHelmfileCommand      = errors.New("invalid helmfile command")

--- a/internal/exec/stack_processor_template_test.go
+++ b/internal/exec/stack_processor_template_test.go
@@ -178,6 +178,58 @@ metadata:
 	}
 }
 
+// TestProcessYAMLConfigFileWithContext_PreservesExplicitYAMLFunctionTag verifies that
+// the structured template pre-processing path does not discard a YAML function tag.
+func TestProcessYAMLConfigFileWithContext_PreservesExplicitYAMLFunctionTag(t *testing.T) {
+	tempDir := t.TempDir()
+	stackPath := filepath.Join(tempDir, "stack.yaml.tmpl")
+	require.NoError(t, os.WriteFile(stackPath, []byte(`
+components:
+  terraform:
+    consumer:
+      vars:
+        state_lookup: !terraform.state producer ".fields.PRIVATE_KEY"
+        output_lookup: !terraform.output producer private_key
+        store_lookup: !store secure-store consumer private_key
+        environment_lookup: !env PRIVATE_KEY
+        template_value: "{{ .value }}"
+`), 0o644))
+
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePath:               tempDir,
+		StacksBaseAbsolutePath: tempDir,
+		Templates: schema.Templates{
+			Settings: schema.TemplatesSettings{Enabled: true},
+		},
+	}
+
+	result, _, err := ProcessYAMLConfigFileWithContext(
+		atmosConfig,
+		tempDir,
+		stackPath,
+		map[string]map[string]any{},
+		map[string]any{"value": "resolved-template-value"},
+		false,
+		false,
+		true,
+		false,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+	)
+
+	require.NoError(t, err)
+	vars := result.DeepMergedConfig["components"].(map[string]any)["terraform"].(map[string]any)["consumer"].(map[string]any)["vars"].(map[string]any)
+	assert.Equal(t, `!terraform.state producer ".fields.PRIVATE_KEY"`, vars["state_lookup"])
+	assert.Equal(t, "!terraform.output producer private_key", vars["output_lookup"])
+	assert.Equal(t, "!store secure-store consumer private_key", vars["store_lookup"])
+	assert.Equal(t, "!env PRIVATE_KEY", vars["environment_lookup"])
+	assert.Equal(t, "resolved-template-value", vars["template_value"])
+}
+
 // TestProcessImportSectionWithTemplates tests that imports correctly identify template files.
 func TestProcessImportSectionWithTemplates(t *testing.T) {
 	testCases := []struct {

--- a/internal/exec/stack_processor_utils.go
+++ b/internal/exec/stack_processor_utils.go
@@ -1166,8 +1166,10 @@ func processYAMLConfigFileWithContextInternal(
 	if !skipTemplatesProcessingInImports && (u.IsTemplateFile(filePath) || len(context) > 0) { //nolint:nestif // Template processing error handling requires conditional formatting based on context
 		stackManifestTemplateInput := stackYamlConfig
 		if len(context) > 0 {
-			var rawStackConfig map[string]any
-			if err := yaml.Unmarshal([]byte(stackYamlConfig), &rawStackConfig); err == nil {
+			// Preserve explicit YAML function tags while evaluating structured template references.
+			// A plain yaml.Unmarshal drops a scalar's custom tag and leaves only its arguments,
+			// which would prevent the later YAML-function resolver from recognizing it.
+			if rawStackConfig, err := u.UnmarshalYAMLFromFile[map[string]any](atmosConfig, stackYamlConfig, filePath); err == nil {
 				if processedStructured, ok := processStructuredTemplateRefs(rawStackConfig, context).(map[string]any); ok {
 					if renderedStructured, err := u.ConvertToYAML(processedStructured); err == nil {
 						stackManifestTemplateInput = renderedStructured

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -18,6 +18,7 @@ import (
 	auth "github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/degradation"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	atmosio "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -34,7 +35,10 @@ import (
 	"github.com/cloudposse/atmos/pkg/terraform/rc"
 	"github.com/cloudposse/atmos/pkg/terraform/tfvars"
 	u "github.com/cloudposse/atmos/pkg/utils"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
+
+var errUnresolvedComputedTerraformVar = errors.New("terraform variable contains an unresolved computed value")
 
 // resolveTerraformCommand sets info.Command from atmosConfig if not already set.
 // Falls back to the cfg.TerraformComponentType default when neither is configured.
@@ -347,15 +351,87 @@ func printAndWriteVarFiles(atmosConfig *schema.AtmosConfiguration, info *schema.
 // varfile-write and env-assembly steps partition the variables identically.
 func computeTerraformSecretVarKeys(info *schema.ConfigAndStacksInfo) {
 	_, secret := tfvars.Partition(info.ComponentVarsSection, atmosio.ContainsSecret)
-	if len(secret) == 0 {
-		info.TerraformSecretVarKeys = nil
-		return
-	}
 	keys := make(map[string]bool, len(secret))
 	for k := range secret {
 		keys[k] = true
 	}
+
+	// Terraform's `sensitive = true` is an explicit declaration that an input must
+	// not be persisted in a generated tfvars file. When masking is disabled, retain
+	// the established compatibility behavior that keeps typed sensitive values in
+	// JSON rather than coercing them through TF_VAR_ environment variables.
+	if atmosio.MaskingEnabled() {
+		for k := range terraformSensitiveVarKeys(info) {
+			if _, supplied := info.ComponentVarsSection[k]; supplied {
+				keys[k] = true
+			}
+		}
+	}
+
+	if len(keys) == 0 {
+		info.TerraformSecretVarKeys = nil
+		return
+	}
 	info.TerraformSecretVarKeys = keys
+}
+
+// terraformSensitiveVarKeys returns the root-module variable names declared
+// `sensitive = true`. Component metadata is populated during stack processing
+// with terraform-config-inspect, so this adds no extra filesystem parsing on
+// the execution hot path.
+func terraformSensitiveVarKeys(info *schema.ConfigAndStacksInfo) map[string]bool {
+	if info == nil {
+		return nil
+	}
+	componentInfo, ok := info.ComponentSection[componentInfoKey].(map[string]any)
+	if !ok {
+		return nil
+	}
+	module, ok := componentInfo[terraformConfigKey].(*tfconfig.Module)
+	if !ok || module == nil {
+		return nil
+	}
+
+	keys := make(map[string]bool)
+	for name, variable := range module.Variables {
+		if variable != nil && variable.Sensitive {
+			keys[name] = true
+		}
+	}
+	return keys
+}
+
+// rejectComputedTerraformVars ensures display-only degraded values cannot cross
+// into Terraform through either tfvars JSON or TF_VAR_ environment variables.
+func rejectComputedTerraformVars(vars map[string]any) error {
+	for key, value := range vars {
+		if containsComputedTerraformValue(value) {
+			return fmt.Errorf("%w: %q", errUnresolvedComputedTerraformVar, key)
+		}
+	}
+	return nil
+}
+
+func containsComputedTerraformValue(value any) bool {
+	switch v := value.(type) {
+	case degradation.AtmosComputedValue:
+		return true
+	case *degradation.AtmosComputedValue:
+		return v != nil
+	case map[string]any:
+		for _, child := range v {
+			if containsComputedTerraformValue(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if containsComputedTerraformValue(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // diskSafeVars returns ComponentVarsSection with secret-bearing top-level keys removed,
@@ -375,6 +451,21 @@ func diskSafeVars(info *schema.ConfigAndStacksInfo) map[string]any {
 			continue
 		}
 		safe[k] = v
+	}
+	return safe
+}
+
+func varsWithoutKeys(vars map[string]any, excluded map[string]bool) map[string]any {
+	if len(excluded) == 0 {
+		return vars
+	}
+	// `excluded` can include declared inputs that this stack does not supply, so
+	// use the source size as the allocation hint rather than subtracting it.
+	safe := make(map[string]any, len(vars))
+	for k, v := range vars {
+		if !excluded[k] {
+			safe[k] = v
+		}
 	}
 	return safe
 }

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -38,8 +38,6 @@ import (
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
-var errUnresolvedComputedTerraformVar = errors.New("terraform variable contains an unresolved computed value")
-
 // resolveTerraformCommand sets info.Command from atmosConfig if not already set.
 // Falls back to the cfg.TerraformComponentType default when neither is configured.
 func resolveTerraformCommand(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) {
@@ -406,7 +404,7 @@ func terraformSensitiveVarKeys(info *schema.ConfigAndStacksInfo) map[string]bool
 func rejectComputedTerraformVars(vars map[string]any) error {
 	for key, value := range vars {
 		if containsComputedTerraformValue(value) {
-			return fmt.Errorf("%w: %q", errUnresolvedComputedTerraformVar, key)
+			return fmt.Errorf("%w: %q", errUtils.ErrUnresolvedComputedTerraformVar, key)
 		}
 	}
 	return nil

--- a/internal/exec/terraform_execute_helpers_exec.go
+++ b/internal/exec/terraform_execute_helpers_exec.go
@@ -102,6 +102,12 @@ func runPreExecutionSteps(
 	workingDir string,
 	tenv *dependencies.ToolchainEnvironment,
 ) error {
+	// `(computed)` is an inspection-only degradation marker. Never permit it to
+	// reach Terraform via a generated tfvars file or TF_VAR_ environment value.
+	if err := rejectComputedTerraformVars(info.ComponentVarsSection); err != nil {
+		return err
+	}
+
 	// Partition variables into disk-safe vs. secret-bearing BEFORE writing the varfile or
 	// assembling env vars (and before the auth pre-hook registers credentials with the
 	// masker), so secrets are kept off disk and injected as TF_VAR_* env vars instead.

--- a/internal/exec/terraform_execute_helpers_test.go
+++ b/internal/exec/terraform_execute_helpers_test.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/degradation"
 	atmosio "github.com/cloudposse/atmos/pkg/io"
 	provWorkdir "github.com/cloudposse/atmos/pkg/provisioner/workdir"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -673,6 +675,72 @@ func TestTerraformSecretVars_NoSecrets(t *testing.T) {
 	env, err := secretVarEnv(info)
 	require.NoError(t, err)
 	assert.Empty(t, env, "no TF_VAR_ entries expected when no secrets present")
+}
+
+func TestTerraformSensitiveDeclaredVars_NeverHitDisk(t *testing.T) {
+	atmosio.Reset()
+	t.Cleanup(atmosio.Reset)
+	require.NoError(t, atmosio.Initialize())
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentVarsSection: map[string]any{
+			"sensitive_value": "ordinary-resolved-value",
+			"region":          "us-east-1-sensitive-declaration",
+		},
+		ComponentSection: map[string]any{
+			componentInfoKey: map[string]any{
+				terraformConfigKey: &tfconfig.Module{Variables: map[string]*tfconfig.Variable{
+					"sensitive_value": {Name: "sensitive_value", Sensitive: true},
+					"not_supplied":    {Name: "not_supplied", Sensitive: true},
+					"region":          {Name: "region", Sensitive: false},
+				}},
+			},
+		},
+	}
+
+	computeTerraformSecretVarKeys(info)
+	require.True(t, info.TerraformSecretVarKeys["sensitive_value"])
+	assert.False(t, info.TerraformSecretVarKeys["region"])
+	assert.NotContains(t, diskSafeVars(info), "sensitive_value")
+	assert.Equal(t, "us-east-1-sensitive-declaration", diskSafeVars(info)["region"])
+	assert.NotContains(t, varfileVarsToWrite(info, true, "test.tfvars.json"), "sensitive_value")
+	assert.Equal(t, "us-east-1-sensitive-declaration", varfileVarsToWrite(info, true, "test.tfvars.json")["region"])
+
+	env, err := secretVarEnv(info)
+	require.NoError(t, err)
+	assert.Contains(t, strings.Join(env, "\n"), "TF_VAR_sensitive_value=ordinary-resolved-value")
+}
+
+func TestTerraformSensitiveDeclaredVars_MaskingDisabledPreservesJSONCompatibility(t *testing.T) {
+	atmosio.Reset()
+	t.Cleanup(atmosio.Reset)
+	require.NoError(t, atmosio.Initialize())
+	atmosio.GetContext().Masker().SetEnabled(false)
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentVarsSection: map[string]any{"sensitive_value": map[string]any{"id": "typed-value"}},
+		ComponentSection: map[string]any{
+			componentInfoKey: map[string]any{
+				terraformConfigKey: &tfconfig.Module{Variables: map[string]*tfconfig.Variable{
+					"sensitive_value": {Name: "sensitive_value", Sensitive: true},
+				}},
+			},
+		},
+	}
+
+	computeTerraformSecretVarKeys(info)
+	assert.Nil(t, info.TerraformSecretVarKeys)
+	assert.Equal(t, info.ComponentVarsSection, diskSafeVars(info))
+}
+
+func TestRejectComputedTerraformVars(t *testing.T) {
+	assert.NoError(t, rejectComputedTerraformVars(map[string]any{"region": "us-east-1"}))
+	err := rejectComputedTerraformVars(map[string]any{"value": degradation.AtmosComputedValue{}})
+	assert.ErrorIs(t, err, errUnresolvedComputedTerraformVar)
+	err = rejectComputedTerraformVars(map[string]any{
+		"nested": []any{map[string]any{"value": degradation.AtmosComputedValue{}}},
+	})
+	assert.ErrorIs(t, err, errUnresolvedComputedTerraformVar)
 }
 
 func TestHandleDeploySubcommand(t *testing.T) {

--- a/internal/exec/terraform_execute_helpers_test.go
+++ b/internal/exec/terraform_execute_helpers_test.go
@@ -736,11 +736,11 @@ func TestTerraformSensitiveDeclaredVars_MaskingDisabledPreservesJSONCompatibilit
 func TestRejectComputedTerraformVars(t *testing.T) {
 	assert.NoError(t, rejectComputedTerraformVars(map[string]any{"region": "us-east-1"}))
 	err := rejectComputedTerraformVars(map[string]any{"value": degradation.AtmosComputedValue{}})
-	assert.ErrorIs(t, err, errUnresolvedComputedTerraformVar)
+	assert.ErrorIs(t, err, errUtils.ErrUnresolvedComputedTerraformVar)
 	err = rejectComputedTerraformVars(map[string]any{
 		"nested": []any{map[string]any{"value": degradation.AtmosComputedValue{}}},
 	})
-	assert.ErrorIs(t, err, errUnresolvedComputedTerraformVar)
+	assert.ErrorIs(t, err, errUtils.ErrUnresolvedComputedTerraformVar)
 }
 
 func TestHandleDeploySubcommand(t *testing.T) {

--- a/internal/exec/terraform_generate_varfile.go
+++ b/internal/exec/terraform_generate_varfile.go
@@ -11,6 +11,7 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	atmosio "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 	provWorkdir "github.com/cloudposse/atmos/pkg/provisioner/workdir"
@@ -107,6 +108,12 @@ func ExecuteGenerateVarfile(opts *VarfileOptions, atmosConfig *schema.AtmosConfi
 	// Display the varfile path relative to the current working directory.
 	displayPath := relativeToCwd(varFilePath)
 
+	// Varfile generation is an execution handoff, not an inspection surface: a
+	// degraded `(computed)` value must never be serialized for Terraform.
+	if err := rejectComputedTerraformVars(info.ComponentVarsSection); err != nil {
+		return err
+	}
+
 	// Write the variables to a file.
 	log.Debug("Writing the variables to file", "file", displayPath)
 
@@ -153,6 +160,12 @@ func varfileVarsToWrite(info *schema.ConfigAndStacksInfo, withSecrets bool, varF
 		if len(info.TerraformSecretVarKeys) > 0 {
 			log.Debug("Writing resolved secret values to the varfile in plaintext (--with-secrets)",
 				"file", varFilePath, "count", len(info.TerraformSecretVarKeys))
+		}
+		// `--with-secrets` preserves its existing opt-in behavior for masker-derived
+		// values, but it must not override a Terraform `sensitive = true` declaration.
+		// Terraform receives those values through TF_VAR_* during execution instead.
+		if atmosio.MaskingEnabled() {
+			return varsWithoutKeys(info.ComponentVarsSection, terraformSensitiveVarKeys(info))
 		}
 		return info.ComponentVarsSection
 	}

--- a/internal/exec/terraform_generate_varfile_test.go
+++ b/internal/exec/terraform_generate_varfile_test.go
@@ -1,12 +1,15 @@
 package exec
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -384,4 +387,79 @@ func TestVarfileVarsToWrite(t *testing.T) {
 		assert.Equal(t, secret, got["db_password"], "secret var must be written with --with-secrets")
 		assert.Equal(t, "us-east-1-genvarfile", got["region"])
 	})
+}
+
+// TestExecuteGenerateVarfile_SensitiveStateValueNeverLeaks reproduces the sensitive
+// YAML-function regression end-to-end. The explicit YAML tag must survive decoding,
+// the state lookup must be evaluated, and the sensitive consumer input must use
+// TF_VAR_ instead of the generated tfvars JSON file.
+func TestExecuteGenerateVarfile_SensitiveStateValueNeverLeaks(t *testing.T) {
+	iolib.Reset()
+	t.Cleanup(iolib.Reset)
+	require.NoError(t, iolib.Initialize())
+	iolib.GetContext().Masker().SetEnabled(true)
+
+	fixtureDir, err := filepath.Abs(filepath.Join("..", "..", "tests", "fixtures", "scenarios", "yaml-sensitive-state-varfile"))
+	require.NoError(t, err)
+
+	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{
+		AtmosBasePath:          fixtureDir,
+		AtmosConfigDirsFromArg: []string{fixtureDir},
+	}, true)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	mockStateGetter := NewMockTerraformStateGetter(ctrl)
+	originalStateGetter := stateGetter
+	stateGetter = mockStateGetter
+	t.Cleanup(func() { stateGetter = originalStateGetter })
+
+	const function = `!terraform.state producer ".fields.PRIVATE_KEY"`
+	const resolved = "demo-secret-value"
+	mockStateGetter.EXPECT().
+		GetState(gomock.Any(), function, "dev", "producer", ".fields.PRIVATE_KEY", false, gomock.Any(), gomock.Any()).
+		Return(resolved, nil).
+		AnyTimes()
+
+	varfilePath := filepath.Join(t.TempDir(), "consumer.tfvars.json")
+	err = ExecuteGenerateVarfile(&VarfileOptions{
+		Component: "consumer",
+		Stack:     "dev",
+		File:      varfilePath,
+		ProcessingOptions: ProcessingOptions{
+			ProcessTemplates: true,
+			ProcessFunctions: true,
+		},
+	}, &atmosConfig)
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(varfilePath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(contents), "sensitive_value")
+	assert.NotContains(t, string(contents), resolved)
+	assert.NotContains(t, string(contents), "producer")
+	assert.NotContains(t, string(contents), "PRIVATE_KEY")
+
+	var written map[string]any
+	require.NoError(t, json.Unmarshal(contents, &written))
+	assert.Equal(t, "ordinary-value", written["ordinary_value"])
+
+	// Re-process once to inspect the exact transient environment handoff without
+	// relying on a Terraform executable. This confirms the resolved value, not
+	// the lookup arguments, becomes TF_VAR_sensitive_value.
+	info, err := ProcessStacks(&atmosConfig, schema.ConfigAndStacksInfo{
+		ComponentFromArg: "consumer",
+		Stack:            "dev",
+		StackFromArg:     "dev",
+		ComponentType:    cfg.TerraformComponentType,
+	}, true, true, true, nil, nil)
+	require.NoError(t, err)
+	computeTerraformSecretVarKeys(&info)
+	env, err := secretVarEnv(&info)
+	require.NoError(t, err)
+	joinedEnv := strings.Join(env, "\n")
+	assert.Contains(t, joinedEnv, "TF_VAR_sensitive_value="+resolved)
+	assert.NotContains(t, joinedEnv, "producer")
+	assert.NotContains(t, joinedEnv, "PRIVATE_KEY")
+	assert.NotContains(t, joinedEnv, function)
 }

--- a/internal/exec/terraform_shell.go
+++ b/internal/exec/terraform_shell.go
@@ -239,6 +239,12 @@ func executeShellLifecycle(atmosConfig *schema.AtmosConfiguration, info *schema.
 func prepareShellExecution(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, cfg *shellConfig, withSecrets bool) error {
 	defer perf.Track(atmosConfig, "exec.prepareShellExecution")()
 
+	// Shell setup also writes a Terraform varfile and can assemble TF_VAR_* values.
+	// Do not allow an inspection-only `(computed)` marker across that boundary.
+	if err := rejectComputedTerraformVars(info.ComponentVarsSection); err != nil {
+		return err
+	}
+
 	// Resolve the terraform/tofu binary (config + toolchain) so init/workspace and the shell
 	// all use the correct executable.
 	resolveTerraformCommand(atmosConfig, info)

--- a/internal/exec/yaml_func_utils.go
+++ b/internal/exec/yaml_func_utils.go
@@ -132,10 +132,22 @@ func processNodesWithContext(
 			result, err := processCustomTagsWithContext(atmosConfig, v, currentStack, skip, resolutionCtx, stackInfo)
 			if err != nil {
 				if onWarning != nil && isRecoverableTerraformError(err) {
+					function := ""
+					if fields := strings.Fields(v); len(fields) > 0 {
+						function = fields[0]
+					}
 					component := ""
 					if stackInfo != nil {
 						component = stackInfo.Component
 					}
+					log.Debug(
+						"Degrading unresolved YAML function to computed value",
+						"function", function,
+						"value", v,
+						"stack", currentStack,
+						"component", component,
+						"error", err.Error(),
+					)
 					onWarning(DegradationWarning{
 						Stack:     currentStack,
 						Component: component,

--- a/pkg/utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils_test.go
@@ -285,6 +285,24 @@ value: 123
 	assert.Equal(t, 123, result.Value)
 }
 
+// TestUnmarshalYAML_ExplicitFunctionTagsPreserveFunctionAndArguments verifies that
+// explicit YAML tags remain complete function expressions after raw decoding. Runtime
+// function resolvers receive these strings later, so dropping the tag here would make
+// them receive only the arguments and could transport those arguments as a value.
+func TestUnmarshalYAML_ExplicitFunctionTagsPreserveFunctionAndArguments(t *testing.T) {
+	input := `
+mapping_value: !terraform.state producer ".fields.PRIVATE_KEY"
+list_values:
+  - !env DEMO_EXPLICIT_TAG_VALUE
+`
+
+	result, err := UnmarshalYAML[map[string]any](input)
+	require.NoError(t, err)
+	assert.Equal(t, `!terraform.state producer ".fields.PRIVATE_KEY"`, result["mapping_value"])
+	require.Len(t, result["list_values"], 1)
+	assert.Equal(t, "!env DEMO_EXPLICIT_TAG_VALUE", result["list_values"].([]any)[0])
+}
+
 // TestUnmarshalYAMLFromFile_BasicFunctionality tests the UnmarshalYAMLFromFile function.
 func TestUnmarshalYAMLFromFile_BasicFunctionality(t *testing.T) {
 	atmosConfig := &schema.AtmosConfiguration{}

--- a/tests/fixtures/scenarios/yaml-sensitive-state-varfile/atmos.yaml
+++ b/tests/fixtures/scenarios/yaml-sensitive-state-varfile/atmos.yaml
@@ -1,0 +1,10 @@
+base_path: "."
+
+components:
+  terraform:
+    base_path: components/terraform
+
+stacks:
+  base_path: stacks
+  included_paths:
+    - "**/*"

--- a/tests/fixtures/scenarios/yaml-sensitive-state-varfile/components/terraform/consumer/variables.tf
+++ b/tests/fixtures/scenarios/yaml-sensitive-state-varfile/components/terraform/consumer/variables.tf
@@ -1,0 +1,8 @@
+variable "sensitive_value" {
+  type      = string
+  sensitive = true
+}
+
+variable "ordinary_value" {
+  type = string
+}

--- a/tests/fixtures/scenarios/yaml-sensitive-state-varfile/components/terraform/producer/main.tf
+++ b/tests/fixtures/scenarios/yaml-sensitive-state-varfile/components/terraform/producer/main.tf
@@ -1,0 +1,1 @@
+# The producer is represented by the mocked !terraform.state lookup in the regression test.

--- a/tests/fixtures/scenarios/yaml-sensitive-state-varfile/stacks/dev.yaml
+++ b/tests/fixtures/scenarios/yaml-sensitive-state-varfile/stacks/dev.yaml
@@ -1,0 +1,6 @@
+components:
+  terraform:
+    consumer:
+      vars:
+        sensitive_value: !terraform.state producer ".fields.PRIVATE_KEY"
+        ordinary_value: ordinary-value


### PR DESCRIPTION
## what

- Keep Terraform-declared sensitive inputs out of generated JSON varfiles and pass them through `TF_VAR_*` during execution.
- Block degraded `(computed)` values from Terraform handoff paths and add function-aware debug logging for graceful YAML-function degradation.
- Add a generic producer/consumer regression fixture covering explicit-tag preservation, resolved state values, and JSON/environment transport.

## why

- A resolved value from a sensitive YAML function could bypass masker-derived detection, be written to a varfile, or be transported as lookup arguments instead of the resolved value.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Terraform inputs marked `sensitive = true` are excluded from generated `*.terraform.tfvars.json` when masking is enabled, including `--with-secrets`.
  * Their resolved values are passed to Terraform via `TF_VAR_<name>` environment variables (not written to disk).
  * Masking-disabled behavior preserves prior JSON compatibility.
* **Bug Fixes**
  * Execution, shell setup, and varfile generation now reject unresolved “(computed)” Terraform values before handoff (including nested maps/slices).
  * Sensitive root-module handling is improved using module metadata.
* **Diagnostics**
  * Added debug logging for recoverable YAML function parsing errors with function name and context.
* **Tests**
  * Added regression tests plus a new sensitive-state fixture covering explicit YAML tags and non-leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->