### PR TITLE
test(scheduler): cover cross-stack name: alias dependency (#2782)

### DIFF
--- a/pkg/scheduler/adapters/terraform_test.go
+++ b/pkg/scheduler/adapters/terraform_test.go
@@ -699,6 +699,55 @@ func TestBuildTerraformGraphSupportsCanonicalAndLegacyComponentDependencyNames(t
 	require.ElementsMatch(t, []string{"canonical-dev", "legacy-dev"}, app.Dependencies)
 }
 
+// TestBuildTerraformGraphSupportsCrossStackNameAliasDependency covers the
+// scenario reported in #2782: a `name:`-keyed dependency pointing at a
+// component in a *different* stack (via the `stack:` sibling key), chained
+// with a same-stack `name:`-keyed dependency. The existing coverage above
+// (TestBuildTerraformGraphSupportsCanonicalAndLegacyComponentDependencyNames)
+// only exercises `name:` within a single stack, so it would not have caught
+// a regression specific to the cross-stack case.
+func TestBuildTerraformGraphSupportsCrossStackNameAliasDependency(t *testing.T) {
+	stacks := map[string]any{
+		"dev_platform": map[string]any{
+			cfg.ComponentsSectionName: map[string]any{
+				cfg.TerraformSectionName: map[string]any{
+					"iam": terraformAdapterComponent("selected", nil, nil),
+				},
+			},
+		},
+		"dev_app": map[string]any{
+			cfg.ComponentsSectionName: map[string]any{
+				cfg.TerraformSectionName: map[string]any{
+					"bootstrap": terraformAdapterComponent(
+						"selected",
+						[]any{map[string]any{"name": "iam", "stack": "dev_platform"}},
+						nil,
+					),
+					"base": terraformAdapterComponent(
+						"selected",
+						[]any{map[string]any{"name": "bootstrap"}},
+						nil,
+					),
+				},
+			},
+		},
+	}
+
+	graph, err := BuildTerraformGraph(stacks)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, graph.Size())
+	require.Len(t, graph.Roots, 1, "expected a single root (iam-dev_platform); got roots=%v", graph.Roots)
+
+	bootstrap, ok := graph.GetNode("bootstrap-dev_app")
+	require.True(t, ok)
+	require.Equal(t, []string{"iam-dev_platform"}, bootstrap.Dependencies)
+
+	base, ok := graph.GetNode("base-dev_app")
+	require.True(t, ok)
+	require.Equal(t, []string{"bootstrap-dev_app"}, base.Dependencies)
+}
+
 func TestBuildTerraformGraphFallsBackToSettingsDependsOn(t *testing.T) {
 	stacks := map[string]any{
 		"dev": map[string]any{


### PR DESCRIPTION
## What

Adds a regression test for the scenario reported in #2782: a `dependencies.components[]` entry using the `name:` alias (instead of `component:`) that points at a component in a **different** stack via the sibling `stack:` key, chained with a same-stack `name:`-keyed entry.

## Why

I investigated #2782 expecting to write a fix, but the reported bug does not reproduce on `main` — `Normalize()` (added in #2755) already promotes `name` into `Component` before `BuildTerraformGraph` reads it, and this exact cross-stack scenario builds a correct, single-root DAG today.

However, the existing coverage for the `name:`/`component:` alias — `TestBuildTerraformGraphSupportsCanonicalAndLegacyComponentDependencyNames`, also from #2755 — only exercises the alias within a single stack. It would not have caught a regression specific to the cross-stack case #2782 describes (a dependency `name:` + `stack:` pointing at a different stack). This PR closes that specific coverage gap so a future regression here fails loudly instead of silently dropping an edge.

This is **test-only**, no production code changes.

## Testing

```
go test ./pkg/scheduler/adapters/... -v -run TestBuildTerraformGraph
go vet ./pkg/scheduler/adapters/...
```

Both green locally, including the new `TestBuildTerraformGraphSupportsCrossStackNameAliasDependency` and the full existing suite in the package (no regressions).

I also left a comment on #2782 with the same finding (fixed in #2755, included since `v1.223.1-rc.3`) since the reporter was on `v1.223.0`, which predates the fix.

Closes/relates to #2782 (no code change needed there — this just adds the missing coverage).
