### PR TITLE
fix(steps): expose shell and atmos outputs to later steps

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -1153,6 +1153,17 @@ func executeCustomCommand(
 					return execErr
 				}
 				return runCommandStep(func(stdout, stderr io.Writer) error {
+					execOpts := []e.ShellCommandOption{
+						e.WithStdoutCapture(stdout),
+						e.WithStderrCapture(stderr),
+					}
+					if step.Output == string(stepPkg.OutputModeNone) {
+						execOpts = append(execOpts, e.WithProcessStreams(process.Streams{
+							Stdin:  os.Stdin,
+							Stdout: io.Discard,
+							Stderr: io.Discard,
+						}))
+					}
 					return e.ExecuteShellCommand(
 						atmosConfig,
 						execPath,
@@ -1161,8 +1172,7 @@ func executeCustomCommand(
 						env,
 						false,
 						"",
-						e.WithStdoutCapture(stdout),
-						e.WithStderrCapture(stderr),
+						execOpts...,
 					)
 				})
 			default:

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -1099,8 +1099,11 @@ func executeCustomCommand(
 		// The dispatch is wrapped in a collapsible CI log group (no-op outside
 		// CI / when disabled), labeled with the step name or command. Exec steps
 		// run bare because a successful Unix exec never returns to close a group.
+		var commandResult *stepPkg.StepResult
 		runCommandStep := func(run func(stdout, stderr io.Writer) error) error {
-			return stepPkg.ExecuteAndStoreCommandResult(stepVars, step.Name, step.Outputs, run)
+			var runErr error
+			commandResult, runErr = stepPkg.ExecuteCommandResult(step.Name, run)
+			return runErr
 		}
 		runStep := func() error {
 			switch stepType {
@@ -1196,9 +1199,13 @@ func executeCustomCommand(
 		}
 		err = stepPkg.RunGroupedForType(&atmosConfig, step.Name, commandToRun, stepType, func() error {
 			if step.Retry != nil {
-				return retry.Do(context.Background(), step.Retry, runStep)
+				if retryErr := retry.Do(context.Background(), step.Retry, runStep); retryErr != nil {
+					return retryErr
+				}
+			} else if runErr := runStep(); runErr != nil {
+				return runErr
 			}
-			return runStep()
+			return stepPkg.StoreCommandResult(stepVars, step.Name, step.Outputs, commandResult)
 		})
 		if err != nil {
 			var silentExit errUtils.ExitCodeError

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
 	pkgFlags "github.com/cloudposse/atmos/pkg/flags"
+	ioLayer "github.com/cloudposse/atmos/pkg/io"
 	l "github.com/cloudposse/atmos/pkg/list"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
@@ -1098,6 +1099,9 @@ func executeCustomCommand(
 		// The dispatch is wrapped in a collapsible CI log group (no-op outside
 		// CI / when disabled), labeled with the step name or command. Exec steps
 		// run bare because a successful Unix exec never returns to close a group.
+		runCommandStep := func(run func(stdout, stderr io.Writer) error) error {
+			return stepPkg.ExecuteAndStoreCommandResult(stepVars, step.Name, step.Outputs, run)
+		}
 		runStep := func() error {
 			switch stepType {
 			case "shell":
@@ -1105,25 +1109,30 @@ func executeCustomCommand(
 				// Steps with tty/interactive attach the user's terminal so commands
 				// like `aws ssm start-session` get a real TTY and own Ctrl-C.
 				commandName := fmt.Sprintf("%s-step-%d", commandConfig.Name, i)
-				return process.RunShellStep(context.Background(), &process.ShellSessionSpec{
-					Command:     commandToRun,
-					Name:        commandName,
-					Dir:         stepWorkDir,
-					Env:         env,
-					TTY:         step.Tty,
-					Interactive: step.Interactive,
-				}, func() error {
-					if step.Output == string(stepPkg.OutputModeNone) {
+				return runCommandStep(func(stdoutCapture, stderrCapture io.Writer) error {
+					return process.RunShellStep(context.Background(), &process.ShellSessionSpec{
+						Command:     commandToRun,
+						Name:        commandName,
+						Dir:         stepWorkDir,
+						Env:         env,
+						TTY:         step.Tty,
+						Interactive: step.Interactive,
+					}, func() error {
+						stdout := ioLayer.MaskWriter(os.Stdout)
+						stderr := ioLayer.MaskWriter(os.Stderr)
+						if step.Output == string(stepPkg.OutputModeNone) {
+							stdout = io.Discard
+							stderr = io.Discard
+						}
 						return e.ExecuteShellWithWriters(&e.ExecuteShellSpec{
 							Command: commandToRun,
 							Name:    commandName,
 							Dir:     stepWorkDir,
 							EnvVars: env,
-							Stdout:  io.Discard,
-							Stderr:  io.Discard,
+							Stdout:  io.MultiWriter(stdout, stdoutCapture),
+							Stderr:  io.MultiWriter(stderr, stderrCapture),
 						})
-					}
-					return e.ExecuteShell(commandToRun, commandName, stepWorkDir, env, false)
+					})
 				})
 			case schema.TaskTypeExec:
 				// Replace the Atmos process with the command (shell exec semantics).
@@ -1140,7 +1149,19 @@ func executeCustomCommand(
 				if execErr != nil {
 					return execErr
 				}
-				return e.ExecuteShellCommand(atmosConfig, execPath, args, stepWorkDir, env, false, "")
+				return runCommandStep(func(stdout, stderr io.Writer) error {
+					return e.ExecuteShellCommand(
+						atmosConfig,
+						execPath,
+						args,
+						stepWorkDir,
+						env,
+						false,
+						"",
+						e.WithStdoutCapture(stdout),
+						e.WithStderrCapture(stderr),
+					)
+				})
 			default:
 				// Check if this is an extended step type (input, confirm, choose, etc.).
 				if stepPkg.IsExtendedStepType(stepType) {

--- a/cmd/custom_command_integration_test.go
+++ b/cmd/custom_command_integration_test.go
@@ -1082,6 +1082,11 @@ func customCommandAttemptHelperCommand(t *testing.T, path string) string {
 	return fmt.Sprintf("%q -test.run=TestCustomCommandIntegrationAttemptHelper -- %s", exe, encodedPath)
 }
 
+func customCommandAtmosAttemptHelperArgs(path string) string {
+	encodedPath := base64.RawURLEncoding.EncodeToString([]byte(path))
+	return fmt.Sprintf("-test.run=TestCustomCommandIntegrationAttemptHelper -- %s", encodedPath)
+}
+
 func TestCustomCommandIntegrationWriteHelper(t *testing.T) {
 	separator := -1
 	for i, arg := range os.Args {

--- a/cmd/custom_command_integration_test.go
+++ b/cmd/custom_command_integration_test.go
@@ -429,6 +429,9 @@ func TestCustomCommandShellOutputNoneSuppressesOutput(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "ran.txt")
+	resultFile := filepath.Join(tmpDir, "result.env")
+	exePath, err := os.Executable()
+	require.NoError(t, err)
 
 	atmosConfig := schema.AtmosConfiguration{
 		BasePath: tmpDir,
@@ -441,14 +444,23 @@ func TestCustomCommandShellOutputNoneSuppressesOutput(t *testing.T) {
 						Type:    "shell",
 						Name:    "quiet",
 						Output:  "none",
-						Command: fmt.Sprintf("echo stdout-visible; echo stderr-visible >&2; printf ran > %q", outputFile),
+						Command: fmt.Sprintf("printf stdout-visible; printf stderr-visible >&2; printf ran > %q", outputFile),
+					},
+					{
+						Type:    "shell",
+						Output:  "none",
+						Command: fmt.Sprintf("%q", exePath),
+						Env: map[string]string{
+							"_ATMOS_TEST_DUMP_ENV": resultFile,
+							"CAPTURED_RESULT":      "{{ .steps.quiet.value }}|{{ .steps.quiet.metadata.stdout }}|{{ .steps.quiet.metadata.stderr }}|{{ .steps.quiet.metadata.exit_code }}",
+						},
 					},
 				},
 			},
 		},
 	}
 
-	err := processCustomCommands(atmosConfig, atmosConfig.Commands, RootCmd)
+	err = processCustomCommands(atmosConfig, atmosConfig.Commands, RootCmd)
 	require.NoError(t, err)
 
 	customCmd, _, err := RootCmd.Find([]string{"test-output-none"})
@@ -465,6 +477,9 @@ func TestCustomCommandShellOutputNoneSuppressesOutput(t *testing.T) {
 	actual, err := os.ReadFile(outputFile)
 	require.NoError(t, err)
 	assert.Equal(t, "ran", string(actual))
+	resultEnv, err := os.ReadFile(resultFile)
+	require.NoError(t, err)
+	assert.Equal(t, "stdout-visible|stdout-visible|stderr-visible|0", extractEnvVar(string(resultEnv), "CAPTURED_RESULT"))
 }
 
 // TestCustomCommandIntegration_MockProviderEnvironment tests that custom commands with mock provider
@@ -761,6 +776,9 @@ func TestCustomCommandIntegration_RetriesShellStep(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	attemptsFile := filepath.Join(tmpDir, "attempts.txt")
+	resultFile := filepath.Join(tmpDir, "result.env")
+	exePath, err := os.Executable()
+	require.NoError(t, err)
 	maxAttempts := 2
 	initialDelay := time.Millisecond
 
@@ -769,12 +787,22 @@ func TestCustomCommandIntegration_RetriesShellStep(t *testing.T) {
 		Description: "Test retry shell step",
 		Steps: schema.Tasks{
 			{
+				Name:    "retry",
 				Command: customCommandRetryHelperCommand(t, attemptsFile),
 				Type:    "shell",
 				Retry: &schema.RetryConfig{
 					MaxAttempts:     &maxAttempts,
 					InitialDelay:    &initialDelay,
 					BackoffStrategy: "constant",
+				},
+			},
+			{
+				Command: fmt.Sprintf("%q", exePath),
+				Type:    "shell",
+				Output:  "none",
+				Env: map[string]string{
+					"_ATMOS_TEST_DUMP_ENV": resultFile,
+					"CAPTURED_RESULT":      "{{ .steps.retry.value }}|{{ .steps.retry.metadata.stdout }}|{{ .steps.retry.metadata.stderr }}",
 				},
 			},
 		},
@@ -798,6 +826,9 @@ func TestCustomCommandIntegration_RetriesShellStep(t *testing.T) {
 	attempts, err := os.ReadFile(attemptsFile)
 	require.NoError(t, err)
 	assert.Equal(t, "2", strings.TrimSpace(string(attempts)))
+	resultEnv, err := os.ReadFile(resultFile)
+	require.NoError(t, err)
+	assert.Equal(t, "attempt-2|attempt-2|warning-2", extractEnvVar(string(resultEnv), "CAPTURED_RESULT"))
 }
 
 func TestCustomCommandIntegration_ShellStepWithoutRetryRunsOnce(t *testing.T) {
@@ -1098,6 +1129,8 @@ func TestCustomCommandIntegrationRetryHelper(t *testing.T) {
 		attempt = parsed + 1
 	}
 	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(attempt)), 0o600))
+	_, _ = fmt.Fprintf(os.Stdout, "attempt-%d", attempt)
+	_, _ = fmt.Fprintf(os.Stderr, "warning-%d", attempt)
 	if attempt < 2 {
 		os.Exit(1)
 	}

--- a/cmd/custom_command_step_output_test.go
+++ b/cmd/custom_command_step_output_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	iolib "github.com/cloudposse/atmos/pkg/io"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+func requireCustomCommandOutputHelper(t *testing.T) {
+	t.Helper()
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	cmd := osexec.Command(exePath, "-test.run=^$")
+	cmd.Env = append(os.Environ(), "_ATMOS_TEST_STDOUT=produced", "_ATMOS_TEST_STDERR=warning")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "produced", stdout.String())
+	assert.Equal(t, "warning", stderr.String())
+}
+
+func TestCustomCommandLegacyStepOutputAvailableToMarkdown(t *testing.T) {
+	if !t.Run("subprocess prerequisite", requireCustomCommandOutputHelper) {
+		return
+	}
+
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			_ = NewTestKit(t)
+
+			exePath, err := os.Executable()
+			require.NoError(t, err)
+			resultPath := filepath.Join(t.TempDir(), "result.env")
+			producerCommand := "version"
+			if stepType == "shell" {
+				producerCommand = fmt.Sprintf("%q", exePath)
+			}
+
+			const expected = "value=produced stdout=produced stderr=warning exit=0 output=produced:warning"
+			commandConfig := schema.Command{
+				Name:        "test-step-output-" + stepType,
+				Description: "Expose legacy step output to markdown",
+				Steps: schema.Tasks{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: producerCommand,
+						Env: map[string]string{
+							"_ATMOS_TEST_STDOUT": "produced",
+							"_ATMOS_TEST_STDERR": "warning",
+						},
+						Outputs: map[string]string{
+							"summary": "{{ .value }}:{{ .metadata.stderr }}",
+						},
+					},
+					{
+						Name:    "render",
+						Type:    "markdown",
+						Content: "value={{ .steps.produce.value }} stdout={{ .steps.produce.metadata.stdout }} stderr={{ .steps.produce.metadata.stderr }} exit={{ .steps.produce.metadata.exit_code }} output={{ .steps.produce.outputs.summary }}",
+					},
+					{
+						Name:    "persist",
+						Type:    "shell",
+						Command: fmt.Sprintf("%q", exePath),
+						Output:  "none",
+						Env: map[string]string{
+							"_ATMOS_TEST_DUMP_ENV": resultPath,
+							"CAPTURED_RESULT":      "{{ .steps.render.value }}",
+						},
+					},
+				},
+			}
+			atmosConfig := schema.AtmosConfiguration{
+				BasePath: t.TempDir(),
+				Commands: []schema.Command{commandConfig},
+			}
+
+			parentCmd := &cobra.Command{Use: "atmos"}
+			err = processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd)
+			require.NoError(t, err)
+
+			originalOsExit := errUtils.OsExit
+			t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+			errUtils.OsExit = func(code int) {
+				panic(fmt.Sprintf("unexpected custom command exit %d", code))
+			}
+
+			customCmd := findSubcommand(parentCmd, commandConfig.Name)
+			require.NotNil(t, customCmd)
+			require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
+
+			envContent, err := os.ReadFile(resultPath)
+			require.NoError(t, err)
+			assert.Equal(t, expected, extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+		})
+	}
+}
+
+func TestCustomCommandShellMasksLiveAndStoredOutput(t *testing.T) {
+	if !t.Run("subprocess prerequisite", requireCustomCommandOutputHelper) {
+		return
+	}
+
+	_ = NewTestKit(t)
+
+	iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
+	secret := "step-live-secret-8f14a2"
+	iolib.GetContext().Masker().RegisterValue(secret)
+	maskedSecret := iolib.MaskString(secret)
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	resultPath := filepath.Join(t.TempDir(), "result.env")
+	commandConfig := schema.Command{
+		Name:        "test-masked-step-output",
+		Description: "Mask live and stored shell output",
+		Steps: schema.Tasks{
+			{
+				Name:    "produce",
+				Type:    "shell",
+				Command: fmt.Sprintf("%q", exePath),
+				Env: map[string]string{
+					"_ATMOS_TEST_STDOUT": secret,
+					"_ATMOS_TEST_STDERR": secret,
+				},
+			},
+			{
+				Type:    "shell",
+				Command: fmt.Sprintf("%q", exePath),
+				Output:  "none",
+				Env: map[string]string{
+					"_ATMOS_TEST_DUMP_ENV": resultPath,
+					"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stderr }}",
+				},
+			},
+		},
+	}
+	atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
+	parentCmd := &cobra.Command{Use: "atmos"}
+	require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
+
+	originalOsExit := errUtils.OsExit
+	t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+	errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
+	customCmd := findSubcommand(parentCmd, commandConfig.Name)
+	require.NotNil(t, customCmd)
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
+	})
+	assert.NotContains(t, stdout, secret)
+	assert.NotContains(t, stderr, secret)
+	assert.Equal(t, 1, strings.Count(stdout, maskedSecret))
+	assert.Equal(t, 1, strings.Count(stderr, maskedSecret))
+
+	envContent, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	assert.Equal(t, maskedSecret+"|"+maskedSecret, extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+}
+
+func TestCustomCommandShellOutputNoneCapturesWithoutStreaming(t *testing.T) {
+	if !t.Run("subprocess prerequisite", requireCustomCommandOutputHelper) {
+		return
+	}
+	_ = NewTestKit(t)
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	resultPath := filepath.Join(t.TempDir(), "result.env")
+	commandConfig := schema.Command{
+		Name:        "test-cross-platform-output-none",
+		Description: "Capture a suppressed shell result",
+		Steps: schema.Tasks{
+			{
+				Name:    "produce",
+				Type:    "shell",
+				Command: fmt.Sprintf("%q", exePath),
+				Output:  "none",
+				Env: map[string]string{
+					"_ATMOS_TEST_STDOUT": "produced",
+					"_ATMOS_TEST_STDERR": "warning",
+				},
+			},
+			{
+				Type:    "shell",
+				Command: fmt.Sprintf("%q", exePath),
+				Output:  "none",
+				Env: map[string]string{
+					"_ATMOS_TEST_DUMP_ENV": resultPath,
+					"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stdout }}|{{ .steps.produce.metadata.stderr }}",
+				},
+			},
+		},
+	}
+	atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
+	parentCmd := &cobra.Command{Use: "atmos"}
+	require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
+
+	originalOsExit := errUtils.OsExit
+	t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+	errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
+	customCmd := findSubcommand(parentCmd, commandConfig.Name)
+	require.NotNil(t, customCmd)
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
+	})
+	assert.NotContains(t, stdout, "produced")
+	assert.NotContains(t, stderr, "warning")
+
+	envContent, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	assert.Equal(t, "produced|produced|warning", extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+}

--- a/cmd/custom_command_step_output_test.go
+++ b/cmd/custom_command_step_output_test.go
@@ -112,120 +112,138 @@ func TestCustomCommandLegacyStepOutputAvailableToMarkdown(t *testing.T) {
 	}
 }
 
-func TestCustomCommandShellMasksLiveAndStoredOutput(t *testing.T) {
+func TestCustomCommandMasksLiveAndStoredOutput(t *testing.T) {
 	if !t.Run("subprocess prerequisite", requireCustomCommandOutputHelper) {
 		return
 	}
 
-	_ = NewTestKit(t)
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			_ = NewTestKit(t)
+			t.Cleanup(iolib.Reset)
 
-	iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
-	secret := "step-live-secret-8f14a2"
-	iolib.GetContext().Masker().RegisterValue(secret)
-	maskedSecret := iolib.MaskString(secret)
-	exePath, err := os.Executable()
-	require.NoError(t, err)
-	resultPath := filepath.Join(t.TempDir(), "result.env")
-	commandConfig := schema.Command{
-		Name:        "test-masked-step-output",
-		Description: "Mask live and stored shell output",
-		Steps: schema.Tasks{
-			{
-				Name:    "produce",
-				Type:    "shell",
-				Command: fmt.Sprintf("%q", exePath),
-				Env: map[string]string{
-					"_ATMOS_TEST_STDOUT": secret,
-					"_ATMOS_TEST_STDERR": secret,
+			iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
+			secret := "step-live-secret-8f14a2"
+			iolib.GetContext().Masker().RegisterValue(secret)
+			maskedSecret := iolib.MaskString(secret)
+			exePath, err := os.Executable()
+			require.NoError(t, err)
+			stepCommand := fmt.Sprintf("%q", exePath)
+			if stepType == "atmos" {
+				stepCommand = "version"
+			}
+			resultPath := filepath.Join(t.TempDir(), "result.env")
+			commandConfig := schema.Command{
+				Name:        "test-masked-step-output-" + stepType,
+				Description: "Mask live and stored command output",
+				Steps: schema.Tasks{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: stepCommand,
+						Env: map[string]string{
+							"_ATMOS_TEST_STDOUT": secret,
+							"_ATMOS_TEST_STDERR": secret,
+						},
+					},
+					{
+						Type:    stepType,
+						Command: stepCommand,
+						Output:  "none",
+						Env: map[string]string{
+							"_ATMOS_TEST_DUMP_ENV": resultPath,
+							"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stderr }}",
+						},
+					},
 				},
-			},
-			{
-				Type:    "shell",
-				Command: fmt.Sprintf("%q", exePath),
-				Output:  "none",
-				Env: map[string]string{
-					"_ATMOS_TEST_DUMP_ENV": resultPath,
-					"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stderr }}",
-				},
-			},
-		},
+			}
+			atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
+			parentCmd := &cobra.Command{Use: "atmos"}
+			require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
+
+			originalOsExit := errUtils.OsExit
+			t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+			errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
+			customCmd := findSubcommand(parentCmd, commandConfig.Name)
+			require.NotNil(t, customCmd)
+
+			stdout, stderr := captureStdoutStderr(t, func() {
+				require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
+			})
+			assert.NotContains(t, stdout, secret)
+			assert.NotContains(t, stderr, secret)
+			assert.Equal(t, 1, strings.Count(stdout, maskedSecret))
+			assert.Equal(t, 1, strings.Count(stderr, maskedSecret))
+
+			envContent, err := os.ReadFile(resultPath)
+			require.NoError(t, err)
+			assert.Equal(t, maskedSecret+"|"+maskedSecret, extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+		})
 	}
-	atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
-	parentCmd := &cobra.Command{Use: "atmos"}
-	require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
-
-	originalOsExit := errUtils.OsExit
-	t.Cleanup(func() { errUtils.OsExit = originalOsExit })
-	errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
-	customCmd := findSubcommand(parentCmd, commandConfig.Name)
-	require.NotNil(t, customCmd)
-
-	stdout, stderr := captureStdoutStderr(t, func() {
-		require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
-	})
-	assert.NotContains(t, stdout, secret)
-	assert.NotContains(t, stderr, secret)
-	assert.Equal(t, 1, strings.Count(stdout, maskedSecret))
-	assert.Equal(t, 1, strings.Count(stderr, maskedSecret))
-
-	envContent, err := os.ReadFile(resultPath)
-	require.NoError(t, err)
-	assert.Equal(t, maskedSecret+"|"+maskedSecret, extractEnvVar(string(envContent), "CAPTURED_RESULT"))
 }
 
-func TestCustomCommandShellOutputNoneCapturesWithoutStreaming(t *testing.T) {
+func TestCustomCommandOutputNoneCapturesWithoutStreaming(t *testing.T) {
 	if !t.Run("subprocess prerequisite", requireCustomCommandOutputHelper) {
 		return
 	}
-	_ = NewTestKit(t)
 
-	exePath, err := os.Executable()
-	require.NoError(t, err)
-	resultPath := filepath.Join(t.TempDir(), "result.env")
-	commandConfig := schema.Command{
-		Name:        "test-cross-platform-output-none",
-		Description: "Capture a suppressed shell result",
-		Steps: schema.Tasks{
-			{
-				Name:    "produce",
-				Type:    "shell",
-				Command: fmt.Sprintf("%q", exePath),
-				Output:  "none",
-				Env: map[string]string{
-					"_ATMOS_TEST_STDOUT": "produced",
-					"_ATMOS_TEST_STDERR": "warning",
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			_ = NewTestKit(t)
+
+			exePath, err := os.Executable()
+			require.NoError(t, err)
+			stepCommand := fmt.Sprintf("%q", exePath)
+			if stepType == "atmos" {
+				stepCommand = "version"
+			}
+			resultPath := filepath.Join(t.TempDir(), "result.env")
+			commandConfig := schema.Command{
+				Name:        "test-cross-platform-output-none-" + stepType,
+				Description: "Capture a suppressed command result",
+				Steps: schema.Tasks{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: stepCommand,
+						Output:  "none",
+						Env: map[string]string{
+							"_ATMOS_TEST_STDOUT": "produced",
+							"_ATMOS_TEST_STDERR": "warning",
+						},
+					},
+					{
+						Type:    stepType,
+						Command: stepCommand,
+						Output:  "none",
+						Env: map[string]string{
+							"_ATMOS_TEST_DUMP_ENV": resultPath,
+							"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stdout }}|{{ .steps.produce.metadata.stderr }}",
+						},
+					},
 				},
-			},
-			{
-				Type:    "shell",
-				Command: fmt.Sprintf("%q", exePath),
-				Output:  "none",
-				Env: map[string]string{
-					"_ATMOS_TEST_DUMP_ENV": resultPath,
-					"CAPTURED_RESULT":      "{{ .steps.produce.value }}|{{ .steps.produce.metadata.stdout }}|{{ .steps.produce.metadata.stderr }}",
-				},
-			},
-		},
+			}
+			atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
+			parentCmd := &cobra.Command{Use: "atmos"}
+			require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
+
+			originalOsExit := errUtils.OsExit
+			t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+			errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
+			customCmd := findSubcommand(parentCmd, commandConfig.Name)
+			require.NotNil(t, customCmd)
+
+			stdout, stderr := captureStdoutStderr(t, func() {
+				require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
+			})
+			assert.NotContains(t, stdout, "produced")
+			assert.NotContains(t, stderr, "warning")
+
+			envContent, err := os.ReadFile(resultPath)
+			require.NoError(t, err)
+			assert.Equal(t, "produced|produced|warning", extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+		})
 	}
-	atmosConfig := schema.AtmosConfiguration{BasePath: t.TempDir(), Commands: []schema.Command{commandConfig}}
-	parentCmd := &cobra.Command{Use: "atmos"}
-	require.NoError(t, processCustomCommands(atmosConfig, atmosConfig.Commands, parentCmd))
-
-	originalOsExit := errUtils.OsExit
-	t.Cleanup(func() { errUtils.OsExit = originalOsExit })
-	errUtils.OsExit = func(code int) { panic(fmt.Sprintf("unexpected custom command exit %d", code)) }
-	customCmd := findSubcommand(parentCmd, commandConfig.Name)
-	require.NotNil(t, customCmd)
-
-	stdout, stderr := captureStdoutStderr(t, func() {
-		require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
-	})
-	assert.NotContains(t, stdout, "produced")
-	assert.NotContains(t, stderr, "warning")
-
-	envContent, err := os.ReadFile(resultPath)
-	require.NoError(t, err)
-	assert.Equal(t, "produced|produced|warning", extractEnvVar(string(envContent), "CAPTURED_RESULT"))
 }
 
 func TestCustomCommandOutputEvaluationFailureDoesNotRetryCommand(t *testing.T) {

--- a/cmd/custom_command_step_output_test.go
+++ b/cmd/custom_command_step_output_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -225,4 +226,60 @@ func TestCustomCommandShellOutputNoneCapturesWithoutStreaming(t *testing.T) {
 	envContent, err := os.ReadFile(resultPath)
 	require.NoError(t, err)
 	assert.Equal(t, "produced|produced|warning", extractEnvVar(string(envContent), "CAPTURED_RESULT"))
+}
+
+func TestCustomCommandOutputEvaluationFailureDoesNotRetryCommand(t *testing.T) {
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			_ = NewTestKit(t)
+
+			attemptsFile := filepath.Join(t.TempDir(), "attempts.txt")
+			producerCommand := customCommandAttemptHelperCommand(t, attemptsFile)
+			if stepType == "atmos" {
+				producerCommand = customCommandAtmosAttemptHelperArgs(attemptsFile)
+			}
+			maxAttempts := 3
+			initialDelay := time.Millisecond
+			commandConfig := &schema.Command{
+				Name:        "test-output-evaluation-no-retry-" + stepType,
+				Description: "Do not retry successful commands when output evaluation fails",
+				Steps: schema.Tasks{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: producerCommand,
+						Outputs: map[string]string{"broken": "{{"},
+						Retry: &schema.RetryConfig{
+							MaxAttempts:     &maxAttempts,
+							InitialDelay:    &initialDelay,
+							BackoffStrategy: "constant",
+						},
+					},
+				},
+			}
+
+			originalOsExit := errUtils.OsExit
+			t.Cleanup(func() { errUtils.OsExit = originalOsExit })
+			var exitCode int
+			errUtils.OsExit = func(code int) {
+				exitCode = code
+				panic(code)
+			}
+
+			assert.Panics(t, func() {
+				executeCustomCommand(
+					schema.AtmosConfiguration{BasePath: t.TempDir()},
+					&cobra.Command{Use: commandConfig.Name, Annotations: map[string]string{}},
+					nil,
+					&cobra.Command{Use: "atmos"},
+					commandConfig,
+				)
+			})
+			assert.Equal(t, 1, exitCode)
+
+			attempts, err := os.ReadFile(attemptsFile)
+			require.NoError(t, err)
+			assert.Equal(t, "1", strings.TrimSpace(string(attempts)))
+		})
+	}
 }

--- a/cmd/custom_command_step_output_test.go
+++ b/cmd/custom_command_step_output_test.go
@@ -237,6 +237,8 @@ func TestCustomCommandOutputNoneCapturesWithoutStreaming(t *testing.T) {
 				require.NotPanics(t, func() { customCmd.Run(customCmd, nil) })
 			})
 			assert.NotContains(t, stdout, "produced")
+			assert.NotContains(t, stdout, "warning")
+			assert.NotContains(t, stderr, "produced")
 			assert.NotContains(t, stderr, "warning")
 
 			envContent, err := os.ReadFile(resultPath)

--- a/cmd/testing_main_test.go
+++ b/cmd/testing_main_test.go
@@ -30,6 +30,19 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
+	wroteOutput := false
+	if stdout := os.Getenv("_ATMOS_TEST_STDOUT"); stdout != "" {
+		_, _ = os.Stdout.WriteString(stdout)
+		wroteOutput = true
+	}
+	if stderr := os.Getenv("_ATMOS_TEST_STDERR"); stderr != "" {
+		_, _ = os.Stderr.WriteString(stderr)
+		wroteOutput = true
+	}
+	if wroteOutput {
+		os.Exit(0)
+	}
+
 	// Initialize the I/O writer and ui formatter so data.Write*/ui.Write* calls
 	// (used throughout cmd/root.go and its helpers) don't panic or silently
 	// no-op during tests.

--- a/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
+++ b/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
@@ -1,0 +1,50 @@
+# Fix: `shell` and `atmos` step output capture
+
+**Date:** 2026-07-22
+
+## Summary
+
+Named `shell` and `atmos` steps now expose their successful command output to
+later custom-command and workflow steps through the documented `.steps.<name>`
+context.
+
+## Context
+
+Legacy command execution streamed output directly to the terminal but did not
+store a step result. A later output step such as `markdown` therefore failed to
+resolve `.steps.<name>.value`, even though the producer had completed
+successfully. The defect is tracked by
+[cloudposse/atmos#2781](https://github.com/cloudposse/atmos/issues/2781).
+
+## Changes
+
+- Captured successful `shell` and `atmos` output without replacing their
+  existing cross-platform execution paths.
+- Stored trimmed stdout as the primary value and preserved masked stdout,
+  stderr, exit code, and declared outputs as result metadata.
+- Preserved live output, retries, custom-command shell `output: none`,
+  terminal-attached sessions, process cleanup, and failure propagation.
+- Added capture support for host, persistent workflow-container, and per-step
+  container shell execution.
+
+## Validation
+
+- Added regressions for `shell` and `atmos` output consumed by `markdown` in
+  custom commands and workflows.
+- Ran complete coverage-enabled tests for `./cmd`, `./internal/exec`,
+  `./pkg/runner/step`, and `./pkg/workflow`; all 44 added statement slots were
+  covered.
+- Ran the focused regressions with the race detector and shuffled test order.
+- Re-ran the original custom-command and workflow reproductions; both rendered
+  the producer's value in the later `markdown` step.
+- Ran `go build ./...` and patch-scoped lint against `upstream/main` with no
+  findings.
+- Built the Docusaurus website and validated this fix record.
+- `atmos test` and `atmos test --coverage` reached and passed all touched
+  packages. Their full-repository runs remained nonzero because of unrelated
+  AWS/XDG environment assertions and a transient vendoring pull; the transient
+  tests passed when isolated.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
+++ b/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
@@ -22,7 +22,7 @@ successfully. The defect is tracked by
   existing cross-platform execution paths.
 - Stored trimmed stdout as the primary value, preserved masked stdout, stderr,
   and exit code as result metadata, and evaluated declared outputs separately.
-- Preserved live output, retries, custom-command shell `output: none`,
+- Preserved live output, retries, custom-command `shell`/`atmos` `output: none`,
   terminal-attached sessions, process cleanup, and failure propagation.
 - Evaluated declared outputs once after a successful command, outside the retry
   envelope, so an output-template error cannot repeat a completed command.
@@ -35,6 +35,8 @@ successfully. The defect is tracked by
   custom commands and workflows.
 - Added custom-command and workflow regressions proving output-template errors
   do not retry successful `shell` or `atmos` commands.
+- Added custom-command masking and `output: none` regressions for both `shell`
+  and `atmos` steps.
 - Audited the implementation against the step-output contract in
   `container-actions-and-step-outputs.md` and the command-step behavior in
   `workflow-step-types.md`.

--- a/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
+++ b/docs/fixes/2026-07-22-shell-atmos-step-output-capture.md
@@ -20,10 +20,12 @@ successfully. The defect is tracked by
 
 - Captured successful `shell` and `atmos` output without replacing their
   existing cross-platform execution paths.
-- Stored trimmed stdout as the primary value and preserved masked stdout,
-  stderr, exit code, and declared outputs as result metadata.
+- Stored trimmed stdout as the primary value, preserved masked stdout, stderr,
+  and exit code as result metadata, and evaluated declared outputs separately.
 - Preserved live output, retries, custom-command shell `output: none`,
   terminal-attached sessions, process cleanup, and failure propagation.
+- Evaluated declared outputs once after a successful command, outside the retry
+  envelope, so an output-template error cannot repeat a completed command.
 - Added capture support for host, persistent workflow-container, and per-step
   container shell execution.
 
@@ -31,9 +33,14 @@ successfully. The defect is tracked by
 
 - Added regressions for `shell` and `atmos` output consumed by `markdown` in
   custom commands and workflows.
+- Added custom-command and workflow regressions proving output-template errors
+  do not retry successful `shell` or `atmos` commands.
+- Audited the implementation against the step-output contract in
+  `container-actions-and-step-outputs.md` and the command-step behavior in
+  `workflow-step-types.md`.
 - Ran complete coverage-enabled tests for `./cmd`, `./internal/exec`,
-  `./pkg/runner/step`, and `./pkg/workflow`; all 44 added statement slots were
-  covered.
+  `./pkg/runner/step`, and `./pkg/workflow`; patch-scoped coverage reported no
+  uncovered added behavior.
 - Ran the focused regressions with the race detector and shuffled test order.
 - Re-ran the original custom-command and workflow reproductions; both rendered
   the producer's value in the later `markdown` step.

--- a/internal/exec/workflow_step_output_capture_test.go
+++ b/internal/exec/workflow_step_output_capture_test.go
@@ -158,6 +158,60 @@ func TestWorkflowShellStepStoresOnlySuccessfulRetryOutput(t *testing.T) {
 	assert.Equal(t, "2", strings.TrimSpace(string(attempts)))
 }
 
+func TestWorkflowOutputEvaluationFailureDoesNotRetryCommand(t *testing.T) {
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			ResetStepExecutorState()
+			t.Cleanup(ResetStepExecutorState)
+
+			attemptsFile := filepath.Join(t.TempDir(), "attempts.txt")
+			producerCommand := workflowOutputAttemptHelperCommand(t, attemptsFile)
+			if stepType == "atmos" {
+				exePath, err := os.Executable()
+				require.NoError(t, err)
+				installWorkflowAtmosTestBinary(t, exePath)
+				producerCommand = workflowOutputAttemptHelperArgs(attemptsFile)
+			}
+			maxAttempts := 3
+			initialDelay := time.Millisecond
+			workflowDef := &schema.WorkflowDefinition{
+				Description: "Do not retry successful commands when output evaluation fails",
+				Steps: []schema.WorkflowStep{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: producerCommand,
+						Outputs: map[string]string{"broken": "{{"},
+						Retry: &schema.RetryConfig{
+							MaxAttempts:     &maxAttempts,
+							InitialDelay:    &initialDelay,
+							BackoffStrategy: "constant",
+						},
+					},
+				},
+			}
+			tmpDir := t.TempDir()
+			err := ExecuteWorkflow(
+				schema.AtmosConfiguration{BasePath: tmpDir},
+				"test-output-evaluation-no-retry-"+stepType,
+				filepath.Join(tmpDir, "workflow.yaml"),
+				workflowDef,
+				false,
+				"",
+				"",
+				"",
+			)
+			require.ErrorContains(t, err, "failed to resolve output broken")
+
+			attempts, readErr := os.ReadFile(attemptsFile)
+			require.NoError(t, readErr)
+			assert.Equal(t, "1", strings.TrimSpace(string(attempts)))
+			_, stored := stepExecutorState.GetResult("produce")
+			assert.False(t, stored)
+		})
+	}
+}
+
 func TestWorkflowContainerShellOutputAvailableToMarkdown(t *testing.T) {
 	for _, mode := range []string{"step", "workflow"} {
 		t.Run(mode, func(t *testing.T) {
@@ -238,6 +292,19 @@ func workflowRetryOutputHelperCommand(t *testing.T, path string) string {
 	return fmt.Sprintf("%q -test.run=TestWorkflowStepOutputRetryHelper -- %s", exePath, encodedPath)
 }
 
+func workflowOutputAttemptHelperCommand(t *testing.T, path string) string {
+	t.Helper()
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	return fmt.Sprintf("%q %s", exePath, workflowOutputAttemptHelperArgs(path))
+}
+
+func workflowOutputAttemptHelperArgs(path string) string {
+	encodedPath := base64.RawURLEncoding.EncodeToString([]byte(path))
+	return fmt.Sprintf("-test.run=TestWorkflowStepOutputAttemptHelper -- %s", encodedPath)
+}
+
 func TestWorkflowStepOutputRetryHelper(t *testing.T) {
 	separator := slices.Index(os.Args, "--")
 	if separator == -1 {
@@ -263,4 +330,26 @@ func TestWorkflowStepOutputRetryHelper(t *testing.T) {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func TestWorkflowStepOutputAttemptHelper(t *testing.T) {
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	require.Len(t, args, 1)
+	pathBytes, err := base64.RawURLEncoding.DecodeString(args[0])
+	require.NoError(t, err)
+	path := string(pathBytes)
+
+	attempt := 1
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		parsed, parseErr := strconv.Atoi(strings.TrimSpace(string(existing)))
+		require.NoError(t, parseErr)
+		attempt = parsed + 1
+	}
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(attempt)), 0o600))
+	_, _ = fmt.Fprint(os.Stdout, "complete")
 }

--- a/internal/exec/workflow_step_output_capture_test.go
+++ b/internal/exec/workflow_step_output_capture_test.go
@@ -1,0 +1,266 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/container"
+	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/cloudposse/atmos/tests/testhelpers"
+)
+
+func requireWorkflowOutputHelper(t *testing.T) {
+	t.Helper()
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	cmd := osexec.Command(exePath, "-test.run=^$")
+	cmd.Env = append(os.Environ(), "_ATMOS_TEST_STDOUT=produced", "_ATMOS_TEST_STDERR=warning")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "produced", stdout.String())
+	assert.Equal(t, "warning", stderr.String())
+}
+
+func TestWorkflowLegacyStepOutputAvailableToMarkdown(t *testing.T) {
+	if !t.Run("subprocess prerequisite", requireWorkflowOutputHelper) {
+		return
+	}
+
+	for _, stepType := range []string{"shell", "atmos"} {
+		t.Run(stepType, func(t *testing.T) {
+			ResetStepExecutorState()
+			t.Cleanup(ResetStepExecutorState)
+
+			exePath, err := os.Executable()
+			require.NoError(t, err)
+			producerCommand := fmt.Sprintf("%q", exePath)
+			if stepType == "atmos" {
+				installWorkflowAtmosTestBinary(t, exePath)
+				producerCommand = "version"
+			}
+
+			const expected = "value=produced stdout=produced stderr=warning exit=0 output=produced:warning"
+			workflowDef := &schema.WorkflowDefinition{
+				Description: "Expose legacy step output to markdown",
+				Steps: []schema.WorkflowStep{
+					{
+						Name:    "produce",
+						Type:    stepType,
+						Command: producerCommand,
+						Env: map[string]string{
+							"_ATMOS_TEST_STDOUT": "produced",
+							"_ATMOS_TEST_STDERR": "warning",
+						},
+						Outputs: map[string]string{
+							"summary": "{{ .value }}:{{ .metadata.stderr }}",
+						},
+					},
+					{
+						Name:    "render",
+						Type:    "markdown",
+						Content: "value={{ .steps.produce.value }} stdout={{ .steps.produce.metadata.stdout }} stderr={{ .steps.produce.metadata.stderr }} exit={{ .steps.produce.metadata.exit_code }} output={{ .steps.produce.outputs.summary }}",
+					},
+				},
+			}
+			tmpDir := t.TempDir()
+			err = ExecuteWorkflow(
+				schema.AtmosConfiguration{BasePath: tmpDir},
+				"test-step-output-"+stepType,
+				filepath.Join(tmpDir, "workflow.yaml"),
+				workflowDef,
+				false,
+				"",
+				"",
+				"",
+			)
+			require.NoError(t, err)
+
+			producer, ok := stepExecutorState.GetResult("produce")
+			require.True(t, ok)
+			assert.Equal(t, "produced", producer.Value)
+			assert.Equal(t, "produced", producer.Metadata["stdout"])
+			assert.Equal(t, "warning", producer.Metadata["stderr"])
+			assert.Equal(t, 0, producer.Metadata["exit_code"])
+			assert.Equal(t, "produced:warning", producer.Outputs["summary"])
+
+			rendered, ok := stepExecutorState.GetResult("render")
+			require.True(t, ok)
+			assert.Equal(t, expected, rendered.Value)
+		})
+	}
+}
+
+func TestWorkflowShellStepStoresOnlySuccessfulRetryOutput(t *testing.T) {
+	ResetStepExecutorState()
+	t.Cleanup(ResetStepExecutorState)
+
+	attemptsFile := filepath.Join(t.TempDir(), "attempts.txt")
+	maxAttempts := 2
+	initialDelay := time.Millisecond
+	workflowDef := &schema.WorkflowDefinition{
+		Description: "Store only successful retry output",
+		Steps: []schema.WorkflowStep{
+			{
+				Name:    "produce",
+				Type:    "shell",
+				Command: workflowRetryOutputHelperCommand(t, attemptsFile),
+				Retry: &schema.RetryConfig{
+					MaxAttempts:     &maxAttempts,
+					InitialDelay:    &initialDelay,
+					BackoffStrategy: "constant",
+				},
+			},
+			{
+				Name:    "render",
+				Type:    "markdown",
+				Content: "{{ .steps.produce.value }}",
+			},
+		},
+	}
+	tmpDir := t.TempDir()
+	err := ExecuteWorkflow(
+		schema.AtmosConfiguration{BasePath: tmpDir},
+		"test-step-output-retry",
+		filepath.Join(tmpDir, "workflow.yaml"),
+		workflowDef,
+		false,
+		"",
+		"",
+		"",
+	)
+	require.NoError(t, err)
+
+	result, ok := stepExecutorState.GetResult("produce")
+	require.True(t, ok)
+	assert.Equal(t, "attempt-2", result.Value)
+	assert.Equal(t, "attempt-2", result.Metadata["stdout"])
+	assert.Equal(t, "warning-2", result.Metadata["stderr"])
+
+	attempts, err := os.ReadFile(attemptsFile)
+	require.NoError(t, err)
+	assert.Equal(t, "2", strings.TrimSpace(string(attempts)))
+}
+
+func TestWorkflowContainerShellOutputAvailableToMarkdown(t *testing.T) {
+	for _, mode := range []string{"step", "workflow"} {
+		t.Run(mode, func(t *testing.T) {
+			ResetStepExecutorState()
+			t.Cleanup(ResetStepExecutorState)
+			testhelpers.InstallFakeContainerRuntime(t, testhelpers.FakeContainerRuntimeSpec{
+				Name: string(container.TypeDocker),
+				Mode: testhelpers.FakeContainerRuntimeWorkflowEnv,
+			})
+
+			containerConfig := &schema.WorkflowContainer{
+				Image:    "alpine",
+				Provider: string(container.TypeDocker),
+			}
+			producer := schema.WorkflowStep{
+				Name:    "produce",
+				Type:    "shell",
+				Command: "echo produced",
+				Outputs: map[string]string{"summary": "{{ .value }}"},
+			}
+			workflowDef := &schema.WorkflowDefinition{
+				Description: "Expose container shell output to markdown",
+				Env:         map[string]string{"ATMOS_FAKE_AUTH": "present"},
+				Steps: []schema.WorkflowStep{
+					producer,
+					{Name: "render", Type: "markdown", Content: "container={{ .steps.produce.outputs.summary }}"},
+				},
+			}
+			if mode == "step" {
+				workflowDef.Steps[0].Container = containerConfig
+			} else {
+				workflowDef.Container = containerConfig
+			}
+
+			tmpDir := t.TempDir()
+			err := ExecuteWorkflow(
+				schema.AtmosConfiguration{BasePath: tmpDir},
+				"test-container-step-output-"+mode,
+				filepath.Join(tmpDir, "workflow.yaml"),
+				workflowDef,
+				false,
+				"",
+				"",
+				"",
+			)
+			require.NoError(t, err)
+
+			producerResult, ok := stepExecutorState.GetResult("produce")
+			require.True(t, ok)
+			assert.Equal(t, "container stdout", producerResult.Value)
+			assert.Equal(t, "container stdout\n", producerResult.Metadata["stdout"])
+			assert.Equal(t, "container stdout", producerResult.Outputs["summary"])
+			rendered, ok := stepExecutorState.GetResult("render")
+			require.True(t, ok)
+			assert.Equal(t, "container=container stdout", rendered.Value)
+		})
+	}
+}
+
+func installWorkflowAtmosTestBinary(t *testing.T, source string) {
+	t.Helper()
+
+	name := "atmos"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binDir := t.TempDir()
+	require.NoError(t, copyFile(source, filepath.Join(binDir, name)))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func workflowRetryOutputHelperCommand(t *testing.T, path string) string {
+	t.Helper()
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	encodedPath := base64.RawURLEncoding.EncodeToString([]byte(path))
+	return fmt.Sprintf("%q -test.run=TestWorkflowStepOutputRetryHelper -- %s", exePath, encodedPath)
+}
+
+func TestWorkflowStepOutputRetryHelper(t *testing.T) {
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	require.Len(t, args, 1)
+	pathBytes, err := base64.RawURLEncoding.DecodeString(args[0])
+	require.NoError(t, err)
+	path := string(pathBytes)
+
+	attempt := 1
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		parsed, parseErr := strconv.Atoi(strings.TrimSpace(string(existing)))
+		require.NoError(t, parseErr)
+		attempt = parsed + 1
+	}
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(attempt)), 0o600))
+	_, _ = fmt.Fprintf(os.Stdout, "attempt-%d", attempt)
+	_, _ = fmt.Fprintf(os.Stderr, "warning-%d", attempt)
+	if attempt < 2 {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -642,8 +642,11 @@ func ExecuteWorkflow(
 			stepEnv = append(stepEnv, ci.LogGroupSentinelEnv())
 		}
 
+		var commandResult *stepPkg.StepResult
 		runCommandStep := func(run func(stdout, stderr io.Writer) error) error {
-			return stepPkg.ExecuteAndStoreCommandResult(workflowVars, step.Name, step.Outputs, run)
+			var runErr error
+			commandResult, runErr = stepPkg.ExecuteCommandResult(step.Name, run)
+			return runErr
 		}
 		executeStep := func() error {
 			// Background steps (start/wait/wait-all/cancel) are coordinated by the
@@ -905,7 +908,10 @@ func ExecuteWorkflow(
 					AtmosConfig: &atmosConfig,
 				})
 			}
-			return err
+			if err != nil {
+				return err
+			}
+			return stepPkg.StoreCommandResult(workflowVars, step.Name, step.Outputs, commandResult)
 		}
 
 		// Wrap each step's output in a collapsible CI log group when grouping is

--- a/internal/exec/workflow_utils.go
+++ b/internal/exec/workflow_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -29,6 +30,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/data"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
+	ioLayer "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/process"
@@ -640,6 +642,9 @@ func ExecuteWorkflow(
 			stepEnv = append(stepEnv, ci.LogGroupSentinelEnv())
 		}
 
+		runCommandStep := func(run func(stdout, stderr io.Writer) error) error {
+			return stepPkg.ExecuteAndStoreCommandResult(workflowVars, step.Name, step.Outputs, run)
+		}
 		executeStep := func() error {
 			// Background steps (start/wait/wait-all/cancel) are coordinated by the
 			// run-scoped registry; everything else falls through to the normal switch.
@@ -704,17 +709,21 @@ func ExecuteWorkflow(
 				switch {
 				case workflowPkg.StepContainerOverride(&step):
 					err = retry.Do(context.Background(), step.Retry, func() error {
-						return workflowPkg.RunStepContainerOverride(context.Background(), &workflowPkg.ContainerStepParams{
-							Workflow:     workflow,
-							WorkflowPath: workflowPath,
-							BasePath:     atmosConfig.BasePath,
-							WorkflowDef:  workflowDefinition,
-							Step:         &step,
-							HostWorkDir:  workDir,
-							Command:      command,
-							StepEnv:      stepEnv,
-							RuntimeEnv:   stepEnv,
-							DryRun:       dryRun,
+						return runCommandStep(func(stdout, stderr io.Writer) error {
+							return workflowPkg.RunStepContainerOverride(context.Background(), &workflowPkg.ContainerStepParams{
+								Workflow:      workflow,
+								WorkflowPath:  workflowPath,
+								BasePath:      atmosConfig.BasePath,
+								WorkflowDef:   workflowDefinition,
+								Step:          &step,
+								HostWorkDir:   workDir,
+								Command:       command,
+								StepEnv:       stepEnv,
+								RuntimeEnv:    stepEnv,
+								DryRun:        dryRun,
+								StdoutCapture: stdout,
+								StderrCapture: stderr,
+							})
 						})
 					})
 				case workflowDefinition.Container != nil && workflowDefinition.Container.IsEnabled() && !workflowPkg.StepContainerDisabled(&step):
@@ -732,26 +741,40 @@ func ExecuteWorkflow(
 						}
 					}
 					err = retry.Do(context.Background(), step.Retry, func() error {
-						return activeContainer.ExecShell(context.Background(), &workflowPkg.ContainerStepParams{
-							Step:        &step,
-							WorkflowDef: workflowDefinition,
-							HostWorkDir: workDir,
-							Command:     command,
-							StepEnv:     stepEnv,
+						return runCommandStep(func(stdout, stderr io.Writer) error {
+							return activeContainer.ExecShell(context.Background(), &workflowPkg.ContainerStepParams{
+								Step:          &step,
+								WorkflowDef:   workflowDefinition,
+								HostWorkDir:   workDir,
+								Command:       command,
+								StepEnv:       stepEnv,
+								StdoutCapture: stdout,
+								StderrCapture: stderr,
+							})
 						})
 					})
 				default:
 					err = retry.Do(context.Background(), step.Retry, func() error {
-						return process.RunShellStep(context.Background(), &process.ShellSessionSpec{
-							Command:     command,
-							Name:        commandName,
-							Dir:         workDir,
-							Env:         stepEnv,
-							TTY:         step.Tty,
-							Interactive: step.Interactive,
-							DryRun:      dryRun,
-						}, func() error {
-							return ExecuteShell(command, commandName, workDir, stepEnv, dryRun)
+						return runCommandStep(func(stdoutCapture, stderrCapture io.Writer) error {
+							return process.RunShellStep(context.Background(), &process.ShellSessionSpec{
+								Command:     command,
+								Name:        commandName,
+								Dir:         workDir,
+								Env:         stepEnv,
+								TTY:         step.Tty,
+								Interactive: step.Interactive,
+								DryRun:      dryRun,
+							}, func() error {
+								return ExecuteShellWithWriters(&ExecuteShellSpec{
+									Command: command,
+									Name:    commandName,
+									Dir:     workDir,
+									EnvVars: stepEnv,
+									DryRun:  dryRun,
+									Stdout:  io.MultiWriter(ioLayer.MaskWriter(os.Stdout), stdoutCapture),
+									Stderr:  io.MultiWriter(ioLayer.MaskWriter(os.Stderr), stderrCapture),
+								})
+							})
 						})
 					})
 				}
@@ -799,7 +822,19 @@ func ExecuteWorkflow(
 
 				ui.Infof("Executing command: `atmos %s`", command)
 				err = retry.Do(context.Background(), step.Retry, func() error {
-					return ExecuteShellCommand(atmosConfig, "atmos", args, ".", stepEnv, dryRun, "")
+					return runCommandStep(func(stdout, stderr io.Writer) error {
+						return ExecuteShellCommand(
+							atmosConfig,
+							"atmos",
+							args,
+							".",
+							stepEnv,
+							dryRun,
+							"",
+							WithStdoutCapture(stdout),
+							WithStderrCapture(stderr),
+						)
+					})
 				})
 			default:
 				// Check if this is an extended step type (input, confirm, choose, etc.).

--- a/internal/exec/workflow_utils_test.go
+++ b/internal/exec/workflow_utils_test.go
@@ -1347,6 +1347,9 @@ func TestExecuteWorkflowContinuesWithFailureConditionAfterStepError(t *testing.T
 	err = ExecuteWorkflow(atmosConfig, "test-failure-continuation", "/path/to/workflow.yaml", workflowDef, false, "", "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrWorkflowStepFailed)
+	assert.Equal(t, 7, errUtils.GetExitCode(err))
+	_, stored := stepExecutorState.GetResult("fail-step")
+	assert.False(t, stored)
 	formattedErr := errUtils.Format(err, errUtils.DefaultFormatterConfig())
 	assert.Contains(t, strings.ReplaceAll(formattedErr, "\n", ""), "fail-step")
 
@@ -1468,7 +1471,13 @@ func TestExecuteWorkflow_DryRunShell(t *testing.T) {
 
 	// Dry run should not execute the command.
 	err = ExecuteWorkflow(atmosConfig, "test-dryrun", "/path/to/workflow.yaml", workflowDef, true, "", "", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	result, stored := stepExecutorState.GetResult("step1")
+	require.True(t, stored)
+	assert.Empty(t, result.Value)
+	assert.Equal(t, "", result.Metadata["stdout"])
+	assert.Equal(t, "", result.Metadata["stderr"])
+	assert.Equal(t, 0, result.Metadata["exit_code"])
 }
 
 func TestExecuteWorkflow_DryRunScriptStep(t *testing.T) {

--- a/pkg/runner/step/command_result.go
+++ b/pkg/runner/step/command_result.go
@@ -1,0 +1,33 @@
+package step
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	iolib "github.com/cloudposse/atmos/pkg/io"
+	"github.com/cloudposse/atmos/pkg/perf"
+)
+
+// ExecuteAndStoreCommandResult captures and stores one successful command attempt.
+func ExecuteAndStoreCommandResult(vars *Variables, name string, outputs map[string]string, run func(stdout, stderr io.Writer) error) error {
+	defer perf.Track(nil, "step.ExecuteAndStoreCommandResult")()
+
+	if name == "" {
+		return run(io.Discard, io.Discard)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run(&stdout, &stderr); err != nil {
+		return err
+	}
+
+	stdoutValue := iolib.MaskString(stdout.String())
+	stderrValue := iolib.MaskString(stderr.String())
+	result := NewStepResult(strings.TrimSpace(stdoutValue)).
+		WithMetadata("stdout", stdoutValue).
+		WithMetadata("stderr", stderrValue).
+		WithMetadata(exitCodeMetadata, 0)
+
+	return vars.SetWithOutputs(name, result, outputs)
+}

--- a/pkg/runner/step/command_result.go
+++ b/pkg/runner/step/command_result.go
@@ -9,17 +9,17 @@ import (
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
-// ExecuteAndStoreCommandResult captures and stores one successful command attempt.
-func ExecuteAndStoreCommandResult(vars *Variables, name string, outputs map[string]string, run func(stdout, stderr io.Writer) error) error {
-	defer perf.Track(nil, "step.ExecuteAndStoreCommandResult")()
+// ExecuteCommandResult captures one successful named command attempt.
+func ExecuteCommandResult(name string, run func(stdout, stderr io.Writer) error) (*StepResult, error) {
+	defer perf.Track(nil, "step.ExecuteCommandResult")()
 
 	if name == "" {
-		return run(io.Discard, io.Discard)
+		return nil, run(io.Discard, io.Discard)
 	}
 
 	var stdout, stderr bytes.Buffer
 	if err := run(&stdout, &stderr); err != nil {
-		return err
+		return nil, err
 	}
 
 	stdoutValue := iolib.MaskString(stdout.String())
@@ -28,6 +28,15 @@ func ExecuteAndStoreCommandResult(vars *Variables, name string, outputs map[stri
 		WithMetadata("stdout", stdoutValue).
 		WithMetadata("stderr", stderrValue).
 		WithMetadata(exitCodeMetadata, 0)
+	return result, nil
+}
 
+// StoreCommandResult evaluates declared outputs and stores a captured result.
+func StoreCommandResult(vars *Variables, name string, outputs map[string]string, result *StepResult) error {
+	defer perf.Track(nil, "step.StoreCommandResult")()
+
+	if name == "" || result == nil {
+		return nil
+	}
 	return vars.SetWithOutputs(name, result, outputs)
 }

--- a/pkg/runner/step/command_result_test.go
+++ b/pkg/runner/step/command_result_test.go
@@ -15,6 +15,7 @@ var errCommandResultRun = errors.New("command result runner failed")
 
 func TestCommandResult(t *testing.T) {
 	t.Run("stores masked command output and declared outputs", func(t *testing.T) {
+		t.Cleanup(iolib.Reset)
 		iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
 		secret := "step-output-secret-4d2793"
 		iolib.GetContext().Masker().RegisterValue(secret)

--- a/pkg/runner/step/command_result_test.go
+++ b/pkg/runner/step/command_result_test.go
@@ -13,7 +13,7 @@ import (
 
 var errCommandResultRun = errors.New("command result runner failed")
 
-func TestExecuteAndStoreCommandResult(t *testing.T) {
+func TestCommandResult(t *testing.T) {
 	t.Run("stores masked command output and declared outputs", func(t *testing.T) {
 		iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
 		secret := "step-output-secret-4d2793"
@@ -21,61 +21,69 @@ func TestExecuteAndStoreCommandResult(t *testing.T) {
 		maskedSecret := iolib.MaskString(secret)
 		vars := NewVariables()
 
-		err := ExecuteAndStoreCommandResult(vars, "produce", map[string]string{
-			"summary": "{{ .value }}:{{ .metadata.stderr }}",
-		}, func(stdout, stderr io.Writer) error {
+		result, err := ExecuteCommandResult("produce", func(stdout, stderr io.Writer) error {
 			_, writeErr := io.WriteString(stdout, "  "+secret+"\n")
 			require.NoError(t, writeErr)
 			_, writeErr = io.WriteString(stderr, "warning-"+secret)
 			return writeErr
 		})
 		require.NoError(t, err)
+		err = StoreCommandResult(vars, "produce", map[string]string{
+			"summary": "{{ .value }}:{{ .metadata.stderr }}",
+		}, result)
+		require.NoError(t, err)
 
-		result, ok := vars.Steps["produce"]
+		stored, ok := vars.Steps["produce"]
 		require.True(t, ok)
-		assert.Equal(t, maskedSecret, result.Value)
-		assert.Equal(t, "  "+maskedSecret+"\n", result.Metadata["stdout"])
-		assert.Equal(t, "warning-"+maskedSecret, result.Metadata["stderr"])
-		assert.Equal(t, 0, result.Metadata[exitCodeMetadata])
-		assert.Equal(t, maskedSecret+":warning-"+maskedSecret, result.Outputs["summary"])
-		assert.NotContains(t, result.Metadata["stdout"], secret)
-		assert.NotContains(t, result.Metadata["stderr"], secret)
+		assert.Equal(t, maskedSecret, stored.Value)
+		assert.Equal(t, "  "+maskedSecret+"\n", stored.Metadata["stdout"])
+		assert.Equal(t, "warning-"+maskedSecret, stored.Metadata["stderr"])
+		assert.Equal(t, 0, stored.Metadata[exitCodeMetadata])
+		assert.Equal(t, maskedSecret+":warning-"+maskedSecret, stored.Outputs["summary"])
+		assert.NotContains(t, stored.Metadata["stdout"], secret)
+		assert.NotContains(t, stored.Metadata["stderr"], secret)
 	})
 
 	t.Run("runs unnamed commands without storing output", func(t *testing.T) {
 		vars := NewVariables()
 		called := false
-		err := ExecuteAndStoreCommandResult(vars, "", nil, func(stdout, stderr io.Writer) error {
+		result, err := ExecuteCommandResult("", func(stdout, stderr io.Writer) error {
 			called = true
 			_, _ = io.WriteString(stdout, "ignored")
 			_, _ = io.WriteString(stderr, "ignored")
 			return nil
 		})
 		require.NoError(t, err)
+		require.NoError(t, StoreCommandResult(vars, "", nil, result))
 		assert.True(t, called)
+		assert.Nil(t, result)
 		assert.Empty(t, vars.Steps)
 	})
 
 	t.Run("does not store failed commands", func(t *testing.T) {
 		vars := NewVariables()
-		err := ExecuteAndStoreCommandResult(vars, "failed", nil, func(stdout, stderr io.Writer) error {
+		result, err := ExecuteCommandResult("failed", func(stdout, stderr io.Writer) error {
 			_, _ = io.WriteString(stdout, "partial")
 			_, _ = io.WriteString(stderr, "failure")
 			return errCommandResultRun
 		})
 		require.ErrorIs(t, err, errCommandResultRun)
+		assert.Nil(t, result)
+		require.NoError(t, StoreCommandResult(vars, "failed", nil, result))
 		_, ok := vars.Steps["failed"]
 		assert.False(t, ok)
 	})
 
 	t.Run("does not store a result when declared output evaluation fails", func(t *testing.T) {
 		vars := NewVariables()
-		err := ExecuteAndStoreCommandResult(vars, "invalid-output", map[string]string{
-			"broken": "{{",
-		}, func(stdout, stderr io.Writer) error {
+		result, err := ExecuteCommandResult("invalid-output", func(stdout, stderr io.Writer) error {
 			_, _ = io.WriteString(stdout, "complete")
 			return nil
 		})
+		require.NoError(t, err)
+		err = StoreCommandResult(vars, "invalid-output", map[string]string{
+			"broken": "{{",
+		}, result)
 		require.Error(t, err)
 		_, ok := vars.Steps["invalid-output"]
 		assert.False(t, ok)
@@ -83,15 +91,16 @@ func TestExecuteAndStoreCommandResult(t *testing.T) {
 
 	t.Run("stores an empty successful result", func(t *testing.T) {
 		vars := NewVariables()
-		err := ExecuteAndStoreCommandResult(vars, "session", nil, func(_, _ io.Writer) error {
+		result, err := ExecuteCommandResult("session", func(_, _ io.Writer) error {
 			return nil
 		})
 		require.NoError(t, err)
-		result, ok := vars.Steps["session"]
+		require.NoError(t, StoreCommandResult(vars, "session", nil, result))
+		stored, ok := vars.Steps["session"]
 		require.True(t, ok)
-		assert.Empty(t, result.Value)
-		assert.Equal(t, "", result.Metadata["stdout"])
-		assert.Equal(t, "", result.Metadata["stderr"])
-		assert.Equal(t, 0, result.Metadata[exitCodeMetadata])
+		assert.Empty(t, stored.Value)
+		assert.Equal(t, "", stored.Metadata["stdout"])
+		assert.Equal(t, "", stored.Metadata["stderr"])
+		assert.Equal(t, 0, stored.Metadata[exitCodeMetadata])
 	})
 }

--- a/pkg/runner/step/command_result_test.go
+++ b/pkg/runner/step/command_result_test.go
@@ -1,0 +1,97 @@
+package step
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	iolib "github.com/cloudposse/atmos/pkg/io"
+)
+
+var errCommandResultRun = errors.New("command result runner failed")
+
+func TestExecuteAndStoreCommandResult(t *testing.T) {
+	t.Run("stores masked command output and declared outputs", func(t *testing.T) {
+		iolib.ApplyMaskingConfig(&iolib.Config{DisableMasking: false})
+		secret := "step-output-secret-4d2793"
+		iolib.GetContext().Masker().RegisterValue(secret)
+		maskedSecret := iolib.MaskString(secret)
+		vars := NewVariables()
+
+		err := ExecuteAndStoreCommandResult(vars, "produce", map[string]string{
+			"summary": "{{ .value }}:{{ .metadata.stderr }}",
+		}, func(stdout, stderr io.Writer) error {
+			_, writeErr := io.WriteString(stdout, "  "+secret+"\n")
+			require.NoError(t, writeErr)
+			_, writeErr = io.WriteString(stderr, "warning-"+secret)
+			return writeErr
+		})
+		require.NoError(t, err)
+
+		result, ok := vars.Steps["produce"]
+		require.True(t, ok)
+		assert.Equal(t, maskedSecret, result.Value)
+		assert.Equal(t, "  "+maskedSecret+"\n", result.Metadata["stdout"])
+		assert.Equal(t, "warning-"+maskedSecret, result.Metadata["stderr"])
+		assert.Equal(t, 0, result.Metadata[exitCodeMetadata])
+		assert.Equal(t, maskedSecret+":warning-"+maskedSecret, result.Outputs["summary"])
+		assert.NotContains(t, result.Metadata["stdout"], secret)
+		assert.NotContains(t, result.Metadata["stderr"], secret)
+	})
+
+	t.Run("runs unnamed commands without storing output", func(t *testing.T) {
+		vars := NewVariables()
+		called := false
+		err := ExecuteAndStoreCommandResult(vars, "", nil, func(stdout, stderr io.Writer) error {
+			called = true
+			_, _ = io.WriteString(stdout, "ignored")
+			_, _ = io.WriteString(stderr, "ignored")
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called)
+		assert.Empty(t, vars.Steps)
+	})
+
+	t.Run("does not store failed commands", func(t *testing.T) {
+		vars := NewVariables()
+		err := ExecuteAndStoreCommandResult(vars, "failed", nil, func(stdout, stderr io.Writer) error {
+			_, _ = io.WriteString(stdout, "partial")
+			_, _ = io.WriteString(stderr, "failure")
+			return errCommandResultRun
+		})
+		require.ErrorIs(t, err, errCommandResultRun)
+		_, ok := vars.Steps["failed"]
+		assert.False(t, ok)
+	})
+
+	t.Run("does not store a result when declared output evaluation fails", func(t *testing.T) {
+		vars := NewVariables()
+		err := ExecuteAndStoreCommandResult(vars, "invalid-output", map[string]string{
+			"broken": "{{",
+		}, func(stdout, stderr io.Writer) error {
+			_, _ = io.WriteString(stdout, "complete")
+			return nil
+		})
+		require.Error(t, err)
+		_, ok := vars.Steps["invalid-output"]
+		assert.False(t, ok)
+	})
+
+	t.Run("stores an empty successful result", func(t *testing.T) {
+		vars := NewVariables()
+		err := ExecuteAndStoreCommandResult(vars, "session", nil, func(_, _ io.Writer) error {
+			return nil
+		})
+		require.NoError(t, err)
+		result, ok := vars.Steps["session"]
+		require.True(t, ok)
+		assert.Empty(t, result.Value)
+		assert.Equal(t, "", result.Metadata["stdout"])
+		assert.Equal(t, "", result.Metadata["stderr"])
+		assert.Equal(t, 0, result.Metadata[exitCodeMetadata])
+	})
+}

--- a/pkg/workflow/container.go
+++ b/pkg/workflow/container.go
@@ -29,16 +29,18 @@ const (
 // container entry points. It keeps the public functions within the
 // argument limit and groups related values together.
 type ContainerStepParams struct {
-	Workflow     string
-	WorkflowPath string
-	BasePath     string
-	WorkflowDef  *schema.WorkflowDefinition
-	Step         *schema.WorkflowStep
-	HostWorkDir  string
-	Command      string
-	StepEnv      []string
-	RuntimeEnv   []string
-	DryRun       bool
+	Workflow      string
+	WorkflowPath  string
+	BasePath      string
+	WorkflowDef   *schema.WorkflowDefinition
+	Step          *schema.WorkflowStep
+	HostWorkDir   string
+	Command       string
+	StepEnv       []string
+	RuntimeEnv    []string
+	DryRun        bool
+	StdoutCapture io.Writer
+	StderrCapture io.Writer
 }
 
 // ContainerSession owns the long-lived container backing a workflow run.
@@ -212,8 +214,8 @@ func (s *ContainerSession) ExecShell(ctx context.Context, params *ContainerStepP
 			AttachStdout: true,
 			AttachStderr: true,
 			Stdin:        stdin,
-			Stdout:       stdout,
-			Stderr:       stderr,
+			Stdout:       teeCapture(stdout, params.StdoutCapture),
+			Stderr:       teeCapture(stderr, params.StderrCapture),
 		})
 	})
 	return err
@@ -313,6 +315,8 @@ func writeEphemeralResult(params *ContainerStepParams, result *container.Ephemer
 	if result == nil || step.Tty || step.Interactive {
 		return
 	}
+	writeCapture(params.StdoutCapture, result.Stdout)
+	writeCapture(params.StderrCapture, result.Stderr)
 	writer := stepPkg.NewOutputModeWriter(stepPkg.GetOutputMode(step, params.WorkflowDef), step.Name, stepPkg.GetViewportConfig(step, params.WorkflowDef))
 	_, _, _ = writer.ExecuteWithIO(func(stdout, stderr io.Writer) error {
 		if result.Stdout != "" {
@@ -323,6 +327,19 @@ func writeEphemeralResult(params *ContainerStepParams, result *container.Ephemer
 		}
 		return runErr
 	})
+}
+
+func teeCapture(primary, capture io.Writer) io.Writer {
+	if capture == nil {
+		return primary
+	}
+	return io.MultiWriter(primary, capture)
+}
+
+func writeCapture(writer io.Writer, value string) {
+	if writer != nil && value != "" {
+		_, _ = io.WriteString(writer, value)
+	}
 }
 
 func mergeWorkflowContainer(base, override *schema.WorkflowContainer) *schema.WorkflowContainer {

--- a/pkg/workflow/container_helpers_test.go
+++ b/pkg/workflow/container_helpers_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -373,14 +374,35 @@ func TestWriteEphemeralResult(t *testing.T) {
 	assert.NotPanics(t, func() {
 		writeEphemeralResult(params, &container.EphemeralResult{Stdout: "out", Stderr: "err"}, nil)
 	})
-	// TTY steps skip rendering.
-	ttyParams := &ContainerStepParams{
-		Step:        &schema.WorkflowStep{Name: "s", Tty: true},
-		WorkflowDef: &schema.WorkflowDefinition{Output: "none"},
+	var stdout, stderr bytes.Buffer
+	capturingParams := &ContainerStepParams{
+		Step:          &schema.WorkflowStep{Name: "s"},
+		WorkflowDef:   &schema.WorkflowDefinition{Output: "none"},
+		StdoutCapture: &stdout,
+		StderrCapture: &stderr,
 	}
-	assert.NotPanics(t, func() {
-		writeEphemeralResult(ttyParams, &container.EphemeralResult{Stdout: "x"}, nil)
-	})
+	writeEphemeralResult(capturingParams, &container.EphemeralResult{Stdout: "out", Stderr: "err"}, nil)
+	assert.Equal(t, "out", stdout.String())
+	assert.Equal(t, "err", stderr.String())
+	// Terminal-attached steps skip rendering and capture.
+	for _, step := range []*schema.WorkflowStep{
+		{Name: "tty", Tty: true},
+		{Name: "interactive", Interactive: true},
+	} {
+		terminalParams := &ContainerStepParams{
+			Step:          step,
+			WorkflowDef:   &schema.WorkflowDefinition{Output: "none"},
+			StdoutCapture: &stdout,
+			StderrCapture: &stderr,
+		}
+		stdout.Reset()
+		stderr.Reset()
+		assert.NotPanics(t, func() {
+			writeEphemeralResult(terminalParams, &container.EphemeralResult{Stdout: "x"}, nil)
+		})
+		assert.Empty(t, stdout.String())
+		assert.Empty(t, stderr.String())
+	}
 }
 
 func TestContainerSessionCleanup(t *testing.T) {
@@ -470,6 +492,7 @@ func TestRunStepContainerOverride_UsesRuntimeEnvWithFakeDocker(t *testing.T) {
 		Mode: testhelpers.FakeContainerRuntimeWorkflowEnv,
 	})
 
+	var stdout, stderr bytes.Buffer
 	err := RunStepContainerOverride(context.Background(), &ContainerStepParams{
 		WorkflowDef: &schema.WorkflowDefinition{Output: "none"},
 		Step: &schema.WorkflowStep{
@@ -479,10 +502,14 @@ func TestRunStepContainerOverride_UsesRuntimeEnvWithFakeDocker(t *testing.T) {
 				Provider: string(container.TypeDocker),
 			},
 		},
-		Command:    "echo hi",
-		RuntimeEnv: []string{"ATMOS_FAKE_AUTH=present"},
+		Command:       "echo hi",
+		RuntimeEnv:    []string{"ATMOS_FAKE_AUTH=present"},
+		StdoutCapture: &stdout,
+		StderrCapture: &stderr,
 	})
 	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "container stdout")
+	assert.Empty(t, stderr.String())
 }
 
 func TestExecShell_NilGuards(t *testing.T) {

--- a/pkg/workflow/container_test.go
+++ b/pkg/workflow/container_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"testing"
@@ -33,11 +34,80 @@ func (f *fakeContainer) Exec(_ context.Context, command []string, opts *containe
 	if opts.Stdout != nil {
 		_, _ = io.WriteString(opts.Stdout, "ok\n")
 	}
+	if opts.Stderr != nil {
+		_, _ = io.WriteString(opts.Stderr, "warning\n")
+	}
 	return nil
 }
 
 func (f *fakeContainer) Cleanup(bool) error {
 	return nil
+}
+
+func TestContainerSessionExecShellCapturesOutput(t *testing.T) {
+	fake := &fakeContainer{id: "container-id", name: "sandbox"}
+	session := &ContainerSession{
+		backend:       fake,
+		config:        &schema.WorkflowContainer{Workspace: "/workspace"},
+		hostWorkspace: "/repo",
+	}
+	var stdout, stderr bytes.Buffer
+
+	err := session.ExecShell(context.Background(), &ContainerStepParams{
+		Step:          &schema.WorkflowStep{Name: "capture", Type: "shell", Command: "echo ok"},
+		WorkflowDef:   &schema.WorkflowDefinition{Output: "none"},
+		HostWorkDir:   "/repo",
+		Command:       "echo ok",
+		StdoutCapture: &stdout,
+		StderrCapture: &stderr,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok\n", stdout.String())
+	assert.Equal(t, "warning\n", stderr.String())
+}
+
+func TestContainerSessionExecShellTerminalSessionDoesNotCaptureOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tty         bool
+		interactive bool
+	}{
+		{name: "tty", tty: true},
+		{name: "interactive", interactive: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeContainer{id: "container-id", name: "sandbox"}
+			session := &ContainerSession{
+				backend:       fake,
+				config:        &schema.WorkflowContainer{Workspace: "/workspace"},
+				hostWorkspace: "/repo",
+			}
+			var stdout, stderr bytes.Buffer
+
+			err := session.ExecShell(context.Background(), &ContainerStepParams{
+				Step: &schema.WorkflowStep{
+					Name:        "session",
+					Type:        "shell",
+					Command:     "interactive",
+					Tty:         tc.tty,
+					Interactive: tc.interactive,
+				},
+				WorkflowDef:   &schema.WorkflowDefinition{Output: "none"},
+				HostWorkDir:   "/repo",
+				Command:       "interactive",
+				StdoutCapture: &stdout,
+				StderrCapture: &stderr,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, fake.opts)
+			assert.Equal(t, tc.tty, fake.opts.Tty)
+			assert.Equal(t, tc.interactive, fake.opts.AttachStdin)
+			assert.Empty(t, stdout.String())
+			assert.Empty(t, stderr.String())
+		})
+	}
 }
 
 func TestContainerSessionExecShellPassesStepEnvAndMappedWorkingDirectory(t *testing.T) {

--- a/website/docs/cli/configuration/commands/command/steps.mdx
+++ b/website/docs/cli/configuration/commands/command/steps.mdx
@@ -165,7 +165,8 @@ With this configuration, `atmos ssh i-1234567890` behaves like `docker run -it`:
   <dd>
     Attach host stdin to the step and let the step handle Ctrl-C (like `docker -i`).
     While the step runs, Atmos suspends its own interrupt handling so pressing Ctrl-C
-    interrupts the step's process, not Atmos. Output is still masked and captured normally.
+    interrupts the step's process, not Atmos. The session writes directly to the terminal
+    and does not produce capturable output. Secret masking requires a supported `tty` session.
   </dd>
 
   <dt>`tty`</dt>

--- a/website/docs/workflows/workflows/workflow/steps/outputs.mdx
+++ b/website/docs/workflows/workflows/workflow/steps/outputs.mdx
@@ -37,6 +37,8 @@ Later steps can read declared outputs with `{{ .steps.<name>.outputs.<key> }}`.
 
 Successful named `shell` and `atmos` steps expose their captured output to later steps. The primary `value` is trimmed, while `metadata.stdout` and `metadata.stderr` preserve the captured streams.
 
+Declared outputs are evaluated once after the command succeeds. A failed command attempt can be retried, but an invalid output template fails the step without running the successful command again.
+
 ```yaml
 steps:
   - name: discover

--- a/website/docs/workflows/workflows/workflow/steps/outputs.mdx
+++ b/website/docs/workflows/workflows/workflow/steps/outputs.mdx
@@ -33,6 +33,28 @@ steps:
 
 Later steps can read declared outputs with `{{ .steps.<name>.outputs.<key> }}`.
 
+## Command Output
+
+Successful named `shell` and `atmos` steps expose their captured output to later steps. The primary `value` is trimmed, while `metadata.stdout` and `metadata.stderr` preserve the captured streams.
+
+```yaml
+steps:
+  - name: discover
+    type: shell
+    command: printf 'vpc\n'
+    outputs:
+      component: "{{ .value }}"
+
+  - name: summary
+    type: markdown
+    content: |
+      Component: `{{ .steps.discover.value }}`
+      Raw stdout: `{{ .steps.discover.metadata.stdout }}`
+      Declared output: `{{ .steps.discover.outputs.component }}`
+```
+
+Shell steps with `tty` or `interactive` attach directly to the terminal. They complete with an empty command result because terminal session output cannot be captured.
+
 ## Step Result Context
 
 Templates can access prior step results:


### PR DESCRIPTION
## what

- Capture successful output from named `shell` and `atmos` steps in custom
  commands and workflows.
- Expose trimmed `.value`, masked stdout/stderr/exit-code metadata, and declared
  outputs through `.steps.<name>`.
- Evaluate declared outputs once after successful command execution, outside the
  retry envelope.
- Support host execution, persistent workflow containers, and per-step container
  overrides.
- Preserve legacy runners, retries, live streaming, custom-command `shell` and
  `atmos` `output: none`, terminal sessions, process cleanup, and failure
  propagation.
- Document command-result behavior and correct the interactive-session capture
  guidance.
- Add regression coverage for markdown consumers, retries, masking, suppression,
  terminal sessions, output-template failures, and container execution.

## why

- Legacy `shell` and `atmos` execution bypassed `StepExecutor` result storage.
- Later steps therefore failed with `map has no entry for key "<name>"`, even
  after the producer completed successfully.
- Retaining the legacy execution paths avoids known Windows regressions and
  child-process cleanup issues while satisfying the documented step-output
  contract.
- Captured values are masked before entering template context so later rendering
  cannot expose registered secrets.
- Keeping output evaluation outside retries prevents a template error from
  repeating a successful, potentially non-idempotent command.

## validation

- Audited against the step-output and `shell`/`atmos` command-step PRDs.
- Patch-scoped coverage reported no uncovered added behavior.
- Passed complete tests for `./cmd`, `./internal/exec`, `./pkg/runner/step`, and
  `./pkg/workflow`.
- Passed focused race tests with shuffled ordering.
- Verified masking and `output: none` behavior for custom-command `shell` and
  `atmos` steps.
- Passed `go build ./...`.
- Passed patch-scoped lint against `upstream/main`.
- Built the Docusaurus website successfully.
- Re-ran the original custom-command and workflow reproductions successfully.
- Full-repository test wrappers reached and passed every touched package;
  unrelated AWS/XDG assertions and an acceptance-test timeout caused the overall
  local run to remain nonzero.

## references

- Closes #2781
- [Step outputs documentation](https://atmos.tools/workflows/steps/outputs)
- [Step-output PRD](https://github.com/cloudposse/atmos/blob/main/docs/prd/container-actions-and-step-outputs.md)
- [`shell` and `atmos` step-type PRD](https://github.com/cloudposse/atmos/blob/main/docs/prd/workflow-step-types.md#command-step-types)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Step output capture for `shell` and `atmos` is now consistent across local and container execution, including retries and named declared outputs (value, stdout, stderr, exit code).
  * Secret masking is applied to both live output and stored step metadata.
* **Bug Fixes**
  * `output: none` now suppresses streamed output while preserving stored results for downstream steps.
  * Output-template evaluation failures no longer cause retries and prevent storing a step result.
  * Retry behavior now ensures only the final successful attempt’s stored outputs are used.
  * Interactive/TTY sessions still attach directly to the terminal and remain non-capturable.
* **Documentation**
  * Updated workflow step output documentation and added a fix note for command output availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
