### PR TITLE
fix(ci): publish Docker images for prereleases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     name: "Build and push Docker image for Atmos CLI"
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ github.event.release.prerelease == false }}
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## what

- Publish the existing multi-architecture Atmos Docker image for both stable and prerelease GitHub releases.
- Keep Docker image publishing disabled for manual workflow dispatches.

## why

- Native CI users consume Atmos through Docker images and need prerelease tags to test upcoming releases.
- Homebrew remains stable-release-only.

## references

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation so the Docker build job runs for release events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->