### PR TITLE
fix(hooks): resolve $ATMOS_COMPONENT_PATH via metadata.component for non-JIT components

### DIFF
--- a/docs/fixes/2026-07-25-hooks-component-path-metadata-component.md
+++ b/docs/fixes/2026-07-25-hooks-component-path-metadata-component.md
@@ -1,0 +1,81 @@
+# Fix: hooks resolve $ATMOS_COMPONENT_PATH to the wrong directory for non-JIT components using metadata.component
+
+**Date:** 2026-07-25
+
+**Issue:** [#2799](https://github.com/cloudposse/atmos/issues/2799)
+
+## Summary
+
+For a component that points at a different local component folder via
+`metadata.component` (the long-standing shared-module/alias pattern, not the JIT
+`source.uri` provisioner), every built-in hook kind that consumes
+`$ATMOS_COMPONENT_PATH` (`infracost`, `trivy`, `checkov`, `kics`, `tflint`, and
+`kind: command` hooks referencing it) resolved the path from the **stack-facing
+component name** instead of the resolved `metadata.component` target, and ran
+against a directory that does not exist. Fixed by backfilling the resolved
+Terraform component onto the hook `ConfigAndStacksInfo` in `GetHooks`, reusing
+the describe output it already fetches.
+
+## Context
+
+The hook context is built in `cmd/terraform/utils.go` `prepareHookContext()`
+from `ProcessCommandLineArgs` only — it never runs stack processing
+(`ProcessStacks`), so `info.FinalComponent` and `info.ComponentFolderPrefix`
+stay empty. `componentPathFor()` in `pkg/hooks/command_engine.go` resolves the
+scan path as:
+
+1. The provisioned JIT workdir, if one resolves and exists (covers the
+   `source.uri` family of fixes: #2364/#2371, #2134/#2137, #2309 Bug 2, #2684).
+2. Otherwise `TerraformDirAbsolutePath / ComponentFolderPrefix / FinalComponent`,
+   falling back to `ComponentFromArg` when `FinalComponent` is empty.
+
+For a plain (non-JIT) aliased component, branch 1 finds no workdir and branch 2
+hits the empty-`FinalComponent` fallback, joining the raw CLI/stack-facing name
+(e.g. `nat-gateway-alias`) onto the components dir — a folder that never exists
+for an alias. For `kind: infracost` the failure is silent: infracost exits 0
+with `Could not autodetect any projects from path <dir>` and reports `$0.00`,
+indistinguishable from a genuinely cost-free component.
+
+`GetHooks` (`pkg/hooks/hooks.go`) already calls `ExecuteDescribeComponent` to
+discover the hooks section, and that output's `component` key carries the
+resolved Terraform component (the `metadata.component` value — exactly what
+`atmos describe component <alias>` shows as `component:`). The information was
+in hand; it just was never copied onto the `info` the hook engines receive.
+
+## Changes
+
+- `pkg/hooks/hooks.go`: added `enrichInfoFromDescribe(info, sections)`, called
+  from `GetHooks` right after `ExecuteDescribeComponent` succeeds. It backfills
+  `info.FinalComponent` (and `info.ComponentFolderPrefix` for
+  `metadata.component` values containing a folder prefix, e.g.
+  `shared/nat-gateway`), mirroring the `ProcessStacks` split in
+  `internal/exec/utils.go`. Both fields are only set when **both** are empty, so
+  a fully populated info (e.g. the CI hook path, which sets `FinalComponent`
+  itself in `pkg/ci/plugins/terraform/handlers.go`) is never overwritten.
+- No change to `componentPathFor()` itself: its JIT-workdir branch still wins
+  when a provisioned workdir exists, and its fallback now receives a populated
+  `FinalComponent`.
+
+## Validation
+
+- `go test ./pkg/hooks/ -run TestGetHooks_ResolvesMetadataComponentForHookPath -count=1`
+  with the `enrichInfoFromDescribe` call removed — **fails** exactly as the
+  issue describes (`.../components/terraform/nat-gateway-alias` instead of
+  `.../components/terraform/nat-gateway`), confirming the test reproduces
+  #2799.
+- Same test with the fix — passes.
+- `TestEnrichInfoFromDescribe` (new, table-driven): backfill, folder-prefix
+  split, both no-overwrite guards, and missing/non-string/empty `component`
+  section no-ops.
+- `go test ./pkg/hooks/ -count=1 -v` — all 477 tests pass, 0 failures.
+- `go build ./...` — passed.
+- `./custom-gcl run pkg/hooks/...` — 15 findings, all pre-existing (hugeParam,
+  file-length, godot, err113 on untouched lines/files); none on changed lines.
+- `gofumpt -l` on changed files — clean.
+
+## Follow-ups
+
+- The issue also suggests that scanner kinds (infracost et al.) should surface
+  "no projects detected at the computed path" as a hook-level warning distinct
+  from a successful `$0.00` run, so a broken path can never masquerade as an
+  empty component. Not addressed here (separate UX change).

--- a/docs/fixes/2026-07-25-hooks-component-path-metadata-component.md
+++ b/docs/fixes/2026-07-25-hooks-component-path-metadata-component.md
@@ -25,9 +25,9 @@ stay empty. `componentPathFor()` in `pkg/hooks/command_engine.go` resolves the
 scan path as:
 
 1. The provisioned JIT workdir, if one resolves and exists (covers the
-   `source.uri` family of fixes: #2364/#2371, #2134/#2137, #2309 Bug 2, #2684).
+  `source.uri` family of fixes: #2364/#2371, #2134/#2137, #2309 Bug 2, #2684).
 2. Otherwise `TerraformDirAbsolutePath / ComponentFolderPrefix / FinalComponent`,
-   falling back to `ComponentFromArg` when `FinalComponent` is empty.
+  falling back to `ComponentFromArg` when `FinalComponent` is empty.
 
 For a plain (non-JIT) aliased component, branch 1 finds no workdir and branch 2
 hits the empty-`FinalComponent` fallback, joining the raw CLI/stack-facing name

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -99,6 +99,8 @@ func GetHooks(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStac
 		return &Hooks{}, err
 	}
 
+	enrichInfoFromDescribe(info, sections)
+
 	hooksSection, ok := sections["hooks"].(map[string]any)
 	if !ok {
 		// No hooks defined or wrong type, return empty hooks.
@@ -128,6 +130,35 @@ func GetHooks(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStac
 	}
 
 	return &hooks, nil
+}
+
+// enrichInfoFromDescribe backfills the resolved Terraform component onto the hook
+// ConfigAndStacksInfo from the `component` section of the describe output.
+//
+// The hook context is built from CLI parsing only (ProcessCommandLineArgs), which
+// never runs stack processing, so FinalComponent is empty for components that
+// point at a different component folder via `metadata.component`. Without this
+// backfill, path-based hook kinds (infracost, trivy, checkov, kics, tflint,
+// command) resolve `$ATMOS_COMPONENT_PATH` from the raw stack-facing component
+// name and scan a directory that does not exist (#2799).
+//
+// It mirrors ProcessStacks: a `metadata.component` value may include a folder
+// prefix (e.g. `shared/nat-gateway`) — the last path segment is the component,
+// the rest is the folder prefix. Both fields are only set when empty so a fully
+// populated info (e.g. from the CI hook path) is never overwritten.
+func enrichInfoFromDescribe(info *schema.ConfigAndStacksInfo, sections map[string]any) {
+	if info.FinalComponent != "" || info.ComponentFolderPrefix != "" {
+		return
+	}
+	component, ok := sections[cfg.ComponentSectionName].(string)
+	if !ok || component == "" {
+		return
+	}
+	parts := strings.Split(component, "/")
+	info.FinalComponent = parts[len(parts)-1]
+	if len(parts) > 1 {
+		info.ComponentFolderPrefix = strings.Join(parts[:len(parts)-1], "/")
+	}
 }
 
 // SetOutcome records the lifecycle operation outcome (success/failure) for the

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -1566,3 +1566,155 @@ func TestCheckExperimental(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichInfoFromDescribe(t *testing.T) {
+	tests := []struct {
+		name           string
+		info           schema.ConfigAndStacksInfo
+		sections       map[string]any
+		wantFinal      string
+		wantFolderPref string
+	}{
+		{
+			name:           "backfills final component from describe output",
+			info:           schema.ConfigAndStacksInfo{ComponentFromArg: "nat-gateway-alias"},
+			sections:       map[string]any{"component": "nat-gateway"},
+			wantFinal:      "nat-gateway",
+			wantFolderPref: "",
+		},
+		{
+			name:           "splits folder prefix from metadata.component subpath",
+			info:           schema.ConfigAndStacksInfo{ComponentFromArg: "nat-gateway-alias"},
+			sections:       map[string]any{"component": "shared/networking/nat-gateway"},
+			wantFinal:      "nat-gateway",
+			wantFolderPref: "shared/networking",
+		},
+		{
+			name:           "does not overwrite populated final component",
+			info:           schema.ConfigAndStacksInfo{FinalComponent: "already-set"},
+			sections:       map[string]any{"component": "nat-gateway"},
+			wantFinal:      "already-set",
+			wantFolderPref: "",
+		},
+		{
+			name:           "does not touch info with populated folder prefix",
+			info:           schema.ConfigAndStacksInfo{ComponentFolderPrefix: "catalog"},
+			sections:       map[string]any{"component": "shared/nat-gateway"},
+			wantFinal:      "",
+			wantFolderPref: "catalog",
+		},
+		{
+			name:           "no-op when component section is missing",
+			info:           schema.ConfigAndStacksInfo{ComponentFromArg: "vpc"},
+			sections:       map[string]any{},
+			wantFinal:      "",
+			wantFolderPref: "",
+		},
+		{
+			name:           "no-op when component section is not a string",
+			info:           schema.ConfigAndStacksInfo{ComponentFromArg: "vpc"},
+			sections:       map[string]any{"component": 42},
+			wantFinal:      "",
+			wantFolderPref: "",
+		},
+		{
+			name:           "no-op when component section is empty",
+			info:           schema.ConfigAndStacksInfo{ComponentFromArg: "vpc"},
+			sections:       map[string]any{"component": ""},
+			wantFinal:      "",
+			wantFolderPref: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enrichInfoFromDescribe(&tc.info, tc.sections)
+			assert.Equal(t, tc.wantFinal, tc.info.FinalComponent)
+			assert.Equal(t, tc.wantFolderPref, tc.info.ComponentFolderPrefix)
+		})
+	}
+}
+
+// TestGetHooks_ResolvesMetadataComponentForHookPath reproduces
+// https://github.com/cloudposse/atmos/issues/2799: for a plain (non-JIT) component
+// that points at a different component folder via `metadata.component`, hook kinds
+// consuming $ATMOS_COMPONENT_PATH must resolve the target folder, not the
+// stack-facing component name.
+func TestGetHooks_ResolvesMetadataComponentForHookPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// The real component folder (the metadata.component target) exists on disk;
+	// the stack-facing alias has no folder of its own.
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "components", "terraform", "nat-gateway"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "components", "terraform", "nat-gateway", "main.tf"),
+		[]byte("# placeholder\n"),
+		0o644,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "stacks"), 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "atmos.yaml"),
+		[]byte(`base_path: "./"
+components:
+  terraform:
+    base_path: "components/terraform"
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "**/*"
+  name_pattern: "{stage}"
+logs:
+  level: Info
+`),
+		0o644,
+	))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "stacks", "test.yaml"),
+		[]byte(`vars:
+  stage: test
+components:
+  terraform:
+    nat-gateway-alias:
+      metadata:
+        component: nat-gateway
+      hooks:
+        cost:
+          events:
+            - after.terraform.plan
+          kind: infracost
+`),
+		0o644,
+	))
+
+	t.Chdir(tempDir)
+
+	atmosConfig := &schema.AtmosConfiguration{}
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "nat-gateway-alias",
+		Stack:            "test",
+	}
+
+	hooks, err := GetHooks(atmosConfig, info)
+	require.NoError(t, err)
+	require.NotNil(t, hooks)
+	assert.Contains(t, hooks.items, "cost")
+
+	// GetHooks must backfill the resolved metadata.component target so path-based
+	// hook kinds do not fall back to the raw stack-facing component name.
+	assert.Equal(t, "nat-gateway", info.FinalComponent,
+		"FinalComponent should resolve metadata.component (issue #2799)")
+
+	// The full path resolution used for $ATMOS_COMPONENT_PATH must point at the
+	// metadata.component target folder, not the (nonexistent) alias folder.
+	execCtx := &ExecContext{
+		AtmosConfig: &schema.AtmosConfiguration{
+			TerraformDirAbsolutePath: filepath.Join(tempDir, "components", "terraform"),
+		},
+		Info: info,
+	}
+	assert.Equal(t, filepath.Join(tempDir, "components", "terraform", "nat-gateway"),
+		componentPathFor(execCtx),
+		"$ATMOS_COMPONENT_PATH should resolve to the metadata.component target folder (issue #2799)")
+}


### PR DESCRIPTION
## what

- Fixed `$ATMOS_COMPONENT_PATH` resolution in lifecycle hooks for plain (non-JIT) components that point at a different local component folder via `metadata.component`.
- `GetHooks` now backfills the resolved Terraform component (`FinalComponent`, and `ComponentFolderPrefix` for subpath values like `shared/nat-gateway`) onto the hook context from the `ExecuteDescribeComponent` output it already fetches — no extra describe call.
- Added a regression test reproducing the exact scenario from the issue (an alias component with no folder of its own plus an `infracost` hook) and a table-driven unit test for the backfill logic.
- Added a fix record at `docs/fixes/2026-07-25-hooks-component-path-metadata-component.md`.

## why

- The hook context is built from CLI parsing only (`prepareHookContext` → `ProcessCommandLineArgs`) and never runs stack processing, so `FinalComponent` was empty for `metadata.component`-aliased components. The path fallback in `componentPathFor` then joined the raw stack-facing component name (e.g. `nat-gateway-alias`) onto the components directory — a folder that never exists for an alias.
- Every built-in hook kind that consumes `$ATMOS_COMPONENT_PATH` (`infracost`, `trivy`, `checkov`, `kics`, `tflint`, and `kind: command` hooks referencing it) therefore scanned a nonexistent directory. For `kind: infracost` the failure was silent: infracost exits 0 with "Could not autodetect any projects" and reports `$0.00`, indistinguishable from a genuinely cost-free component.
- The backfill only sets fields that are empty, so contexts that already populate `FinalComponent` (e.g. the CI hook path in `pkg/ci/plugins/terraform/handlers.go`) are never overwritten, and the JIT-workdir resolution branch (the `source.uri` family of fixes from #2371 / #2137 / #2309 / #2684) still takes precedence when a provisioned workdir exists.

## references

- closes #2799
- Related prior fixes in the JIT/`source.uri` code path: #2364 / #2371, #2134 / #2137, #2309 (Bug 2), #2684 — this PR covers the plain/local `metadata.component` branch they didn't reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook path resolution for components using `metadata.component`.
  * Hooks now use the resolved metadata component directory (not the stack-facing alias path).
  * Improved preservation and population of component folder prefix details during hook execution setup.
* **Tests**
  * Added unit coverage for enrichment behavior, including missing/non-string component values and existing info preservation.
  * Added integration-style coverage to ensure correct metadata resolution for hook path computation.
* **Documentation**
  * Added release documentation explaining the hook path resolution fix and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->