### PR TITLE
fix(utils): initialize yq globals once instead of per evaluation

### DIFF
--- a/pkg/utils/yq_utils.go
+++ b/pkg/utils/yq_utils.go
@@ -8,6 +8,7 @@ package utils
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	logging "gopkg.in/op/go-logging.v1"
@@ -17,10 +18,43 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
+// yqLogModule is the go-logging module name that yq registers its internal
+// logger under.
+const yqLogModule = "yq-lib"
+
 // yqSilentLevel is lower than yq's critical level, so its IsEnabledFor()
 // gate rejects every message. Using a level keeps logger configuration
 // reversible across repeated configureYqLogger calls.
 const yqSilentLevel logging.Level = -1
+
+// yqLogLevelMu serializes Atmos reads and writes of go-logging's module
+// level registry. That registry is a plain map with no synchronization of
+// its own, and yq reads it from every decoder it runs, so an unguarded
+// write from one goroutine while another goroutine is decoding ends the
+// process with a runtime fatal error that recover cannot intercept.
+var yqLogLevelMu sync.Mutex
+
+// yqParserOnce guards yq's process-global expression parser.
+var yqParserOnce sync.Once
+
+// init installs the default yq log level before main runs, and therefore
+// before any goroutine exists. A non-Trace run then finds the level it
+// wants already installed and never writes the registry while stack
+// processing goroutines are live.
+func init() {
+	logging.SetLevel(yqSilentLevel, yqLogModule)
+}
+
+// initYqExpressionParser initializes yq's process-global expression parser
+// exactly once. yqlib.InitExpressionParser guards yqlib.ExpressionParser
+// with a plain nil check and every Evaluate call runs it, so concurrent
+// first evaluations otherwise write and read that global at the same time.
+// Doing it under a Once gives the later readers a happens-before edge, and
+// keeps the one-time cost (~0.4ms here) off commands that never evaluate a
+// yq expression.
+func initYqExpressionParser() {
+	yqParserOnce.Do(yqlib.InitExpressionParser)
+}
 
 // configureYqLogger configures the yq logger based on Atmos configuration.
 // Non-Trace log levels suppress yq's internal diagnostics; Trace
@@ -29,11 +63,28 @@ const yqSilentLevel logging.Level = -1
 func configureYqLogger(atmosConfig *schema.AtmosConfiguration) {
 	defer perf.Track(atmosConfig, "utils.configureYqLogger")()
 
-	if atmosConfig == nil || atmosConfig.Logs.Level != LogLevelTrace {
-		logging.SetLevel(yqSilentLevel, "yq-lib")
+	desired := yqSilentLevel
+	if atmosConfig != nil && atmosConfig.Logs.Level == LogLevelTrace {
+		desired = logging.DEBUG
+	}
+	setYqLogLevel(desired)
+}
+
+// setYqLogLevel installs level for yq's logger, writing only when some
+// other level is currently installed. Callers may run concurrently.
+//
+// Skipping the redundant write is what makes this safe rather than merely
+// tidy: yq's own reads of the level registry are outside our control, so
+// the only way to keep them from racing a write is to not write at all
+// once the wanted level is in place.
+func setYqLogLevel(level logging.Level) {
+	yqLogLevelMu.Lock()
+	defer yqLogLevelMu.Unlock()
+
+	if logging.GetLevel(yqLogModule) == level {
 		return
 	}
-	logging.SetLevel(logging.DEBUG, "yq-lib")
+	logging.SetLevel(level, yqLogModule)
 }
 
 func EvaluateYqExpression(atmosConfig *schema.AtmosConfiguration, data any, yq string) (any, error) {
@@ -41,6 +92,7 @@ func EvaluateYqExpression(atmosConfig *schema.AtmosConfiguration, data any, yq s
 
 	// Configure the yq logger based on Atmos configuration
 	configureYqLogger(atmosConfig)
+	initYqExpressionParser()
 
 	evaluator := yqlib.NewStringEvaluator()
 
@@ -207,6 +259,7 @@ func EvaluateYqExpressionWithType[T any](atmosConfig *schema.AtmosConfiguration,
 
 	// Configure the yq logger based on Atmos configuration
 	configureYqLogger(atmosConfig)
+	initYqExpressionParser()
 
 	evaluator := yqlib.NewStringEvaluator()
 

--- a/pkg/utils/yq_utils_test.go
+++ b/pkg/utils/yq_utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -719,6 +720,66 @@ func TestConfigureYqLogger_LevelIsReversible(t *testing.T) {
 	// And back again to confirm the toggle is not accidentally sticky.
 	configureYqLogger(nil)
 	assert.Equal(t, yqSilentLevel, logging.GetLevel("yq-lib"), "nil config must re-silence")
+}
+
+// TestEvaluateYqExpression_ConcurrentCallsAreRaceFree covers #2821 and
+// pins both of the process-global writes that used to happen on every
+// call:
+//
+//   - configureYqLogger called logging.SetLevel each time, so concurrent
+//     stack file processing wrote go-logging's unsynchronized module level
+//     map and died with "fatal error: concurrent map writes", or with the
+//     read/write variant, because yq reads that same map from every
+//     decoder.
+//   - yqlib.InitExpressionParser lazily assigns yqlib.ExpressionParser
+//     behind a plain nil check, so first evaluations wrote and read that
+//     global at the same time. That one is a pointer write rather than a
+//     map write, so the runtime does not catch it.
+//
+// Run under -race (make test-race) to see this fail without the fix.
+func TestEvaluateYqExpression_ConcurrentCallsAreRaceFree(t *testing.T) {
+	// Leave the level the rest of the package expects to find.
+	defer setYqLogLevel(yqSilentLevel)
+
+	atmosConfig := &schema.AtmosConfiguration{Logs: schema.Logs{Level: "Info"}}
+
+	// Install the level a non-Trace run installs, so the goroutines below
+	// exercise the steady state rather than a first-time transition.
+	configureYqLogger(atmosConfig)
+	require.Equal(t, yqSilentLevel, logging.GetLevel(yqLogModule))
+
+	const goroutines = 32
+	data := map[string]any{"a": map[string]any{"b": "value"}}
+
+	var wg sync.WaitGroup
+	results := make(chan any, goroutines)
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := EvaluateYqExpression(atmosConfig, data, ".a.b")
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- result
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, results, goroutines, "every goroutine must produce a result")
+	for result := range results {
+		assert.Equal(t, "value", result)
+	}
+	assert.Equal(t, yqSilentLevel, logging.GetLevel(yqLogModule),
+		"concurrent evaluation must leave the configured level in place")
 }
 
 // TestEvaluateYqExpression_EdgeCases tests additional edge cases.


### PR DESCRIPTION
Concurrent stack file processing can end an Atmos run with `fatal error: concurrent map writes`. That is a runtime fatal error rather than a panic, so the global handler added in #2334 cannot intercept it and no retry inside Atmos can either. `go test -race` flags the cause on `main` from a 20 line test, and the fix keeps the hot path read-only.

## what

- `configureYqLogger` no longer calls `logging.SetLevel` on every `EvaluateYqExpression` and `EvaluateYqExpressionWithType` call. The default level is installed in `init()`, and later calls rewrite it only when the wanted level is not already installed, under a mutex.
- yq's process-global expression parser is initialized under a `sync.Once` rather than being lazily assigned by every `Evaluate` call.
- Adds `TestEvaluateYqExpression_ConcurrentCallsAreRaceFree`, which fails under `-race` without either change.

## why

Both globals were written on every evaluation, from the per stack file goroutines that `processYAMLConfigFileWithContextInternal` spawns:

- `logging.SetLevel` writes an unsynchronized map inside `go-logging`, and yq reads that same map from every decoder through `Logger.Debugf`. The Go runtime checks concurrent map access, so this is the one that reaches users as a crash.
- `yqlib.InitExpressionParser` assigns the exported global `yqlib.ExpressionParser` behind a plain nil check. That write is a pointer, so the runtime does not catch it and it corrupts quietly instead.

On unmodified `main` at fc4960a the new test reports `Found 2 data race(s)`. With the change, `pkg/utils`, `pkg/yaml/...` and `internal/exec` all pass, the last two unchanged here but sharing the same yq globals.

Two notes for reviewers:

- Installing the level in `init()` is what removes the write entirely for a non-Trace run. `--logs-level Trace` still performs one write on the first transition, which could in principle race a yq read already in flight. Hoisting the call to configuration load would close that as well; I did not want to reach into `pkg/config` uninvited.
- `pkg/yaml/edit.go:71` calls `logging.SetLevel` on every `evaluateWithOptions`, so it writes the same map. I have not measured whether that path runs concurrently, so I left it alone rather than guess. Happy to fold it in here, or to file it separately, whichever you prefer.

Cost: `yqlib.InitExpressionParser` measures about 0.4ms once, and the `sync.Once` keeps that off commands which never evaluate an expression.

## references

- Closes #2821
- #2347 looks like the same class of failure in the same goroutine fan-out, for the shared merged context
- #2334 added the global panic handler that cannot catch this one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when evaluating yq expressions concurrently.
  * Prevented unexpected yq logging changes during parallel evaluations.
  * Ensured expression parsing is initialized consistently before use.

* **Tests**
  * Added coverage for concurrent evaluations, including result consistency and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->