### PR TITLE
fix(config): stop recommending deprecated stacks.name_pattern

### DIFF
--- a/cmd/aws/eks/update_kubeconfig.go
+++ b/cmd/aws/eks/update_kubeconfig.go
@@ -23,7 +23,7 @@ then ` + "`" + `atmos` + "`" + ` executes the command without requiring the ` + 
 
 2. If 'component' and 'stack' are provided on the command-line,
    then ` + "`" + `atmos` + "`" + ` executes the command using the ` + "`" + `atmos.yaml` + "`" + ` CLI config and stack's context by searching for the following settings:
-  - 'components.helmfile.cluster_name_pattern' in the 'atmos.yaml' CLI config (and calculates the '--name' parameter using the pattern)
+  - 'components.helmfile.cluster_name_template' in the 'atmos.yaml' CLI config (and calculates the '--name' parameter using the Go template; the deprecated 'components.helmfile.cluster_name_pattern' token syntax also works)
   - 'components.helmfile.helm_aws_profile_pattern' in the 'atmos.yaml' CLI config (and calculates the ` + "`" + `--profile` + "`" + ` parameter using the pattern)
   - 'components.helmfile.kubeconfig_path' in the 'atmos.yaml' CLI config
   - the variables for the component in the provided stack

--- a/demo/casts/fixtures/basic/atmos.yaml
+++ b/demo/casts/fixtures/basic/atmos.yaml
@@ -12,8 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/demo/casts/fixtures/demo-vendoring/atmos.yaml
+++ b/demo/casts/fixtures/demo-vendoring/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 vendor:
   # Single file
   base_path: "./vendor.yaml"

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -96,7 +96,7 @@ var (
 	ErrNoDocsGenerateEntry                   = errors.New("no docs.generate entry found")
 	ErrMissingDocType                        = errors.New("doc-type argument missing")
 	ErrUnsupportedInputType                  = errors.New("unsupported input type")
-	ErrMissingStackNameTemplateAndPattern    = errors.New("'stacks.name_pattern' or 'stacks.name_template' needs to be specified in 'atmos.yaml'")
+	ErrMissingStackNameTemplateAndPattern    = errors.New("'stacks.name_template' (or the deprecated 'stacks.name_pattern') needs to be specified in 'atmos.yaml'")
 	ErrStackNamePatternPartMissing           = errors.New("stack name pattern references a context part that is not defined in the stack file")
 	ErrFailedMarshalConfigToYaml             = errors.New("failed to marshal config to YAML")
 	ErrStacksDirectoryDoesNotExist           = errors.New("directory for Atmos stacks does not exist")

--- a/examples/caching/atmos.yaml
+++ b/examples/caching/atmos.yaml
@@ -59,8 +59,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/config-profiles/atmos.yaml
+++ b/examples/config-profiles/atmos.yaml
@@ -18,8 +18,7 @@ stacks:
   excluded_paths:
     - "globals/**/*"
     - "catalog/**/*"
-  name_pattern: "{tenant}-{environment}-{stage}"
-
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 # Schemas for validation
 schemas:
   jsonschema:

--- a/examples/custom-components/atmos.yaml
+++ b/examples/custom-components/atmos.yaml
@@ -4,8 +4,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 components:
   script:
     base_path: "components/script"

--- a/examples/demo-atlantis/atmos.yaml
+++ b/examples/demo-atlantis/atmos.yaml
@@ -15,8 +15,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/demo-component-versions/atmos.yaml
+++ b/examples/demo-component-versions/atmos.yaml
@@ -15,8 +15,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 vendor:
   base_path: "./vendor.yaml"
 

--- a/examples/demo-helmfile/atmos.yaml
+++ b/examples/demo-helmfile/atmos.yaml
@@ -22,8 +22,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/demo-stacks/atmos.yaml
+++ b/examples/demo-stacks/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/demo-vendoring/atmos.yaml
+++ b/examples/demo-vendoring/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 vendor:
   # Single file
   base_path: "./vendor.yaml"

--- a/examples/demo-workflows/atmos.yaml
+++ b/examples/demo-workflows/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 workflows:
   base_path: "stacks/workflows"
 

--- a/examples/devcontainer/atmos.yaml
+++ b/examples/devcontainer/atmos.yaml
@@ -73,4 +73,4 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"

--- a/examples/helm/atmos.yaml
+++ b/examples/helm/atmos.yaml
@@ -20,8 +20,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/hooks-checkov/atmos.yaml
+++ b/examples/hooks-checkov/atmos.yaml
@@ -21,8 +21,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/hooks-custom-command/atmos.yaml
+++ b/examples/hooks-custom-command/atmos.yaml
@@ -18,8 +18,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/hooks-infracost/atmos.yaml
+++ b/examples/hooks-infracost/atmos.yaml
@@ -18,8 +18,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/hooks-kics/atmos.yaml
+++ b/examples/hooks-kics/atmos.yaml
@@ -29,8 +29,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/hooks-tflint/atmos.yaml
+++ b/examples/hooks-tflint/atmos.yaml
@@ -18,8 +18,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/hooks-trivy/atmos.yaml
+++ b/examples/hooks-trivy/atmos.yaml
@@ -21,8 +21,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/interactive-workflows/atmos.yaml
+++ b/examples/interactive-workflows/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 workflows:
   base_path: "stacks/workflows"
 

--- a/examples/kubernetes/atmos.yaml
+++ b/examples/kubernetes/atmos.yaml
@@ -21,8 +21,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/kustomize/atmos.yaml
+++ b/examples/kustomize/atmos.yaml
@@ -11,8 +11,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/local-gitops/atmos.yaml
+++ b/examples/local-gitops/atmos.yaml
@@ -37,8 +37,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/onepassword-secrets/atmos.yaml
+++ b/examples/onepassword-secrets/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/quick-start-simple/atmos.yaml
+++ b/examples/quick-start-simple/atmos.yaml
@@ -14,8 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
   file: "/dev/stderr"

--- a/examples/say-something/atmos.yaml
+++ b/examples/say-something/atmos.yaml
@@ -18,8 +18,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   level: Info
 

--- a/examples/scaffolding/atmos.yaml
+++ b/examples/scaffolding/atmos.yaml
@@ -17,8 +17,7 @@ stacks:
   # Path to stack files (relative to base_path).
   base_path: "stacks"
   # Stack naming pattern.
-  name_pattern: "{environment}-{stage}"
-
+  name_template: "{{.vars.environment}}-{{.vars.stage}}"
 # Template configuration.
 templates:
   settings:

--- a/examples/scaffolding/atmos.yaml
+++ b/examples/scaffolding/atmos.yaml
@@ -16,7 +16,7 @@ components:
 stacks:
   # Path to stack files (relative to base_path).
   base_path: "stacks"
-  # Stack naming pattern.
+  # Stack naming template.
   name_template: "{{.vars.environment}}-{{.vars.stage}}"
 # Template configuration.
 templates:

--- a/examples/secrets-masking/atmos.yaml
+++ b/examples/secrets-masking/atmos.yaml
@@ -16,8 +16,7 @@ stacks:
   base_path: stacks
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{tenant}-{environment}-{stage}"
-
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 logs:
   level: Info
 

--- a/examples/sops-secrets/atmos.yaml
+++ b/examples/sops-secrets/atmos.yaml
@@ -23,8 +23,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/examples/toolchain/atmos.yaml
+++ b/examples/toolchain/atmos.yaml
@@ -92,8 +92,7 @@ stacks:
   included_paths:
     - "deploy/**/*"
   excluded_paths: []
-  name_pattern: "{stage}"
-
+  name_template: "{{.vars.stage}}"
 # Workflows configuration
 workflows:
   base_path: "workflows"

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -270,7 +270,7 @@ func resolveStackFromContext(atmosConfig *schema.AtmosConfiguration, kubeconfigC
 				"stage":       kubeconfigContext.Stage,
 			},
 		}
-		return ProcessTmpl(atmosConfig, "name-template-from-context", GetStackNameTemplate(atmosConfig), ctx, false)
+		return ProcessTmpl(atmosConfig, "name-template-from-context", GetStackNameTemplate(atmosConfig), ctx, atmosConfig.Templates.Settings.IgnoreMissingTemplateValues)
 
 	case GetStackNamePattern(atmosConfig) != "":
 		return cfg.GetStackNameFromContextAndStackNamePattern(

--- a/internal/exec/aws_eks_update_kubeconfig.go
+++ b/internal/exec/aws_eks_update_kubeconfig.go
@@ -1,13 +1,13 @@
 package exec
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	log "github.com/cloudposse/atmos/pkg/logger"
@@ -140,17 +140,7 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 				return err
 			}
 
-			if len(GetStackNamePattern(&atmosConfig)) < 1 {
-				return errors.New("stack name pattern must be provided in `stacks.name_pattern` CLI config or `ATMOS_STACKS_NAME_PATTERN` ENV variable")
-			}
-
-			stack, err := cfg.GetStackNameFromContextAndStackNamePattern(
-				kubeconfigContext.Namespace,
-				kubeconfigContext.Tenant,
-				kubeconfigContext.Environment,
-				kubeconfigContext.Stage,
-				GetStackNamePattern(&atmosConfig),
-			)
+			stack, err := resolveStackFromContext(&atmosConfig, &kubeconfigContext)
 			if err != nil {
 				return err
 			}
@@ -264,4 +254,34 @@ func ExecuteAwsEksUpdateKubeconfig(kubeconfigContext schema.AwsEksUpdateKubeconf
 	}
 
 	return nil
+}
+
+// resolveStackFromContext calculates the logical stack name from the namespace/tenant/environment/stage
+// context when no `--stack` was provided on the command line.
+// Precedence: stacks.name_template (Go template) > stacks.name_pattern (deprecated, token-based) > error.
+func resolveStackFromContext(atmosConfig *schema.AtmosConfiguration, kubeconfigContext *schema.AwsEksUpdateKubeconfigContext) (string, error) {
+	switch {
+	case GetStackNameTemplate(atmosConfig) != "":
+		ctx := map[string]any{
+			"vars": map[string]any{
+				"namespace":   kubeconfigContext.Namespace,
+				"tenant":      kubeconfigContext.Tenant,
+				"environment": kubeconfigContext.Environment,
+				"stage":       kubeconfigContext.Stage,
+			},
+		}
+		return ProcessTmpl(atmosConfig, "name-template-from-context", GetStackNameTemplate(atmosConfig), ctx, false)
+
+	case GetStackNamePattern(atmosConfig) != "":
+		return cfg.GetStackNameFromContextAndStackNamePattern(
+			kubeconfigContext.Namespace,
+			kubeconfigContext.Tenant,
+			kubeconfigContext.Environment,
+			kubeconfigContext.Stage,
+			GetStackNamePattern(atmosConfig),
+		)
+
+	default:
+		return "", errUtils.ErrMissingStackNameTemplateAndPattern
+	}
 }

--- a/internal/exec/aws_eks_update_kubeconfig_test.go
+++ b/internal/exec/aws_eks_update_kubeconfig_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -134,11 +135,12 @@ func TestResolveStackFromContext(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		atmosConfig   *schema.AtmosConfiguration
-		expectedStack string
-		expectError   bool
-		expectedErrIs error
+		name                string
+		atmosConfig         *schema.AtmosConfiguration
+		expectedStack       string
+		expectError         bool
+		expectedErrIs       error
+		expectedErrContains string
 	}{
 		{
 			name: "name_template takes precedence and resolves the stack",
@@ -172,7 +174,8 @@ func TestResolveStackFromContext(t *testing.T) {
 					NameTemplate: "{{.vars.tenant}}-{{.vars.region}}",
 				},
 			},
-			expectError: true,
+			expectError:         true,
+			expectedErrContains: "region",
 		},
 		{
 			name: "name_template referencing an undefined var honors ignore_missing_template_values",
@@ -198,6 +201,9 @@ func TestResolveStackFromContext(t *testing.T) {
 				if tt.expectedErrIs != nil {
 					assert.ErrorIs(t, err, tt.expectedErrIs)
 				}
+				if tt.expectedErrContains != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrContains)
+				}
 				return
 			}
 			require.NoError(t, err)
@@ -216,7 +222,7 @@ func TestResolveStackFromContext(t *testing.T) {
 // some error was returned.
 func TestExecuteAwsEksUpdateKubeconfig_ResolvesStackFromNameTemplateContext(t *testing.T) {
 	t.Setenv("ATMOS_CLI_CONFIG_PATH", ".")
-	t.Chdir("../../tests/fixtures/scenarios/complete")
+	t.Chdir(filepath.Join("..", "..", "tests", "fixtures", "scenarios", "complete"))
 
 	ctx := schema.AwsEksUpdateKubeconfigContext{
 		Tenant:      "nonexistent-tenant",

--- a/internal/exec/aws_eks_update_kubeconfig_test.go
+++ b/internal/exec/aws_eks_update_kubeconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -121,6 +122,59 @@ func TestGetStackNamePattern(t *testing.T) {
 			} else {
 				assert.Empty(t, result)
 			}
+		})
+	}
+}
+
+func TestResolveStackFromContext(t *testing.T) {
+	kubeconfigContext := schema.AwsEksUpdateKubeconfigContext{
+		Tenant:      "tenant1",
+		Environment: "ue2",
+		Stage:       "dev",
+	}
+
+	tests := []struct {
+		name          string
+		atmosConfig   *schema.AtmosConfiguration
+		expectedStack string
+		expectError   bool
+	}{
+		{
+			name: "name_template takes precedence and resolves the stack",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stacks: schema.Stacks{
+					NameTemplate: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}",
+					NamePattern:  "{tenant}-{environment}-{stage}",
+				},
+			},
+			expectedStack: "tenant1-ue2-dev",
+		},
+		{
+			name: "deprecated name_pattern still works when name_template is not set",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stacks: schema.Stacks{
+					NamePattern: "{tenant}-{environment}-{stage}",
+				},
+			},
+			expectedStack: "tenant1-ue2-dev",
+		},
+		{
+			name:        "neither name_template nor name_pattern configured",
+			atmosConfig: &schema.AtmosConfiguration{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stack, err := resolveStackFromContext(tt.atmosConfig, &kubeconfigContext)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errUtils.ErrMissingStackNameTemplateAndPattern)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedStack, stack)
 		})
 	}
 }

--- a/internal/exec/aws_eks_update_kubeconfig_test.go
+++ b/internal/exec/aws_eks_update_kubeconfig_test.go
@@ -138,6 +138,7 @@ func TestResolveStackFromContext(t *testing.T) {
 		atmosConfig   *schema.AtmosConfiguration
 		expectedStack string
 		expectError   bool
+		expectedErrIs error
 	}{
 		{
 			name: "name_template takes precedence and resolves the stack",
@@ -159,9 +160,33 @@ func TestResolveStackFromContext(t *testing.T) {
 			expectedStack: "tenant1-ue2-dev",
 		},
 		{
-			name:        "neither name_template nor name_pattern configured",
-			atmosConfig: &schema.AtmosConfiguration{},
+			name:          "neither name_template nor name_pattern configured",
+			atmosConfig:   &schema.AtmosConfiguration{},
+			expectError:   true,
+			expectedErrIs: errUtils.ErrMissingStackNameTemplateAndPattern,
+		},
+		{
+			name: "name_template referencing an undefined var errors when ignore_missing_template_values is false",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stacks: schema.Stacks{
+					NameTemplate: "{{.vars.tenant}}-{{.vars.region}}",
+				},
+			},
 			expectError: true,
+		},
+		{
+			name: "name_template referencing an undefined var honors ignore_missing_template_values",
+			atmosConfig: &schema.AtmosConfiguration{
+				Stacks: schema.Stacks{
+					NameTemplate: "{{.vars.tenant}}-{{.vars.region}}",
+				},
+				Templates: schema.Templates{
+					Settings: schema.TemplatesSettings{
+						IgnoreMissingTemplateValues: true,
+					},
+				},
+			},
+			expectedStack: "tenant1-<no value>",
 		},
 	}
 
@@ -170,7 +195,9 @@ func TestResolveStackFromContext(t *testing.T) {
 			stack, err := resolveStackFromContext(tt.atmosConfig, &kubeconfigContext)
 			if tt.expectError {
 				require.Error(t, err)
-				assert.ErrorIs(t, err, errUtils.ErrMissingStackNameTemplateAndPattern)
+				if tt.expectedErrIs != nil {
+					assert.ErrorIs(t, err, tt.expectedErrIs)
+				}
 				return
 			}
 			require.NoError(t, err)

--- a/internal/exec/aws_eks_update_kubeconfig_test.go
+++ b/internal/exec/aws_eks_update_kubeconfig_test.go
@@ -206,6 +206,30 @@ func TestResolveStackFromContext(t *testing.T) {
 	}
 }
 
+// TestExecuteAwsEksUpdateKubeconfig_ResolvesStackFromNameTemplateContext covers the call site in
+// ExecuteAwsEksUpdateKubeconfig that invokes resolveStackFromContext when no `--stack` flag was
+// given. It uses the `complete` fixture, whose atmos.yaml configures `stacks.name_template:
+// "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"`. Passing a tenant that doesn't match
+// any real stack lets us assert on the exact templated stack name embedded in the resulting
+// "component not found" error, proving the namespace/tenant/environment/stage context was
+// actually rendered through name_template and threaded into stack processing -- not just that
+// some error was returned.
+func TestExecuteAwsEksUpdateKubeconfig_ResolvesStackFromNameTemplateContext(t *testing.T) {
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", ".")
+	t.Chdir("../../tests/fixtures/scenarios/complete")
+
+	ctx := schema.AwsEksUpdateKubeconfigContext{
+		Tenant:      "nonexistent-tenant",
+		Environment: "ue2",
+		Stage:       "dev",
+		Component:   "infra/vpc",
+	}
+
+	err := ExecuteAwsEksUpdateKubeconfig(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-tenant-ue2-dev")
+}
+
 func TestExecuteAwsEksUpdateKubeconfig_WithRequiredParams(t *testing.T) {
 	// Test with all required parameters provided (profile and cluster name).
 	// With DryRun=true, the function should succeed without actually calling AWS CLI.

--- a/internal/exec/spacelift_utils.go
+++ b/internal/exec/spacelift_utils.go
@@ -23,63 +23,111 @@ func BuildSpaceliftStackName(spaceliftSettings map[string]any, context schema.Co
 	}
 }
 
+// SpaceliftStackNaming bundles the two (mutually preferred) stack-naming schemes so callers that
+// need to resolve a stack's logical name don't have to pass them as separate positional arguments.
+type SpaceliftStackNaming struct {
+	// NameTemplate is `stacks.name_template` (Go template, recommended).
+	NameTemplate string
+	// NamePattern is `stacks.name_pattern` (deprecated, token-based). Only consulted when
+	// NameTemplate is empty.
+	NamePattern string
+}
+
+// ResolveSpaceliftContextPrefix computes the logical stack name (context prefix) used for
+// Spacelift stack naming. Precedence: naming.NameTemplate (Go template, recommended) >
+// naming.NamePattern (deprecated, token-based) > the raw stack name. Callers decide which of the
+// two configured naming schemes (if any) applies — e.g. explicit-file-path invocations
+// intentionally pass an empty SpaceliftStackNaming to preserve raw path-based naming.
+func ResolveSpaceliftContextPrefix(
+	atmosConfig *schema.AtmosConfiguration,
+	stackName string,
+	context *schema.Context,
+	componentVars map[string]any,
+	naming SpaceliftStackNaming,
+) (string, error) {
+	defer perf.Track(atmosConfig, "exec.ResolveSpaceliftContextPrefix")()
+
+	switch {
+	case naming.NameTemplate != "":
+		return ProcessTmpl(
+			atmosConfig,
+			"spacelift-stack-name-template",
+			naming.NameTemplate,
+			map[string]any{cfg.VarsSectionName: componentVars},
+			atmosConfig.Templates.Settings.IgnoreMissingTemplateValues,
+		)
+	case naming.NamePattern != "":
+		return cfg.GetContextPrefix(stackName, *context, naming.NamePattern, stackName)
+	default:
+		return strings.ReplaceAll(stackName, "/", "-"), nil
+	}
+}
+
+// buildSpaceliftStackNameForComponent resolves a single Terraform component's Spacelift stack name.
+func buildSpaceliftStackNameForComponent(
+	atmosConfig *schema.AtmosConfiguration,
+	stackName string,
+	component string,
+	componentMap map[string]any,
+	naming SpaceliftStackNaming,
+) (string, error) {
+	componentVars := map[string]any{}
+	if i, ok := componentMap["vars"]; ok {
+		componentVars = i.(map[string]any)
+	}
+
+	spaceliftSettings := map[string]any{}
+	if i, ok := componentMap["settings"]; ok {
+		componentSettings := i.(map[string]any)
+		if i2, ok2 := componentSettings["spacelift"]; ok2 {
+			spaceliftSettings = i2.(map[string]any)
+		}
+	}
+
+	context := cfg.GetContextFromVars(componentVars)
+
+	contextPrefix, err := ResolveSpaceliftContextPrefix(atmosConfig, stackName, &context, componentVars, naming)
+	if err != nil {
+		return "", err
+	}
+
+	context.Component = component
+
+	spaceliftStackName, _, err := BuildSpaceliftStackName(spaceliftSettings, context, contextPrefix)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ReplaceAll(spaceliftStackName, "/", "-"), nil
+}
+
 // BuildSpaceliftStackNames builds Spacelift stack names.
-func BuildSpaceliftStackNames(stacks map[string]any, stackNamePattern string) ([]string, error) {
-	defer perf.Track(nil, "exec.BuildSpaceliftStackNames")()
+func BuildSpaceliftStackNames(atmosConfig *schema.AtmosConfiguration, stacks map[string]any, naming SpaceliftStackNaming) ([]string, error) {
+	defer perf.Track(atmosConfig, "exec.BuildSpaceliftStackNames")()
 
 	var allStackNames []string
 
 	for stackName, stackConfig := range stacks {
 		config := stackConfig.(map[string]any)
 
-		if i, ok := config["components"]; ok {
-			componentsSection := i.(map[string]any)
+		i, ok := config["components"]
+		if !ok {
+			continue
+		}
+		componentsSection := i.(map[string]any)
 
-			if terraformComponents, ok := componentsSection["terraform"]; ok {
-				terraformComponentsMap := terraformComponents.(map[string]any)
+		terraformComponents, ok := componentsSection["terraform"]
+		if !ok {
+			continue
+		}
+		terraformComponentsMap := terraformComponents.(map[string]any)
 
-				for component, v := range terraformComponentsMap {
-					componentMap := v.(map[string]any)
-					componentVars := map[string]any{}
-					spaceliftSettings := map[string]any{}
-
-					if i, ok2 := componentMap["vars"]; ok2 {
-						componentVars = i.(map[string]any)
-					}
-
-					componentSettings := map[string]any{}
-					if i, ok2 := componentMap["settings"]; ok2 {
-						componentSettings = i.(map[string]any)
-					}
-
-					if i, ok2 := componentSettings["spacelift"]; ok2 {
-						spaceliftSettings = i.(map[string]any)
-					}
-
-					context := cfg.GetContextFromVars(componentVars)
-
-					var contextPrefix string
-					var err error
-
-					if stackNamePattern != "" {
-						contextPrefix, err = cfg.GetContextPrefix(stackName, context, stackNamePattern, stackName)
-						if err != nil {
-							return nil, err
-						}
-					} else {
-						contextPrefix = strings.Replace(stackName, "/", "-", -1)
-					}
-
-					context.Component = component
-
-					spaceliftStackName, _, err := BuildSpaceliftStackName(spaceliftSettings, context, contextPrefix)
-					if err != nil {
-						return nil, err
-					}
-
-					allStackNames = append(allStackNames, strings.Replace(spaceliftStackName, "/", "-", -1))
-				}
+		for component, v := range terraformComponentsMap {
+			spaceliftStackName, err := buildSpaceliftStackNameForComponent(atmosConfig, stackName, component, v.(map[string]any), naming)
+			if err != nil {
+				return nil, err
 			}
+			allStackNames = append(allStackNames, spaceliftStackName)
 		}
 	}
 

--- a/internal/exec/spacelift_utils_test.go
+++ b/internal/exec/spacelift_utils_test.go
@@ -1,0 +1,88 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+func TestResolveSpaceliftContextPrefix(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	context := schema.Context{Tenant: "tenant1", Environment: "ue2", Stage: "dev"}
+	componentVars := map[string]any{"tenant": "tenant1", "environment": "ue2", "stage": "dev"}
+
+	tests := []struct {
+		name          string
+		nameTemplate  string
+		namePattern   string
+		expectedStack string
+	}{
+		{
+			name:          "name_template takes precedence",
+			nameTemplate:  "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}",
+			namePattern:   "{tenant}-{environment}-{stage}",
+			expectedStack: "tenant1-ue2-dev",
+		},
+		{
+			name:          "deprecated name_pattern still works when name_template is not set",
+			namePattern:   "{tenant}-{environment}-{stage}",
+			expectedStack: "tenant1-ue2-dev",
+		},
+		{
+			name:          "neither configured falls back to the raw stack name",
+			expectedStack: "orgs-cp-tenant1-dev-us-east-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			naming := SpaceliftStackNaming{NameTemplate: tt.nameTemplate, NamePattern: tt.namePattern}
+			result, err := ResolveSpaceliftContextPrefix(atmosConfig, "orgs/cp/tenant1/dev/us-east-2", &context, componentVars, naming)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedStack, result)
+		})
+	}
+}
+
+func TestBuildSpaceliftStackNames(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	stacks := map[string]any{
+		"orgs/cp/tenant1/dev/us-east-2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"infra-vpc": map[string]any{
+						"vars": map[string]any{
+							"tenant":      "tenant1",
+							"environment": "ue2",
+							"stage":       "dev",
+						},
+						"settings": map[string]any{},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("name_template resolves logical stack names", func(t *testing.T) {
+		naming := SpaceliftStackNaming{NameTemplate: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"}
+		names, err := BuildSpaceliftStackNames(atmosConfig, stacks, naming)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tenant1-ue2-dev-infra-vpc"}, names)
+	})
+
+	t.Run("deprecated name_pattern still resolves logical stack names", func(t *testing.T) {
+		naming := SpaceliftStackNaming{NamePattern: "{tenant}-{environment}-{stage}"}
+		names, err := BuildSpaceliftStackNames(atmosConfig, stacks, naming)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tenant1-ue2-dev-infra-vpc"}, names)
+	})
+
+	t.Run("neither configured falls back to raw stack name", func(t *testing.T) {
+		names, err := BuildSpaceliftStackNames(atmosConfig, stacks, SpaceliftStackNaming{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"orgs-cp-tenant1-dev-us-east-2-infra-vpc"}, names)
+	})
+}

--- a/internal/exec/spacelift_utils_test.go
+++ b/internal/exec/spacelift_utils_test.go
@@ -86,3 +86,96 @@ func TestBuildSpaceliftStackNames(t *testing.T) {
 		assert.Equal(t, []string{"orgs-cp-tenant1-dev-us-east-2-infra-vpc"}, names)
 	})
 }
+
+func TestBuildSpaceliftStackNames_ComponentLevelSpaceliftSettingsOverride(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	stacks := map[string]any{
+		"orgs/cp/tenant1/dev/us-east-2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"infra-vpc": map[string]any{
+						"vars": map[string]any{
+							"tenant":      "tenant1",
+							"environment": "ue2",
+							"stage":       "dev",
+						},
+						"settings": map[string]any{
+							"spacelift": map[string]any{
+								"stack_name": "custom-explicit-stack-name",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	names, err := BuildSpaceliftStackNames(atmosConfig, stacks, SpaceliftStackNaming{NamePattern: "{tenant}-{environment}-{stage}"})
+	require.NoError(t, err)
+	// A component-level `settings.spacelift.stack_name` overrides the computed context
+	// prefix entirely. This confirms buildSpaceliftStackNameForComponent actually reads
+	// componentMap["settings"]["spacelift"] instead of always falling back to the
+	// naming-derived default.
+	assert.Equal(t, []string{"custom-explicit-stack-name"}, names)
+}
+
+func TestBuildSpaceliftStackNames_NameTemplateErrorPropagates(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	stacks := map[string]any{
+		"orgs/cp/tenant1/dev/us-east-2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"infra-vpc": map[string]any{
+						"vars": map[string]any{
+							"tenant": "tenant1",
+						},
+						"settings": map[string]any{},
+					},
+				},
+			},
+		},
+	}
+
+	naming := SpaceliftStackNaming{NameTemplate: "{{.vars.environment}}"}
+	names, err := BuildSpaceliftStackNames(atmosConfig, stacks, naming)
+	// The component's `vars` doesn't define `environment`, so the template execution
+	// must fail loudly (missingkey=error) instead of silently producing a wrong or
+	// empty stack name, and BuildSpaceliftStackNames must forward that error rather
+	// than swallowing it.
+	require.Error(t, err)
+	assert.Nil(t, names)
+	assert.Contains(t, err.Error(), "environment")
+}
+
+func TestBuildSpaceliftStackNames_SkipsStacksWithoutTerraformComponents(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	stacks := map[string]any{
+		"stack-without-components": map[string]any{},
+		"stack-without-terraform": map[string]any{
+			"components": map[string]any{
+				"helmfile": map[string]any{},
+			},
+		},
+		"stack-with-terraform": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"infra-vpc": map[string]any{
+						"vars": map[string]any{
+							"tenant":      "tenant1",
+							"environment": "ue2",
+							"stage":       "dev",
+						},
+						"settings": map[string]any{},
+					},
+				},
+			},
+		},
+	}
+
+	names, err := BuildSpaceliftStackNames(atmosConfig, stacks, SpaceliftStackNaming{})
+	require.NoError(t, err)
+	// Stacks missing a `components` section, or missing a `components.terraform`
+	// section (e.g. helmfile-only stacks), are silently skipped rather than causing a
+	// type-assertion panic or contributing a spurious name.
+	assert.Equal(t, []string{"stack-with-terraform-infra-vpc"}, names)
+}

--- a/pkg/config/profile_stacks_discovery_test.go
+++ b/pkg/config/profile_stacks_discovery_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestInitCliConfig_ProfileMergedStacksSettingsUsedDuringDiscovery reproduces
+// https://github.com/cloudposse/atmos/issues/2827: `atmos describe config --profile test`
+// reports the profile-merged `stacks.base_path`/`included_paths`, but commands that
+// discover stacks (processStacks=true, e.g. `atmos list dependencies`) failed to find
+// any stack manifests under those very same profile-supplied settings.
+func TestInitCliConfig_ProfileMergedStacksSettingsUsedDuringDiscovery(t *testing.T) {
+	setupTestAdapters()
+
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	t.Setenv("TEST_GIT_ROOT", tempDir)
+	require.NoError(t, os.Unsetenv("ATMOS_PROFILE"))
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "profiles", "test"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "profile-stacks", "deploy"), 0o755))
+
+	// Base atmos.yaml intentionally defines NO `stacks:` section at all — every
+	// stack-discovery setting comes from the profile, exactly as in the issue repro.
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "atmos.yaml"), []byte(`
+base_path: .
+profiles:
+  base_path: profiles
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "profiles", "test", "atmos.yaml"), []byte(`
+stacks:
+  base_path: profile-stacks
+  included_paths:
+    - "deploy/**/*.yaml"
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "profile-stacks", "deploy", "dev.yaml"), []byte(`
+vars:
+  stage: dev
+
+components:
+  terraform:
+    app:
+      metadata:
+        component: app
+      dependencies:
+        components:
+          - component: database
+    database:
+      metadata:
+        component: database
+`), 0o644))
+
+	// Mirrors `atmos describe config --profile test`: processStacks=false, never
+	// exercises stack discovery.
+	describeConfigInfo := schema.ConfigAndStacksInfo{ProfilesFromArg: []string{"test"}}
+	describeCfg, err := InitCliConfig(describeConfigInfo, false)
+	require.NoError(t, err)
+	require.Equal(t, "profile-stacks", describeCfg.Stacks.BasePath,
+		"precondition: describe config should report the profile-merged stacks.base_path")
+	require.Equal(t, []string{"deploy/**/*.yaml"}, describeCfg.Stacks.IncludedPaths,
+		"precondition: describe config should report the profile-merged stacks.included_paths")
+
+	// Mirrors `atmos list dependencies --profile test --stack dev`: processStacks=true,
+	// which must discover stack manifests using the same profile-merged settings.
+	listDepsInfo := schema.ConfigAndStacksInfo{
+		ProfilesFromArg: []string{"test"},
+		Stack:           "dev",
+	}
+	listDepsCfg, err := InitCliConfig(listDepsInfo, true)
+	require.NoError(t, err,
+		"list dependencies should discover the stack using the same profile-merged stacks "+
+			"config that describe config reports")
+	require.NotEmpty(t, listDepsCfg.StackConfigFilesAbsolutePaths,
+		"stack discovery should find dev.yaml under the profile-merged base_path/included_paths")
+	assert.Contains(t, filepath.ToSlash(listDepsCfg.StackConfigFilesAbsolutePaths[0]),
+		"profile-stacks/deploy/dev.yaml")
+}

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -840,8 +840,7 @@ func GetContextFromVars(vars map[string]any) schema.Context {
 // GetContextPrefix calculates context prefix from the context.
 func GetContextPrefix(stack string, context schema.Context, stackNamePattern string, stackFile string) (string, error) {
 	if len(stackNamePattern) == 0 {
-		return "",
-			errors.New("stack name pattern must be provided in 'stacks.name_pattern' config or 'ATMOS_STACKS_NAME_PATTERN' ENV variable")
+		return "", errUtils.ErrMissingStackNameTemplateAndPattern
 	}
 
 	contextPrefix := ""
@@ -921,8 +920,7 @@ func GetStackNameFromContextAndStackNamePattern(
 	stackNamePattern string,
 ) (string, error) {
 	if len(stackNamePattern) == 0 {
-		return "",
-			fmt.Errorf("stack name pattern must be provided")
+		return "", errUtils.ErrMissingStackNameTemplateAndPattern
 	}
 
 	var stack string

--- a/pkg/config/utils_additional_test.go
+++ b/pkg/config/utils_additional_test.go
@@ -459,7 +459,7 @@ func TestGetContextPrefix(t *testing.T) {
 			stackNamePattern: "",
 			stackFile:        "stacks/test.yaml",
 			expectError:      true,
-			errorContains:    "stack name pattern must be provided",
+			errorContains:    "needs to be specified",
 		},
 		{
 			name:             "missing namespace",
@@ -658,7 +658,7 @@ func TestGetStackNameFromContextAndStackNamePattern(t *testing.T) {
 			stage:            "prod",
 			stackNamePattern: "",
 			expectError:      true,
-			errorContains:    "stack name pattern must be provided",
+			errorContains:    "needs to be specified",
 		},
 		{
 			name:             "missing namespace",

--- a/pkg/helmfile/cluster.go
+++ b/pkg/helmfile/cluster.go
@@ -104,6 +104,7 @@ func ResolveClusterName(
 	}
 
 	// No cluster name source configured.
-	return nil, fmt.Errorf("%w: use --cluster-name flag, or configure cluster_name, cluster_name_template, or cluster_name_pattern",
+	return nil, fmt.Errorf("%w: use --cluster-name flag, or configure cluster_name or cluster_name_template "+
+		"(the deprecated cluster_name_pattern also works, but cluster_name_template is recommended)",
 		errUtils.ErrMissingHelmfileClusterName)
 }

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -334,12 +334,16 @@ func TransformStackConfigToSpaceliftStacks(
 						if stackComponentSettingsDependsOnContext.Stage == "" {
 							stackComponentSettingsDependsOnContext.Stage = context.Stage
 						}
+						if stackComponentSettingsDependsOnContext.Region == "" {
+							stackComponentSettingsDependsOnContext.Region = context.Region
+						}
 
 						dependsOnVars := map[string]any{
 							"namespace":   stackComponentSettingsDependsOnContext.Namespace,
 							"tenant":      stackComponentSettingsDependsOnContext.Tenant,
 							"environment": stackComponentSettingsDependsOnContext.Environment,
 							"stage":       stackComponentSettingsDependsOnContext.Stage,
+							"region":      stackComponentSettingsDependsOnContext.Region,
 						}
 						contextPrefixDependsOn, err := e.ResolveSpaceliftContextPrefix(
 							atmosConfig,

--- a/pkg/spacelift/spacelift_stack_processor.go
+++ b/pkg/spacelift/spacelift_stack_processor.go
@@ -50,10 +50,14 @@ func CreateSpaceliftStacks(
 			return nil, err
 		}
 
+		// Explicit file paths bypass base_path discovery entirely, so — matching legacy
+		// behavior — stacks are identified by their raw file path rather than a
+		// name_template/name_pattern-resolved logical name.
 		return TransformStackConfigToSpaceliftStacks(
 			&atmosConfig,
 			stacks,
 			stackConfigPathTemplate,
+			"",
 			"",
 			processImports,
 			rawStackConfigs,
@@ -79,6 +83,7 @@ func CreateSpaceliftStacks(
 			&atmosConfig,
 			stacks,
 			stackConfigPathTemplate,
+			e.GetStackNameTemplate(&atmosConfig),
 			e.GetStackNamePattern(&atmosConfig),
 			processImports,
 			rawStackConfigs,
@@ -91,6 +96,7 @@ func TransformStackConfigToSpaceliftStacks(
 	atmosConfig *schema.AtmosConfiguration,
 	stacks map[string]any,
 	stackConfigPathTemplate string,
+	stackNameTemplate string,
 	stackNamePattern string,
 	processImports bool,
 	rawStackConfigs map[string]map[string]any,
@@ -98,7 +104,9 @@ func TransformStackConfigToSpaceliftStacks(
 	var err error
 	res := map[string]any{}
 
-	allStackNames, err := e.BuildSpaceliftStackNames(stacks, stackNamePattern)
+	stackNaming := e.SpaceliftStackNaming{NameTemplate: stackNameTemplate, NamePattern: stackNamePattern}
+
+	allStackNames, err := e.BuildSpaceliftStackNames(atmosConfig, stacks, stackNaming)
 	if err != nil {
 		return nil, err
 	}
@@ -182,15 +190,9 @@ func TransformStackConfigToSpaceliftStacks(
 					context.Component = component
 					context.BaseComponent = baseComponentName
 
-					var contextPrefix string
-
-					if stackNamePattern != "" {
-						contextPrefix, err = cfg.GetContextPrefix(stackName, context, stackNamePattern, stackName)
-						if err != nil {
-							return nil, err
-						}
-					} else {
-						contextPrefix = strings.Replace(stackName, "/", "-", -1)
+					contextPrefix, err := e.ResolveSpaceliftContextPrefix(atmosConfig, stackName, &context, componentVars, stackNaming)
+					if err != nil {
+						return nil, err
 					}
 
 					spaceliftConfig[cfg.ComponentSectionName] = component
@@ -333,20 +335,21 @@ func TransformStackConfigToSpaceliftStacks(
 							stackComponentSettingsDependsOnContext.Stage = context.Stage
 						}
 
-						var contextPrefixDependsOn string
-
-						if stackNamePattern != "" {
-							contextPrefixDependsOn, err = cfg.GetContextPrefix(
-								stackName,
-								stackComponentSettingsDependsOnContext,
-								stackNamePattern,
-								stackName,
-							)
-							if err != nil {
-								return nil, err
-							}
-						} else {
-							contextPrefixDependsOn = strings.Replace(stackName, "/", "-", -1)
+						dependsOnVars := map[string]any{
+							"namespace":   stackComponentSettingsDependsOnContext.Namespace,
+							"tenant":      stackComponentSettingsDependsOnContext.Tenant,
+							"environment": stackComponentSettingsDependsOnContext.Environment,
+							"stage":       stackComponentSettingsDependsOnContext.Stage,
+						}
+						contextPrefixDependsOn, err := e.ResolveSpaceliftContextPrefix(
+							atmosConfig,
+							stackName,
+							&stackComponentSettingsDependsOnContext,
+							dependsOnVars,
+							stackNaming,
+						)
+						if err != nil {
+							return nil, err
 						}
 
 						spaceliftStackNameDependsOn, err := e.BuildDependentStackNameFromDependsOn(
@@ -383,9 +386,10 @@ func TransformStackConfigToSpaceliftStacks(
 					if !u.MapKeyExists(res, spaceliftStackNameKey) {
 						res[spaceliftStackNameKey] = spaceliftConfig
 					} else {
-						errorMessage := fmt.Sprintf("\nDuplicate Spacelift stack name '%s' for component '%s' in the stack '%s'."+
-							"\nCheck if the component name is correct and the Spacelift stack name pattern 'stack_name_pattern=%s' is specific enough."+
-							"\nDid you specify the correct context tokens {namespace}, {tenant}, {environment}, {stage}, {component}?",
+						errorMessage := fmt.Sprintf(
+							"\nDuplicate Spacelift stack name '%s' for component '%s' in the stack '%s'."+
+								"\nCheck if the component name is correct and the Spacelift stack name pattern 'stack_name_pattern=%s' is specific enough."+
+								"\nDid you specify the correct context tokens {namespace}, {tenant}, {environment}, {stage}, {component}?",
 							spaceliftStackName,
 							component,
 							stackName,

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -251,7 +251,7 @@ func TestTransformStackConfigToSpaceliftStacks_DuplicateStackName(t *testing.T) 
 	assert.Contains(t, err.Error(), "dup-stack")
 }
 
-func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateMissingVar(t *testing.T) {
+func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateResolvesRegion(t *testing.T) {
 	atmosConfig := &schema.AtmosConfiguration{}
 
 	stacks := map[string]any{
@@ -288,16 +288,19 @@ func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateMissingVar(t
 		},
 	}
 
-	// name_template references `.vars.region`, which is present in each component's own
-	// `vars` (so the component's own stack-name resolution succeeds), but the
-	// `settings.depends_on` resolution only ever synthesizes namespace/tenant/environment/
-	// stage for the referenced component -- it never carries a "region" key. That asymmetry
-	// means a name_template referencing anything outside those four tokens fails specifically
-	// while resolving a `depends_on` entry, even though the identical template renders fine
-	// for the component's own stack name a few lines earlier in the same function.
+	// name_template references `.vars.region`. The `settings.depends_on` resolution path
+	// defaults namespace/tenant/environment/stage/region from the *depending* component's
+	// own context (comp1) when the depends_on entry doesn't declare them explicitly, so the
+	// template renders successfully for the depends_on label too, not just the component's
+	// own stack name.
 	stackNameTemplate := "{{.vars.tenant}}-{{.vars.region}}"
 
-	_, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", stackNameTemplate, "", false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "region")
+	result, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", stackNameTemplate, "", false, nil)
+	require.NoError(t, err)
+
+	comp1, ok := result["tenant1-us-east-2-comp1"].(map[string]any)
+	require.True(t, ok, "expected comp1's Spacelift stack config to be present")
+	labels, ok := comp1["labels"].([]string)
+	require.True(t, ok, "expected comp1's labels to be a []string")
+	assert.Contains(t, labels, "depends-on:tenant1-us-east-2-comp2")
 }

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/cloudposse/atmos/pkg/schema"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
@@ -202,4 +204,100 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestTransformStackConfigToSpaceliftStacks_DuplicateStackName(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	// Two different stacks, each with a component whose `settings.spacelift.stack_name`
+	// explicitly resolves to the same literal name -- this must be rejected rather than
+	// silently overwriting the first stack's config.
+	stacks := map[string]any{
+		"stackA": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"compA": map[string]any{
+						"vars": map[string]any{},
+						"settings": map[string]any{
+							"spacelift": map[string]any{
+								"workspace_enabled": true,
+								"stack_name":        "dup-stack",
+							},
+						},
+					},
+				},
+			},
+		},
+		"stackB": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"compB": map[string]any{
+						"vars": map[string]any{},
+						"settings": map[string]any{
+							"spacelift": map[string]any{
+								"workspace_enabled": true,
+								"stack_name":        "dup-stack",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", "", "", false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Duplicate Spacelift stack name")
+	assert.Contains(t, err.Error(), "dup-stack")
+}
+
+func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateMissingVar(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+
+	stacks := map[string]any{
+		"orgs/cp/tenant1/dev/us-east-2": map[string]any{
+			"components": map[string]any{
+				"terraform": map[string]any{
+					"comp1": map[string]any{
+						"vars": map[string]any{
+							"tenant":      "tenant1",
+							"environment": "ue2",
+							"stage":       "dev",
+							"region":      "us-east-2",
+						},
+						"settings": map[string]any{
+							"spacelift": map[string]any{"workspace_enabled": true},
+							"depends_on": map[string]any{
+								"1": map[string]any{"component": "comp2"},
+							},
+						},
+					},
+					"comp2": map[string]any{
+						"vars": map[string]any{
+							"tenant":      "tenant1",
+							"environment": "ue2",
+							"stage":       "dev",
+							"region":      "us-east-2",
+						},
+						"settings": map[string]any{
+							"spacelift": map[string]any{"workspace_enabled": true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// name_template references `.vars.region`, which is present in each component's own
+	// `vars` (so the component's own stack-name resolution succeeds), but the
+	// `settings.depends_on` resolution only ever synthesizes namespace/tenant/environment/
+	// stage for the referenced component -- it never carries a "region" key. That asymmetry
+	// means a name_template referencing anything outside those four tokens fails specifically
+	// while resolving a `depends_on` entry, even though the identical template renders fine
+	// for the component's own stack name a few lines earlier in the same function.
+	stackNameTemplate := "{{.vars.tenant}}-{{.vars.region}}"
+
+	_, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", stackNameTemplate, "", false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region")
 }

--- a/pkg/spacelift/spacelift_stack_processor_test.go
+++ b/pkg/spacelift/spacelift_stack_processor_test.go
@@ -272,12 +272,21 @@ func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateResolvesRegi
 							},
 						},
 					},
+					// comp2 deliberately uses a DIFFERENT region than comp1. If the
+					// depends_on resolution path used comp2's own vars instead of
+					// defaulting from comp1's context, the computed depends-on name
+					// would use "us-west-2" and coincidentally match comp2's own
+					// resolved name -- masking the bug. Using distinct regions forces
+					// the depends-on name to only match if it's genuinely derived from
+					// comp1's context (region "us-east-2"), which comp2 doesn't share,
+					// so the lookup correctly fails and the error content proves which
+					// region was actually used.
 					"comp2": map[string]any{
 						"vars": map[string]any{
 							"tenant":      "tenant1",
 							"environment": "ue2",
 							"stage":       "dev",
-							"region":      "us-east-2",
+							"region":      "us-west-2",
 						},
 						"settings": map[string]any{
 							"spacelift": map[string]any{"workspace_enabled": true},
@@ -291,16 +300,18 @@ func TestTransformStackConfigToSpaceliftStacks_DependsOnNameTemplateResolvesRegi
 	// name_template references `.vars.region`. The `settings.depends_on` resolution path
 	// defaults namespace/tenant/environment/stage/region from the *depending* component's
 	// own context (comp1) when the depends_on entry doesn't declare them explicitly, so the
-	// template renders successfully for the depends_on label too, not just the component's
-	// own stack name.
+	// template renders successfully (no missing-key error) for the depends_on label too,
+	// not just the component's own stack name.
 	stackNameTemplate := "{{.vars.tenant}}-{{.vars.region}}"
 
-	result, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", stackNameTemplate, "", false, nil)
-	require.NoError(t, err)
+	_, err := TransformStackConfigToSpaceliftStacks(atmosConfig, stacks, "stacks/%s.yaml", stackNameTemplate, "", false, nil)
 
-	comp1, ok := result["tenant1-us-east-2-comp1"].(map[string]any)
-	require.True(t, ok, "expected comp1's Spacelift stack config to be present")
-	labels, ok := comp1["labels"].([]string)
-	require.True(t, ok, "expected comp1's labels to be a []string")
-	assert.Contains(t, labels, "depends-on:tenant1-us-east-2-comp2")
+	// comp2's own resolved name is "tenant1-us-west-2-comp2" (its own region), which does
+	// not match "tenant1-us-east-2-comp2" (comp1's region) -- so the depends_on lookup
+	// fails to find a match. That failure, naming the comp1-region-derived stack, is the
+	// proof that region was defaulted from comp1's context and not silently pulled from
+	// comp2's own vars (which would have rendered fine and hidden the distinction).
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant1-us-east-2")
+	assert.NotContains(t, err.Error(), "tenant1-us-west-2")
 }

--- a/tests/fixtures/scenarios/atmos-auth-invalid/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-auth-invalid/atmos.yaml
@@ -23,6 +23,6 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
   included_paths:
     - "**/*"

--- a/tests/fixtures/scenarios/atmos-auth-mock/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-auth-mock/atmos.yaml
@@ -6,7 +6,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # Mock AWS authentication provider for testing purposes only.
 # This provider simulates AWS authentication without requiring real cloud credentials.

--- a/tests/fixtures/scenarios/atmos-auth/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-auth/atmos.yaml
@@ -6,7 +6,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 auth:
   providers:

--- a/tests/fixtures/scenarios/atmos-describe-affected-with-include/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-describe-affected-with-include/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/atmos-functions/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-functions/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/atmos-include-yaml-function/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-include-yaml-function/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/atmos-pro/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-pro/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 templates:
   settings:

--- a/tests/fixtures/scenarios/atmos-template-yaml-function/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-template-yaml-function/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/atmos-terraform-flags/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-terraform-flags/atmos.yaml
@@ -16,7 +16,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/atmos-terraform-state-custom-delimiters/atmos.yaml
+++ b/tests/fixtures/scenarios/atmos-terraform-state-custom-delimiters/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/auth-realm-profile-bug/atmos.yaml
+++ b/tests/fixtures/scenarios/auth-realm-profile-bug/atmos.yaml
@@ -9,7 +9,7 @@ stacks:
   included_paths:
     - "**/*"
   excluded_paths: []
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 
 components:
   terraform:

--- a/tests/fixtures/scenarios/auth-stack-loading-bug/atmos.yaml
+++ b/tests/fixtures/scenarios/auth-stack-loading-bug/atmos.yaml
@@ -9,7 +9,7 @@ stacks:
   included_paths:
     - "**/*"
   excluded_paths: []
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 components:
   terraform:

--- a/tests/fixtures/scenarios/authmanager-nested-propagation/atmos.yaml
+++ b/tests/fixtures/scenarios/authmanager-nested-propagation/atmos.yaml
@@ -13,7 +13,7 @@ stacks:
   included_paths:
     - "**/*"
   excluded_paths: []
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/authmanager-propagation/atmos.yaml
+++ b/tests/fixtures/scenarios/authmanager-propagation/atmos.yaml
@@ -13,7 +13,7 @@ stacks:
   included_paths:
     - "**/*"
   excluded_paths: []
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/aws-secrets-floci/atmos.yaml
+++ b/tests/fixtures/scenarios/aws-secrets-floci/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 stores:
   secrets/ssm:

--- a/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci-inherit/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 templates:
   settings:

--- a/tests/fixtures/scenarios/aws-store-hooks-floci/atmos.yaml
+++ b/tests/fixtures/scenarios/aws-store-hooks-floci/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 templates:
   settings:

--- a/tests/fixtures/scenarios/azure-secrets-floci/atmos.yaml
+++ b/tests/fixtures/scenarios/azure-secrets-floci/atmos.yaml
@@ -9,7 +9,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 stores:
   secrets/azure:

--- a/tests/fixtures/scenarios/basic/atmos.yaml
+++ b/tests/fixtures/scenarios/basic/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/cli-config-path/config/atmos.yaml
+++ b/tests/fixtures/scenarios/cli-config-path/config/atmos.yaml
@@ -25,7 +25,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/completions/atmos.yaml
+++ b/tests/fixtures/scenarios/completions/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
+++ b/tests/fixtures/scenarios/component-list-merge-strategy/atmos.yaml
@@ -21,7 +21,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/component-menu-filtering/atmos.yaml
+++ b/tests/fixtures/scenarios/component-menu-filtering/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/component-path-resolution/atmos.yaml
+++ b/tests/fixtures/scenarios/component-path-resolution/atmos.yaml
@@ -19,7 +19,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/config-profiles-default/atmos.yaml
+++ b/tests/fixtures/scenarios/config-profiles-default/atmos.yaml
@@ -4,7 +4,7 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/config-profiles/atmos.yaml
+++ b/tests/fixtures/scenarios/config-profiles/atmos.yaml
@@ -5,7 +5,7 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/custom-version-flag/atmos.yaml
+++ b/tests/fixtures/scenarios/custom-version-flag/atmos.yaml
@@ -7,7 +7,7 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
   included_paths:
     - "**/*"
 

--- a/tests/fixtures/scenarios/dependencies-components-inheritance-append/atmos.yaml
+++ b/tests/fixtures/scenarios/dependencies-components-inheritance-append/atmos.yaml
@@ -19,7 +19,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/dependencies-components-inheritance/atmos.yaml
+++ b/tests/fixtures/scenarios/dependencies-components-inheritance/atmos.yaml
@@ -17,7 +17,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/devcontainer-basic/atmos.yaml
+++ b/tests/fixtures/scenarios/devcontainer-basic/atmos.yaml
@@ -20,4 +20,4 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"

--- a/tests/fixtures/scenarios/emulator-azure/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-azure/atmos.yaml
@@ -7,7 +7,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/emulator-gcp/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-gcp/atmos.yaml
@@ -7,7 +7,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/emulator-kubernetes/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-kubernetes/atmos.yaml
@@ -7,7 +7,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/emulator-native-aws/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-native-aws/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # A single aws/emulator identity binds every component to the emulator. The
 # provider contributor injects the AWS provider behaviour flags; the identity

--- a/tests/fixtures/scenarios/emulator-openbao/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-openbao/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # The secret store talks to the OpenBao emulator (Vault KV v2 API). A store lives in
 # atmos.yaml (global config, no stack context), so it cannot use the stack-scoped

--- a/tests/fixtures/scenarios/emulator-registry/atmos.yaml
+++ b/tests/fixtures/scenarios/emulator-registry/atmos.yaml
@@ -8,7 +8,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/env-inheritance/atmos.yaml
+++ b/tests/fixtures/scenarios/env-inheritance/atmos.yaml
@@ -16,7 +16,7 @@ stacks:
   excluded_paths:
     - "globals.yaml"
     - "catalog/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   verbose: false

--- a/tests/fixtures/scenarios/env/atmos.yaml
+++ b/tests/fixtures/scenarios/env/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/exit-codes/atmos.yaml
+++ b/tests/fixtures/scenarios/exit-codes/atmos.yaml
@@ -6,7 +6,7 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
   included_paths:
     - "**/*"
 

--- a/tests/fixtures/scenarios/exitCode/atmos.yaml
+++ b/tests/fixtures/scenarios/exitCode/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "stacks/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/flag-inheritance/atmos.yaml
+++ b/tests/fixtures/scenarios/flag-inheritance/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # Custom commands that test flag inheritance
 commands:

--- a/tests/fixtures/scenarios/gcp-secrets-floci/atmos.yaml
+++ b/tests/fixtures/scenarios/gcp-secrets-floci/atmos.yaml
@@ -9,7 +9,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 stores:
   secrets/gcp:

--- a/tests/fixtures/scenarios/global-env/atmos.yaml
+++ b/tests/fixtures/scenarios/global-env/atmos.yaml
@@ -20,7 +20,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/hooks-keychain-test/atmos.yaml
+++ b/tests/fixtures/scenarios/hooks-keychain-test/atmos.yaml
@@ -21,7 +21,7 @@ stacks:
     - "stacks/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/hooks-test/atmos.yaml
+++ b/tests/fixtures/scenarios/hooks-test/atmos.yaml
@@ -18,7 +18,7 @@ stacks:
     - "stacks/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/indentation/atmos.yaml
+++ b/tests/fixtures/scenarios/indentation/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/invalid-manifest-schema/atmos.yaml
+++ b/tests/fixtures/scenarios/invalid-manifest-schema/atmos.yaml
@@ -8,7 +8,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "orgs/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/invalid-stack-yaml-syntax/atmos.yaml
+++ b/tests/fixtures/scenarios/invalid-stack-yaml-syntax/atmos.yaml
@@ -8,7 +8,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "orgs/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/invalid-stacks/atmos.yaml
+++ b/tests/fixtures/scenarios/invalid-stacks/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "orgs/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{namespace}-{tenant}-{stage}"
+  name_template: "{{.vars.namespace}}-{{.vars.tenant}}-{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/merge-type-override/atmos.yaml
+++ b/tests/fixtures/scenarios/merge-type-override/atmos.yaml
@@ -10,4 +10,4 @@ stacks:
     - "orgs/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"

--- a/tests/fixtures/scenarios/metadata/atmos.yaml
+++ b/tests/fixtures/scenarios/metadata/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/native-ci-gha-plan/atmos.yaml
+++ b/tests/fixtures/scenarios/native-ci-gha-plan/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "orgs/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 
 settings:
   experimental: silence

--- a/tests/fixtures/scenarios/native-ci/atmos.yaml
+++ b/tests/fixtures/scenarios/native-ci/atmos.yaml
@@ -58,7 +58,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 settings:
   experimental: silence

--- a/tests/fixtures/scenarios/nested-config-empty-base-path/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/tests/fixtures/scenarios/nested-config-empty-base-path/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -23,7 +23,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/opentofu-module-source-interpolation/atmos.yaml
+++ b/tests/fixtures/scenarios/opentofu-module-source-interpolation/atmos.yaml
@@ -15,7 +15,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/planfile-artifacts-e2e/atmos.yaml
+++ b/tests/fixtures/scenarios/planfile-artifacts-e2e/atmos.yaml
@@ -33,7 +33,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 settings:
   experimental: silence

--- a/tests/fixtures/scenarios/plugin-cache/atmos.yaml
+++ b/tests/fixtures/scenarios/plugin-cache/atmos.yaml
@@ -14,4 +14,4 @@ stacks:
   included_paths:
     - "deploy/**/*"
   excluded_paths: []
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"

--- a/tests/fixtures/scenarios/relative-paths/atmos.yaml
+++ b/tests/fixtures/scenarios/relative-paths/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "orgs/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{namespace}-{tenant}-{stage}"
+  name_template: "{{.vars.namespace}}-{{.vars.tenant}}-{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/secrets-helmfile/atmos.yaml
+++ b/tests/fixtures/scenarios/secrets-helmfile/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/slash-components/atmos.yaml
+++ b/tests/fixtures/scenarios/slash-components/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/sops-kms-floci/atmos.yaml
+++ b/tests/fixtures/scenarios/sops-kms-floci/atmos.yaml
@@ -11,7 +11,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "**/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # A SOPS aws-kms secrets provider. The data key is wrapped with an AWS KMS key, so
 # encrypt/decrypt require AWS credentials. The `identity` here is what issue #2637 is about:

--- a/tests/fixtures/scenarios/source-provisioner-workdir/atmos.yaml
+++ b/tests/fixtures/scenarios/source-provisioner-workdir/atmos.yaml
@@ -37,7 +37,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/source-provisioner/atmos.yaml
+++ b/tests/fixtures/scenarios/source-provisioner/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/stack-auth-defaults/atmos.yaml
+++ b/tests/fixtures/scenarios/stack-auth-defaults/atmos.yaml
@@ -9,7 +9,7 @@ stacks:
   included_paths:
     - "**/*"
   excluded_paths: []
-  name_pattern: "{tenant}-{environment}-{stage}"
+  name_template: "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}"
 
 components:
   terraform:

--- a/tests/fixtures/scenarios/subcommand-alias/atmos.yaml
+++ b/tests/fixtures/scenarios/subcommand-alias/atmos.yaml
@@ -26,7 +26,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/terraform-apply-all-dependencies/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-apply-all-dependencies/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/*.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Debug

--- a/tests/fixtures/scenarios/terraform-output-jit-workdir/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-output-jit-workdir/atmos.yaml
@@ -16,7 +16,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/terraform-state-jit-workdir/atmos.yaml
+++ b/tests/fixtures/scenarios/terraform-state-jit-workdir/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   level: Info

--- a/tests/fixtures/scenarios/toolchain-terraform-integration/atmos.yaml
+++ b/tests/fixtures/scenarios/toolchain-terraform-integration/atmos.yaml
@@ -12,7 +12,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 # Toolchain configuration
 toolchain:

--- a/tests/fixtures/scenarios/top-level-stack-composition-explicit-name/atmos.yaml
+++ b/tests/fixtures/scenarios/top-level-stack-composition-explicit-name/atmos.yaml
@@ -10,4 +10,4 @@ stacks:
     - parents/**/*
   excluded_paths:
     - catalog/**/*
-  name_pattern: "{environment}-{stage}"
+  name_template: "{{.vars.environment}}-{{.vars.stage}}"

--- a/tests/fixtures/scenarios/vendor-creds-sanitize/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor-creds-sanitize/atmos.yaml
@@ -16,4 +16,4 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"

--- a/tests/fixtures/scenarios/vendor-globs/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor-globs/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 vendor:
   # Single file

--- a/tests/fixtures/scenarios/vendor-pulls-ssh/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor-pulls-ssh/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 logs:
   file: "/dev/stderr"
   level: Info

--- a/tests/fixtures/scenarios/vendor-simple-excludes/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor-simple-excludes/atmos.yaml
@@ -10,7 +10,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 components:
   terraform:

--- a/tests/fixtures/scenarios/vendor/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 vendor:
   # Single file

--- a/tests/fixtures/scenarios/vendor2/atmos.yaml
+++ b/tests/fixtures/scenarios/vendor2/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/vendoring-dry-run/atmos.yaml
+++ b/tests/fixtures/scenarios/vendoring-dry-run/atmos.yaml
@@ -14,4 +14,4 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"

--- a/tests/fixtures/scenarios/workdir/atmos.yaml
+++ b/tests/fixtures/scenarios/workdir/atmos.yaml
@@ -15,7 +15,7 @@ stacks:
   base_path: "stacks"
   included_paths:
     - "deploy/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 logs:
   file: "/dev/stderr"

--- a/tests/fixtures/scenarios/workflows/atmos.yaml
+++ b/tests/fixtures/scenarios/workflows/atmos.yaml
@@ -14,7 +14,7 @@ stacks:
     - "deploy/**/*"
   excluded_paths:
     - "**/_defaults.yaml"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 workflows:
   base_path: "stacks/workflows"

--- a/tests/fixtures/scenarios/yaml-functions-circular-deps-mixed/atmos.yaml
+++ b/tests/fixtures/scenarios/yaml-functions-circular-deps-mixed/atmos.yaml
@@ -8,4 +8,4 @@ stacks:
   base_path: "scenarios/yaml-functions-circular-deps-mixed/stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"

--- a/tests/fixtures/scenarios/yaml-functions-circular-deps/atmos.yaml
+++ b/tests/fixtures/scenarios/yaml-functions-circular-deps/atmos.yaml
@@ -8,4 +8,4 @@ stacks:
   base_path: "scenarios/yaml-functions-circular-deps/stacks"
   included_paths:
     - "**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"

--- a/tests/fixtures/scenarios/yaml-functions-in-lists/atmos.yaml
+++ b/tests/fixtures/scenarios/yaml-functions-in-lists/atmos.yaml
@@ -10,7 +10,7 @@ stacks:
     - "**/*"
   excluded_paths:
     - "workflows/**/*"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 
 schemas:
   jsonschema:

--- a/tests/snapshots/TestCLICommands_atmos_describe_config.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_config.stdout.golden
@@ -78,8 +78,8 @@
     "excluded_paths": [
       "**/_defaults.yaml"
     ],
-    "name_pattern": "{stage}",
-    "name_template": "",
+    "name_pattern": "",
+    "name_template": "{{.vars.stage}}",
     "list": {
       "format": "",
       "columns": null

--- a/tests/snapshots/TestCLICommands_atmos_describe_config_-f_yaml.stdout.golden
+++ b/tests/snapshots/TestCLICommands_atmos_describe_config_-f_yaml.stdout.golden
@@ -52,8 +52,8 @@ stacks:
     - deploy/**/*
   excluded_paths:
     - '**/_defaults.yaml'
-  name_pattern: '{stage}'
-  name_template: ""
+  name_pattern: ""
+  name_template: '{{.vars.stage}}'
 logs:
   file: /dev/stderr
   level: Info

--- a/tests/snapshots/TestCLICommands_describe_component_from_nested_dir_discovers_atmos.yaml_in_parent.stdout.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_from_nested_dir_discovers_atmos.yaml_in_parent.stdout.golden
@@ -48,8 +48,8 @@ atmos_cli_config:
     included_paths:
       - '**/*'
     excluded_paths: []
-    name_pattern: '{stage}'
-    name_template: ""
+    name_pattern: ""
+    name_template: '{{.vars.stage}}'
   workflows:
     base_path: ""
     list:
@@ -146,4 +146,3 @@ vars:
   simple_var: simple_value
   stage: test
 workspace: test
-

--- a/tests/snapshots/TestCLICommands_indentation.stdout.golden
+++ b/tests/snapshots/TestCLICommands_indentation.stdout.golden
@@ -51,8 +51,8 @@ stacks:
     included_paths:
         - deploy/**/*
     excluded_paths: []
-    name_pattern: '{stage}'
-    name_template: ""
+    name_pattern: ""
+    name_template: '{{.vars.stage}}'
 logs:
     file: /dev/stderr
     level: Info

--- a/tests/snapshots/TestCLICommands_secrets-masking_describe_config.stdout.golden
+++ b/tests/snapshots/TestCLICommands_secrets-masking_describe_config.stdout.golden
@@ -80,8 +80,8 @@
       "deploy/**/*"
     ],
     "excluded_paths": null,
-    "name_pattern": "{tenant}-{environment}-{stage}",
-    "name_template": "",
+    "name_pattern": "",
+    "name_template": "{{.vars.tenant}}-{{.vars.environment}}-{{.vars.stage}}",
     "list": {
       "format": "",
       "columns": null

--- a/website/docs/cli/commands/aws/eks/update-kubeconfig.mdx
+++ b/website/docs/cli/commands/aws/eks/update-kubeconfig.mdx
@@ -30,7 +30,7 @@ This command downloads kubeconfig from an EKS cluster and saves it to a file. It
 2. **Component and stack**: If `component` and `stack` are provided on the command-line, then Atmos executes the command using the `atmos.yaml` CLI config and stack's context
    by searching for the following settings:
 
-    - `components.helmfile.cluster_name_pattern` in the `atmos.yaml` CLI config (and calculates the `--name` parameter using the pattern)
+    - `components.helmfile.cluster_name_template` in the `atmos.yaml` CLI config (and calculates the `--name` parameter using the Go template; the deprecated `components.helmfile.cluster_name_pattern` token syntax also works)
     - `components.helmfile.helm_aws_profile_pattern` in the `atmos.yaml` CLI config (and calculates the `--profile` parameter using the pattern)
     - `components.helmfile.kubeconfig_path` in the `atmos.yaml` CLI config the variables for the component in the provided stack
     - `region` from the variables for the component in the stack

--- a/website/docs/learn/first-stack.mdx
+++ b/website/docs/learn/first-stack.mdx
@@ -99,7 +99,7 @@ components:
 
 stacks:
   base_path: "stacks"
-  name_pattern: "{stage}"
+  name_template: "{{.vars.stage}}"
 ```
 </File>
 


### PR DESCRIPTION
## what

- `atmos aws eks update-kubeconfig` and Spacelift stack-name generation now check `stacks.name_template` before falling back to the deprecated `stacks.name_pattern`, instead of only supporting the deprecated field.
- Error messages in `pkg/config`, `errors/errors.go`, and `pkg/helmfile/cluster.go` that previously only pointed users at the deprecated fields now recommend `name_template`/`cluster_name_template`.
- The Getting Started tutorial and the `aws eks update-kubeconfig` command help/docs no longer teach the deprecated `name_pattern`/`cluster_name_pattern` fields.
- Converted all `examples/`, `demo/`, and non-backward-compat-test `tests/fixtures` scenarios from `name_pattern` to `name_template` (a handful of fixtures that specifically test the deprecated field, precedence, or backward compatibility were left untouched on purpose).
- Added unit tests covering both the new `name_template` support and continued `name_pattern` backward compatibility for the two code paths that changed.

## why

- Investigating [#2827](https://github.com/cloudposse/atmos/issues/2827) ("profile-merged `stacks` settings are not consistently applied") showed the profile-merge pipeline was already correct and consistent between `describe config` and `list dependencies`.
- The actual bug was that `stacks.name_pattern` — deprecated in favor of `stacks.name_template` — was still treated as the primary/only stack-naming mechanism in a couple of code paths and in several error messages, which is what produced the reported inconsistency and general user confusion about which field to use.
- `name_pattern` continues to work unchanged for backward compatibility; only the recommended path and documentation change.

## references

- Investigates cloudposse/atmos#2827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Go-template support for stack, Spacelift stack, and EKS cluster naming using context variables.
* **Compatibility**
  * Existing pattern-based naming remains supported as a deprecated fallback.
  * Template settings take precedence when both options are configured.
* **Documentation**
  * Updated configuration guidance, examples, and error messages to promote template-based naming.
* **Tests**
  * Added coverage for naming precedence, fallback behavior, template errors, duplicate names, and profile-based stack discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->