### PR TITLE
feat: propagate component execution context

### DIFF
--- a/cmd/ansible/ansible_test.go
+++ b/cmd/ansible/ansible_test.go
@@ -1,6 +1,7 @@
 package ansible
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,10 +11,31 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/cmd/internal"
+	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/flags/preprocess"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
+
+func TestRunVersionFallbackPreservesCommandContext(t *testing.T) {
+	originalGet, originalExecute := getComponentProvider, executeVersionDirect
+	t.Cleanup(func() {
+		getComponentProvider, executeVersionDirect = originalGet, originalExecute
+	})
+	getComponentProvider = func(string) (component.ComponentProvider, bool) { return nil, false }
+
+	type contextKey struct{}
+	want := context.WithValue(context.Background(), contextKey{}, "ansible-version")
+	executeVersionDirect = func(got context.Context, _ *schema.ConfigAndStacksInfo) error {
+		assert.Same(t, want, got)
+		assert.Equal(t, "ansible-version", got.Value(contextKey{}))
+		return nil
+	}
+
+	command := &cobra.Command{Use: "version"}
+	command.SetContext(want)
+	require.NoError(t, runVersion(command, nil))
+}
 
 func initAnsibleCommandTest(t *testing.T) {
 	t.Helper()

--- a/cmd/ansible/playbook.go
+++ b/cmd/ansible/playbook.go
@@ -60,6 +60,7 @@ func runPlaybook(cmd *cobra.Command, args []string) error {
 
 	// Build execution context for the component provider.
 	ctx := &component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       "ansible",
 		Component:           info.ComponentFromArg,
 		Stack:               info.Stack,

--- a/cmd/ansible/version.go
+++ b/cmd/ansible/version.go
@@ -47,6 +47,7 @@ func runVersion(cmd *cobra.Command, _ []string) error {
 
 	// Build execution context for the component provider.
 	ctx := &component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       "ansible",
 		Command:             "ansible",
 		SubCommand:          "version",

--- a/cmd/ansible/version.go
+++ b/cmd/ansible/version.go
@@ -3,6 +3,8 @@
 package ansible
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -10,6 +12,13 @@ import (
 	ansibleComp "github.com/cloudposse/atmos/pkg/component/ansible"
 	"github.com/cloudposse/atmos/pkg/flags"
 	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+var (
+	getComponentProvider = component.GetProvider
+	executeVersionDirect = func(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
+		return ansibleComp.ExecuteVersion(ctx, info)
+	}
 )
 
 // versionCmd represents the `atmos ansible version` command.
@@ -39,10 +48,10 @@ func runVersion(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Get the ansible component provider from the registry.
-	provider, ok := component.GetProvider("ansible")
+	provider, ok := getComponentProvider("ansible")
 	if !ok {
 		// Fallback to direct execution if provider not found.
-		return ansibleComp.ExecuteVersion(&configAndStacksInfo)
+		return executeVersionDirect(cmd.Context(), &configAndStacksInfo)
 	}
 
 	// Build execution context for the component provider.

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -176,6 +176,7 @@ func runVerb(cmd *cobra.Command, subCommand string, args []string) error {
 	info := initConfigAndStacksInfo(cmd, subCommand, args)
 	provider := component.MustGetProvider(cfg.ContainerComponentType)
 	return provider.Execute(&component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       cfg.ContainerComponentType,
 		Component:           info.ComponentFromArg,
 		Stack:               info.Stack,

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"context"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -163,7 +162,7 @@ func runVerb(cmd *cobra.Command, subCommand string, args []string) error {
 		return err
 	}
 	if parser, ok := componentPromptParsers[cmd]; ok {
-		parsed, err := parser.Parse(context.Background(), args)
+		parsed, err := parser.Parse(cmd.Context(), args)
 		if err != nil {
 			return err
 		}

--- a/cmd/emulator/emulator.go
+++ b/cmd/emulator/emulator.go
@@ -1,8 +1,6 @@
 package emulator
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -184,7 +182,7 @@ func runVerb(cmd *cobra.Command, subCommand string, args []string) error {
 		}
 	}
 	if parser, ok := componentPromptParsers[cmd]; ok {
-		parsed, err := parser.Parse(context.Background(), positional)
+		parsed, err := parser.Parse(cmd.Context(), positional)
 		if err != nil {
 			return err
 		}
@@ -213,7 +211,7 @@ func runVerb(cmd *cobra.Command, subCommand string, args []string) error {
 // in the parsed result, so the value is carried forward explicitly rather than
 // by mutating global Viper state.
 func applyParsedStackFlag(cmd *cobra.Command, positional []string) error {
-	parsed, err := emulatorParser.Parse(context.Background(), positional)
+	parsed, err := emulatorParser.Parse(cmd.Context(), positional)
 	if err != nil {
 		return err
 	}

--- a/cmd/emulator/emulator.go
+++ b/cmd/emulator/emulator.go
@@ -195,6 +195,7 @@ func runVerb(cmd *cobra.Command, subCommand string, args []string) error {
 	info := initConfigAndStacksInfo(cmd, subCommand, args)
 	provider := component.MustGetProvider(cfg.EmulatorComponentType)
 	return provider.Execute(&component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       cfg.EmulatorComponentType,
 		Component:           info.ComponentFromArg,
 		Stack:               info.Stack,

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -150,6 +150,9 @@ func operationFlagOptions(name string) []flags.Option {
 			flags.WithBoolFlag("split", "", false, "Write one rendered manifest file per object. Requires --output-dir."),
 		)
 	}
+	if name != "delete" {
+		options = append(options, flags.WithBoolFlag("dependency-update", "", false, "Update missing chart dependencies before rendering or applying."))
+	}
 
 	if name == "apply" || name == "deploy" {
 		options = append(
@@ -301,6 +304,9 @@ func getOperationFlags(cmd *cobra.Command) map[string]any {
 	}
 	if flag := cmd.Flag("namespace"); flag != nil && flag.Changed {
 		result["namespace"] = flag.Value.String()
+	}
+	if flag := cmd.Flag("dependency-update"); flag != nil && flag.Changed {
+		result[cfg.HelmDependencyUpdateSectionName] = flag.Value.String() == valueTrue
 	}
 	addLifecycleOperationFlags(cmd, result)
 	return result

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -89,7 +89,7 @@ func newOperationCommand(name, short string) *cobra.Command {
 		Use:   name + " [component]",
 		Short: short,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			parsed, err := parser.Parse(context.Background(), args)
+			parsed, err := parser.Parse(cmd.Context(), args)
 			if err != nil {
 				return err
 			}
@@ -261,6 +261,7 @@ func runOperation(cmd *cobra.Command, subCommand string, args []string) error {
 	provider := component.MustGetProvider(cfg.HelmComponentType)
 
 	return provider.Execute(&component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       cfg.HelmComponentType,
 		Component:           info.ComponentFromArg,
 		Stack:               info.Stack,

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -37,12 +37,12 @@ func TestCommandProviderMetadata(t *testing.T) {
 
 func TestNewOperationCommandRegistersExpectedFlags(t *testing.T) {
 	templateCmd := newOperationCommand("template", "Render")
-	for _, name := range []string{"namespace", "all", "affected", "include-dependents", "repo-path", "base", "ref", "sha", "ssh-key", "ssh-key-password", "clone-target-ref", "output", "output-dir", "split", "tags", "labels"} {
+	for _, name := range []string{"namespace", "all", "affected", "include-dependents", "repo-path", "base", "ref", "sha", "ssh-key", "ssh-key-password", "clone-target-ref", "output", "output-dir", "split", "tags", "labels", "dependency-update"} {
 		assert.NotNil(t, templateCmd.Flag(name), "expected template flag %q", name)
 	}
 
 	applyCmd := newOperationCommand("apply", "Apply")
-	for _, name := range []string{"namespace", "target", "on-failure", "cleanup-on-failure", "wait", "wait-for-jobs", "timeout", "history-max", "no-hooks", "skip-crds"} {
+	for _, name := range []string{"namespace", "target", "on-failure", "cleanup-on-failure", "wait", "wait-for-jobs", "timeout", "history-max", "no-hooks", "skip-crds", "dependency-update"} {
 		assert.NotNil(t, applyCmd.Flag(name), "expected apply flag %q", name)
 	}
 	assert.Equal(t, "watcher", applyCmd.Flag("wait").NoOptDefVal)
@@ -61,6 +61,7 @@ func TestNewOperationCommandRegistersExpectedFlags(t *testing.T) {
 		assert.NotNil(t, deleteCmd.Flag(name), "expected delete flag %q", name)
 	}
 	assert.Nil(t, deleteCmd.Flag("on-failure"))
+	assert.Nil(t, deleteCmd.Flag("dependency-update"))
 
 	// diff/plan get the baseline-selection flags; other operations do not.
 	for _, opName := range []string{"diff", "plan"} {
@@ -68,6 +69,7 @@ func TestNewOperationCommandRegistersExpectedFlags(t *testing.T) {
 		for _, name := range []string{"against", "from-manifest", "context"} {
 			assert.NotNil(t, opCmd.Flag(name), "expected %q flag on %q", name, opName)
 		}
+		assert.NotNil(t, opCmd.Flag("dependency-update"))
 	}
 	assert.Nil(t, applyCmd.Flag("against"))
 	assert.Nil(t, templateCmd.Flag("from-manifest"))
@@ -95,6 +97,7 @@ func TestGetOperationFlagsIncludesOnlyExplicitLifecycleFlags(t *testing.T) {
 		"history-max":        "0",
 		"no-hooks":           "true",
 		"skip-crds":          "true",
+		"dependency-update":  "true",
 	})
 
 	actual := getOperationFlags(cmd)
@@ -107,6 +110,7 @@ func TestGetOperationFlagsIncludesOnlyExplicitLifecycleFlags(t *testing.T) {
 	assert.Equal(t, 0, actual[cfg.HelmHistoryMaxSectionName])
 	assert.Equal(t, false, actual[cfg.HelmChartHooksSectionName])
 	assert.Equal(t, "skip", actual[cfg.HelmCRDsSectionName])
+	assert.Equal(t, true, actual[cfg.HelmDependencyUpdateSectionName])
 
 	defaults := getOperationFlags(newOperationCommand("apply", "Apply"))
 	assert.NotContains(t, defaults, "namespace")
@@ -119,6 +123,7 @@ func TestGetOperationFlagsIncludesOnlyExplicitLifecycleFlags(t *testing.T) {
 		cfg.HelmHistoryMaxSectionName,
 		cfg.HelmChartHooksSectionName,
 		cfg.HelmCRDsSectionName,
+		cfg.HelmDependencyUpdateSectionName,
 	} {
 		assert.NotContains(t, defaults, key)
 	}

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -304,6 +304,8 @@ func TestRunOperationBuildsExecutionContext(t *testing.T) {
 		"against": "target",
 		"context": "5",
 	})
+	type contextKey struct{}
+	cmd.SetContext(context.WithValue(context.Background(), contextKey{}, "command"))
 	cmd.Flags().String("stack", "", "")
 	require.NoError(t, cmd.Flags().Set("stack", "dev"))
 
@@ -316,6 +318,7 @@ func TestRunOperationBuildsExecutionContext(t *testing.T) {
 	assert.Equal(t, []string{"app"}, provider.ctx.Args)
 	assert.Equal(t, "target", provider.ctx.Flags["against"])
 	assert.Equal(t, 5, provider.ctx.Flags["context"])
+	assert.Equal(t, "command", provider.ctx.GoContext().Value(contextKey{}))
 }
 
 func TestRunOperationBuildsApplyDryRunExecutionContext(t *testing.T) {

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -256,6 +256,7 @@ func runOperation(cmd *cobra.Command, subCommand string, args []string) error {
 	provider := component.MustGetProvider(cfg.KubernetesComponentType)
 
 	return provider.Execute(&component.ExecutionContext{
+		Context:             cmd.Context(),
 		ComponentType:       cfg.KubernetesComponentType,
 		Component:           info.ComponentFromArg,
 		Stack:               info.Stack,

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -103,7 +103,7 @@ func newOperationCommand(name string, short string) *cobra.Command {
 		Use:   name + " [component]",
 		Short: short,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			parsed, err := parser.Parse(context.Background(), args)
+			parsed, err := parser.Parse(cmd.Context(), args)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -578,7 +579,7 @@ var RootCmd = &cobra.Command{
 		// The global masker may have been created before CLI flags were parsed (e.g. by early
 		// output), so its enabled state reflects the `--mask` default, not the parsed flag.
 		// Reconcile it now that flags are available so `--mask=false` reliably disables masking.
-		iolib.ReconcileMasking()
+		reconcileMaskingForCommand(cmd)
 		ioCtx := iolib.GetContext()
 		ui.InitFormatter(ioCtx)
 		data.InitWriter(ioCtx)
@@ -680,6 +681,29 @@ var RootCmd = &cobra.Command{
 		err := e.ExecuteAtmosCmd()
 		return err
 	},
+}
+
+// reconcileMaskingForCommand applies the configured masking policy and then
+// honors a command-local --mask flag when a subcommand shadows the root flag.
+// Several component command groups register their own persistent common flags;
+// Viper remains bound to the root flag, so the changed local value must win.
+func reconcileMaskingForCommand(cmd *cobra.Command) {
+	iolib.ReconcileMasking()
+	if cmd == nil {
+		return
+	}
+	for current := cmd; current != nil; current = current.Parent() {
+		maskFlag := current.PersistentFlags().Lookup("mask")
+		if maskFlag == nil || !maskFlag.Changed {
+			continue
+		}
+		enabled, err := strconv.ParseBool(maskFlag.Value.String())
+		if err != nil {
+			return
+		}
+		iolib.GetContext().Masker().SetEnabled(enabled)
+		return
+	}
 }
 
 // debugModePromotion records the outcome of a CI-driven log-level promotion.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -582,7 +583,7 @@ var RootCmd = &cobra.Command{
 		// The global masker may have been created before CLI flags were parsed (e.g. by early
 		// output), so its enabled state reflects the `--mask` default, not the parsed flag.
 		// Reconcile it now that flags are available so `--mask=false` reliably disables masking.
-		iolib.ReconcileMasking()
+		reconcileMaskingForCommand(cmd)
 		ioCtx := iolib.GetContext()
 		ui.InitFormatter(ioCtx)
 		data.InitWriter(ioCtx)
@@ -685,6 +686,29 @@ var RootCmd = &cobra.Command{
 		err := e.ExecuteAtmosCmd()
 		return err
 	},
+}
+
+// reconcileMaskingForCommand applies the configured masking policy and then
+// honors a command-local --mask flag when a subcommand shadows the root flag.
+// Several component command groups register their own persistent common flags;
+// Viper remains bound to the root flag, so the changed local value must win.
+func reconcileMaskingForCommand(cmd *cobra.Command) {
+	iolib.ReconcileMasking()
+	if cmd == nil {
+		return
+	}
+	for current := cmd; current != nil; current = current.Parent() {
+		maskFlag := current.PersistentFlags().Lookup("mask")
+		if maskFlag == nil || !maskFlag.Changed {
+			continue
+		}
+		enabled, err := strconv.ParseBool(maskFlag.Value.String())
+		if err != nil {
+			return
+		}
+		iolib.GetContext().Masker().SetEnabled(enabled)
+		return
+	}
 }
 
 // debugModePromotion records the outcome of a CI-driven log-level promotion.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,9 +13,34 @@ import (
 	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	iolib "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
+
+func TestReconcileMaskingForCommandHonorsShadowingFlag(t *testing.T) {
+	t.Cleanup(func() {
+		iolib.Reset()
+		viper.Reset()
+	})
+	iolib.Reset()
+	viper.Reset()
+	viper.Set("mask", true)
+	require.NoError(t, iolib.Initialize())
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().Bool("mask", true, "")
+	group := &cobra.Command{Use: "group"}
+	group.PersistentFlags().Bool("mask", true, "")
+	leaf := &cobra.Command{Use: "leaf"}
+	root.AddCommand(group)
+	group.AddCommand(leaf)
+	require.NoError(t, group.PersistentFlags().Set("mask", "false"))
+
+	reconcileMaskingForCommand(leaf)
+
+	assert.False(t, iolib.MaskingEnabled())
+}
 
 func TestNoColorLog(t *testing.T) {
 	// Skip in CI environments without TTY.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,6 +27,7 @@ func TestReconcileMaskingForCommandHonorsShadowingFlag(t *testing.T) {
 	viper.Reset()
 	viper.Set("mask", true)
 	require.NoError(t, iolib.Initialize())
+	require.True(t, iolib.MaskingEnabled(), "masking should start enabled")
 
 	root := &cobra.Command{Use: "root"}
 	root.PersistentFlags().Bool("mask", true, "")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -23,24 +24,62 @@ func TestReconcileMaskingForCommandHonorsShadowingFlag(t *testing.T) {
 		iolib.Reset()
 		viper.Reset()
 	})
-	iolib.Reset()
-	viper.Reset()
-	viper.Set("mask", true)
-	require.NoError(t, iolib.Initialize())
-	require.True(t, iolib.MaskingEnabled(), "masking should start enabled")
 
-	root := &cobra.Command{Use: "root"}
-	root.PersistentFlags().Bool("mask", true, "")
-	group := &cobra.Command{Use: "group"}
-	group.PersistentFlags().Bool("mask", true, "")
-	leaf := &cobra.Command{Use: "leaf"}
-	root.AddCommand(group)
-	group.AddCommand(leaf)
-	require.NoError(t, group.PersistentFlags().Set("mask", "false"))
+	boolPtr := func(value bool) *bool { return &value }
+	tests := []struct {
+		name       string
+		configured bool
+		root       *bool
+		group      *bool
+		leaf       *bool
+		want       bool
+	}{
+		{
+			name:       "changed leaf wins over changed group",
+			configured: true,
+			group:      boolPtr(false),
+			leaf:       boolPtr(true),
+			want:       true,
+		},
+		{
+			name:       "changed root wins without child override",
+			configured: false,
+			root:       boolPtr(true),
+			want:       true,
+		},
+		{
+			name:       "no local override preserves reconciled viper state",
+			configured: false,
+			want:       false,
+		},
+	}
 
-	reconcileMaskingForCommand(leaf)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iolib.Reset()
+			viper.Reset()
+			viper.Set("mask", tt.configured)
+			require.NoError(t, iolib.Initialize())
 
-	assert.False(t, iolib.MaskingEnabled())
+			root := &cobra.Command{Use: "root"}
+			root.PersistentFlags().Bool("mask", true, "")
+			group := &cobra.Command{Use: "group"}
+			group.PersistentFlags().Bool("mask", true, "")
+			leaf := &cobra.Command{Use: "leaf"}
+			leaf.PersistentFlags().Bool("mask", true, "")
+			root.AddCommand(group)
+			group.AddCommand(leaf)
+
+			for command, value := range map[*cobra.Command]*bool{root: tt.root, group: tt.group, leaf: tt.leaf} {
+				if value != nil {
+					require.NoError(t, command.PersistentFlags().Set("mask", strconv.FormatBool(*value)))
+				}
+			}
+
+			reconcileMaskingForCommand(leaf)
+			assert.Equal(t, tt.want, iolib.MaskingEnabled())
+		})
+	}
 }
 
 func TestNoColorLog(t *testing.T) {

--- a/docs/prd/native-helm-release-lifecycle.md
+++ b/docs/prd/native-helm-release-lifecycle.md
@@ -53,6 +53,7 @@ These gaps force users migrating from Helm or Helmfile to choose between depende
 - Fix apply dry-run propagation as a release-blocking safety prerequisite, then correctly propagate delete dry-run, cancellation, and deadlines through cluster operations.
 - Validate configuration before chart download or cluster mutation.
 - Keep template and diff complete by including Helm chart hook resources alongside the ordinary release manifest.
+- Allow callers to opt into fetching missing chart dependencies with Helm-compatible `--dependency-update` semantics.
 - Keep the design compatible with future pre-rollback diagnostics without requiring another public configuration rename.
 - Follow Atmos schema, stack-processing, command parsing, provider, error, logging, and testing conventions.
 
@@ -60,7 +61,7 @@ These gaps force users migrating from Helm or Helmfile to choose between depende
 
 - Collecting Pod status, Kubernetes Events, or container logs before rollback. This release uses Helm's built-in rollback behavior; failure diagnostics require separate orchestration.
 - Configuring chart download, OCI registry, client-side render, or external provision-target delivery timeouts.
-- Automatically running `helm dependency build` after chart provisioning. Atmos MUST report missing dependencies with the explicit build command. Dependency acquisition remains caller-controlled: Atmos only fetches missing dependencies when the user explicitly passes `--dependency-update`.
+- Implicitly running `helm dependency build` after chart provisioning. Atmos MUST report missing dependencies with the explicit build command and the `--dependency-update` alternative. Dependency acquisition remains caller-controlled and occurs only when the user explicitly passes `--dependency-update`, avoiding unexpected network access and chart-directory mutation.
 - Adding `--set-file`; Atmos `!include.raw` already covers byte-preserving file-backed value content, including a source file's terminal newline. Content normalization is separate from Helm lifecycle behavior.
 - Supporting Helm CLI subcommand, getter, downloader, post-renderer, or Wasm plugins in native SDK operations.
 - Adding force replacement, server-side apply selection, value reuse/reset, ownership takeover, validation bypass, or uninstall history/cascade options. In particular, Helm `Uninstall.KeepHistory`, the `--keep-history` flag, and a `keep_history` component field are deferred from R1.
@@ -238,6 +239,8 @@ atmos helm delete demo-api -s example-prod \
 ```
 
 `template`, `diff`, and `plan` do not register release-lifecycle flags because they do not perform a release operation.
+
+All chart-loading operations (`template`, `diff`, `plan`, `apply`, and `deploy`) accept `--dependency-update`. Atmos invokes Helm's dependency manager only when a declared dependency is missing. The flag is intentionally invocation-scoped: without it, Atmos does not access dependency repositories or mutate the chart directory and instead reports both the equivalent `helm dependency build <chart>` command and the opt-in flag.
 
 ## Configuration Contract
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1537,6 +1537,7 @@ var (
 	ErrHelmLifecycleFlagInapplicable = errors.New("helm release lifecycle flag does not apply to selected operation")
 	ErrHelmLifecycleExternalTarget   = errors.New("helm release lifecycle flags require a Kubernetes target")
 	ErrHelmReleaseHistory            = errors.New("failed to inspect helm release history")
+	ErrHelmReleaseUpgrade            = errors.New("failed to upgrade helm release")
 	ErrHelmReleaseUninstall          = errors.New("failed to uninstall helm release")
 )
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1636,6 +1636,7 @@ var (
 	ErrHelmLifecycleFlagInapplicable = errors.New("helm release lifecycle flag does not apply to selected operation")
 	ErrHelmLifecycleExternalTarget   = errors.New("helm release lifecycle flags require a Kubernetes target")
 	ErrHelmReleaseHistory            = errors.New("failed to inspect helm release history")
+	ErrHelmReleaseUpgrade            = errors.New("failed to upgrade helm release")
 	ErrHelmReleaseUninstall          = errors.New("failed to uninstall helm release")
 )
 

--- a/pkg/component/ansible/ansible.go
+++ b/pkg/component/ansible/ansible.go
@@ -138,10 +138,10 @@ func (a *AnsibleComponentProvider) Execute(ctx *component.ExecutionContext) erro
 	case "version":
 		return ExecuteVersion(ctx.GoContext(), &ctx.ConfigAndStacksInfo)
 	case "playbook":
-		return ExecutePlaybook(&ctx.ConfigAndStacksInfo, flags)
+		return ExecutePlaybook(ctx.GoContext(), &ctx.ConfigAndStacksInfo, flags)
 	default:
 		// For unknown subcommands, default to playbook behavior.
-		return ExecutePlaybook(&ctx.ConfigAndStacksInfo, flags)
+		return ExecutePlaybook(ctx.GoContext(), &ctx.ConfigAndStacksInfo, flags)
 	}
 }
 

--- a/pkg/component/ansible/ansible.go
+++ b/pkg/component/ansible/ansible.go
@@ -136,7 +136,7 @@ func (a *AnsibleComponentProvider) Execute(ctx *component.ExecutionContext) erro
 	// Route to the appropriate executor based on subcommand.
 	switch ctx.SubCommand {
 	case "version":
-		return ExecuteVersion(&ctx.ConfigAndStacksInfo)
+		return ExecuteVersion(ctx.GoContext(), &ctx.ConfigAndStacksInfo)
 	case "playbook":
 		return ExecutePlaybook(&ctx.ConfigAndStacksInfo, flags)
 	default:

--- a/pkg/component/ansible/executor.go
+++ b/pkg/component/ansible/executor.go
@@ -241,7 +241,7 @@ func ExecutePlaybook(
 }
 
 // ExecuteVersion executes the ansible version command.
-func ExecuteVersion(info *schema.ConfigAndStacksInfo) error {
+func ExecuteVersion(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
 	defer perf.Track(nil, "ansible.ExecuteVersion")()
 
 	atmosConfig, err := cfg.InitCliConfig(*info, false)
@@ -264,6 +264,7 @@ func ExecuteVersion(info *schema.ConfigAndStacksInfo) error {
 		nil,   // env
 		false, // dryRun
 		"",    // redirectStdError
+		e.WithProcessContext(ctx),
 	)
 }
 

--- a/pkg/component/ansible/executor.go
+++ b/pkg/component/ansible/executor.go
@@ -71,6 +71,7 @@ func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.
 
 // ExecutePlaybook executes an Ansible playbook command.
 func ExecutePlaybook(
+	ctx context.Context,
 	info *schema.ConfigAndStacksInfo,
 	flags *Flags,
 ) error {
@@ -237,6 +238,7 @@ func ExecutePlaybook(
 		envVars,
 		info.DryRun,
 		info.RedirectStdErr,
+		e.WithProcessContext(ctx),
 	)
 }
 

--- a/pkg/component/ansible/executor.go
+++ b/pkg/component/ansible/executor.go
@@ -264,7 +264,7 @@ func executePlaybookCommandWithRetry(
 }
 
 // ExecuteVersion executes the ansible version command.
-func ExecuteVersion(info *schema.ConfigAndStacksInfo) error {
+func ExecuteVersion(ctx context.Context, info *schema.ConfigAndStacksInfo) error {
 	defer perf.Track(nil, "ansible.ExecuteVersion")()
 
 	atmosConfig, err := cfg.InitCliConfig(*info, false)
@@ -287,6 +287,7 @@ func ExecuteVersion(info *schema.ConfigAndStacksInfo) error {
 		nil,   // env
 		false, // dryRun
 		"",    // redirectStdError
+		e.WithProcessContext(ctx),
 	)
 }
 

--- a/pkg/component/ansible/executor.go
+++ b/pkg/component/ansible/executor.go
@@ -72,6 +72,7 @@ func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.
 
 // ExecutePlaybook executes an Ansible playbook command.
 func ExecutePlaybook(
+	ctx context.Context,
 	info *schema.ConfigAndStacksInfo,
 	flags *Flags,
 ) error {
@@ -230,7 +231,7 @@ func ExecutePlaybook(
 		return nil
 	}
 
-	return executePlaybookCommandWithRetry(&atmosConfig, info, cmdArgs, componentPath, envVars)
+	return executePlaybookCommandWithRetry(ctx, &atmosConfig, info, cmdArgs, componentPath, envVars)
 }
 
 // executePlaybookCommandWithRetry runs the resolved ansible-playbook command through
@@ -238,6 +239,7 @@ func ExecutePlaybook(
 // be unit-tested directly with a fake invoke, without standing up ExecutePlaybook's full
 // stack-processing/auth preamble or requiring a real ansible-playbook binary.
 func executePlaybookCommandWithRetry(
+	ctx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	cmdArgs *CommandArgs,
@@ -260,6 +262,7 @@ func executePlaybookCommandWithRetry(
 				o...,
 			)
 		},
+		e.WithProcessContext(ctx),
 	)
 }
 

--- a/pkg/component/ansible/executor_test.go
+++ b/pkg/component/ansible/executor_test.go
@@ -1,6 +1,7 @@
 package ansible
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1264,7 +1265,7 @@ func TestExecutePlaybookCommandWithRetry_MatchingError_Retries(t *testing.T) {
 	}
 
 	atmosConfig := schema.AtmosConfiguration{}
-	err = executePlaybookCommandWithRetry(&atmosConfig, info, cmdArgs, t.TempDir(), envVars)
+	err = executePlaybookCommandWithRetry(context.Background(), &atmosConfig, info, cmdArgs, t.TempDir(), envVars)
 	require.Error(t, err, "all 3 attempts fail in this fixture, so the final error must propagate")
 
 	counterBytes, readErr := os.ReadFile(counterFile)
@@ -1298,7 +1299,7 @@ func TestExecutePlaybookCommandWithRetry_NonMatchingError_FailsFast(t *testing.T
 	}
 
 	atmosConfig := schema.AtmosConfiguration{}
-	err = executePlaybookCommandWithRetry(&atmosConfig, info, cmdArgs, t.TempDir(), envVars)
+	err = executePlaybookCommandWithRetry(context.Background(), &atmosConfig, info, cmdArgs, t.TempDir(), envVars)
 	require.Error(t, err)
 
 	counterBytes, readErr := os.ReadFile(counterFile)

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -64,7 +64,7 @@ func ExecuteGraph(ctx context.Context, opts *GraphExecutionOptions) error {
 		default:
 		}
 
-		if err := executeGraphNode(opts, &order[i]); err != nil {
+		if err := executeGraphNode(ctx, opts, &order[i]); err != nil {
 			return err
 		}
 	}
@@ -103,7 +103,7 @@ func prepareExecutionOrder(opts *GraphExecutionOptions) (dependency.ExecutionOrd
 }
 
 // executeGraphNode executes a single graph node through the component provider.
-func executeGraphNode(opts *GraphExecutionOptions, node *dependency.Node) error {
+func executeGraphNode(ctx context.Context, opts *GraphExecutionOptions, node *dependency.Node) error {
 	nodeInfo := *opts.Info
 	nodeInfo.ComponentType = opts.ComponentType
 	nodeInfo.ComponentFromArg = node.Component
@@ -115,6 +115,7 @@ func executeGraphNode(opts *GraphExecutionOptions, node *dependency.Node) error 
 	nodeInfo.Affected = false
 
 	if err := opts.Provider.Execute(&ExecutionContext{
+		Context:             ctx,
 		AtmosConfig:         opts.AtmosConfig,
 		ComponentType:       opts.ComponentType,
 		Component:           node.Component,

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -67,8 +68,8 @@ func ExecuteGraph(ctx context.Context, opts *GraphExecutionOptions) error {
 		}
 
 		if err := executeGraphNode(ctx, opts, &order[i]); err != nil {
-			if ctx.Err() != nil {
-				return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrGraphExecutionCanceled, err)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrGraphExecutionCanceled, errors.Join(ctxErr, err))
 			}
 			return err
 		}

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -38,6 +38,8 @@ type GraphExecutionOptions struct {
 	Selection     *GraphSelection
 }
 
+// ExecuteGraph runs selected components in dependency order and stops before
+// starting another component when the caller context is canceled.
 func ExecuteGraph(ctx context.Context, opts *GraphExecutionOptions) error {
 	defer perf.Track(nil, "component.ExecuteGraph")()
 

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -73,6 +73,9 @@ func ExecuteGraph(ctx context.Context, opts *GraphExecutionOptions) error {
 			}
 			return err
 		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrGraphExecutionCanceled, ctxErr)
+		}
 	}
 
 	return nil

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -116,6 +116,22 @@ func executeGraphNode(ctx context.Context, opts *GraphExecutionOptions, node *de
 	nodeInfo.SubCommand = opts.SubCommand
 	nodeInfo.All = false
 	nodeInfo.Affected = false
+	nodeInfo.Query = ""
+	nodeInfo.Components = nil
+	nodeInfo.Tags = nil
+	nodeInfo.Labels = nil
+
+	// Selection flags belong to the outer graph dispatch. Passing them to a node
+	// can make providers treat the node as another bulk invocation and recurse.
+	nodeFlags := make(map[string]any, len(opts.Flags))
+	for key, value := range opts.Flags {
+		switch key {
+		case "all", "affected", "components", "query", "tags", "labels", "include-dependents":
+			continue
+		default:
+			nodeFlags[key] = value
+		}
+	}
 
 	if err := opts.Provider.Execute(&ExecutionContext{
 		Context:             ctx,
@@ -127,7 +143,7 @@ func executeGraphNode(ctx context.Context, opts *GraphExecutionOptions, node *de
 		SubCommand:          opts.SubCommand,
 		ComponentConfig:     node.Metadata,
 		ConfigAndStacksInfo: nodeInfo,
-		Flags:               opts.Flags,
+		Flags:               nodeFlags,
 	}); err != nil {
 		return fmt.Errorf("%w: component=%s stack=%s: %w", errUtils.ErrComponentExecutionFailed, node.Component, node.Stack, err)
 	}

--- a/pkg/component/graph.go
+++ b/pkg/component/graph.go
@@ -65,6 +65,9 @@ func ExecuteGraph(ctx context.Context, opts *GraphExecutionOptions) error {
 		}
 
 		if err := executeGraphNode(ctx, opts, &order[i]); err != nil {
+			if ctx.Err() != nil {
+				return fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrGraphExecutionCanceled, err)
+			}
 			return err
 		}
 	}

--- a/pkg/component/graph_test.go
+++ b/pkg/component/graph_test.go
@@ -9,6 +9,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/dependency"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -152,6 +153,60 @@ func TestExecuteGraphRunsComponentsInDependencyOrder(t *testing.T) {
 		assert.False(t, call.ConfigAndStacksInfo.Affected)
 		assert.Equal(t, true, call.Flags["dry-run"])
 	}
+}
+
+func TestExecuteGraphNodeDoesNotRedispatchBulkSelection(t *testing.T) {
+	provider := &graphTestProvider{}
+	info := &schema.ConfigAndStacksInfo{
+		All:        true,
+		Affected:   true,
+		Query:      ".components",
+		Components: []string{"base"},
+		Tags:       []string{"lifecycle-dag"},
+		Labels:     map[string]string{"tier": "platform"},
+	}
+	flags := map[string]any{
+		"all":                true,
+		"affected":           true,
+		"query":              ".components",
+		"components":         []string{"base"},
+		"tags":               []string{"lifecycle-dag"},
+		"labels":             "tier=platform",
+		"include-dependents": true,
+		"dry-run":            true,
+	}
+
+	err := executeGraphNode(context.Background(), &GraphExecutionOptions{
+		Provider:      provider,
+		Info:          info,
+		ComponentType: cfg.KubernetesComponentType,
+		SubCommand:    "apply",
+		Flags:         flags,
+	}, &dependency.Node{Component: "base", Stack: "dev"})
+
+	require.NoError(t, err)
+	require.Len(t, provider.calls, 1)
+	call := provider.calls[0]
+	assert.False(t, call.ConfigAndStacksInfo.All)
+	assert.False(t, call.ConfigAndStacksInfo.Affected)
+	assert.Empty(t, call.ConfigAndStacksInfo.Query)
+	assert.Empty(t, call.ConfigAndStacksInfo.Components)
+	assert.Empty(t, call.ConfigAndStacksInfo.Tags)
+	assert.Empty(t, call.ConfigAndStacksInfo.Labels)
+	for _, key := range []string{"all", "affected", "query", "components", "tags", "labels", "include-dependents"} {
+		assert.NotContains(t, call.Flags, key)
+	}
+	assert.Equal(t, true, call.Flags["dry-run"])
+	assert.Equal(t, flags, map[string]any{
+		"all":                true,
+		"affected":           true,
+		"query":              ".components",
+		"components":         []string{"base"},
+		"tags":               []string{"lifecycle-dag"},
+		"labels":             "tier=platform",
+		"include-dependents": true,
+		"dry-run":            true,
+	}, "outer graph flags must remain unchanged")
 }
 
 type graphContextKey struct{}

--- a/pkg/component/graph_test.go
+++ b/pkg/component/graph_test.go
@@ -18,6 +18,7 @@ type graphTestProvider struct {
 	calls         []ExecutionContext
 	cancelOnFirst context.CancelFunc
 	errorOnFirst  error
+	nilOnCancel   bool
 }
 
 func (p *graphTestProvider) GetType() string { return cfg.KubernetesComponentType }
@@ -38,6 +39,9 @@ func (p *graphTestProvider) Execute(ctx *ExecutionContext) error {
 		p.cancelOnFirst()
 		if p.errorOnFirst != nil {
 			return p.errorOnFirst
+		}
+		if p.nilOnCancel {
+			return nil
 		}
 		return ctx.GoContext().Err()
 	}
@@ -292,6 +296,21 @@ func TestExecuteGraphCancelsActiveNodeAndStopsDependents(t *testing.T) {
 	require.ErrorIs(t, err, errUtils.ErrGraphExecutionCanceled)
 	require.Len(t, provider.calls, 1)
 	assert.Equal(t, "base", provider.calls[0].Component)
+}
+
+func TestExecuteGraphReportsCancellationAfterSuccessfulDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &graphTestProvider{cancelOnFirst: cancel, nilOnCancel: true}
+	err := ExecuteGraph(ctx, &GraphExecutionOptions{
+		Provider:      provider,
+		Info:          &schema.ConfigAndStacksInfo{Stack: "dev"},
+		Stacks:        graphTestStacks(),
+		ComponentType: cfg.KubernetesComponentType,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, errUtils.ErrGraphExecutionCanceled)
+	require.Len(t, provider.calls, 1)
 }
 
 func TestLegacyDependsOnParsing(t *testing.T) {

--- a/pkg/component/graph_test.go
+++ b/pkg/component/graph_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ import (
 type graphTestProvider struct {
 	calls         []ExecutionContext
 	cancelOnFirst context.CancelFunc
+	errorOnFirst  error
 }
 
 func (p *graphTestProvider) GetType() string { return cfg.KubernetesComponentType }
@@ -34,6 +36,9 @@ func (p *graphTestProvider) Execute(ctx *ExecutionContext) error {
 	p.calls = append(p.calls, *ctx)
 	if p.cancelOnFirst != nil && len(p.calls) == 1 {
 		p.cancelOnFirst()
+		if p.errorOnFirst != nil {
+			return p.errorOnFirst
+		}
 		return ctx.GoContext().Err()
 	}
 	return nil
@@ -272,7 +277,8 @@ func TestExecuteGraphHonorsCanceledContext(t *testing.T) {
 
 func TestExecuteGraphCancelsActiveNodeAndStopsDependents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	provider := &graphTestProvider{cancelOnFirst: cancel}
+	providerErr := errors.New("provider canceled operation")
+	provider := &graphTestProvider{cancelOnFirst: cancel, errorOnFirst: providerErr}
 	err := ExecuteGraph(ctx, &GraphExecutionOptions{
 		Provider:      provider,
 		Info:          &schema.ConfigAndStacksInfo{Stack: "dev"},
@@ -281,6 +287,7 @@ func TestExecuteGraphCancelsActiveNodeAndStopsDependents(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, providerErr)
 	require.ErrorIs(t, err, errUtils.ErrComponentExecutionFailed)
 	require.ErrorIs(t, err, errUtils.ErrGraphExecutionCanceled)
 	require.Len(t, provider.calls, 1)

--- a/pkg/component/graph_test.go
+++ b/pkg/component/graph_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 type graphTestProvider struct {
-	calls []ExecutionContext
+	calls         []ExecutionContext
+	cancelOnFirst context.CancelFunc
 }
 
 func (p *graphTestProvider) GetType() string { return cfg.KubernetesComponentType }
@@ -30,6 +31,10 @@ func (p *graphTestProvider) ValidateComponent(map[string]any) error { return nil
 
 func (p *graphTestProvider) Execute(ctx *ExecutionContext) error {
 	p.calls = append(p.calls, *ctx)
+	if p.cancelOnFirst != nil && len(p.calls) == 1 {
+		p.cancelOnFirst()
+		return ctx.GoContext().Err()
+	}
 	return nil
 }
 
@@ -124,8 +129,9 @@ func TestFilterGraph(t *testing.T) {
 
 func TestExecuteGraphRunsComponentsInDependencyOrder(t *testing.T) {
 	provider := &graphTestProvider{}
+	ctx := context.WithValue(context.Background(), graphContextKey{}, "graph")
 
-	err := ExecuteGraph(context.Background(), &GraphExecutionOptions{
+	err := ExecuteGraph(ctx, &GraphExecutionOptions{
 		Provider:      provider,
 		Info:          &schema.ConfigAndStacksInfo{},
 		Stacks:        graphTestStacks(),
@@ -139,6 +145,7 @@ func TestExecuteGraphRunsComponentsInDependencyOrder(t *testing.T) {
 	assertLessCallIndex(t, provider.calls, "base", "dev", "api", "dev")
 	assertLessCallIndex(t, provider.calls, "base", "prod", "worker", "dev")
 	for _, call := range provider.calls {
+		assert.Equal(t, "graph", call.GoContext().Value(graphContextKey{}))
 		assert.Equal(t, cfg.KubernetesComponentType, call.ComponentType)
 		assert.Equal(t, "apply", call.SubCommand)
 		assert.False(t, call.ConfigAndStacksInfo.All)
@@ -146,6 +153,8 @@ func TestExecuteGraphRunsComponentsInDependencyOrder(t *testing.T) {
 		assert.Equal(t, true, call.Flags["dry-run"])
 	}
 }
+
+type graphContextKey struct{}
 
 func TestExecuteGraphValidatesRequiredOptions(t *testing.T) {
 	err := ExecuteGraph(context.Background(), &GraphExecutionOptions{Info: &schema.ConfigAndStacksInfo{}})
@@ -204,6 +213,21 @@ func TestExecuteGraphHonorsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorIs(t, err, errUtils.ErrGraphExecutionCanceled)
 	assert.Empty(t, provider.calls)
+}
+
+func TestExecuteGraphCancelsActiveNodeAndStopsDependents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &graphTestProvider{cancelOnFirst: cancel}
+	err := ExecuteGraph(ctx, &GraphExecutionOptions{
+		Provider:      provider,
+		Info:          &schema.ConfigAndStacksInfo{Stack: "dev"},
+		Stacks:        graphTestStacks(),
+		ComponentType: cfg.KubernetesComponentType,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, provider.calls, 1)
+	assert.Equal(t, "base", provider.calls[0].Component)
 }
 
 func TestLegacyDependsOnParsing(t *testing.T) {

--- a/pkg/component/graph_test.go
+++ b/pkg/component/graph_test.go
@@ -226,6 +226,8 @@ func TestExecuteGraphCancelsActiveNodeAndStopsDependents(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, errUtils.ErrComponentExecutionFailed)
+	require.ErrorIs(t, err, errUtils.ErrGraphExecutionCanceled)
 	require.Len(t, provider.calls, 1)
 	assert.Equal(t, "base", provider.calls[0].Component)
 }

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -138,16 +138,16 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 func loadChart(chartPath string) (helmchart.Charter, error) {
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 	}
 
 	accessor, err := helmchart.NewAccessor(loaded)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect Helm chart %q: %w", chartPath, err)
+		return nil, fmt.Errorf("%w: failed to inspect Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 	}
 	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
 		if err := action.CheckDependencies(loaded, dependencies); err != nil {
-			return nil, fmt.Errorf("an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", chartPath, err)
+			return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 		}
 	}
 

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -75,6 +75,9 @@ func renderManifest(ctx context.Context, spec *chartSpec) (string, error) {
 
 	manifest, err := runInstall(ctx, client, settings, spec)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", err
 		}
@@ -196,6 +199,9 @@ func loadChartForAction(
 			loaded, err = loader.Load(chartPath)
 			if err != nil {
 				return nil, fmt.Errorf("%w: failed to reload Helm chart %q after dependency update: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
+			if depErr := action.CheckDependencies(loaded, dependencies); depErr != nil {
+				return nil, fmt.Errorf("%w: Helm chart %q is still missing dependencies after 'helm dependency update': %w", errUtils.ErrHelmRenderFailed, chartPath, depErr)
 			}
 		}
 	}

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
+	helmchart "helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/registry"
@@ -113,9 +115,9 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loader.Load(chartPath)
+	loaded, err := loadChart(chartPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return "", err
 	}
 
 	rel, err := client.RunWithContext(ctx, loaded, spec.Values)
@@ -127,7 +129,47 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return rendered.Manifest, nil
+	return renderReleaseManifest(rendered), nil
+}
+
+// loadChart loads a chart and verifies that every declared dependency is present.
+// The Helm action package assumes its CLI caller performed this check; without it,
+// a missing library chart fails later with an unrelated template-definition error.
+func loadChart(chartPath string) (helmchart.Charter, error) {
+	loaded, err := loader.Load(chartPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+	}
+
+	accessor, err := helmchart.NewAccessor(loaded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect Helm chart %q: %w", chartPath, err)
+	}
+	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
+		if err := action.CheckDependencies(loaded, dependencies); err != nil {
+			return nil, fmt.Errorf("an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", chartPath, err)
+		}
+	}
+
+	return loaded, nil
+}
+
+// renderReleaseManifest returns the same manifest surface as `helm template`:
+// regular resources followed by hook resources with their source annotations.
+// Helm keeps hooks outside Release.Manifest, so returning that field alone makes
+// template, plan, and diff silently omit resources such as migration Jobs.
+func renderReleaseManifest(rendered *release.Release) string {
+	var manifests bytes.Buffer
+	if manifest := strings.TrimSpace(rendered.Manifest); manifest != "" {
+		fmt.Fprintln(&manifests, manifest)
+	}
+	for _, hook := range rendered.Hooks {
+		if hook == nil || strings.TrimSpace(hook.Manifest) == "" {
+			continue
+		}
+		fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", hook.Path, strings.TrimSpace(hook.Manifest))
+	}
+	return manifests.String()
 }
 
 // resolveChartRef maps a "repo/name" chart reference to an explicit RepoURL +

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -123,7 +123,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 
 	chartPath, err := client.LocateChart(chartRef, settings)
 	if err != nil {
-		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
+		return "", fmt.Errorf("%w: failed to locate Helm chart %q: %w", errUtils.ErrHelmRenderFailed, spec.Chart, err)
 	}
 
 	loaded, err := loadChartForAction(ctx, chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -70,6 +71,9 @@ func renderManifest(ctx context.Context, spec *chartSpec) (string, error) {
 
 	manifest, err := runInstall(ctx, client, settings, spec)
 	if err != nil {
+		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
+			return "", err
+		}
 		return "", fmt.Errorf("%w: %w", errUtils.ErrHelmRenderFailed, err)
 	}
 	return manifest, nil

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -116,6 +116,9 @@ func newInstallAction(spec *chartSpec) (*action.Install, *cli.EnvSettings, error
 // runInstall resolves the chart reference, loads the chart, runs the action, and
 // returns the rendered manifest string.
 func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSettings, spec *chartSpec) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	chartRef := resolveChartRef(client, spec)
 
 	chartPath, err := client.LocateChart(chartRef, settings)
@@ -123,7 +126,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loadChartForAction(chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
+	loaded, err := loadChartForAction(ctx, chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}
@@ -144,15 +147,19 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 // The Helm action package assumes its CLI caller performed this check; without it,
 // a missing library chart fails later with an unrelated template-definition error.
 func loadChart(chartPath string) (helmchart.Charter, error) {
-	return loadChartForAction(chartPath, nil, nil, false)
+	return loadChartForAction(context.Background(), chartPath, nil, nil, false)
 }
 
 func loadChartForAction(
+	ctx context.Context,
 	chartPath string,
 	settings *cli.EnvSettings,
 	registryClient *registry.Client,
 	dependencyUpdate bool,
 ) (helmchart.Charter, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
@@ -179,6 +186,9 @@ func loadChartForAction(
 				ContentCache:     settings.ContentCache,
 				RegistryClient:   registryClient,
 				Debug:            settings.Debug,
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
 			}
 			if updateErr := manager.Update(); updateErr != nil {
 				return nil, fmt.Errorf("%w: failed to update dependencies for Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, updateErr)

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -13,6 +13,8 @@ import (
 	helmchart "helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/downloader"
+	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/registry"
 	release "helm.sh/helm/v4/pkg/release/v1"
 
@@ -38,6 +40,8 @@ type chartSpec struct {
 	Values map[string]any
 	// IncludeCRDs includes CRDs from the chart's crds/ directory in the output.
 	IncludeCRDs bool
+	// DependencyUpdate fetches missing dependencies before loading the chart.
+	DependencyUpdate bool
 	// Repositories lists declarative chart repositories for "repo/name" refs.
 	Repositories []chartRepository
 	// Release is the presence-aware policy tree before an action is selected.
@@ -119,7 +123,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loadChart(chartPath)
+	loaded, err := loadChartForAction(chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}
@@ -140,6 +144,15 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 // The Helm action package assumes its CLI caller performed this check; without it,
 // a missing library chart fails later with an unrelated template-definition error.
 func loadChart(chartPath string) (helmchart.Charter, error) {
+	return loadChartForAction(chartPath, nil, nil, false)
+}
+
+func loadChartForAction(
+	chartPath string,
+	settings *cli.EnvSettings,
+	registryClient *registry.Client,
+	dependencyUpdate bool,
+) (helmchart.Charter, error) {
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
@@ -151,7 +164,29 @@ func loadChart(chartPath string) (helmchart.Charter, error) {
 	}
 	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
 		if err := action.CheckDependencies(loaded, dependencies); err != nil {
-			return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			if !dependencyUpdate {
+				return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' or pass '--dependency-update' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
+			if settings == nil {
+				return nil, fmt.Errorf("%w: cannot update dependencies for Helm chart %q without Helm environment settings", errUtils.ErrHelmRenderFailed, chartPath)
+			}
+			manager := &downloader.Manager{
+				Out:              io.Discard,
+				ChartPath:        chartPath,
+				Getters:          getter.All(settings),
+				RepositoryConfig: settings.RepositoryConfig,
+				RepositoryCache:  settings.RepositoryCache,
+				ContentCache:     settings.ContentCache,
+				RegistryClient:   registryClient,
+				Debug:            settings.Debug,
+			}
+			if updateErr := manager.Update(); updateErr != nil {
+				return nil, fmt.Errorf("%w: failed to update dependencies for Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, updateErr)
+			}
+			loaded, err = loader.Load(chartPath)
+			if err != nil {
+				return nil, fmt.Errorf("%w: failed to reload Helm chart %q after dependency update: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
 		}
 	}
 

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -154,6 +154,9 @@ func newInstallAction(spec *chartSpec) (*action.Install, *cli.EnvSettings, error
 // runInstall resolves the chart reference, loads the chart, runs the action, and
 // returns the rendered manifest string.
 func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSettings, spec *chartSpec) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	chartRef := resolveChartRef(client, spec)
 
 	chartPath, err := client.LocateChart(chartRef, settings)
@@ -161,7 +164,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loadChartForAction(chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
+	loaded, err := loadChartForAction(ctx, chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}
@@ -182,15 +185,19 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 // The Helm action package assumes its CLI caller performed this check; without it,
 // a missing library chart fails later with an unrelated template-definition error.
 func loadChart(chartPath string) (helmchart.Charter, error) {
-	return loadChartForAction(chartPath, nil, nil, false)
+	return loadChartForAction(context.Background(), chartPath, nil, nil, false)
 }
 
 func loadChartForAction(
+	ctx context.Context,
 	chartPath string,
 	settings *cli.EnvSettings,
 	registryClient *registry.Client,
 	dependencyUpdate bool,
 ) (helmchart.Charter, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
@@ -217,6 +224,9 @@ func loadChartForAction(
 				ContentCache:     settings.ContentCache,
 				RegistryClient:   registryClient,
 				Debug:            settings.Debug,
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
 			}
 			if updateErr := manager.Update(); updateErr != nil {
 				return nil, fmt.Errorf("%w: failed to update dependencies for Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, updateErr)

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -14,6 +14,8 @@ import (
 	helmchart "helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/downloader"
+	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/registry"
 	release "helm.sh/helm/v4/pkg/release/v1"
 
@@ -50,6 +52,8 @@ type chartSpec struct {
 	Values map[string]any
 	// IncludeCRDs includes CRDs from the chart's crds/ directory in the output.
 	IncludeCRDs bool
+	// DependencyUpdate fetches missing dependencies before loading the chart.
+	DependencyUpdate bool
 	// Repositories lists declarative chart repositories for "repo/name" refs.
 	Repositories []chartRepository
 	// Release is the presence-aware policy tree before an action is selected.
@@ -157,7 +161,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loadChart(chartPath)
+	loaded, err := loadChartForAction(chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}
@@ -178,6 +182,15 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 // The Helm action package assumes its CLI caller performed this check; without it,
 // a missing library chart fails later with an unrelated template-definition error.
 func loadChart(chartPath string) (helmchart.Charter, error) {
+	return loadChartForAction(chartPath, nil, nil, false)
+}
+
+func loadChartForAction(
+	chartPath string,
+	settings *cli.EnvSettings,
+	registryClient *registry.Client,
+	dependencyUpdate bool,
+) (helmchart.Charter, error) {
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
@@ -189,7 +202,29 @@ func loadChart(chartPath string) (helmchart.Charter, error) {
 	}
 	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
 		if err := action.CheckDependencies(loaded, dependencies); err != nil {
-			return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			if !dependencyUpdate {
+				return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' or pass '--dependency-update' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
+			if settings == nil {
+				return nil, fmt.Errorf("%w: cannot update dependencies for Helm chart %q without Helm environment settings", errUtils.ErrHelmRenderFailed, chartPath)
+			}
+			manager := &downloader.Manager{
+				Out:              io.Discard,
+				ChartPath:        chartPath,
+				Getters:          getter.All(settings),
+				RepositoryConfig: settings.RepositoryConfig,
+				RepositoryCache:  settings.RepositoryCache,
+				ContentCache:     settings.ContentCache,
+				RegistryClient:   registryClient,
+				Debug:            settings.Debug,
+			}
+			if updateErr := manager.Update(); updateErr != nil {
+				return nil, fmt.Errorf("%w: failed to update dependencies for Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, updateErr)
+			}
+			loaded, err = loader.Load(chartPath)
+			if err != nil {
+				return nil, fmt.Errorf("%w: failed to reload Helm chart %q after dependency update: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
 		}
 	}
 

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -161,7 +161,7 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 
 	chartPath, err := client.LocateChart(chartRef, settings)
 	if err != nil {
-		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
+		return "", fmt.Errorf("%w: failed to locate Helm chart %q: %w", errUtils.ErrHelmRenderFailed, spec.Chart, err)
 	}
 
 	loaded, err := loadChartForAction(ctx, chartPath, settings, client.GetRegistryClient(), spec.DependencyUpdate)

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
+	helmchart "helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/registry"
@@ -151,9 +153,9 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
 
-	loaded, err := loader.Load(chartPath)
+	loaded, err := loadChart(chartPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return "", err
 	}
 
 	rel, err := client.RunWithContext(ctx, loaded, spec.Values)
@@ -165,7 +167,47 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return rendered.Manifest, nil
+	return renderReleaseManifest(rendered), nil
+}
+
+// loadChart loads a chart and verifies that every declared dependency is present.
+// The Helm action package assumes its CLI caller performed this check; without it,
+// a missing library chart fails later with an unrelated template-definition error.
+func loadChart(chartPath string) (helmchart.Charter, error) {
+	loaded, err := loader.Load(chartPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+	}
+
+	accessor, err := helmchart.NewAccessor(loaded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect Helm chart %q: %w", chartPath, err)
+	}
+	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
+		if err := action.CheckDependencies(loaded, dependencies); err != nil {
+			return nil, fmt.Errorf("an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", chartPath, err)
+		}
+	}
+
+	return loaded, nil
+}
+
+// renderReleaseManifest returns the same manifest surface as `helm template`:
+// regular resources followed by hook resources with their source annotations.
+// Helm keeps hooks outside Release.Manifest, so returning that field alone makes
+// template, plan, and diff silently omit resources such as migration Jobs.
+func renderReleaseManifest(rendered *release.Release) string {
+	var manifests bytes.Buffer
+	if manifest := strings.TrimSpace(rendered.Manifest); manifest != "" {
+		fmt.Fprintln(&manifests, manifest)
+	}
+	for _, hook := range rendered.Hooks {
+		if hook == nil || strings.TrimSpace(hook.Manifest) == "" {
+			continue
+		}
+		fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", hook.Path, strings.TrimSpace(hook.Manifest))
+	}
+	return manifests.String()
 }
 
 // resolveChartRef maps a "repo/name" chart reference to an explicit RepoURL +

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -176,16 +176,16 @@ func runInstall(ctx context.Context, client *action.Install, settings *cli.EnvSe
 func loadChart(chartPath string) (helmchart.Charter, error) {
 	loaded, err := loader.Load(chartPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return nil, fmt.Errorf("%w: failed to load Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 	}
 
 	accessor, err := helmchart.NewAccessor(loaded)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect Helm chart %q: %w", chartPath, err)
+		return nil, fmt.Errorf("%w: failed to inspect Helm chart %q: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 	}
 	if dependencies := accessor.MetaDependencies(); len(dependencies) > 0 {
 		if err := action.CheckDependencies(loaded, dependencies); err != nil {
-			return nil, fmt.Errorf("an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", chartPath, err)
+			return nil, fmt.Errorf("%w: an error occurred while checking Helm chart dependencies; run 'helm dependency build %s' to fetch missing dependencies: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
 		}
 	}
 

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -113,6 +113,9 @@ func renderManifest(ctx context.Context, spec *chartSpec) (string, error) {
 
 	manifest, err := runInstall(ctx, client, settings, spec)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", err
 		}
@@ -234,6 +237,9 @@ func loadChartForAction(
 			loaded, err = loader.Load(chartPath)
 			if err != nil {
 				return nil, fmt.Errorf("%w: failed to reload Helm chart %q after dependency update: %w", errUtils.ErrHelmRenderFailed, chartPath, err)
+			}
+			if depErr := action.CheckDependencies(loaded, dependencies); depErr != nil {
+				return nil, fmt.Errorf("%w: Helm chart %q is still missing dependencies after 'helm dependency update': %w", errUtils.ErrHelmRenderFailed, chartPath, depErr)
 			}
 		}
 	}

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -108,6 +109,9 @@ func renderManifest(ctx context.Context, spec *chartSpec) (string, error) {
 
 	manifest, err := runInstall(ctx, client, settings, spec)
 	if err != nil {
+		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
+			return "", err
+		}
 		return "", fmt.Errorf("%w: %w", errUtils.ErrHelmRenderFailed, err)
 	}
 	return manifest, nil

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -127,7 +127,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loadChart(chartPath)
+	loaded, err := loadChartForAction(chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -68,6 +68,9 @@ var newActionContext = func(namespace string) (*actionContext, error) {
 // returned for preview.
 func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseActionResult, error) {
 	defer perf.Track(nil, "helm.applyRelease")()
+	if err := ctx.Err(); err != nil {
+		return releaseActionResult{}, err
+	}
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"helm.sh/helm/v4/pkg/action"
-	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/registry"
@@ -128,9 +127,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loader.Load(chartPath)
+	loaded, err := loadChart(chartPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return "", err
 	}
 
 	rel, err := client.RunWithContext(ctx, spec.ReleaseName, loaded, spec.Values)
@@ -141,7 +140,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return rendered.Manifest, nil
+	return renderReleaseManifest(rendered), nil
 }
 
 // resolveUpgradeChartRef applies the same repo/name resolution as the install
@@ -186,7 +185,7 @@ func getDeployedManifest(releaseName, namespace string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return deployed.Manifest, nil
+	return renderReleaseManifest(deployed), nil
 }
 
 // deleteRelease uninstalls the release.

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cli"
@@ -84,7 +85,9 @@ func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseAct
 			return releaseActionResult{Operation: releaseOperationInstall}, resolveErr
 		}
 		spec.Lifecycle = lifecycle
-		manifest, installErr := installRelease(ctx, actx, spec, dryRun)
+		operationCtx, cancel := releaseOperationContext(ctx, lifecycle.Policy.Timeout)
+		defer cancel()
+		manifest, installErr := installRelease(operationCtx, actx, spec, dryRun)
 		return releaseActionResult{Manifest: manifest, Operation: releaseOperationInstall, Lifecycle: lifecycle}, installErr
 	} else if historyErr != nil {
 		return releaseActionResult{}, fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseHistory, spec.ReleaseName, historyErr)
@@ -94,8 +97,27 @@ func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseAct
 		return releaseActionResult{Operation: releaseOperationUpgrade}, resolveErr
 	}
 	spec.Lifecycle = lifecycle
-	manifest, upgradeErr := upgradeRelease(ctx, actx, spec, dryRun)
+	operationCtx, cancel := releaseOperationContext(ctx, lifecycle.Policy.Timeout)
+	defer cancel()
+	manifest, upgradeErr := upgradeRelease(operationCtx, actx, spec, dryRun)
 	return releaseActionResult{Manifest: manifest, Operation: releaseOperationUpgrade, Lifecycle: lifecycle}, upgradeErr
+}
+
+// releaseOperationContext applies the effective lifecycle timeout to every
+// cluster-side Helm action. A zero timeout intentionally remains unbounded
+// during the timeout-default migration.
+func releaseOperationContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func releaseWaitOptions(ctx context.Context) []kube.WaitOption {
+	return []kube.WaitOption{
+		kube.WithWaitContext(ctx),
+		kube.WithWaitForDeleteMethodContext(ctx),
+	}
 }
 
 func installRelease(ctx context.Context, actx *actionContext, spec *chartSpec, dryRun bool) (string, error) {
@@ -106,6 +128,7 @@ func installRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	client.CreateNamespace = true
 	client.Version = spec.Version
 	configureInstallLifecycle(client, spec.Lifecycle.Policy)
+	client.WaitOptions = releaseWaitOptions(ctx)
 	if dryRun {
 		client.DryRunStrategy = action.DryRunServer
 	}
@@ -121,6 +144,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	client.Namespace = spec.Namespace
 	client.Version = spec.Version
 	configureUpgradeLifecycle(client, spec.Lifecycle.Policy)
+	client.WaitOptions = releaseWaitOptions(ctx)
 	if dryRun {
 		client.DryRunStrategy = action.DryRunServer
 	}
@@ -203,6 +227,8 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	operationCtx, cancel := releaseOperationContext(ctx, spec.Lifecycle.Policy.Timeout)
+	defer cancel()
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {
@@ -211,21 +237,18 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 
 	client := action.NewUninstall(actx.cfg)
 	configureUninstallLifecycle(client, spec.Lifecycle.Policy, dryRun)
-	client.WaitOptions = []kube.WaitOption{
-		kube.WithWaitContext(ctx),
-		kube.WithWaitForDeleteMethodContext(ctx),
-	}
+	client.WaitOptions = releaseWaitOptions(operationCtx)
 	if _, err := client.Run(spec.ReleaseName); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil
 		}
 		uninstallErr := fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := operationCtx.Err(); ctxErr != nil {
 			return errors.Join(ctxErr, uninstallErr)
 		}
 		return uninstallErr
 	}
-	if err := ctx.Err(); err != nil {
+	if err := operationCtx.Err(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -210,7 +210,11 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil
 		}
-		return fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+		uninstallErr := fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return errors.Join(ctxErr, uninstallErr)
+		}
+		return uninstallErr
 	}
 	if err := ctx.Err(); err != nil {
 		return err

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -140,7 +140,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
 		}
-		return "", err
+		return "", fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUpgrade, spec.ReleaseName, err)
 	}
 	rendered, ok := rel.(*release.Release)
 	if !ok {

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -186,8 +186,11 @@ func getDeployedManifest(releaseName, namespace string) (string, error) {
 }
 
 // deleteRelease uninstalls the release.
-func deleteRelease(spec *chartSpec, dryRun bool) error {
+func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 	defer perf.Track(nil, "helm.deleteRelease")()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {
@@ -201,6 +204,9 @@ func deleteRelease(spec *chartSpec, dryRun bool) error {
 			return nil
 		}
 		return fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -113,6 +113,9 @@ func installRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 }
 
 func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, dryRun bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	client := action.NewUpgrade(actx.cfg)
 	client.SetRegistryClient(actx.cfg.RegistryClient)
 	client.Namespace = spec.Namespace
@@ -127,7 +130,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loadChartForAction(chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
+	loaded, err := loadChartForAction(ctx, chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -128,7 +128,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	chartRef := resolveUpgradeChartRef(client, spec)
 	chartPath, err := client.LocateChart(chartRef, actx.settings)
 	if err != nil {
-		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
+		return "", fmt.Errorf("%w: failed to locate Helm chart %q for upgrade: %w", errUtils.ErrHelmRenderFailed, spec.Chart, err)
 	}
 	loaded, err := loadChartForAction(ctx, chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
@@ -137,6 +137,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 
 	rel, err := client.RunWithContext(ctx, spec.ReleaseName, loaded, spec.Values)
 	if err != nil {
+		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
+			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
+		}
 		return "", err
 	}
 	rendered, ok := rel.(*release.Release)

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -137,6 +137,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 
 	rel, err := client.RunWithContext(ctx, spec.ReleaseName, loaded, spec.Values)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
 		}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -10,6 +10,7 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/registry"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
@@ -199,6 +200,10 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 
 	client := action.NewUninstall(actx.cfg)
 	configureUninstallLifecycle(client, spec.Lifecycle.Policy, dryRun)
+	client.WaitOptions = []kube.WaitOption{
+		kube.WithWaitContext(ctx),
+		kube.WithWaitForDeleteMethodContext(ctx),
+	}
 	if _, err := client.Run(spec.ReleaseName); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -132,8 +132,9 @@ func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseAct
 }
 
 // releaseOperationContext applies the effective lifecycle timeout to every
-// cluster-side Helm action. A zero timeout intentionally remains unbounded
-// during the timeout-default migration.
+// cluster-side Helm action. A zero timeout intentionally leaves the outer
+// action context unbounded during the migration; Helm then applies the
+// selected wait strategy's own zero-timeout behavior.
 func releaseOperationContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		return parent, func() {}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -165,7 +165,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loadChart(chartPath)
+	loaded, err := loadChartForAction(chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -96,6 +96,9 @@ func verifyExpectedKubernetesEndpoint(settings *cli.EnvSettings) error {
 // returned for preview.
 func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseActionResult, error) {
 	defer perf.Track(nil, "helm.applyRelease")()
+	if err := ctx.Err(); err != nil {
+		return releaseActionResult{}, err
+	}
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -12,6 +12,7 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/registry"
 	helmrelease "helm.sh/helm/v4/pkg/release"
 	release "helm.sh/helm/v4/pkg/release/v1"
@@ -299,6 +300,10 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 
 	client := action.NewUninstall(actx.cfg)
 	configureUninstallLifecycle(client, spec.Lifecycle.Policy, dryRun)
+	client.WaitOptions = []kube.WaitOption{
+		kube.WithWaitContext(ctx),
+		kube.WithWaitForDeleteMethodContext(ctx),
+	}
 	if _, err := client.Run(spec.ReleaseName); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -286,8 +286,11 @@ func getDeployedManifest(releaseName, namespace string) (string, error) {
 }
 
 // deleteRelease uninstalls the release.
-func deleteRelease(spec *chartSpec, dryRun bool) error {
+func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 	defer perf.Track(nil, "helm.deleteRelease")()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {
@@ -301,6 +304,9 @@ func deleteRelease(spec *chartSpec, dryRun bool) error {
 			return nil
 		}
 		return fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -180,6 +180,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 		}
 	}
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
 		}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -151,6 +151,7 @@ func releaseWaitOptions(ctx context.Context) []kube.WaitOption {
 
 func installRelease(ctx context.Context, actx *actionContext, spec *chartSpec, dryRun bool) (string, error) {
 	client := newInstallClient(actx, spec, dryRun)
+	client.WaitOptions = releaseWaitOptions(ctx)
 	return runInstall(ctx, client, actx.settings, spec)
 }
 
@@ -167,7 +168,6 @@ func newInstallClient(actx *actionContext, spec *chartSpec, dryRun bool) *action
 	client.CreateNamespace = spec.CreateNamespace
 	client.Version = spec.Version
 	configureInstallLifecycle(client, spec.Lifecycle.Policy)
-	client.WaitOptions = releaseWaitOptions(ctx)
 	if dryRun {
 		client.DryRunStrategy = action.DryRunServer
 	}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cli"
@@ -112,7 +113,9 @@ func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseAct
 			return releaseActionResult{Operation: releaseOperationInstall}, resolveErr
 		}
 		spec.Lifecycle = lifecycle
-		manifest, installErr := installRelease(ctx, actx, spec, dryRun)
+		operationCtx, cancel := releaseOperationContext(ctx, lifecycle.Policy.Timeout)
+		defer cancel()
+		manifest, installErr := installRelease(operationCtx, actx, spec, dryRun)
 		return releaseActionResult{Manifest: manifest, Operation: releaseOperationInstall, Lifecycle: lifecycle}, installErr
 	} else if historyErr != nil {
 		return releaseActionResult{}, fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseHistory, spec.ReleaseName, historyErr)
@@ -122,8 +125,27 @@ func applyRelease(ctx context.Context, spec *chartSpec, dryRun bool) (releaseAct
 		return releaseActionResult{Operation: releaseOperationUpgrade}, resolveErr
 	}
 	spec.Lifecycle = lifecycle
-	manifest, upgradeErr := upgradeRelease(ctx, actx, spec, dryRun)
+	operationCtx, cancel := releaseOperationContext(ctx, lifecycle.Policy.Timeout)
+	defer cancel()
+	manifest, upgradeErr := upgradeRelease(operationCtx, actx, spec, dryRun)
 	return releaseActionResult{Manifest: manifest, Operation: releaseOperationUpgrade, Lifecycle: lifecycle}, upgradeErr
+}
+
+// releaseOperationContext applies the effective lifecycle timeout to every
+// cluster-side Helm action. A zero timeout intentionally remains unbounded
+// during the timeout-default migration.
+func releaseOperationContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func releaseWaitOptions(ctx context.Context) []kube.WaitOption {
+	return []kube.WaitOption{
+		kube.WithWaitContext(ctx),
+		kube.WithWaitForDeleteMethodContext(ctx),
+	}
 }
 
 func installRelease(ctx context.Context, actx *actionContext, spec *chartSpec, dryRun bool) (string, error) {
@@ -144,6 +166,7 @@ func newInstallClient(actx *actionContext, spec *chartSpec, dryRun bool) *action
 	client.CreateNamespace = spec.CreateNamespace
 	client.Version = spec.Version
 	configureInstallLifecycle(client, spec.Lifecycle.Policy)
+	client.WaitOptions = releaseWaitOptions(ctx)
 	if dryRun {
 		client.DryRunStrategy = action.DryRunServer
 	}
@@ -159,6 +182,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	client.Namespace = spec.Namespace
 	client.Version = spec.Version
 	configureUpgradeLifecycle(client, spec.Lifecycle.Policy)
+	client.WaitOptions = releaseWaitOptions(ctx)
 	if dryRun {
 		client.DryRunStrategy = action.DryRunServer
 	}
@@ -303,6 +327,8 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	operationCtx, cancel := releaseOperationContext(ctx, spec.Lifecycle.Policy.Timeout)
+	defer cancel()
 
 	actx, err := newActionContext(spec.Namespace)
 	if err != nil {
@@ -311,21 +337,18 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 
 	client := action.NewUninstall(actx.cfg)
 	configureUninstallLifecycle(client, spec.Lifecycle.Policy, dryRun)
-	client.WaitOptions = []kube.WaitOption{
-		kube.WithWaitContext(ctx),
-		kube.WithWaitForDeleteMethodContext(ctx),
-	}
+	client.WaitOptions = releaseWaitOptions(operationCtx)
 	if _, err := client.Run(spec.ReleaseName); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil
 		}
 		uninstallErr := fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := operationCtx.Err(); ctxErr != nil {
 			return errors.Join(ctxErr, uninstallErr)
 		}
 		return uninstallErr
 	}
-	if err := ctx.Err(); err != nil {
+	if err := operationCtx.Err(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -151,6 +151,9 @@ func newInstallClient(actx *actionContext, spec *chartSpec, dryRun bool) *action
 }
 
 func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, dryRun bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	client := action.NewUpgrade(actx.cfg)
 	client.SetRegistryClient(actx.cfg.RegistryClient)
 	client.Namespace = spec.Namespace
@@ -165,7 +168,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loadChartForAction(chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
+	loaded, err := loadChartForAction(ctx, chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -166,7 +166,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	chartRef := resolveUpgradeChartRef(client, spec)
 	chartPath, err := client.LocateChart(chartRef, actx.settings)
 	if err != nil {
-		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
+		return "", fmt.Errorf("%w: failed to locate Helm chart %q for upgrade: %w", errUtils.ErrHelmRenderFailed, spec.Chart, err)
 	}
 	loaded, err := loadChartForAction(ctx, chartPath, actx.settings, actx.cfg.RegistryClient, spec.DependencyUpdate)
 	if err != nil {
@@ -180,6 +180,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 		}
 	}
 	if err != nil {
+		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
+			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
+		}
 		return "", err
 	}
 	rendered, ok := rel.(*release.Release)

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -310,7 +310,11 @@ func deleteRelease(ctx context.Context, spec *chartSpec, dryRun bool) error {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil
 		}
-		return fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+		uninstallErr := fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUninstall, spec.ReleaseName, err)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return errors.Join(ctxErr, uninstallErr)
+		}
+		return uninstallErr
 	}
 	if err := ctx.Err(); err != nil {
 		return err

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -183,7 +183,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 		if errors.Is(err, errUtils.ErrHelmRenderFailed) {
 			return "", fmt.Errorf("failed to upgrade Helm release %q: %w", spec.ReleaseName, err)
 		}
-		return "", err
+		return "", fmt.Errorf("%w %q: %w", errUtils.ErrHelmReleaseUpgrade, spec.ReleaseName, err)
 	}
 	rendered, ok := rel.(*release.Release)
 	if !ok {

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
-	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/registry"
@@ -166,9 +165,9 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if err != nil {
 		return "", fmt.Errorf("failed to locate Helm chart %q: %w", spec.Chart, err)
 	}
-	loaded, err := loader.Load(chartPath)
+	loaded, err := loadChart(chartPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load Helm chart %q: %w", chartPath, err)
+		return "", err
 	}
 
 	rel, err := client.RunWithContext(ctx, spec.ReleaseName, loaded, spec.Values)
@@ -184,7 +183,7 @@ func upgradeRelease(ctx context.Context, actx *actionContext, spec *chartSpec, d
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return rendered.Manifest, nil
+	return renderReleaseManifest(rendered), nil
 }
 
 // enforceReleaseHistoryLimit repairs Helm's rollback-on-failure path, which
@@ -286,7 +285,7 @@ func getDeployedManifest(releaseName, namespace string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%w: unexpected release type %T", errUtils.ErrHelmRenderFailed, rel)
 	}
-	return deployed.Manifest, nil
+	return renderReleaseManifest(deployed), nil
 }
 
 // deleteRelease uninstalls the release.

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -142,7 +142,11 @@ func releaseOperationContext(parent context.Context, timeout time.Duration) (con
 	return context.WithTimeout(parent, timeout)
 }
 
-func releaseWaitOptions(ctx context.Context) []kube.WaitOption {
+// releaseWaitOptions builds the Helm wait options bound to the operation
+// context. It is a package variable so tests can observe the context wired into
+// the waiters (Helm's waitOptions.ctx is unexported and the fake waiter ignores
+// it), mirroring the newActionContext seam above.
+var releaseWaitOptions = func(ctx context.Context) []kube.WaitOption {
 	return []kube.WaitOption{
 		kube.WithWaitContext(ctx),
 		kube.WithWaitForDeleteMethodContext(ctx),

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -73,11 +73,13 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Equal(t, "install", result.Operation)
 	assert.Contains(t, result.Manifest, "kind: ConfigMap")
 	assert.Contains(t, result.Manifest, "name: lifecycle")
+	assert.Contains(t, result.Manifest, "name: lifecycle-settings")
 
 	// The installed release is now the diff baseline.
 	deployed, err := getDeployedManifest("lifecycle", "testns")
 	require.NoError(t, err)
 	assert.Contains(t, deployed, "kind: ConfigMap")
+	assert.Contains(t, deployed, "name: lifecycle-settings")
 
 	// Release exists -> applyRelease takes the upgrade branch.
 	upgraded, err := applyRelease(context.Background(), spec, false)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -209,7 +209,7 @@ func TestReleaseOperationContextPreservesZeroTimeout(t *testing.T) {
 	ctx, cancel := releaseOperationContext(parent, 0)
 	defer cancel()
 
-	assert.Same(t, parent, ctx)
+	assert.Equal(t, parent, ctx)
 	_, hasDeadline := ctx.Deadline()
 	assert.False(t, hasDeadline)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,4 +177,39 @@ func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {
 	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, getErr)
 	assert.NotEmpty(t, deployed)
+}
+
+func TestApplyReleaseUsesLifecycleTimeoutAndWaitContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "bounded-upgrade")
+
+	_, err := applyRelease(context.Background(), spec, false)
+	require.NoError(t, err)
+
+	kubeClient, ok := actx.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	require.True(t, ok)
+	kubeClient.RecordedWaitOptions = nil
+	kubeClient.WaitDuration = 2 * time.Second
+	timeout := "25ms"
+	spec.Release.Upgrade.Timeout = &timeout
+
+	started := time.Now()
+	result, err := applyRelease(context.Background(), spec, false)
+	elapsed := time.Since(started)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, releaseOperationUpgrade, result.Operation)
+	assert.Less(t, elapsed, time.Second, "upgrade must return at the lifecycle deadline")
+	assert.NotEmpty(t, kubeClient.RecordedWaitOptions, "Helm waiters must receive the operation context")
+}
+
+func TestReleaseOperationContextPreservesZeroTimeout(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel := releaseOperationContext(parent, 0)
+	defer cancel()
+
+	assert.Same(t, parent, ctx)
+	_, hasDeadline := ctx.Deadline()
+	assert.False(t, hasDeadline)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -86,8 +86,8 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Contains(t, upgraded.Manifest, "kind: ConfigMap")
 
 	// Delete removes it; deleting an absent release is a no-op (idempotent).
-	require.NoError(t, deleteRelease(spec, false))
-	require.NoError(t, deleteRelease(spec, false))
+	require.NoError(t, deleteRelease(context.Background(), spec, false))
+	require.NoError(t, deleteRelease(context.Background(), spec, false))
 
 	// After delete the baseline is empty (release not found), not an error.
 	deployed, err = getDeployedManifest("lifecycle", "testns")
@@ -135,9 +135,36 @@ func TestDeleteReleaseDryRunPreservesRelease(t *testing.T) {
 
 	_, err := applyRelease(context.Background(), spec, false)
 	require.NoError(t, err)
-	require.NoError(t, deleteRelease(spec, true))
+	require.NoError(t, deleteRelease(context.Background(), spec, true))
 
 	deployed, err := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, err)
 	assert.Contains(t, deployed, "kind: ConfigMap")
+}
+
+func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "canceled")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := applyRelease(ctx, spec, false)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "delete-canceled")
+	_, err := applyRelease(context.Background(), spec, false)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, deleteRelease(ctx, spec, false), context.Canceled)
+
+	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
+	require.NoError(t, getErr)
+	assert.NotEmpty(t, deployed)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -73,13 +73,13 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Equal(t, "install", result.Operation)
 	assert.Contains(t, result.Manifest, "kind: ConfigMap")
 	assert.Contains(t, result.Manifest, "name: lifecycle")
-	assert.Contains(t, result.Manifest, "name: lifecycle-settings")
+	assert.Contains(t, result.Manifest, `name: "lifecycle-settings"`)
 
 	// The installed release is now the diff baseline.
 	deployed, err := getDeployedManifest("lifecycle", "testns")
 	require.NoError(t, err)
 	assert.Contains(t, deployed, "kind: ConfigMap")
-	assert.Contains(t, deployed, "name: lifecycle-settings")
+	assert.Contains(t, deployed, `name: "lifecycle-settings"`)
 
 	// Release exists -> applyRelease takes the upgrade branch.
 	upgraded, err := applyRelease(context.Background(), spec, false)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -151,6 +151,10 @@ func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
 
 	_, err := applyRelease(ctx, spec, false)
 	require.ErrorIs(t, err, context.Canceled)
+
+	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
+	require.NoError(t, getErr)
+	assert.Empty(t, deployed)
 }
 
 func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -16,6 +16,8 @@ import (
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage"
 	"helm.sh/helm/v4/pkg/storage/driver"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 // memoryActionContext builds an actionContext backed by Helm's in-memory storage
@@ -153,6 +155,7 @@ func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
 
 	_, err := applyRelease(ctx, spec, false)
 	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, errUtils.ErrHelmReleaseUpgrade)
 
 	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, getErr)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -256,29 +256,34 @@ func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {
 	assert.NotEmpty(t, deployed)
 }
 
-func TestApplyReleaseUsesLifecycleTimeoutAndWaitContext(t *testing.T) {
+func TestApplyReleaseWiresWaitContext(t *testing.T) {
 	actx := memoryActionContext(t)
 	stubActionContext(t, actx)
-	spec := testdataChartSpec(t, "bounded-upgrade")
-
-	_, err := applyRelease(context.Background(), spec, false)
-	require.NoError(t, err)
+	spec := testdataChartSpec(t, "wait-context")
 
 	kubeClient, ok := actx.cfg.KubeClient.(*kubefake.FailingKubeClient)
 	require.True(t, ok)
-	kubeClient.RecordedWaitOptions = nil
-	kubeClient.WaitDuration = 2 * time.Second
-	timeout := "25ms"
-	spec.Release.Upgrade.Timeout = &timeout
+	waitErr := errors.New("wait failed")
+	kubeClient.WaitError = waitErr
+	timeout := "5s"
+	spec.Release.Install.Timeout = &timeout
 
-	started := time.Now()
 	result, err := applyRelease(context.Background(), spec, false)
-	elapsed := time.Since(started)
 
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, releaseOperationUpgrade, result.Operation)
-	assert.Less(t, elapsed, time.Second, "upgrade must return at the lifecycle deadline")
+	require.ErrorIs(t, err, waitErr)
+	assert.Equal(t, releaseOperationInstall, result.Operation)
 	assert.NotEmpty(t, kubeClient.RecordedWaitOptions, "Helm waiters must receive the operation context")
+}
+
+func TestReleaseOperationContextAppliesTimeout(t *testing.T) {
+	const timeout = time.Minute
+	started := time.Now()
+	ctx, cancel := releaseOperationContext(context.Background(), timeout)
+	defer cancel()
+
+	deadline, hasDeadline := ctx.Deadline()
+	require.True(t, hasDeadline)
+	assert.WithinDuration(t, started.Add(timeout), deadline, time.Second)
 }
 
 func TestReleaseOperationContextPreservesZeroTimeout(t *testing.T) {

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -118,13 +118,13 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Equal(t, "install", result.Operation)
 	assert.Contains(t, result.Manifest, "kind: ConfigMap")
 	assert.Contains(t, result.Manifest, "name: lifecycle")
-	assert.Contains(t, result.Manifest, "name: lifecycle-settings")
+	assert.Contains(t, result.Manifest, `name: "lifecycle-settings"`)
 
 	// The installed release is now the diff baseline.
 	deployed, err := getDeployedManifest("lifecycle", "testns")
 	require.NoError(t, err)
 	assert.Contains(t, deployed, "kind: ConfigMap")
-	assert.Contains(t, deployed, "name: lifecycle-settings")
+	assert.Contains(t, deployed, `name: "lifecycle-settings"`)
 
 	// Release exists -> applyRelease takes the upgrade branch.
 	upgraded, err := applyRelease(context.Background(), spec, false)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -286,7 +286,7 @@ func TestReleaseOperationContextPreservesZeroTimeout(t *testing.T) {
 	ctx, cancel := releaseOperationContext(parent, 0)
 	defer cancel()
 
-	assert.Same(t, parent, ctx)
+	assert.Equal(t, parent, ctx)
 	_, hasDeadline := ctx.Deadline()
 	assert.False(t, hasDeadline)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -118,11 +118,13 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Equal(t, "install", result.Operation)
 	assert.Contains(t, result.Manifest, "kind: ConfigMap")
 	assert.Contains(t, result.Manifest, "name: lifecycle")
+	assert.Contains(t, result.Manifest, "name: lifecycle-settings")
 
 	// The installed release is now the diff baseline.
 	deployed, err := getDeployedManifest("lifecycle", "testns")
 	require.NoError(t, err)
 	assert.Contains(t, deployed, "kind: ConfigMap")
+	assert.Contains(t, deployed, "name: lifecycle-settings")
 
 	// Release exists -> applyRelease takes the upgrade branch.
 	upgraded, err := applyRelease(context.Background(), spec, false)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -19,6 +19,8 @@ import (
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage"
 	"helm.sh/helm/v4/pkg/storage/driver"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 // memoryActionContext builds an actionContext backed by Helm's in-memory storage
@@ -230,6 +232,7 @@ func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
 
 	_, err := applyRelease(ctx, spec, false)
 	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, errUtils.ErrHelmReleaseUpgrade)
 
 	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, getErr)

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,4 +254,39 @@ func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {
 	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, getErr)
 	assert.NotEmpty(t, deployed)
+}
+
+func TestApplyReleaseUsesLifecycleTimeoutAndWaitContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "bounded-upgrade")
+
+	_, err := applyRelease(context.Background(), spec, false)
+	require.NoError(t, err)
+
+	kubeClient, ok := actx.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	require.True(t, ok)
+	kubeClient.RecordedWaitOptions = nil
+	kubeClient.WaitDuration = 2 * time.Second
+	timeout := "25ms"
+	spec.Release.Upgrade.Timeout = &timeout
+
+	started := time.Now()
+	result, err := applyRelease(context.Background(), spec, false)
+	elapsed := time.Since(started)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, releaseOperationUpgrade, result.Operation)
+	assert.Less(t, elapsed, time.Second, "upgrade must return at the lifecycle deadline")
+	assert.NotEmpty(t, kubeClient.RecordedWaitOptions, "Helm waiters must receive the operation context")
+}
+
+func TestReleaseOperationContextPreservesZeroTimeout(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel := releaseOperationContext(parent, 0)
+	defer cancel()
+
+	assert.Same(t, parent, ctx)
+	_, hasDeadline := ctx.Deadline()
+	assert.False(t, hasDeadline)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -131,8 +131,8 @@ func TestClientReleaseLifecycleInMemory(t *testing.T) {
 	assert.Contains(t, upgraded.Manifest, "kind: ConfigMap")
 
 	// Delete removes it; deleting an absent release is a no-op (idempotent).
-	require.NoError(t, deleteRelease(spec, false))
-	require.NoError(t, deleteRelease(spec, false))
+	require.NoError(t, deleteRelease(context.Background(), spec, false))
+	require.NoError(t, deleteRelease(context.Background(), spec, false))
 
 	// After delete the baseline is empty (release not found), not an error.
 	deployed, err = getDeployedManifest("lifecycle", "testns")
@@ -180,7 +180,7 @@ func TestDeleteReleaseDryRunPreservesRelease(t *testing.T) {
 
 	_, err := applyRelease(context.Background(), spec, false)
 	require.NoError(t, err)
-	require.NoError(t, deleteRelease(spec, true))
+	require.NoError(t, deleteRelease(context.Background(), spec, true))
 
 	deployed, err := getDeployedManifest(spec.ReleaseName, spec.Namespace)
 	require.NoError(t, err)
@@ -217,4 +217,31 @@ func TestUpgradeRollbackPreservesHistoryLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, history, maxHistory)
 	assert.Equal(t, maxHistory, actx.cfg.Releases.MaxHistory)
+}
+
+func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "canceled")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := applyRelease(ctx, spec, false)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {
+	actx := memoryActionContext(t)
+	stubActionContext(t, actx)
+	spec := testdataChartSpec(t, "delete-canceled")
+	_, err := applyRelease(context.Background(), spec, false)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, deleteRelease(ctx, spec, false), context.Canceled)
+
+	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
+	require.NoError(t, getErr)
+	assert.NotEmpty(t, deployed)
 }

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -228,6 +228,10 @@ func TestApplyReleaseHonorsCanceledContext(t *testing.T) {
 
 	_, err := applyRelease(ctx, spec, false)
 	require.ErrorIs(t, err, context.Canceled)
+
+	deployed, getErr := getDeployedManifest(spec.ReleaseName, spec.Namespace)
+	require.NoError(t, getErr)
+	assert.Empty(t, deployed)
 }
 
 func TestDeleteReleaseHonorsCanceledContext(t *testing.T) {

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -268,11 +268,30 @@ func TestApplyReleaseWiresWaitContext(t *testing.T) {
 	timeout := "5s"
 	spec.Release.Install.Timeout = &timeout
 
+	// Capture the context handed to the Helm waiters. Asserting only that
+	// RecordedWaitOptions is non-empty proves a waiter ran, not that it received
+	// the timed operation context: a regression passing context.Background()
+	// would still populate RecordedWaitOptions. Helm's waitOptions.ctx is
+	// unexported and the fake waiter ignores it, so observe it through the seam.
+	var waitCtx context.Context
+	originalWaitOptions := releaseWaitOptions
+	t.Cleanup(func() { releaseWaitOptions = originalWaitOptions })
+	releaseWaitOptions = func(ctx context.Context) []kube.WaitOption {
+		waitCtx = ctx
+		return originalWaitOptions(ctx)
+	}
+
+	start := time.Now()
 	result, err := applyRelease(context.Background(), spec, false)
 
 	require.ErrorIs(t, err, waitErr)
 	assert.Equal(t, releaseOperationInstall, result.Operation)
 	assert.NotEmpty(t, kubeClient.RecordedWaitOptions, "Helm waiters must receive the operation context")
+
+	require.NotNil(t, waitCtx, "releaseWaitOptions must receive the operation context")
+	deadline, hasDeadline := waitCtx.Deadline()
+	require.True(t, hasDeadline, "wait context must carry the 5s operation timeout, not context.Background()")
+	assert.WithinDuration(t, start.Add(5*time.Second), deadline, 2*time.Second)
 }
 
 func TestReleaseOperationContextAppliesTimeout(t *testing.T) {

--- a/pkg/component/helm/client_lifecycle_test.go
+++ b/pkg/component/helm/client_lifecycle_test.go
@@ -274,14 +274,18 @@ func TestApplyReleaseWiresWaitContext(t *testing.T) {
 	// would still populate RecordedWaitOptions. Helm's waitOptions.ctx is
 	// unexported and the fake waiter ignores it, so observe it through the seam.
 	var waitCtx context.Context
+	var waitOptionsAt time.Time
 	originalWaitOptions := releaseWaitOptions
 	t.Cleanup(func() { releaseWaitOptions = originalWaitOptions })
 	releaseWaitOptions = func(ctx context.Context) []kube.WaitOption {
+		// Stamp the moment the operation context is wired into the waiters so
+		// the deadline can be compared against a near-exact reference; this
+		// rejects a materially wrong timeout that a looser tolerance would miss.
+		waitOptionsAt = time.Now()
 		waitCtx = ctx
 		return originalWaitOptions(ctx)
 	}
 
-	start := time.Now()
 	result, err := applyRelease(context.Background(), spec, false)
 
 	require.ErrorIs(t, err, waitErr)
@@ -291,7 +295,7 @@ func TestApplyReleaseWiresWaitContext(t *testing.T) {
 	require.NotNil(t, waitCtx, "releaseWaitOptions must receive the operation context")
 	deadline, hasDeadline := waitCtx.Deadline()
 	require.True(t, hasDeadline, "wait context must carry the 5s operation timeout, not context.Background()")
-	assert.WithinDuration(t, start.Add(5*time.Second), deadline, 2*time.Second)
+	assert.WithinDuration(t, waitOptionsAt.Add(5*time.Second), deadline, 250*time.Millisecond)
 }
 
 func TestReleaseOperationContextAppliesTimeout(t *testing.T) {

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -131,6 +131,7 @@ func TestInstallAndUpgradeReleaseLocateChartErrors(t *testing.T) {
 	_, err := installRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `failed to locate Helm chart "missing-chart"`)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 
 	_, err = upgradeRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -11,6 +11,8 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
+
+	errUtils "github.com/cloudposse/atmos/errors"
 )
 
 func TestResolveUpgradeChartRef(t *testing.T) {
@@ -133,4 +135,5 @@ func TestInstallAndUpgradeReleaseLocateChartErrors(t *testing.T) {
 	_, err = upgradeRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `failed to locate Helm chart "missing-chart"`)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 }

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -115,7 +115,7 @@ func TestClusterOperationsReturnActionContextErrors(t *testing.T) {
 	_, err = getDeployedManifest("nginx", "apps")
 	require.ErrorIs(t, err, sentinel)
 
-	err = deleteRelease(spec, false)
+	err = deleteRelease(context.Background(), spec, false)
 	require.ErrorIs(t, err, sentinel)
 }
 

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -177,4 +177,5 @@ func TestInstallAndUpgradeReleaseLocateChartErrors(t *testing.T) {
 	_, err = upgradeRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `failed to locate Helm chart "missing-chart"`)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 }

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -173,6 +173,7 @@ func TestInstallAndUpgradeReleaseLocateChartErrors(t *testing.T) {
 	_, err := installRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `failed to locate Helm chart "missing-chart"`)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 
 	_, err = upgradeRelease(context.Background(), actx, spec, true)
 	require.Error(t, err)

--- a/pkg/component/helm/client_test.go
+++ b/pkg/component/helm/client_test.go
@@ -159,7 +159,7 @@ func TestClusterOperationsReturnActionContextErrors(t *testing.T) {
 	_, err = getDeployedManifest("nginx", "apps")
 	require.ErrorIs(t, err, sentinel)
 
-	err = deleteRelease(spec, false)
+	err = deleteRelease(context.Background(), spec, false)
 	require.ErrorIs(t, err, sentinel)
 }
 

--- a/pkg/component/helm/diff_test.go
+++ b/pkg/component/helm/diff_test.go
@@ -125,3 +125,13 @@ func TestResolveDiffBaseline_FromManifestFileMissing(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrHelmBaselineRead)
 }
+
+func TestResolveDiffBaseline_FromManifestHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	flags := map[string]any{flagFromManifest: filepath.Join(t.TempDir(), "nope.yaml")}
+
+	_, err := resolveDiffBaseline(ctx, &schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{}, flags, &chartSpec{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, errUtils.ErrHelmBaselineRead)
+}

--- a/pkg/component/helm/diff_test.go
+++ b/pkg/component/helm/diff_test.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,7 +112,7 @@ func TestResolveDiffBaseline_FromManifestFile(t *testing.T) {
 	spec := &chartSpec{ReleaseName: "app", Namespace: "demo"}
 	flags := map[string]any{flagFromManifest: path}
 
-	got, err := resolveDiffBaseline(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{}, flags, spec)
+	got, err := resolveDiffBaseline(context.Background(), &schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{}, flags, spec)
 	require.NoError(t, err)
 	assert.Equal(t, baseConfigMap, got)
 }
@@ -120,7 +121,7 @@ func TestResolveDiffBaseline_FromManifestFileMissing(t *testing.T) {
 	spec := &chartSpec{ReleaseName: "app", Namespace: "demo"}
 	flags := map[string]any{flagFromManifest: filepath.Join(t.TempDir(), "nope.yaml")}
 
-	_, err := resolveDiffBaseline(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{}, flags, spec)
+	_, err := resolveDiffBaseline(context.Background(), &schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{}, flags, spec)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrHelmBaselineRead)
 }

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -301,6 +301,10 @@ func resolveDiffBaseline(
 	flags map[string]any,
 	spec *chartSpec,
 ) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
 	if path := flagString(flags, flagFromManifest); path != "" {
 		content, err := os.ReadFile(path)
 		if err != nil {

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -165,6 +165,9 @@ func runWithHooks(
 	if namespace, ok := ctx.Flags["namespace"].(string); ok && namespace != "" {
 		spec.Namespace = namespace
 	}
+	if dependencyUpdate, ok := ctx.Flags[cfg.HelmDependencyUpdateSectionName].(bool); ok {
+		spec.DependencyUpdate = dependencyUpdate
+	}
 	if operation == OperationApply {
 		spec.LifecycleFlags = ctx.Flags
 	}
@@ -520,13 +523,14 @@ func helmSummary(info *schema.ConfigAndStacksInfo, spec *chartSpec, flags map[st
 		target = value
 	}
 	return map[string]any{
-		"component":    info.ComponentFromArg,
-		"stack":        info.Stack,
-		"command":      info.SubCommand,
-		"chart":        spec.Chart,
-		"release_name": spec.ReleaseName,
-		"namespace":    spec.Namespace,
-		"target":       target,
+		"component":         info.ComponentFromArg,
+		"stack":             info.Stack,
+		"command":           info.SubCommand,
+		"chart":             spec.Chart,
+		"release_name":      spec.ReleaseName,
+		"namespace":         spec.Namespace,
+		"target":            target,
+		"dependency_update": spec.DependencyUpdate,
 	}
 }
 

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -107,7 +107,7 @@ func executeSingle(
 		return err
 	}
 
-	componentPath, err := resolveComponentPath(atmosConfig, info)
+	componentPath, err := resolveComponentPath(ctx.GoContext(), atmosConfig, info)
 	if err != nil {
 		return err
 	}
@@ -216,15 +216,15 @@ func runOperation(
 		addObjectsToSummary(summary, objects)
 		return summary, err
 	case OperationDiff:
-		diffText, err := runDiff(atmosConfig, info, ctx.Flags, spec)
+		diffText, err := runDiff(ctx.GoContext(), atmosConfig, info, ctx.Flags, spec)
 		summary["diff"] = diffText
 		return summary, err
 	case OperationApply:
-		applySummary, err := deliverApply(atmosConfig, info, ctx.Flags, spec)
+		applySummary, err := deliverApply(ctx.GoContext(), atmosConfig, info, ctx.Flags, spec)
 		mergeSummary(summary, applySummary)
 		return summary, err
 	case OperationDelete:
-		err := deleteHelmRelease(spec, info.DryRun)
+		err := deleteHelmRelease(ctx.GoContext(), spec, info.DryRun)
 		summary["release"] = lifecycleSummary(releaseOperationDelete, spec.Lifecycle.Policy)
 		return summary, err
 	default:
@@ -240,7 +240,7 @@ func emitLifecycleWarnings(warnings []lifecycleWarning) {
 
 // runTemplate renders the chart and writes the manifests per the render options.
 func runTemplate(ctx *component.ExecutionContext, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, spec *chartSpec) ([]*unstructured.Unstructured, error) {
-	objects, err := renderObjects(spec)
+	objects, err := renderObjects(ctx.GoContext(), spec)
 	if err != nil {
 		return nil, err
 	}
@@ -259,12 +259,13 @@ func runTemplate(ctx *component.ExecutionContext, atmosConfig *schema.AtmosConfi
 // The diff is written to the data channel (secrets are redacted) and returned for
 // the CI job summary.
 func runDiff(
+	callerCtx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	flags map[string]any,
 	spec *chartSpec,
 ) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+	ctx, cancel := context.WithTimeout(callerCtx, renderTimeout)
 	defer cancel()
 
 	desired, err := renderChartManifest(ctx, spec)
@@ -272,7 +273,7 @@ func runDiff(
 		return "", err
 	}
 
-	baseline, err := resolveDiffBaseline(atmosConfig, info, flags, spec)
+	baseline, err := resolveDiffBaseline(callerCtx, atmosConfig, info, flags, spec)
 	if err != nil {
 		return "", err
 	}
@@ -294,6 +295,7 @@ func runDiff(
 // flags, in precedence order: --from-manifest (file), --against=target (GitOps),
 // otherwise the deployed release.
 func resolveDiffBaseline(
+	ctx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	flags map[string]any,
@@ -309,7 +311,7 @@ func resolveDiffBaseline(
 
 	against := flagString(flags, flagAgainst)
 	if against != "" && against != againstRelease {
-		return fetchTargetBaseline(atmosConfig, info, against)
+		return fetchTargetBaseline(ctx, atmosConfig, info, against)
 	}
 
 	return getDeployedManifest(spec.ReleaseName, spec.Namespace)
@@ -319,7 +321,7 @@ func resolveDiffBaseline(
 // target (e.g. the git deployment repository) so a render can be diffed against
 // the live GitOps state offline. The value is "target" (the default/selected
 // target) or "target:<name>".
-func fetchTargetBaseline(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, against string) (string, error) {
+func fetchTargetBaseline(callerCtx context.Context, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, against string) (string, error) {
 	targetName := ""
 	if _, name, ok := strings.Cut(against, ":"); ok {
 		targetName = name
@@ -334,7 +336,7 @@ func fetchTargetBaseline(atmosConfig *schema.AtmosConfiguration, info *schema.Co
 		return "", fmt.Errorf("%w: --against=target requires a non-cluster provision target such as a git deployment repository", errUtils.ErrHelmDiffFailed)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), deliveryTimeout)
+	ctx, cancel := context.WithTimeout(callerCtx, deliveryTimeout)
 	defer cancel()
 
 	artifact, err := target.Fetch(ctx, selected.Kind, &target.FetchInput{
@@ -385,8 +387,8 @@ func diffContextFromFlags(flags map[string]any) int {
 }
 
 // renderObjects renders the chart to manifest objects (client-side, no cluster).
-func renderObjects(spec *chartSpec) ([]*unstructured.Unstructured, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+func renderObjects(callerCtx context.Context, spec *chartSpec) ([]*unstructured.Unstructured, error) {
+	ctx, cancel := context.WithTimeout(callerCtx, renderTimeout)
 	defer cancel()
 
 	rendered, err := renderChartManifest(ctx, spec)
@@ -428,13 +430,13 @@ func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.
 	return nil
 }
 
-func resolveComponentPath(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {
+func resolveComponentPath(ctx context.Context, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {
 	initialPath, err := u.GetComponentPath(atmosConfig, cfg.HelmComponentType, info.ComponentFolderPrefix, info.FinalComponent)
 	if err != nil {
 		return "", errors.Join(errUtils.ErrPathResolution, fmt.Errorf("component path: %w", err))
 	}
 
-	provisionCtx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+	provisionCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 	path, _, err := provisionAndResolveComponentPath(provisionCtx, atmosConfig, info, cfg.HelmComponentType, initialPath)
 	return path, err

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -181,6 +181,9 @@ func runWithHooks(
 		}
 		emitLifecycleWarnings(spec.Lifecycle.Warnings)
 	}
+	if err := ctx.GoContext().Err(); err != nil {
+		return err
+	}
 	if operation != OperationDelete {
 		if err := setupRepositories(spec.Repositories); err != nil {
 			return err

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -146,6 +146,9 @@ func runWithHooks(
 	operation Operation,
 	componentPath string,
 ) error {
+	if err := ctx.GoContext().Err(); err != nil {
+		return err
+	}
 	hookSet, err := getHooks(atmosConfig, info)
 	if err != nil {
 		return err

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -228,6 +228,9 @@ func runWithHooks(
 		}
 		emitLifecycleWarnings(spec.Lifecycle.Warnings)
 	}
+	if err := ctx.GoContext().Err(); err != nil {
+		return err
+	}
 	if operation != OperationDelete {
 		if err := setupRepositories(spec.Repositories); err != nil {
 			return err

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -350,6 +350,10 @@ func resolveDiffBaseline(
 	flags map[string]any,
 	spec *chartSpec,
 ) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
 	if path := flagString(flags, flagFromManifest); path != "" {
 		content, err := os.ReadFile(path)
 		if err != nil {

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -193,6 +193,9 @@ func runWithHooks(
 	operation Operation,
 	componentPath string,
 ) error {
+	if err := ctx.GoContext().Err(); err != nil {
+		return err
+	}
 	hookSet, err := getHooks(atmosConfig, info)
 	if err != nil {
 		return err

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -212,6 +212,9 @@ func runWithHooks(
 	if namespace, ok := ctx.Flags["namespace"].(string); ok && namespace != "" {
 		spec.Namespace = namespace
 	}
+	if dependencyUpdate, ok := ctx.Flags[cfg.HelmDependencyUpdateSectionName].(bool); ok {
+		spec.DependencyUpdate = dependencyUpdate
+	}
 	if operation == OperationApply {
 		spec.LifecycleFlags = ctx.Flags
 	}
@@ -707,13 +710,14 @@ func helmSummary(info *schema.ConfigAndStacksInfo, spec *chartSpec, flags map[st
 		target = value
 	}
 	return map[string]any{
-		"component":    info.ComponentFromArg,
-		"stack":        info.Stack,
-		"command":      info.SubCommand,
-		"chart":        spec.Chart,
-		"release_name": spec.ReleaseName,
-		"namespace":    spec.Namespace,
-		"target":       target,
+		"component":         info.ComponentFromArg,
+		"stack":             info.Stack,
+		"command":           info.SubCommand,
+		"chart":             spec.Chart,
+		"release_name":      spec.ReleaseName,
+		"namespace":         spec.Namespace,
+		"target":            target,
+		"dependency_update": spec.DependencyUpdate,
 	}
 }
 

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -115,7 +115,7 @@ func executeSingle(
 		return err
 	}
 
-	componentPath, err := resolveComponentPath(atmosConfig, info)
+	componentPath, err := resolveComponentPath(ctx.GoContext(), atmosConfig, info)
 	if err != nil {
 		return err
 	}
@@ -263,16 +263,16 @@ func runOperation(
 		addObjectsToSummary(summary, objects)
 		return summary, err
 	case OperationDiff:
-		diffText, err := runDiff(atmosConfig, info, ctx.Flags, spec)
+		diffText, err := runDiff(ctx.GoContext(), atmosConfig, info, ctx.Flags, spec)
 		summary["diff"] = diffText
 		return summary, err
 	case OperationApply:
-		applySummary, err := deliverApply(atmosConfig, info, ctx.Flags, spec)
+		applySummary, err := deliverApply(ctx.GoContext(), atmosConfig, info, ctx.Flags, spec)
 		mergeSummary(summary, applySummary)
 		emitOperationStatus(OperationApply, summary, err)
 		return summary, err
 	case OperationDelete:
-		err := deleteHelmRelease(spec, info.DryRun)
+		err := deleteHelmRelease(ctx.GoContext(), spec, info.DryRun)
 		summary["release"] = lifecycleSummary(releaseOperationDelete, spec.Lifecycle.Policy)
 		emitOperationStatus(OperationDelete, summary, err)
 		return summary, err
@@ -289,7 +289,7 @@ func emitLifecycleWarnings(warnings []lifecycleWarning) {
 
 // runTemplate renders the chart and writes the manifests per the render options.
 func runTemplate(ctx *component.ExecutionContext, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, spec *chartSpec) ([]*unstructured.Unstructured, error) {
-	objects, err := renderObjects(spec)
+	objects, err := renderObjects(ctx.GoContext(), spec)
 	if err != nil {
 		return nil, err
 	}
@@ -308,12 +308,13 @@ func runTemplate(ctx *component.ExecutionContext, atmosConfig *schema.AtmosConfi
 // The diff is written to the data channel (secrets are redacted) and returned for
 // the CI job summary.
 func runDiff(
+	callerCtx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	flags map[string]any,
 	spec *chartSpec,
 ) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+	ctx, cancel := context.WithTimeout(callerCtx, renderTimeout)
 	defer cancel()
 
 	desired, err := renderChartManifest(ctx, spec)
@@ -321,7 +322,7 @@ func runDiff(
 		return "", err
 	}
 
-	baseline, err := resolveDiffBaseline(atmosConfig, info, flags, spec)
+	baseline, err := resolveDiffBaseline(callerCtx, atmosConfig, info, flags, spec)
 	if err != nil {
 		return "", err
 	}
@@ -343,6 +344,7 @@ func runDiff(
 // flags, in precedence order: --from-manifest (file), --against=target (GitOps),
 // otherwise the deployed release.
 func resolveDiffBaseline(
+	ctx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	flags map[string]any,
@@ -358,7 +360,7 @@ func resolveDiffBaseline(
 
 	against := flagString(flags, flagAgainst)
 	if against != "" && against != againstRelease {
-		return fetchTargetBaseline(atmosConfig, info, against)
+		return fetchTargetBaseline(ctx, atmosConfig, info, against)
 	}
 
 	return getDeployedManifest(spec.ReleaseName, spec.Namespace)
@@ -368,7 +370,7 @@ func resolveDiffBaseline(
 // target (e.g. the git deployment repository) so a render can be diffed against
 // the live GitOps state offline. The value is "target" (the default/selected
 // target) or "target:<name>".
-func fetchTargetBaseline(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, against string) (string, error) {
+func fetchTargetBaseline(callerCtx context.Context, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, against string) (string, error) {
 	targetName := ""
 	if _, name, ok := strings.Cut(against, ":"); ok {
 		targetName = name
@@ -383,7 +385,7 @@ func fetchTargetBaseline(atmosConfig *schema.AtmosConfiguration, info *schema.Co
 		return "", fmt.Errorf("%w: --against=target requires a non-cluster provision target such as a git deployment repository", errUtils.ErrHelmDiffFailed)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), deliveryTimeout)
+	ctx, cancel := context.WithTimeout(callerCtx, deliveryTimeout)
 	defer cancel()
 
 	artifact, err := target.Fetch(ctx, selected.Kind, &target.FetchInput{
@@ -434,8 +436,8 @@ func diffContextFromFlags(flags map[string]any) int {
 }
 
 // renderObjects renders the chart to manifest objects (client-side, no cluster).
-func renderObjects(spec *chartSpec) ([]*unstructured.Unstructured, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+func renderObjects(callerCtx context.Context, spec *chartSpec) ([]*unstructured.Unstructured, error) {
+	ctx, cancel := context.WithTimeout(callerCtx, renderTimeout)
 	defer cancel()
 
 	rendered, err := renderChartManifest(ctx, spec)
@@ -582,13 +584,13 @@ func operationContactsCluster(operation Operation, flags map[string]any) bool {
 	}
 }
 
-func resolveComponentPath(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {
+func resolveComponentPath(ctx context.Context, atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {
 	initialPath, err := u.GetComponentPath(atmosConfig, cfg.HelmComponentType, info.ComponentFolderPrefix, info.FinalComponent)
 	if err != nil {
 		return "", errors.Join(errUtils.ErrPathResolution, fmt.Errorf("component path: %w", err))
 	}
 
-	provisionCtx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+	provisionCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 	path, _, err := provisionAndResolveComponentPath(provisionCtx, atmosConfig, info, cfg.HelmComponentType, initialPath)
 	return path, err

--- a/pkg/component/helm/executor_bulk.go
+++ b/pkg/component/helm/executor_bulk.go
@@ -1,8 +1,6 @@
 package helm
 
 import (
-	"context"
-
 	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/ci"
@@ -44,7 +42,7 @@ func executeBulk(
 		return err
 	}
 
-	return executeGraph(context.Background(), &component.GraphExecutionOptions{
+	return executeGraph(ctx.GoContext(), &component.GraphExecutionOptions{
 		Provider:      &ComponentProvider{},
 		AtmosConfig:   atmosConfig,
 		Info:          info,

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -13,6 +13,7 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/component"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	"github.com/cloudposse/atmos/pkg/hooks"
 	"github.com/cloudposse/atmos/pkg/provisioner/target"
@@ -176,9 +177,9 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 		return &hooks.Hooks{}, nil
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
-	var appliedNamespace string
+	var appliedSpec *chartSpec
 	applyHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) (releaseActionResult, error) {
-		appliedNamespace = spec.Namespace
+		appliedSpec = spec
 		return releaseActionResult{Manifest: helmExecutorManifest, Operation: "install"}, nil
 	}
 	var setup []chartRepository
@@ -199,9 +200,14 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 			},
 		},
 	}
-	err := runWithHooks(&component.ExecutionContext{Flags: map[string]any{"namespace": "incident-ns"}}, &schema.AtmosConfiguration{}, info, OperationApply, "")
+	err := runWithHooks(&component.ExecutionContext{Flags: map[string]any{
+		"namespace":                         "incident-ns",
+		cfg.HelmDependencyUpdateSectionName: true,
+	}}, &schema.AtmosConfiguration{}, info, OperationApply, "")
 	require.NoError(t, err)
-	assert.Equal(t, "incident-ns", appliedNamespace)
+	require.NotNil(t, appliedSpec)
+	assert.Equal(t, "incident-ns", appliedSpec.Namespace)
+	assert.True(t, appliedSpec.DependencyUpdate)
 	require.Len(t, setup, 1)
 	assert.Equal(t, "bitnami", setup[0].Name)
 }

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -212,6 +212,35 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 	assert.Equal(t, "bitnami", setup[0].Name)
 }
 
+func TestRunWithHooks_CanceledContextSkipsHooksAndRepositories(t *testing.T) {
+	originalHooks := getHooks
+	originalSetup := setupRepositories
+	t.Cleanup(func() {
+		getHooks = originalHooks
+		setupRepositories = originalSetup
+	})
+
+	getHooks = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (*hooks.Hooks, error) {
+		t.Fatal("canceled operation must not discover or run hooks")
+		return nil, nil
+	}
+	setupRepositories = func([]chartRepository) error {
+		t.Fatal("canceled operation must not set up repositories")
+		return nil
+	}
+
+	goContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := runWithHooks(
+		&component.ExecutionContext{Context: goContext, Flags: map[string]any{}},
+		&schema.AtmosConfiguration{},
+		&schema.ConfigAndStacksInfo{},
+		OperationApply,
+		"",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRunWithHooks_GetHooksError(t *testing.T) {
 	originalHooks := getHooks
 	t.Cleanup(func() { getHooks = originalHooks })

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -69,7 +69,7 @@ func TestExecuteSingle_HappyPath(t *testing.T) {
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
 	var deleted string
-	deleteHelmRelease = func(spec *chartSpec, _ bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) error {
 		deleted = spec.ReleaseName
 		return nil
 	}
@@ -141,7 +141,7 @@ func TestRunWithHooks_DeleteSuccess(t *testing.T) {
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
 	var deleted string
-	deleteHelmRelease = func(spec *chartSpec, _ bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) error {
 		deleted = spec.ReleaseName
 		return nil
 	}
@@ -232,6 +232,7 @@ func TestResolveDiffBaseline_AgainstTarget(t *testing.T) {
 		},
 	}}
 	got, err := resolveDiffBaseline(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		info,
 		map[string]any{flagAgainst: "target"},
@@ -252,6 +253,7 @@ func TestResolveDiffBaseline_DeployedRelease(t *testing.T) {
 	stubActionContext(t, actx)
 
 	got, err := resolveDiffBaseline(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		&schema.ConfigAndStacksInfo{},
 		map[string]any{},
@@ -263,7 +265,7 @@ func TestResolveDiffBaseline_DeployedRelease(t *testing.T) {
 
 func TestFetchTargetBaseline_RejectsKubernetesTarget(t *testing.T) {
 	// No provision section + no name resolves to the implicit cluster target.
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}, "target")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}, "target")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrHelmDiffFailed)
 }
@@ -275,7 +277,7 @@ func TestFetchTargetBaseline_SelectTargetError(t *testing.T) {
 		},
 	}}
 	// "target:nope" requests a named target that is not configured.
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, info, "target:nope")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, info, "target:nope")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrProvisionTargetNotFound)
 }
@@ -289,7 +291,7 @@ func TestFetchTargetBaseline_FetchError(t *testing.T) {
 			"targets": map[string]any{"repo": map[string]any{"kind": "diff-fetch-err"}},
 		},
 	}}
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, info, "target")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, info, "target")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fetch boom")
 }
@@ -303,7 +305,7 @@ func TestResolveComponentPath(t *testing.T) {
 	}
 	atmosConfig := &schema.AtmosConfiguration{}
 	atmosConfig.Components.Helm.BasePath = "components/helm"
-	path, err := resolveComponentPath(atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
+	path, err := resolveComponentPath(context.Background(), atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
 	require.NoError(t, err)
 	assert.Contains(t, filepath.ToSlash(path), "components/helm")
 
@@ -311,7 +313,7 @@ func TestResolveComponentPath(t *testing.T) {
 	provisionAndResolveComponentPath = func(context.Context, *schema.AtmosConfiguration, *schema.ConfigAndStacksInfo, string, string) (string, bool, error) {
 		return "", false, sentinel
 	}
-	_, err = resolveComponentPath(atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
+	_, err = resolveComponentPath(context.Background(), atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -341,7 +343,7 @@ func TestRenderObjects_Errors(t *testing.T) {
 	renderChartManifest = func(context.Context, *chartSpec) (string, error) {
 		return "", errors.New("render boom")
 	}
-	_, err := renderObjects(&chartSpec{Chart: "demo"})
+	_, err := renderObjects(context.Background(), &chartSpec{Chart: "demo"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "render boom")
 
@@ -349,7 +351,7 @@ func TestRenderObjects_Errors(t *testing.T) {
 	renderChartManifest = func(context.Context, *chartSpec) (string, error) {
 		return "", nil
 	}
-	_, err = renderObjects(&chartSpec{Chart: "demo"})
+	_, err = renderObjects(context.Background(), &chartSpec{Chart: "demo"})
 	require.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 }
 

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -241,6 +241,39 @@ func TestRunWithHooks_CanceledContextSkipsHooksAndRepositories(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestRunWithHooks_CanceledDuringPreparationSkipsRepositories(t *testing.T) {
+	originalHooks := getHooks
+	originalSetup := setupRepositories
+	t.Cleanup(func() {
+		getHooks = originalHooks
+		setupRepositories = originalSetup
+	})
+
+	goContext, cancel := context.WithCancel(context.Background())
+	getHooks = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (*hooks.Hooks, error) {
+		cancel()
+		return &hooks.Hooks{}, nil
+	}
+	setupRepositories = func([]chartRepository) error {
+		t.Fatal("canceled operation must not set up repositories")
+		return nil
+	}
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "apps/app",
+		SubCommand:       "apply",
+		ComponentSection: map[string]any{"chart": "bitnami/nginx", "name": "app"},
+	}
+	err := runWithHooks(
+		&component.ExecutionContext{Context: goContext, Flags: map[string]any{}},
+		&schema.AtmosConfiguration{},
+		info,
+		OperationApply,
+		"",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRunWithHooks_GetHooksError(t *testing.T) {
 	originalHooks := getHooks
 	t.Cleanup(func() { getHooks = originalHooks })

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -74,7 +74,7 @@ func TestExecuteSingle_HappyPath(t *testing.T) {
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
 	var deleted string
-	deleteHelmRelease = func(spec *chartSpec, _ bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) error {
 		deleted = spec.ReleaseName
 		return nil
 	}
@@ -146,7 +146,7 @@ func TestRunWithHooks_DeleteSuccess(t *testing.T) {
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
 	var deleted string
-	deleteHelmRelease = func(spec *chartSpec, _ bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) error {
 		deleted = spec.ReleaseName
 		return nil
 	}
@@ -237,6 +237,7 @@ func TestResolveDiffBaseline_AgainstTarget(t *testing.T) {
 		},
 	}}
 	got, err := resolveDiffBaseline(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		info,
 		map[string]any{flagAgainst: "target"},
@@ -257,6 +258,7 @@ func TestResolveDiffBaseline_DeployedRelease(t *testing.T) {
 	stubActionContext(t, actx)
 
 	got, err := resolveDiffBaseline(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		&schema.ConfigAndStacksInfo{},
 		map[string]any{},
@@ -268,7 +270,7 @@ func TestResolveDiffBaseline_DeployedRelease(t *testing.T) {
 
 func TestFetchTargetBaseline_RejectsKubernetesTarget(t *testing.T) {
 	// No provision section + no name resolves to the implicit cluster target.
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}, "target")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}, "target")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrHelmDiffFailed)
 }
@@ -280,7 +282,7 @@ func TestFetchTargetBaseline_SelectTargetError(t *testing.T) {
 		},
 	}}
 	// "target:nope" requests a named target that is not configured.
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, info, "target:nope")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, info, "target:nope")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrProvisionTargetNotFound)
 }
@@ -294,7 +296,7 @@ func TestFetchTargetBaseline_FetchError(t *testing.T) {
 			"targets": map[string]any{"repo": map[string]any{"kind": "diff-fetch-err"}},
 		},
 	}}
-	_, err := fetchTargetBaseline(&schema.AtmosConfiguration{}, info, "target")
+	_, err := fetchTargetBaseline(context.Background(), &schema.AtmosConfiguration{}, info, "target")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fetch boom")
 }
@@ -308,7 +310,7 @@ func TestResolveComponentPath(t *testing.T) {
 	}
 	atmosConfig := &schema.AtmosConfiguration{}
 	atmosConfig.Components.Helm.BasePath = "components/helm"
-	path, err := resolveComponentPath(atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
+	path, err := resolveComponentPath(context.Background(), atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
 	require.NoError(t, err)
 	assert.Contains(t, filepath.ToSlash(path), "components/helm")
 
@@ -316,7 +318,7 @@ func TestResolveComponentPath(t *testing.T) {
 	provisionAndResolveComponentPath = func(context.Context, *schema.AtmosConfiguration, *schema.ConfigAndStacksInfo, string, string) (string, bool, error) {
 		return "", false, sentinel
 	}
-	_, err = resolveComponentPath(atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
+	_, err = resolveComponentPath(context.Background(), atmosConfig, &schema.ConfigAndStacksInfo{FinalComponent: "app"})
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -346,7 +348,7 @@ func TestRenderObjects_Errors(t *testing.T) {
 	renderChartManifest = func(context.Context, *chartSpec) (string, error) {
 		return "", errors.New("render boom")
 	}
-	_, err := renderObjects(&chartSpec{Chart: "demo"})
+	_, err := renderObjects(context.Background(), &chartSpec{Chart: "demo"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "render boom")
 
@@ -354,7 +356,7 @@ func TestRenderObjects_Errors(t *testing.T) {
 	renderChartManifest = func(context.Context, *chartSpec) (string, error) {
 		return "", nil
 	}
-	_, err = renderObjects(&chartSpec{Chart: "demo"})
+	_, err = renderObjects(context.Background(), &chartSpec{Chart: "demo"})
 	require.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 }
 

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -217,6 +217,35 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 	assert.Equal(t, "bitnami", setup[0].Name)
 }
 
+func TestRunWithHooks_CanceledContextSkipsHooksAndRepositories(t *testing.T) {
+	originalHooks := getHooks
+	originalSetup := setupRepositories
+	t.Cleanup(func() {
+		getHooks = originalHooks
+		setupRepositories = originalSetup
+	})
+
+	getHooks = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (*hooks.Hooks, error) {
+		t.Fatal("canceled operation must not discover or run hooks")
+		return nil, nil
+	}
+	setupRepositories = func([]chartRepository) error {
+		t.Fatal("canceled operation must not set up repositories")
+		return nil
+	}
+
+	goContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := runWithHooks(
+		&component.ExecutionContext{Context: goContext, Flags: map[string]any{}},
+		&schema.AtmosConfiguration{},
+		&schema.ConfigAndStacksInfo{},
+		OperationApply,
+		"",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRunWithHooks_GetHooksError(t *testing.T) {
 	originalHooks := getHooks
 	t.Cleanup(func() { getHooks = originalHooks })

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -13,6 +13,7 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/component"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	"github.com/cloudposse/atmos/pkg/hooks"
 	"github.com/cloudposse/atmos/pkg/provisioner/target"
@@ -181,9 +182,9 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 		return &hooks.Hooks{}, nil
 	}
 	runCIHooks = func(*hooks.RunCIHooksOptions) error { return nil }
-	var appliedNamespace string
+	var appliedSpec *chartSpec
 	applyHelmRelease = func(_ context.Context, spec *chartSpec, _ bool) (releaseActionResult, error) {
-		appliedNamespace = spec.Namespace
+		appliedSpec = spec
 		return releaseActionResult{Manifest: helmExecutorManifest, Operation: "install"}, nil
 	}
 	var setup []chartRepository
@@ -204,9 +205,14 @@ func TestRunWithHooks_ApplySetsUpRepositories(t *testing.T) {
 			},
 		},
 	}
-	err := runWithHooks(&component.ExecutionContext{Flags: map[string]any{"namespace": "incident-ns"}}, &schema.AtmosConfiguration{}, info, OperationApply, "")
+	err := runWithHooks(&component.ExecutionContext{Flags: map[string]any{
+		"namespace":                         "incident-ns",
+		cfg.HelmDependencyUpdateSectionName: true,
+	}}, &schema.AtmosConfiguration{}, info, OperationApply, "")
 	require.NoError(t, err)
-	assert.Equal(t, "incident-ns", appliedNamespace)
+	require.NotNil(t, appliedSpec)
+	assert.Equal(t, "incident-ns", appliedSpec.Namespace)
+	assert.True(t, appliedSpec.DependencyUpdate)
 	require.Len(t, setup, 1)
 	assert.Equal(t, "bitnami", setup[0].Name)
 }

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -246,6 +246,39 @@ func TestRunWithHooks_CanceledContextSkipsHooksAndRepositories(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestRunWithHooks_CanceledDuringPreparationSkipsRepositories(t *testing.T) {
+	originalHooks := getHooks
+	originalSetup := setupRepositories
+	t.Cleanup(func() {
+		getHooks = originalHooks
+		setupRepositories = originalSetup
+	})
+
+	goContext, cancel := context.WithCancel(context.Background())
+	getHooks = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (*hooks.Hooks, error) {
+		cancel()
+		return &hooks.Hooks{}, nil
+	}
+	setupRepositories = func([]chartRepository) error {
+		t.Fatal("canceled operation must not set up repositories")
+		return nil
+	}
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentFromArg: "apps/app",
+		SubCommand:       "apply",
+		ComponentSection: map[string]any{"chart": "bitnami/nginx", "name": "app"},
+	}
+	err := runWithHooks(
+		&component.ExecutionContext{Context: goContext, Flags: map[string]any{}},
+		&schema.AtmosConfiguration{},
+		info,
+		OperationApply,
+		"",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRunWithHooks_GetHooksError(t *testing.T) {
 	originalHooks := getHooks
 	t.Cleanup(func() { getHooks = originalHooks })

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -282,9 +282,12 @@ func TestSummaryHelpers(t *testing.T) {
 	summary := helmSummary(info, spec, map[string]any{})
 	assert.Equal(t, "kubernetes", summary["target"])
 	assert.Equal(t, "release", summary["release_name"])
+	assert.Equal(t, false, summary["dependency_update"])
 
+	spec.DependencyUpdate = true
 	summary = helmSummary(info, spec, map[string]any{"target": "git"})
 	assert.Equal(t, "git", summary["target"])
+	assert.Equal(t, true, summary["dependency_update"])
 
 	mergeSummary(summary, map[string]any{"target": "gitops", "extra": true})
 	assert.Equal(t, "gitops", summary["target"])

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -59,7 +59,7 @@ func TestRunOperationDispatchesWithSummaries(t *testing.T) {
 	}
 	var deletedRelease, deletedNamespace string
 	var deleteDryRun bool
-	deleteHelmRelease = func(spec *chartSpec, dryRun bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, dryRun bool) error {
 		deletedRelease = spec.ReleaseName
 		deletedNamespace = spec.Namespace
 		deleteDryRun = dryRun

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/hooks"
 	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 const helmExecutorManifest = `apiVersion: v1
@@ -404,7 +405,7 @@ func TestRenderInputTemplates(t *testing.T) {
 		cfg.ChartSectionName:       "./{{ .name }}",
 		cfg.ValuesFilesSectionName: []string{"{{ .name }}.yaml"},
 		cfg.ValuesSectionName: map[string]any{
-			"image": "{{ .name }}:1.0",
+			"password": "{{ .Values.kafka.password }}",
 		},
 		cfg.RepositoriesSectionName: []any{
 			map[string]any{"name": "{{ .name }}", "url": "https://example.com/{{ .name }}"},
@@ -425,9 +426,23 @@ func TestRenderInputTemplates(t *testing.T) {
 	assert.Equal(t, "1.2.3", section["version"])
 	assert.Equal(t, "https://repo.example.com/demo", section["repository"])
 	assert.Equal(t, []any{"demo.yaml"}, section[cfg.ValuesFilesSectionName])
-	assert.Equal(t, "demo:1.0", section[cfg.ValuesSectionName].(map[string]any)["image"])
+	assert.Equal(t, "{{ .Values.kafka.password }}", section[cfg.ValuesSectionName].(map[string]any)["password"])
 	assert.Equal(t, "demo.rendered.yaml", section[cfg.RenderSectionName].(map[string]any)["output"].(map[string]any)["path"])
 	assert.Equal(t, "demo", section[cfg.RepositoriesSectionName].([]any)[0].(map[string]any)["name"])
+}
+
+func TestRenderInputTemplatesPreservesLiteralHelmValues(t *testing.T) {
+	section, err := u.UnmarshalYAML[map[string]any](`
+name: demo
+values:
+  password: !literal "{{ .Values.kafka.password }}"
+`)
+	require.NoError(t, err)
+
+	require.NoError(t, renderInputTemplates(&schema.AtmosConfiguration{}, section))
+	values, ok := section[cfg.ValuesSectionName].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "{{ .Values.kafka.password }}", values["password"])
 }
 
 func TestBulkAffectedFlagsAndSelection(t *testing.T) {

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -54,7 +54,7 @@ func TestRunOperationDispatchesWithSummaries(t *testing.T) {
 	}
 	var deletedRelease, deletedNamespace string
 	var deleteDryRun bool
-	deleteHelmRelease = func(spec *chartSpec, dryRun bool) error {
+	deleteHelmRelease = func(_ context.Context, spec *chartSpec, dryRun bool) error {
 		deletedRelease = spec.ReleaseName
 		deletedNamespace = spec.Namespace
 		deleteDryRun = dryRun

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	"github.com/cloudposse/atmos/pkg/hooks"
 	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
 )
 
 const helmExecutorManifest = `apiVersion: v1
@@ -405,7 +406,7 @@ func TestRenderInputTemplates(t *testing.T) {
 		cfg.ChartSectionName:       "./{{ .name }}",
 		cfg.ValuesFilesSectionName: []string{"{{ .name }}.yaml"},
 		cfg.ValuesSectionName: map[string]any{
-			"image": "{{ .name }}:1.0",
+			"password": "{{ .Values.kafka.password }}",
 		},
 		cfg.RepositoriesSectionName: []any{
 			map[string]any{"name": "{{ .name }}", "url": "https://example.com/{{ .name }}"},
@@ -426,9 +427,23 @@ func TestRenderInputTemplates(t *testing.T) {
 	assert.Equal(t, "1.2.3", section["version"])
 	assert.Equal(t, "https://repo.example.com/demo", section["repository"])
 	assert.Equal(t, []any{"demo.yaml"}, section[cfg.ValuesFilesSectionName])
-	assert.Equal(t, "demo:1.0", section[cfg.ValuesSectionName].(map[string]any)["image"])
+	assert.Equal(t, "{{ .Values.kafka.password }}", section[cfg.ValuesSectionName].(map[string]any)["password"])
 	assert.Equal(t, "demo.rendered.yaml", section[cfg.RenderSectionName].(map[string]any)["output"].(map[string]any)["path"])
 	assert.Equal(t, "demo", section[cfg.RepositoriesSectionName].([]any)[0].(map[string]any)["name"])
+}
+
+func TestRenderInputTemplatesPreservesLiteralHelmValues(t *testing.T) {
+	section, err := u.UnmarshalYAML[map[string]any](`
+name: demo
+values:
+  password: !literal "{{ .Values.kafka.password }}"
+`)
+	require.NoError(t, err)
+
+	require.NoError(t, renderInputTemplates(&schema.AtmosConfiguration{}, section))
+	values, ok := section[cfg.ValuesSectionName].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "{{ .Values.kafka.password }}", values["password"])
 }
 
 func TestBulkAffectedFlagsAndSelection(t *testing.T) {

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -190,6 +190,27 @@ func TestBuildValues_MergeAndFiles(t *testing.T) {
 	assert.Equal(t, "override", img["tag"]) // inline values win over values_files
 }
 
+func TestBuildValues_PreservesHelmTemplateSyntaxAcrossSources(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	dir := t.TempDir()
+	valuesFile := filepath.Join(dir, "templated.yaml")
+	templateValue := "{{ .Values.kafka.password }}"
+	require.NoError(t, os.WriteFile(valuesFile, []byte("fromFile: '{{ .Values.kafka.password }}'\n"), 0o600))
+
+	section := map[string]any{
+		cfg.ValuesFilesSectionName: []any{valuesFile},
+		cfg.ValuesSectionName: map[string]any{
+			"inline": templateValue,
+		},
+	}
+
+	values, err := buildValues(atmosConfig, section, "")
+	require.NoError(t, err)
+	assert.Equal(t, templateValue, values["fromFile"])
+	assert.Equal(t, templateValue, values["inline"])
+	assert.Equal(t, values["fromFile"], values["inline"])
+}
+
 func TestResolveRenderOptions_FlagsOverrideComponent(t *testing.T) {
 	componentSection := map[string]any{
 		"render": map[string]any{"output": map[string]any{"path": "from-component.yaml"}},

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -288,8 +288,21 @@ func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
 	settings.RepositoryCache = filepath.Join(testdataRoot, "repository")
 	settings.ContentCache = filepath.Join(testdataRoot, "content")
 
-	loaded, err := loadChartForAction(chartPath, settings, nil, true)
+	loaded, err := loadChartForAction(context.Background(), chartPath, settings, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	assert.FileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
+}
+
+func TestLoadChartDoesNotUpdateDependenciesAfterCancellation(t *testing.T) {
+	testdataRoot := t.TempDir()
+	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))
+	chartPath := filepath.Join(testdataRoot, "chart-missing-dependency")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := loadChartForAction(ctx, chartPath, newSettings(), nil, true)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NoFileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -248,7 +247,6 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, "nginx:9.9")
 	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
 	assert.Contains(t, rendered, `name: "unit-settings"`)
-	assert.True(t, strings.Contains(rendered, "ConfigMap"))
 }
 
 func TestLoadChartReportsMissingDependencies(t *testing.T) {

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -275,4 +275,21 @@ func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
 	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 	assert.Equal(t, 1, strings.Count(err.Error(), errUtils.ErrHelmRenderFailed.Error()))
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
+	assert.Contains(t, err.Error(), "--dependency-update")
+}
+
+func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
+	testdataRoot := t.TempDir()
+	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))
+	chartPath := filepath.Join(testdataRoot, "chart-missing-dependency")
+
+	settings := newSettings()
+	settings.RepositoryConfig = filepath.Join(testdataRoot, "repositories.yaml")
+	settings.RepositoryCache = filepath.Join(testdataRoot, "repository")
+	settings.ContentCache = filepath.Join(testdataRoot, "content")
+
+	loaded, err := loadChartForAction(chartPath, settings, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.FileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -278,6 +278,19 @@ func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
 	assert.Contains(t, err.Error(), "--dependency-update")
 }
 
+func TestRenderManifestPreservesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := renderManifest(ctx, &chartSpec{
+		Chart:       filepath.Join("testdata", "chart"),
+		ReleaseName: "unit",
+		Namespace:   "testns",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, errUtils.ErrHelmRenderFailed)
+}
+
 func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
 	testdataRoot := t.TempDir()
 	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -225,5 +225,18 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, "namespace: testns")
 	assert.Contains(t, rendered, `replicas: "5"`)
 	assert.Contains(t, rendered, "nginx:9.9")
+	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
+	assert.Contains(t, rendered, "name: unit-settings")
 	assert.True(t, strings.Contains(rendered, "ConfigMap"))
+}
+
+func TestLoadChartReportsMissingDependencies(t *testing.T) {
+	chartPath, err := filepath.Abs(filepath.Join("testdata", "chart-missing-dependency"))
+	require.NoError(t, err)
+
+	_, err = loadChart(chartPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
+	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
+	assert.Contains(t, err.Error(), "helm-test-library")
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -236,6 +236,7 @@ func TestLoadChartReportsMissingDependencies(t *testing.T) {
 
 	_, err = loadChart(chartPath)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 	assert.Contains(t, err.Error(), "helm-test-library")

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -259,4 +260,19 @@ func TestLoadChartReportsMissingDependencies(t *testing.T) {
 	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 	assert.Contains(t, err.Error(), "helm-test-library")
+}
+
+func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
+	chartPath, err := filepath.Abs(filepath.Join("testdata", "chart-missing-dependency"))
+	require.NoError(t, err)
+
+	_, err = renderManifest(context.Background(), &chartSpec{
+		Chart:       chartPath,
+		ReleaseName: "unit",
+		Namespace:   "testns",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
+	assert.Equal(t, 1, strings.Count(err.Error(), errUtils.ErrHelmRenderFailed.Error()))
+	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -247,7 +247,7 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, `replicas: "5"`)
 	assert.Contains(t, rendered, "nginx:9.9")
 	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
-	assert.Contains(t, rendered, "name: unit-settings")
+	assert.Contains(t, rendered, `name: "unit-settings"`)
 	assert.True(t, strings.Contains(rendered, "ConfigMap"))
 }
 

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -309,6 +309,18 @@ func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
 	assert.FileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
 }
 
+func TestLoadChartUpdateRequiresSettings(t *testing.T) {
+	chartPath, err := filepath.Abs(filepath.Join("testdata", "chart-missing-dependency"))
+	require.NoError(t, err)
+
+	// dependencyUpdate is requested but no Helm environment settings are
+	// supplied, so the missing dependency cannot be fetched and the operation
+	// must fail with an actionable error rather than dereferencing nil settings.
+	_, err = loadChartForAction(context.Background(), chartPath, nil, nil, true)
+	require.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
+	assert.Contains(t, err.Error(), "without Helm environment settings")
+}
+
 func TestLoadChartDoesNotUpdateDependenciesAfterCancellation(t *testing.T) {
 	testdataRoot := t.TempDir()
 	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -250,7 +249,6 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, "nginx:9.9")
 	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
 	assert.Contains(t, rendered, `name: "unit-settings"`)
-	assert.True(t, strings.Contains(rendered, "ConfigMap"))
 }
 
 func TestLoadChartReportsMissingDependencies(t *testing.T) {

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -192,6 +192,27 @@ func TestBuildValues_MergeAndFiles(t *testing.T) {
 	assert.Equal(t, "override", img["tag"]) // inline values win over values_files
 }
 
+func TestBuildValues_PreservesHelmTemplateSyntaxAcrossSources(t *testing.T) {
+	atmosConfig := &schema.AtmosConfiguration{}
+	dir := t.TempDir()
+	valuesFile := filepath.Join(dir, "templated.yaml")
+	templateValue := "{{ .Values.kafka.password }}"
+	require.NoError(t, os.WriteFile(valuesFile, []byte("fromFile: '{{ .Values.kafka.password }}'\n"), 0o600))
+
+	section := map[string]any{
+		cfg.ValuesFilesSectionName: []any{valuesFile},
+		cfg.ValuesSectionName: map[string]any{
+			"inline": templateValue,
+		},
+	}
+
+	values, err := buildValues(atmosConfig, section, "")
+	require.NoError(t, err)
+	assert.Equal(t, templateValue, values["fromFile"])
+	assert.Equal(t, templateValue, values["inline"])
+	assert.Equal(t, values["fromFile"], values["inline"])
+}
+
 func TestResolveRenderOptions_FlagsOverrideComponent(t *testing.T) {
 	componentSection := map[string]any{
 		"render": map[string]any{"output": map[string]any{"path": "from-component.yaml"}},

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -249,7 +249,7 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, `replicas: "5"`)
 	assert.Contains(t, rendered, "nginx:9.9")
 	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
-	assert.Contains(t, rendered, "name: unit-settings")
+	assert.Contains(t, rendered, `name: "unit-settings"`)
 	assert.True(t, strings.Contains(rendered, "ConfigMap"))
 }
 

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -227,5 +227,18 @@ func TestRenderManifest_LocalChart(t *testing.T) {
 	assert.Contains(t, rendered, "namespace: testns")
 	assert.Contains(t, rendered, `replicas: "5"`)
 	assert.Contains(t, rendered, "nginx:9.9")
+	assert.Contains(t, rendered, "# Source: testchart/templates/hook.yaml")
+	assert.Contains(t, rendered, "name: unit-settings")
 	assert.True(t, strings.Contains(rendered, "ConfigMap"))
+}
+
+func TestLoadChartReportsMissingDependencies(t *testing.T) {
+	chartPath, err := filepath.Abs(filepath.Join("testdata", "chart-missing-dependency"))
+	require.NoError(t, err)
+
+	_, err = loadChart(chartPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
+	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
+	assert.Contains(t, err.Error(), "helm-test-library")
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -290,8 +290,21 @@ func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
 	settings.RepositoryCache = filepath.Join(testdataRoot, "repository")
 	settings.ContentCache = filepath.Join(testdataRoot, "content")
 
-	loaded, err := loadChartForAction(chartPath, settings, nil, true)
+	loaded, err := loadChartForAction(context.Background(), chartPath, settings, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	assert.FileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
+}
+
+func TestLoadChartDoesNotUpdateDependenciesAfterCancellation(t *testing.T) {
+	testdataRoot := t.TempDir()
+	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))
+	chartPath := filepath.Join(testdataRoot, "chart-missing-dependency")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := loadChartForAction(ctx, chartPath, newSettings(), nil, true)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NoFileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -238,6 +238,7 @@ func TestLoadChartReportsMissingDependencies(t *testing.T) {
 
 	_, err = loadChart(chartPath)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 	assert.Contains(t, err.Error(), "helm-test-library")

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -277,4 +277,21 @@ func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
 	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
 	assert.Equal(t, 1, strings.Count(err.Error(), errUtils.ErrHelmRenderFailed.Error()))
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
+	assert.Contains(t, err.Error(), "--dependency-update")
+}
+
+func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
+	testdataRoot := t.TempDir()
+	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))
+	chartPath := filepath.Join(testdataRoot, "chart-missing-dependency")
+
+	settings := newSettings()
+	settings.RepositoryConfig = filepath.Join(testdataRoot, "repositories.yaml")
+	settings.RepositoryCache = filepath.Join(testdataRoot, "repository")
+	settings.ContentCache = filepath.Join(testdataRoot, "content")
+
+	loaded, err := loadChartForAction(chartPath, settings, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.FileExists(t, filepath.Join(chartPath, "charts", "helm-test-library-0.1.0.tgz"))
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -261,4 +262,19 @@ func TestLoadChartReportsMissingDependencies(t *testing.T) {
 	assert.Contains(t, err.Error(), "while checking Helm chart dependencies")
 	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 	assert.Contains(t, err.Error(), "helm-test-library")
+}
+
+func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
+	chartPath, err := filepath.Abs(filepath.Join("testdata", "chart-missing-dependency"))
+	require.NoError(t, err)
+
+	_, err = renderManifest(context.Background(), &chartSpec{
+		Chart:       chartPath,
+		ReleaseName: "unit",
+		Namespace:   "testns",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrHelmRenderFailed)
+	assert.Equal(t, 1, strings.Count(err.Error(), errUtils.ErrHelmRenderFailed.Error()))
+	assert.Contains(t, err.Error(), "helm dependency build "+chartPath)
 }

--- a/pkg/component/helm/helm_test.go
+++ b/pkg/component/helm/helm_test.go
@@ -280,6 +280,19 @@ func TestRenderManifestReportsMissingDependenciesOnce(t *testing.T) {
 	assert.Contains(t, err.Error(), "--dependency-update")
 }
 
+func TestRenderManifestPreservesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := renderManifest(ctx, &chartSpec{
+		Chart:       filepath.Join("testdata", "chart"),
+		ReleaseName: "unit",
+		Namespace:   "testns",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, errUtils.ErrHelmRenderFailed)
+}
+
 func TestLoadChartUpdatesMissingDependenciesWhenRequested(t *testing.T) {
 	testdataRoot := t.TempDir()
 	require.NoError(t, os.CopyFS(testdataRoot, os.DirFS("testdata")))

--- a/pkg/component/helm/provision.go
+++ b/pkg/component/helm/provision.go
@@ -24,6 +24,7 @@ const targetKey = "target"
 // upgrades the Helm release directly; any other kind (e.g. "git") receives the
 // rendered manifests as a producer-agnostic ProvisionArtifact via the registry.
 func deliverApply(
+	ctx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	flags map[string]any,
@@ -46,7 +47,7 @@ func deliverApply(
 
 	// Cluster delivery installs/upgrades the Helm release directly.
 	if selected.Kind == target.KindKubernetes {
-		result, err := applyHelmRelease(context.Background(), spec, info.DryRun)
+		result, err := applyHelmRelease(ctx, spec, info.DryRun)
 		spec.Lifecycle = result.Lifecycle
 		emitLifecycleWarnings(result.Lifecycle.Warnings)
 		summary["manifest_bytes"] = len(result.Manifest)
@@ -65,7 +66,7 @@ func deliverApply(
 		"reason":      "external_target",
 	}
 
-	return deliverToExternalTarget(atmosConfig, info, selected, spec, summary)
+	return deliverToExternalTarget(ctx, atmosConfig, info, selected, spec, summary)
 }
 
 func lifecycleSummary(operation string, policy effectiveReleasePolicy) map[string]any {
@@ -95,13 +96,14 @@ func lifecycleSummary(operation string, policy effectiveReleasePolicy) map[strin
 // to a non-cluster provision target (e.g. a Git deployment repository) as a
 // producer-agnostic ProvisionArtifact via the target registry.
 func deliverToExternalTarget(
+	callerCtx context.Context,
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	selected *target.SelectedTarget,
 	spec *chartSpec,
 	summary map[string]any,
 ) (map[string]any, error) {
-	objects, err := renderObjects(spec)
+	objects, err := renderObjects(callerCtx, spec)
 	if err != nil {
 		return summary, err
 	}
@@ -123,7 +125,7 @@ func deliverToExternalTarget(
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), deliveryTimeout)
+	ctx, cancel := context.WithTimeout(callerCtx, deliveryTimeout)
 	defer cancel()
 
 	return summary, target.Deliver(ctx, selected.Kind, &target.DeliverInput{

--- a/pkg/component/helm/provision_test.go
+++ b/pkg/component/helm/provision_test.go
@@ -19,6 +19,7 @@ import (
 // fakeTarget is a registrable provision target that records what it received and
 // can be told to fail. It implements both Provisioner and Fetcher.
 type fakeTarget struct {
+	deliverCtx    context.Context
 	delivered     *target.DeliverInput
 	fetched       *target.FetchInput
 	deliverErr    error
@@ -26,9 +27,31 @@ type fakeTarget struct {
 	fetchErr      error
 }
 
-func (f *fakeTarget) Deliver(_ context.Context, in *target.DeliverInput) error {
+func (f *fakeTarget) Deliver(ctx context.Context, in *target.DeliverInput) error {
+	f.deliverCtx = ctx
 	f.delivered = in
 	return f.deliverErr
+}
+
+func TestDeliverApplyPropagatesCallerContextToExternalTarget(t *testing.T) {
+	ft := &fakeTarget{}
+	registerFakeTarget(t, "helm-context-external", ft)
+	stubRenderChartManifest(t, helmExecutorManifest, nil)
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "caller")
+	info := &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{
+		"provision": map[string]any{
+			"default": "deploy-repo",
+			"targets": map[string]any{
+				"deploy-repo": map[string]any{"kind": "helm-context-external"},
+			},
+		},
+	}}
+
+	_, err := deliverApply(ctx, &schema.AtmosConfiguration{}, info, map[string]any{}, &chartSpec{})
+	require.NoError(t, err)
+	require.NotNil(t, ft.deliverCtx)
+	assert.Equal(t, "caller", ft.deliverCtx.Value(contextKey{}))
 }
 
 func (f *fakeTarget) Fetch(_ context.Context, in *target.FetchInput) (target.ProvisionArtifact, error) {
@@ -59,7 +82,7 @@ func TestDeliverToExternalTarget_DeliversRenderedManifests(t *testing.T) {
 	info := &schema.ConfigAndStacksInfo{ComponentFromArg: "apps/app", Stack: "dev"}
 	selected := &target.SelectedTarget{Name: "deploy-repo", Kind: "helm-external-test", Config: map[string]any{}}
 
-	summary, err := deliverToExternalTarget(&schema.AtmosConfiguration{}, info, selected, &chartSpec{Chart: "demo"}, map[string]any{})
+	summary, err := deliverToExternalTarget(context.Background(), &schema.AtmosConfiguration{}, info, selected, &chartSpec{Chart: "demo"}, map[string]any{})
 	require.NoError(t, err)
 
 	require.NotNil(t, ft.delivered)
@@ -79,6 +102,7 @@ func TestDeliverToExternalTarget_RenderError(t *testing.T) {
 	stubRenderChartManifest(t, "", errors.New("render boom"))
 
 	_, err := deliverToExternalTarget(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		&schema.ConfigAndStacksInfo{},
 		&target.SelectedTarget{Name: "deploy-repo", Kind: "helm-external-test"},
@@ -95,6 +119,7 @@ func TestDeliverToExternalTarget_DeliverError(t *testing.T) {
 	stubRenderChartManifest(t, helmExecutorManifest, nil)
 
 	_, err := deliverToExternalTarget(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		&schema.ConfigAndStacksInfo{ComponentFromArg: "apps/app"},
 		&target.SelectedTarget{Name: "deploy-repo", Kind: "helm-external-err"},
@@ -126,7 +151,7 @@ func TestDeliverApply_RoutesToExternalTarget(t *testing.T) {
 		},
 	}
 
-	summary, err := deliverApply(&schema.AtmosConfiguration{}, info, map[string]any{}, &chartSpec{Chart: "demo"})
+	summary, err := deliverApply(context.Background(), &schema.AtmosConfiguration{}, info, map[string]any{}, &chartSpec{Chart: "demo"})
 	require.NoError(t, err)
 	assert.Equal(t, "deploy-repo", summary[targetKey])
 	assert.Equal(t, map[string]any{"applied": false, "target_kind": "helm-apply-external", "reason": "external_target"}, summary["release"])
@@ -144,7 +169,7 @@ func TestDeliverApply_RejectsLifecycleFlagsForExternalTarget(t *testing.T) {
 		},
 	}}
 
-	summary, err := deliverApply(&schema.AtmosConfiguration{}, info, map[string]any{
+	summary, err := deliverApply(context.Background(), &schema.AtmosConfiguration{}, info, map[string]any{
 		cfg.HelmTimeoutSectionName: "10m",
 	}, &chartSpec{})
 	require.ErrorIs(t, err, errUtils.ErrHelmLifecycleExternalTarget)
@@ -156,7 +181,11 @@ func TestDeliverApply_PropagatesDryRunToKubernetesTarget(t *testing.T) {
 	t.Cleanup(func() { applyHelmRelease = originalApply })
 
 	var receivedDryRun bool
-	applyHelmRelease = func(_ context.Context, _ *chartSpec, dryRun bool) (releaseActionResult, error) {
+	type contextKey struct{}
+	callerCtx := context.WithValue(context.Background(), contextKey{}, "caller")
+	var receivedCtx context.Context
+	applyHelmRelease = func(ctx context.Context, _ *chartSpec, dryRun bool) (releaseActionResult, error) {
+		receivedCtx = ctx
 		receivedDryRun = dryRun
 		return releaseActionResult{Manifest: helmExecutorManifest, Operation: releaseOperationInstall}, nil
 	}
@@ -165,9 +194,10 @@ func TestDeliverApply_PropagatesDryRunToKubernetesTarget(t *testing.T) {
 		DryRun:           true,
 		ComponentSection: map[string]any{},
 	}
-	summary, err := deliverApply(&schema.AtmosConfiguration{}, info, map[string]any{}, &chartSpec{Chart: "demo"})
+	summary, err := deliverApply(callerCtx, &schema.AtmosConfiguration{}, info, map[string]any{}, &chartSpec{Chart: "demo"})
 	require.NoError(t, err)
 	assert.True(t, receivedDryRun)
+	assert.Equal(t, "caller", receivedCtx.Value(contextKey{}))
 	assert.Equal(t, "cluster", summary[targetKey])
 }
 
@@ -208,6 +238,7 @@ func TestLifecycleSummary(t *testing.T) {
 func TestDeliverApply_SelectTargetError(t *testing.T) {
 	// An explicitly requested target that is not configured fails to resolve.
 	_, err := deliverApply(
+		context.Background(),
 		&schema.AtmosConfiguration{},
 		&schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}},
 		map[string]any{"target": "does-not-exist"},

--- a/pkg/component/helm/templates.go
+++ b/pkg/component/helm/templates.go
@@ -9,13 +9,13 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
-// renderInputTemplates renders Go templates in the component input sections so
-// fields that reference component values (e.g. chart version, a git target's
-// path/commit.message, value file paths) are materialized before use.
+// renderInputTemplates renders Go templates in Helm component control fields so
+// chart versions, paths, repositories, and provision metadata are materialized.
+// Helm values are deliberately excluded: Helm treats them as data and charts may
+// evaluate template expressions in values later with `tpl`.
 func renderInputTemplates(atmosConfig *schema.AtmosConfiguration, componentSection map[string]any) error {
 	for _, key := range []string{
 		cfg.ChartSectionName,
-		cfg.ValuesSectionName,
 		cfg.ValuesFilesSectionName,
 		cfg.RepositoriesSectionName,
 		cfg.RenderSectionName,

--- a/pkg/component/helm/testdata/chart-missing-dependency/Chart.yaml
+++ b/pkg/component/helm/testdata/chart-missing-dependency/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: missing-dependency
+description: Chart fixture with an intentionally unbuilt local library dependency.
+type: application
+version: 0.1.0
+dependencies:
+  - name: helm-test-library
+    version: 0.1.0
+    repository: file://../helm-test-library

--- a/pkg/component/helm/testdata/chart-missing-dependency/templates/configmap.yaml
+++ b/pkg/component/helm/testdata/chart-missing-dependency/templates/configmap.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}

--- a/pkg/component/helm/testdata/chart-missing-dependency/templates/configmap.yaml
+++ b/pkg/component/helm/testdata/chart-missing-dependency/templates/configmap.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name | quote }}

--- a/pkg/component/helm/testdata/chart/templates/hook.yaml
+++ b/pkg/component/helm/testdata/chart/templates/hook.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-settings
-  namespace: {{ .Release.Namespace }}
+  name: "{{ .Release.Name }}-settings"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-2"

--- a/pkg/component/helm/testdata/chart/templates/hook.yaml
+++ b/pkg/component/helm/testdata/chart/templates/hook.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-settings
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
+data:
+  settings.conf: test

--- a/pkg/component/helm/testdata/helm-test-library/Chart.yaml
+++ b/pkg/component/helm/testdata/helm-test-library/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: helm-test-library
+description: Local library chart used by dependency-update tests.
+type: library
+version: 0.1.0

--- a/pkg/component/provider.go
+++ b/pkg/component/provider.go
@@ -45,6 +45,7 @@ type ComponentProvider interface {
 }
 
 // ExecutionContext provides all necessary context for component execution.
+// Construct values with keyed fields; new execution metadata may be added over time.
 type ExecutionContext struct {
 	// Context carries caller cancellation and deadlines into component execution.
 	// Use GoContext so legacy callers that omit it retain background behavior.

--- a/pkg/component/provider.go
+++ b/pkg/component/provider.go
@@ -44,8 +44,8 @@ type ComponentProvider interface {
 	GetAvailableCommands() []string
 }
 
-// ExecutionContext provides all necessary context for component execution.
-// Construct values with keyed fields; new execution metadata may be added over time.
+// ExecutionContext contains component execution metadata and the caller context.
+// Construct values with keyed fields because new execution metadata may be added over time.
 type ExecutionContext struct {
 	// Context carries caller cancellation and deadlines into component execution.
 	// Use GoContext so legacy callers that omit it retain background behavior.

--- a/pkg/component/provider.go
+++ b/pkg/component/provider.go
@@ -46,6 +46,9 @@ type ComponentProvider interface {
 
 // ExecutionContext provides all necessary context for component execution.
 type ExecutionContext struct {
+	// Context carries caller cancellation and deadlines into component execution.
+	// Use GoContext so legacy callers that omit it retain background behavior.
+	Context             context.Context
 	AtmosConfig         *schema.AtmosConfiguration
 	ComponentType       string
 	Component           string
@@ -56,6 +59,14 @@ type ExecutionContext struct {
 	ConfigAndStacksInfo schema.ConfigAndStacksInfo
 	Args                []string
 	Flags               map[string]any
+}
+
+// GoContext returns the caller context or a non-nil compatibility fallback.
+func (e *ExecutionContext) GoContext() context.Context {
+	if e != nil && e.Context != nil {
+		return e.Context
+	}
+	return context.Background()
 }
 
 // ComponentInfo provides metadata about a component provider.

--- a/pkg/component/provider_test.go
+++ b/pkg/component/provider_test.go
@@ -1,0 +1,17 @@
+package component
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecutionContextGoContext(t *testing.T) {
+	assert.NotNil(t, (*ExecutionContext)(nil).GoContext())
+	assert.NotNil(t, (&ExecutionContext{}).GoContext())
+
+	type key struct{}
+	want := context.WithValue(context.Background(), key{}, "caller")
+	assert.Same(t, want, (&ExecutionContext{Context: want}).GoContext())
+}

--- a/pkg/component/provider_test.go
+++ b/pkg/component/provider_test.go
@@ -8,10 +8,26 @@ import (
 )
 
 func TestExecutionContextGoContext(t *testing.T) {
-	assert.NotNil(t, (*ExecutionContext)(nil).GoContext())
-	assert.NotNil(t, (&ExecutionContext{}).GoContext())
-
 	type key struct{}
-	want := context.WithValue(context.Background(), key{}, "caller")
-	assert.Same(t, want, (&ExecutionContext{Context: want}).GoContext())
+	caller := context.WithValue(context.Background(), key{}, "caller")
+	tests := []struct {
+		name     string
+		execCtx  *ExecutionContext
+		want     context.Context
+		identity bool
+	}{
+		{name: "nil receiver", want: context.Background()},
+		{name: "nil context", execCtx: &ExecutionContext{}, want: context.Background()},
+		{name: "caller context", execCtx: &ExecutionContext{Context: caller}, want: caller, identity: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.execCtx.GoContext()
+			assert.Equal(t, tt.want, got)
+			if tt.identity {
+				assert.Same(t, tt.want, got)
+			}
+		})
+	}
 }

--- a/pkg/composition/executor.go
+++ b/pkg/composition/executor.go
@@ -48,6 +48,7 @@ type status struct {
 }
 
 type lifecycleRun struct {
+	ctx         context.Context
 	atmosConfig *schema.AtmosConfiguration
 	info        *schema.ConfigAndStacksInfo
 	verb        string
@@ -153,6 +154,7 @@ func ExecuteLifecycle(ctx context.Context, info *schema.ConfigAndStacksInfo, ver
 	}
 
 	return runLifecycleTargets(lifecycleRun{
+		ctx:         ctx,
 		atmosConfig: &atmosConfig,
 		info:        info,
 		verb:        verb,
@@ -446,6 +448,7 @@ func runLifecycleTargets(run lifecycleRun) error {
 		itemInfo.All = false
 
 		err := executeProvider(provider, &component.ExecutionContext{
+			Context:             run.ctx,
 			AtmosConfig:         run.atmosConfig,
 			ComponentType:       target.ComponentType,
 			Component:           target.Component,

--- a/pkg/composition/executor.go
+++ b/pkg/composition/executor.go
@@ -427,6 +427,12 @@ func isReverseVerb(verb string) bool {
 func runLifecycleTargets(run lifecycleRun) error {
 	var errs []error
 	for _, target := range run.targets {
+		if run.ctx != nil {
+			if err := run.ctx.Err(); err != nil {
+				errs = append(errs, err)
+				break
+			}
+		}
 		provider, ok := getComponentProvider(target.ComponentType)
 		if !ok {
 			errs = append(errs, fmt.Errorf("%w: %s", errUtils.ErrComponentProviderNotFound, target.ComponentType))

--- a/pkg/composition/executor.go
+++ b/pkg/composition/executor.go
@@ -468,9 +468,11 @@ func runLifecycleTargets(run lifecycleRun) error {
 			ui.Errorf("%s/%s.%s: %s failed: %v", target.Stack, target.ComponentType, target.Component, run.verb, err)
 			errs = append(errs, fmt.Errorf("%s/%s.%s: %w", target.Stack, target.ComponentType, target.Component, err))
 		}
-		if ctxErr := run.ctx.Err(); ctxErr != nil {
-			errs = append(errs, ctxErr)
-			break
+		if run.ctx != nil {
+			if ctxErr := run.ctx.Err(); ctxErr != nil {
+				errs = append(errs, ctxErr)
+				break
+			}
 		}
 	}
 	if len(errs) > 0 {

--- a/pkg/composition/executor.go
+++ b/pkg/composition/executor.go
@@ -468,6 +468,10 @@ func runLifecycleTargets(run lifecycleRun) error {
 			ui.Errorf("%s/%s.%s: %s failed: %v", target.Stack, target.ComponentType, target.Component, run.verb, err)
 			errs = append(errs, fmt.Errorf("%s/%s.%s: %w", target.Stack, target.ComponentType, target.Component, err))
 		}
+		if ctxErr := run.ctx.Err(); ctxErr != nil {
+			errs = append(errs, ctxErr)
+			break
+		}
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/pkg/composition/executor_lifecycle_test.go
+++ b/pkg/composition/executor_lifecycle_test.go
@@ -230,6 +230,68 @@ func TestRunLifecycleTargetsStopsDispatchingAfterCancellation(t *testing.T) {
 	assert.Equal(t, []string{"frontend"}, calls)
 }
 
+func TestRunLifecycleTargetsDoesNotDispatchWhenAlreadyCanceled(t *testing.T) {
+	provider := testCompositionProvider{componentType: cfg.ContainerComponentType, commands: []string{"up"}}
+	origGet, origExec := getComponentProvider, executeProvider
+	t.Cleanup(func() {
+		getComponentProvider, executeProvider = origGet, origExec
+	})
+	getComponentProvider = func(string) (component.ComponentProvider, bool) {
+		return provider, true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dispatched := false
+	executeProvider = func(_ component.ComponentProvider, _ *component.ExecutionContext) error {
+		dispatched = true
+		return nil
+	}
+
+	err := runLifecycleTargets(lifecycleRun{
+		ctx:         ctx,
+		atmosConfig: &schema.AtmosConfiguration{},
+		info:        &schema.ConfigAndStacksInfo{},
+		verb:        "up",
+		targets: []member{
+			{Stack: "local", Composition: "storefront", ComponentType: cfg.ContainerComponentType, Component: "frontend"},
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, dispatched)
+}
+
+func TestRunLifecycleTargetsPreservesContextValues(t *testing.T) {
+	type contextKey struct{}
+	provider := testCompositionProvider{componentType: cfg.ContainerComponentType, commands: []string{"up"}}
+	origGet, origExec := getComponentProvider, executeProvider
+	t.Cleanup(func() {
+		getComponentProvider, executeProvider = origGet, origExec
+	})
+	getComponentProvider = func(string) (component.ComponentProvider, bool) {
+		return provider, true
+	}
+
+	ctx := context.WithValue(context.Background(), contextKey{}, "lifecycle")
+	executeProvider = func(_ component.ComponentProvider, execCtx *component.ExecutionContext) error {
+		assert.Equal(t, "lifecycle", execCtx.GoContext().Value(contextKey{}))
+		return nil
+	}
+
+	err := runLifecycleTargets(lifecycleRun{
+		ctx:         ctx,
+		atmosConfig: &schema.AtmosConfiguration{},
+		info:        &schema.ConfigAndStacksInfo{},
+		verb:        "up",
+		targets: []member{
+			{Stack: "local", Composition: "storefront", ComponentType: cfg.ContainerComponentType, Component: "frontend"},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
 func TestRunLifecycleTargetsReportsCancellationAfterSuccessfulFinalDispatch(t *testing.T) {
 	provider := testCompositionProvider{componentType: cfg.ContainerComponentType, commands: []string{"up"}}
 	origGet, origExec := getComponentProvider, executeProvider

--- a/pkg/composition/executor_lifecycle_test.go
+++ b/pkg/composition/executor_lifecycle_test.go
@@ -196,3 +196,36 @@ func TestRunLifecycleTargetsContinuesAndAggregatesFailures(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Equal(t, []string{"frontend", "api"}, calls)
 }
+
+func TestRunLifecycleTargetsStopsDispatchingAfterCancellation(t *testing.T) {
+	provider := testCompositionProvider{componentType: cfg.ContainerComponentType, commands: []string{"up"}}
+	origGet, origExec := getComponentProvider, executeProvider
+	t.Cleanup(func() {
+		getComponentProvider, executeProvider = origGet, origExec
+	})
+	getComponentProvider = func(string) (component.ComponentProvider, bool) {
+		return provider, true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls []string
+	executeProvider = func(_ component.ComponentProvider, execCtx *component.ExecutionContext) error {
+		calls = append(calls, execCtx.Component)
+		cancel()
+		return nil
+	}
+
+	err := runLifecycleTargets(lifecycleRun{
+		ctx:         ctx,
+		atmosConfig: &schema.AtmosConfiguration{},
+		info:        &schema.ConfigAndStacksInfo{},
+		verb:        "up",
+		targets: []member{
+			{Stack: "local", Composition: "storefront", ComponentType: cfg.ContainerComponentType, Component: "frontend"},
+			{Stack: "local", Composition: "storefront", ComponentType: cfg.ContainerComponentType, Component: "api"},
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []string{"frontend"}, calls)
+}

--- a/pkg/composition/executor_lifecycle_test.go
+++ b/pkg/composition/executor_lifecycle_test.go
@@ -229,3 +229,32 @@ func TestRunLifecycleTargetsStopsDispatchingAfterCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, []string{"frontend"}, calls)
 }
+
+func TestRunLifecycleTargetsReportsCancellationAfterSuccessfulFinalDispatch(t *testing.T) {
+	provider := testCompositionProvider{componentType: cfg.ContainerComponentType, commands: []string{"up"}}
+	origGet, origExec := getComponentProvider, executeProvider
+	t.Cleanup(func() {
+		getComponentProvider, executeProvider = origGet, origExec
+	})
+	getComponentProvider = func(string) (component.ComponentProvider, bool) {
+		return provider, true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	executeProvider = func(_ component.ComponentProvider, _ *component.ExecutionContext) error {
+		cancel()
+		return nil
+	}
+
+	err := runLifecycleTargets(lifecycleRun{
+		ctx:         ctx,
+		atmosConfig: &schema.AtmosConfiguration{},
+		info:        &schema.ConfigAndStacksInfo{},
+		verb:        "up",
+		targets: []member{
+			{Stack: "local", Composition: "storefront", ComponentType: cfg.ContainerComponentType, Component: "frontend"},
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -145,6 +145,7 @@ const (
 	HelmHistoryMaxSectionName         = "max"
 	HelmChartHooksSectionName         = "chart_hooks"
 	HelmCRDsSectionName               = "crds"
+	HelmDependencyUpdateSectionName   = "dependency_update"
 	HelmDefaultMaxHistory             = 10
 	InheritanceSectionName            = "inheritance"
 	IntegrationsSectionName           = "integrations"

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -147,6 +147,7 @@ const (
 	HelmHistoryMaxSectionName         = "max"
 	HelmChartHooksSectionName         = "chart_hooks"
 	HelmCRDsSectionName               = "crds"
+	HelmDependencyUpdateSectionName   = "dependency_update"
 	HelmDefaultMaxHistory             = 10
 	InheritanceSectionName            = "inheritance"
 	IntegrationsSectionName           = "integrations"

--- a/pkg/datafetcher/schema_section_coverage_test.go
+++ b/pkg/datafetcher/schema_section_coverage_test.go
@@ -106,6 +106,7 @@ var nonManifestSections = map[string]struct{}{
 	"max":                {}, // Native Helm history maximum.
 	"chart_hooks":        {}, // Native Helm chart-hook policy.
 	"crds":               {}, // Native Helm CRD policy.
+	"dependency_update":  {}, // Native Helm invocation summary field; not stack-authored.
 	"workspace":          {}, // Terraform workspace (derived/metadata).
 	"required_version":   {}, // Introspected from Terraform, not authored.
 	"required_providers": {}, // Introspected from Terraform, not authored.

--- a/pkg/datafetcher/schema_section_coverage_test.go
+++ b/pkg/datafetcher/schema_section_coverage_test.go
@@ -111,6 +111,7 @@ var nonManifestSections = map[string]struct{}{
 	"max":                {}, // Native Helm history maximum.
 	"chart_hooks":        {}, // Native Helm chart-hook policy.
 	"crds":               {}, // Native Helm CRD policy.
+	"dependency_update":  {}, // Native Helm invocation summary field; not stack-authored.
 	"workspace":          {}, // Terraform workspace (derived/metadata).
 	"inheritance":        {}, // Describe output.
 	"integrations":       {}, // atmos.yaml / describe output.

--- a/website/docs/cli/commands/helm/helm-apply.mdx
+++ b/website/docs/cli/commands/helm/helm-apply.mdx
@@ -55,6 +55,9 @@ atmos helm apply --affected --labels cost-center=platform
   <dt>`--target` <em>(optional)</em></dt>
   <dd>Provision target to deliver to (e.g. a Git deployment repository). Defaults to `provision.default`, otherwise the cluster.</dd>
 
+  <dt>`--dependency-update` <em>(optional)</em></dt>
+  <dd>Fetch declared chart dependencies when they are missing. This may access dependency repositories and update the chart's <code>charts/</code> directory and lock file.</dd>
+
   <dt>`--all` <em>(optional)</em></dt>
   <dd>Apply all Helm components in dependency order.</dd>
 

--- a/website/docs/cli/commands/helm/helm-diff.mdx
+++ b/website/docs/cli/commands/helm/helm-diff.mdx
@@ -64,6 +64,9 @@ precedence (`--from-manifest` → `--against` → deployed release):
   <dt>`--context=<n>` <em>(optional)</em></dt>
   <dd>Number of unchanged context lines shown around each change. Defaults to <code>3</code>.</dd>
 
+  <dt>`--dependency-update` <em>(optional)</em></dt>
+  <dd>Fetch declared chart dependencies when they are missing. This may access dependency repositories and update the chart's <code>charts/</code> directory and lock file.</dd>
+
   <dt>`--all` / `--affected` / `--include-dependents` <em>(optional)</em></dt>
   <dd>Process multiple Helm components in dependency order.</dd>
 

--- a/website/docs/cli/commands/helm/helm-template.mdx
+++ b/website/docs/cli/commands/helm/helm-template.mdx
@@ -75,6 +75,9 @@ atmos helm template --affected --labels cost-center=platform
   <dt>`--split` <em>(optional)</em></dt>
   <dd>Write one YAML file per object. Requires `--output-dir`.</dd>
 
+  <dt>`--dependency-update` <em>(optional)</em></dt>
+  <dd>Fetch declared chart dependencies when they are missing. This may access dependency repositories and update the chart's <code>charts/</code> directory and lock file.</dd>
+
   <dt>`--all` <em>(optional)</em></dt>
   <dd>Render all Helm components in dependency order.</dd>
 


### PR DESCRIPTION
## what

- Add a backward-compatible caller context to component execution.
- Propagate command and scheduler cancellation through direct Helm operations, bulk graph execution, rendering, diffing, delivery, and cluster actions.
- Preserve fallback behavior for existing callers that do not provide a context.
- Add cross-provider regression coverage so the shared execution change does not regress Ansible, Kubernetes, container, or emulator components.
- Add opt-in `--dependency-update` support to chart-loading operations without hidden network access by default.

This is **3 of 4** in the native Helm lifecycle stack and is based on #2847:

1. #2846 — approved PRD and public contract
2. #2847 — release model, schema, CLI, and Helm actions
3. **#2848 — execution context, cancellation propagation, and opt-in dependency acquisition**
4. #2849 — operational reporting, documentation, and integration coverage

## why

- Several native Helm paths replaced the caller context with `context.Background()`, preventing signals and scheduler cancellation from consistently reaching active operations.
- Context belongs in the shared component execution contract so direct and dependency-ordered execution observe the same cancellation semantics.
- Missing chart dependencies should be actionable without making repository access or chart-directory mutation implicit.

## validation

- 147 Helm package tests.
- 59 Helm CLI tests.
- 217 shared component-provider tests.
- 202 manifest-schema tests.
- The branch is a clean descendant of #2847 and `git diff --check` passes.

## references

- Depends on #2847
- PRD: `docs/prd/native-helm-release-lifecycle.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--dependency-update` support for Helm template, apply, diff, and plan operations.
  * Missing Helm dependencies can now be fetched automatically when requested.
  * Helm rendering includes eligible hooks and preserves literal Helm expressions.

* **Bug Fixes**
  * Improved cancellation and timeout handling across Helm, Ansible, Kubernetes, and lifecycle operations.
  * Canceled operations stop before starting additional targets or components.
  * Improved Helm upgrade and render error reporting.
  * Corrected command-level masking precedence.

* **Documentation**
  * Documented Helm dependency-update behavior and affected chart files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->