### PR TITLE
fix(auth): prevent Azure CLI cache corruption for guest users

### DIFF
--- a/pkg/auth/cloud/azure/msal_cache_test.go
+++ b/pkg/auth/cloud/azure/msal_cache_test.go
@@ -13,6 +13,12 @@ import (
 )
 
 func TestNewMSALCache(t *testing.T) {
+	// Redirect HOME/USERPROFILE so the default-path case creates its cache
+	// directory under a temp home instead of the real ~/.azure.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
 	tests := []struct {
 		name          string
 		cachePath     string

--- a/pkg/auth/cloud/azure/setup.go
+++ b/pkg/auth/cloud/azure/setup.go
@@ -86,7 +86,8 @@ func SetAuthContext(params *SetAuthContextParams) error {
 	// Check for component-level location override from merged auth config.
 	if locationOverride := getComponentLocationOverride(params.StackInfo, params.IdentityName); locationOverride != "" {
 		location = locationOverride
-		log.Debug("Using component-level location override",
+		log.Debug(
+			"Using component-level location override",
 			"identity", params.IdentityName,
 			"location", location,
 		)
@@ -106,7 +107,8 @@ func SetAuthContext(params *SetAuthContextParams) error {
 		TokenFilePath: azureCreds.TokenFilePath,
 	}
 
-	log.Debug("Set Azure auth context",
+	log.Debug(
+		"Set Azure auth context",
 		"profile", params.IdentityName,
 		"credentials", credentialsPath,
 		"subscription", azureCreds.SubscriptionID,
@@ -206,6 +208,16 @@ func UpdateAzureCLIFiles(creds types.ICredentials, tenantID, subscriptionID, clo
 		return nil // Not Azure credentials, nothing to do.
 	}
 
+	// Credentials minted BY the Azure CLI must not be written back into the CLI's
+	// own cache: az already holds the authoritative entry for this account, and a
+	// second Account entry (with a home_account_id derived from the target tenant)
+	// makes az fail with "Found multiple accounts with the same username" for
+	// guest/B2B users (https://github.com/Azure/azure-cli/issues/20168).
+	if azureCreds.AuthMethod == types.AzureAuthMethodCLI {
+		log.Debug("Skipping Azure CLI file update; credentials originated from the Azure CLI")
+		return nil
+	}
+
 	// Extract user OID and username from token.
 	userOID, err := extractOIDFromToken(azureCreds.AccessToken)
 	if err != nil {
@@ -264,6 +276,7 @@ func updateMSALCacheFromCreds(home string, azureCreds *types.AzureCredentials, u
 		KeyVaultExpiration: azureCreds.KeyVaultExpiration,
 		UserOID:            userOID,
 		TenantID:           tenantID,
+		HomeAccountID:      azureCreds.HomeAccountID,
 		ClientID:           azureCreds.ClientID,
 		IsServicePrincipal: azureCreds.IsServicePrincipal,
 		LoginEndpoint:      cloudEnv.LoginEndpoint,
@@ -287,6 +300,11 @@ type msalCacheUpdate struct {
 	KeyVaultExpiration string
 	UserOID            string
 	TenantID           string
+	// HomeAccountID is MSAL's "{home-oid}.{home-tenant-id}" for the authenticated
+	// account, when the provider received it from MSAL. For guest (B2B) users this
+	// differs from "{UserOID}.{TenantID}" and MUST be used for the cache Account
+	// entry so az does not see two accounts with the same username.
+	HomeAccountID string
 	// ClientID is set for service principal authentication (OIDC).
 	ClientID string
 	// IsServicePrincipal indicates this is service principal auth.
@@ -381,9 +399,18 @@ type msalIdentifiers struct {
 
 // addUserAccountAndTokens adds account entry and tokens for user authentication.
 func addUserAccountAndTokens(sections *msalCacheSections, params *msalCacheUpdate) {
+	// Prefer MSAL's own home account ID: for guest (B2B) users the home tenant
+	// differs from the target tenant, and deriving "{oid}.{target-tenant}" would
+	// create a second Account entry with the same username, breaking az
+	// (https://github.com/Azure/azure-cli/issues/20168).
+	homeAccountID := params.HomeAccountID
+	if homeAccountID == "" {
+		homeAccountID = fmt.Sprintf("%s.%s", params.UserOID, params.TenantID)
+	}
+
 	// Create common MSAL identifiers for user auth.
 	ids := msalIdentifiers{
-		homeAccountID: fmt.Sprintf("%s.%s", params.UserOID, params.TenantID),
+		homeAccountID: homeAccountID,
 		environment:   params.LoginEndpoint,
 		clientID:      "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // Azure CLI public client.
 		realm:         params.TenantID,

--- a/pkg/auth/cloud/azure/setup_test.go
+++ b/pkg/auth/cloud/azure/setup_test.go
@@ -1600,4 +1600,76 @@ func TestUpdateAzureCLIFiles(t *testing.T) {
 		err := UpdateAzureCLIFiles(creds, "sp-tenant", "sp-sub", "")
 		assert.NoError(t, err)
 	})
+
+	t.Run("CLI-sourced credentials skip write-back", func(t *testing.T) {
+		// Credentials minted BY az must not be written back into az's own cache:
+		// the derived home_account_id duplicates az's Account entry for guest
+		// users and breaks az (azure-cli#20168).
+		subHome := t.TempDir()
+		t.Setenv("HOME", subHome)
+		t.Setenv("USERPROFILE", subHome)
+
+		now := time.Now().UTC()
+		accessToken := createTestJWT(map[string]interface{}{
+			"oid": "cli-oid-123",
+			"upn": "cli-user@contoso.com",
+		})
+
+		creds := &types.AzureCredentials{
+			AccessToken:    accessToken,
+			Expiration:     now.Add(1 * time.Hour).Format(time.RFC3339),
+			TenantID:       "cli-tenant",
+			SubscriptionID: "cli-sub",
+			AuthMethod:     types.AzureAuthMethodCLI,
+		}
+
+		err := UpdateAzureCLIFiles(creds, "cli-tenant", "cli-sub", "")
+		assert.NoError(t, err)
+
+		_, msalErr := os.Stat(filepath.Join(subHome, ".azure", "msal_token_cache.json"))
+		_, profileErr := os.Stat(filepath.Join(subHome, ".azure", "azureProfile.json"))
+		assert.True(t, os.IsNotExist(msalErr), "MSAL cache must not be written for CLI-sourced credentials")
+		assert.True(t, os.IsNotExist(profileErr), "Azure profile must not be written for CLI-sourced credentials")
+	})
+
+	t.Run("guest user home account id from MSAL is used", func(t *testing.T) {
+		// For guest (B2B) users the MSAL home account ID ("{home-oid}.{home-tenant}")
+		// differs from "{oid}.{target-tenant}"; the cache entry must carry the former.
+		subHome := t.TempDir()
+		t.Setenv("HOME", subHome)
+		t.Setenv("USERPROFILE", subHome)
+
+		now := time.Now().UTC()
+		accessToken := createTestJWT(map[string]interface{}{
+			"oid": "guest-oid-in-target",
+			"upn": "guest@hometenant.com",
+		})
+
+		creds := &types.AzureCredentials{
+			AccessToken:    accessToken,
+			Expiration:     now.Add(1 * time.Hour).Format(time.RFC3339),
+			TenantID:       "target-tenant",
+			SubscriptionID: "target-sub",
+			AuthMethod:     types.AzureAuthMethodDeviceCode,
+			HomeAccountID:  "home-oid.home-tenant",
+		}
+
+		err := UpdateAzureCLIFiles(creds, "target-tenant", "target-sub", "")
+		assert.NoError(t, err)
+
+		data, readErr := os.ReadFile(filepath.Join(subHome, ".azure", "msal_token_cache.json"))
+		require.NoError(t, readErr)
+
+		var cache map[string]map[string]map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &cache))
+
+		accounts := cache["Account"]
+		require.Len(t, accounts, 1, "exactly one Account entry expected")
+		for key, entry := range accounts {
+			assert.Contains(t, key, "home-oid.home-tenant", "cache key must use the MSAL home account ID")
+			assert.Equal(t, "home-oid.home-tenant", entry[FieldHomeAccountID])
+			assert.Equal(t, "guest-oid-in-target", entry["local_account_id"], "local account id stays the target-tenant OID")
+			assert.Equal(t, "target-tenant", entry[FieldRealm], "realm stays the target tenant")
+		}
+	})
 }

--- a/pkg/auth/identities/azure/subscription.go
+++ b/pkg/auth/identities/azure/subscription.go
@@ -86,7 +86,8 @@ func (i *subscriptionIdentity) GetProviderName() (string, error) {
 func (i *subscriptionIdentity) Authenticate(ctx context.Context, baseCreds authTypes.ICredentials) (authTypes.ICredentials, error) {
 	defer perf.Track(nil, "azure.subscriptionIdentity.Authenticate")()
 
-	log.Debug("Authenticating Azure subscription identity",
+	log.Debug(
+		"Authenticating Azure subscription identity",
 		azureCloud.LogFieldIdentity, i.name,
 		azureCloud.LogFieldSubscription, i.subscriptionID,
 	)
@@ -97,32 +98,21 @@ func (i *subscriptionIdentity) Authenticate(ctx context.Context, baseCreds authT
 		return nil, fmt.Errorf("%w: Azure subscription identity requires Azure credentials from provider", errUtils.ErrAuthenticationFailed)
 	}
 
-	// Create new credentials with subscription-specific configuration.
-	// Override subscription ID if different from provider.
-	creds := &authTypes.AzureCredentials{
-		AccessToken:        azureCreds.AccessToken,
-		TokenType:          azureCreds.TokenType,
-		Expiration:         azureCreds.Expiration,
-		TenantID:           azureCreds.TenantID,
-		SubscriptionID:     i.subscriptionID,              // Use identity's subscription.
-		Location:           i.location,                    // Use identity's location if specified.
-		GraphAPIToken:      azureCreds.GraphAPIToken,      // Preserve Graph API token from provider.
-		GraphAPIExpiration: azureCreds.GraphAPIExpiration, // Preserve Graph API token expiration.
-		KeyVaultToken:      azureCreds.KeyVaultToken,      // Preserve KeyVault API token from provider.
-		KeyVaultExpiration: azureCreds.KeyVaultExpiration, // Preserve KeyVault token expiration.
-		ClientID:           azureCreds.ClientID,           // Preserve client ID for MSAL cache format.
-		IsServicePrincipal: azureCreds.IsServicePrincipal, // Preserve auth type for MSAL cache format.
-		TokenFilePath:      azureCreds.TokenFilePath,      // Preserve token file path for OIDC.
-		FederatedToken:     azureCreds.FederatedToken,     // Preserve federated token for Azure CLI.
-		CloudEnvironment:   azureCreds.CloudEnvironment,   // Preserve cloud environment for MSAL cache.
+	// Copy the provider credentials wholesale, then apply subscription-specific
+	// overrides. A field-by-field copy silently drops newly added fields (this
+	// lost AuthMethod/HomeAccountID and re-broke the Azure CLI cache for guest
+	// users), so keep this a struct copy.
+	credsCopy := *azureCreds
+	creds := &credsCopy
+	creds.SubscriptionID = i.subscriptionID // Use identity's subscription.
+
+	// Use identity's location if specified; otherwise keep the provider's.
+	if i.location != "" {
+		creds.Location = i.location
 	}
 
-	// If location not specified in identity, use provider's location.
-	if creds.Location == "" {
-		creds.Location = azureCreds.Location
-	}
-
-	log.Debug("Successfully authenticated Azure subscription identity",
+	log.Debug(
+		"Successfully authenticated Azure subscription identity",
 		azureCloud.LogFieldIdentity, i.name,
 		azureCloud.LogFieldSubscription, i.subscriptionID,
 	)
@@ -185,7 +175,8 @@ func (i *subscriptionIdentity) PrepareEnvironment(ctx context.Context, environ m
 func (i *subscriptionIdentity) PostAuthenticate(ctx context.Context, params *authTypes.PostAuthenticateParams) error {
 	defer perf.Track(nil, "azure.subscriptionIdentity.PostAuthenticate")()
 
-	log.Debug("Post-authenticate for Azure subscription identity",
+	log.Debug(
+		"Post-authenticate for Azure subscription identity",
 		azureCloud.LogFieldIdentity, i.name,
 		azureCloud.LogFieldSubscription, i.subscriptionID,
 	)
@@ -224,7 +215,8 @@ func (i *subscriptionIdentity) PostAuthenticate(ctx context.Context, params *aut
 		return fmt.Errorf("failed to set Azure environment variables: %w", err)
 	}
 
-	log.Debug("Post-authenticate complete for Azure subscription identity",
+	log.Debug(
+		"Post-authenticate complete for Azure subscription identity",
 		azureCloud.LogFieldIdentity, i.name,
 		azureCloud.LogFieldSubscription, i.subscriptionID,
 	)

--- a/pkg/auth/identities/azure/subscription_test.go
+++ b/pkg/auth/identities/azure/subscription_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -219,6 +220,51 @@ func TestSubscriptionIdentity_GetProviderName(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedName, providerName)
 		})
+	}
+}
+
+func TestSubscriptionIdentity_Authenticate_PreservesAllProviderFields(t *testing.T) {
+	// Regression: the identity used to rebuild AzureCredentials field-by-field,
+	// silently dropping newly added fields (AuthMethod, HomeAccountID) — which
+	// disabled the Azure CLI write-back gating and re-broke az for guest users.
+	// Populate every field via reflection so any future field is covered
+	// automatically without updating this test.
+	base := &types.AzureCredentials{}
+	bv := reflect.ValueOf(base).Elem()
+	for idx := 0; idx < bv.NumField(); idx++ {
+		f := bv.Field(idx)
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString(bv.Type().Field(idx).Name + "-sentinel")
+		case reflect.Bool:
+			f.SetBool(true)
+		default:
+			t.Fatalf("unhandled field kind %s for %s; extend this test", f.Kind(), bv.Type().Field(idx).Name)
+		}
+	}
+
+	identity := &subscriptionIdentity{
+		name:           "azure-test",
+		subscriptionID: "identity-sub",
+		location:       "identity-location",
+	}
+
+	result, err := identity.Authenticate(context.Background(), base)
+	require.NoError(t, err)
+	creds, ok := result.(*types.AzureCredentials)
+	require.True(t, ok)
+
+	rv := reflect.ValueOf(creds).Elem()
+	for idx := 0; idx < rv.NumField(); idx++ {
+		field := rv.Type().Field(idx)
+		switch field.Name {
+		case "SubscriptionID":
+			assert.Equal(t, "identity-sub", creds.SubscriptionID, "identity subscription must override the provider's")
+		case "Location":
+			assert.Equal(t, "identity-location", creds.Location, "identity location must override the provider's")
+		default:
+			assert.False(t, rv.Field(idx).IsZero(), "field %s was dropped by the identity credential wrap", field.Name)
+		}
 	}
 }
 

--- a/pkg/auth/identities/azure/subscription_test.go
+++ b/pkg/auth/identities/azure/subscription_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -260,7 +261,7 @@ func TestSubscriptionIdentity_PostAuthenticate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Credentials file was written under the sandboxed home.
-	credsPath := tmpHome + "/.azure/atmos/test-realm/azure-cli/credentials.json"
+	credsPath := filepath.Join(tmpHome, ".azure", "atmos", "test-realm", "azure-cli", "credentials.json")
 	_, statErr := os.Stat(credsPath)
 	assert.NoError(t, statErr, "credentials.json should be written by SetupFiles")
 
@@ -271,7 +272,7 @@ func TestSubscriptionIdentity_PostAuthenticate(t *testing.T) {
 	assert.Equal(t, "sub-123", stackInfo.ComponentEnvSection["ARM_SUBSCRIPTION_ID"])
 
 	// CLI-sourced credentials must not have created az CLI cache files.
-	_, msalErr := os.Stat(tmpHome + "/.azure/msal_token_cache.json")
+	_, msalErr := os.Stat(filepath.Join(tmpHome, ".azure", "msal_token_cache.json"))
 	assert.True(t, os.IsNotExist(msalErr), "az MSAL cache must not be written for CLI-sourced credentials")
 }
 

--- a/pkg/auth/identities/azure/subscription_test.go
+++ b/pkg/auth/identities/azure/subscription_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -221,6 +222,57 @@ func TestSubscriptionIdentity_GetProviderName(t *testing.T) {
 			assert.Equal(t, tt.expectedName, providerName)
 		})
 	}
+}
+
+func TestSubscriptionIdentity_PostAuthenticate(t *testing.T) {
+	// Sandbox HOME so credential files land under a temp dir.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	identity := &subscriptionIdentity{
+		name:           "azure-test",
+		subscriptionID: "sub-123",
+		location:       "centralus",
+	}
+	identity.SetRealm("test-realm")
+
+	creds := &types.AzureCredentials{
+		AccessToken:    "access-token",
+		Expiration:     time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339),
+		TenantID:       "tenant-123",
+		SubscriptionID: "sub-123",
+		Location:       "centralus",
+		AuthMethod:     types.AzureAuthMethodCLI, // CLI-sourced: az cache write-back is skipped.
+	}
+
+	authContext := &schema.AuthContext{}
+	stackInfo := &schema.ConfigAndStacksInfo{}
+
+	err := identity.PostAuthenticate(context.Background(), &types.PostAuthenticateParams{
+		AuthContext:  authContext,
+		StackInfo:    stackInfo,
+		ProviderName: "azure-cli",
+		IdentityName: "azure-test",
+		Credentials:  creds,
+		Realm:        "test-realm",
+	})
+	require.NoError(t, err)
+
+	// Credentials file was written under the sandboxed home.
+	credsPath := tmpHome + "/.azure/atmos/test-realm/azure-cli/credentials.json"
+	_, statErr := os.Stat(credsPath)
+	assert.NoError(t, statErr, "credentials.json should be written by SetupFiles")
+
+	// Auth context was populated and env vars derived into stack info.
+	require.NotNil(t, authContext.Azure)
+	assert.Equal(t, "sub-123", authContext.Azure.SubscriptionID)
+	assert.Equal(t, "tenant-123", authContext.Azure.TenantID)
+	assert.Equal(t, "sub-123", stackInfo.ComponentEnvSection["ARM_SUBSCRIPTION_ID"])
+
+	// CLI-sourced credentials must not have created az CLI cache files.
+	_, msalErr := os.Stat(tmpHome + "/.azure/msal_token_cache.json")
+	assert.True(t, os.IsNotExist(msalErr), "az MSAL cache must not be written for CLI-sourced credentials")
 }
 
 func TestSubscriptionIdentity_Authenticate_PreservesAllProviderFields(t *testing.T) {

--- a/pkg/auth/providers/azure/auth_flows_coverage_test.go
+++ b/pkg/auth/providers/azure/auth_flows_coverage_test.go
@@ -20,14 +20,22 @@ import (
 )
 
 // stubAz puts a fake `az` executable on PATH that prints the given JSON.
+// The output is written to a data file so no shell quoting is needed, making
+// the same approach work for both the POSIX script and the Windows batch file
+// (exec.LookPath resolves az.bat via PATHEXT).
 func stubAz(t *testing.T, stdout string, exitCode int) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("PATH stub script not supported on Windows")
-	}
 	dir := t.TempDir()
-	script := fmt.Sprintf("#!/bin/sh\ncat <<'JSON'\n%s\nJSON\nexit %d\n", stdout, exitCode)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "az"), []byte(script), 0o755))
+	outFile := filepath.Join(dir, "az_output.txt")
+	require.NoError(t, os.WriteFile(outFile, []byte(stdout+"\n"), 0o644))
+
+	if runtime.GOOS == "windows" {
+		script := fmt.Sprintf("@echo off\r\ntype \"%s\"\r\nexit /b %d\r\n", outFile, exitCode)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "az.bat"), []byte(script), 0o755))
+	} else {
+		script := fmt.Sprintf("#!/bin/sh\ncat \"%s\"\nexit %d\n", outFile, exitCode)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "az"), []byte(script), 0o755))
+	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
@@ -143,34 +151,42 @@ func TestDeviceCodeProvider_TrySilentTokenAcquisition(t *testing.T) {
 	p := newTestDeviceCodeProvider(t)
 	client := newOfflineMSALClient(t)
 
-	t.Run("no cached accounts", func(t *testing.T) {
-		result := p.trySilentTokenAcquisition(context.Background(), &client, nil)
-		assert.Empty(t, result.accessToken)
-		assert.Empty(t, result.homeAccountID)
-	})
+	tests := []struct {
+		name     string
+		accounts []public.Account
+	}{
+		{
+			name:     "no cached accounts",
+			accounts: nil,
+		},
+		{
+			name: "no account for tenant",
+			accounts: []public.Account{{
+				HomeAccountID:     "oid.other-tenant",
+				Realm:             "other-tenant",
+				PreferredUsername: "user@example.com",
+			}},
+		},
+		{
+			// The account matches the tenant but is not in the MSAL cache, so
+			// the silent call fails locally and the flow falls through to
+			// device code.
+			name: "matching account but silent acquisition fails",
+			accounts: []public.Account{{
+				HomeAccountID:     "home-oid.home-tenant",
+				Realm:             "tenant-123",
+				PreferredUsername: "user@example.com",
+			}},
+		},
+	}
 
-	t.Run("no account for tenant", func(t *testing.T) {
-		accounts := []public.Account{{
-			HomeAccountID:     "oid.other-tenant",
-			Realm:             "other-tenant",
-			PreferredUsername: "user@example.com",
-		}}
-		result := p.trySilentTokenAcquisition(context.Background(), &client, accounts)
-		assert.Empty(t, result.accessToken)
-	})
-
-	t.Run("matching account but silent acquisition fails", func(t *testing.T) {
-		// The account matches the tenant but is not in the MSAL cache, so the
-		// silent call fails locally and the flow falls through to device code.
-		accounts := []public.Account{{
-			HomeAccountID:     "home-oid.home-tenant",
-			Realm:             "tenant-123",
-			PreferredUsername: "user@example.com",
-		}}
-		result := p.trySilentTokenAcquisition(context.Background(), &client, accounts)
-		assert.Empty(t, result.accessToken)
-		assert.Empty(t, result.homeAccountID, "home account id must not be set when silent acquisition fails")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.trySilentTokenAcquisition(context.Background(), &client, tt.accounts)
+			assert.Empty(t, result.accessToken)
+			assert.Empty(t, result.homeAccountID, "home account id must not be set when silent acquisition does not succeed")
+		})
+	}
 }
 
 func TestDeviceCodeProvider_AcquireAdditionalTokens_SilentFailures(t *testing.T) {

--- a/pkg/auth/providers/azure/auth_flows_coverage_test.go
+++ b/pkg/auth/providers/azure/auth_flows_coverage_test.go
@@ -1,0 +1,241 @@
+package azure
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	authTypes "github.com/cloudposse/atmos/pkg/auth/types"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// stubAz puts a fake `az` executable on PATH that prints the given JSON.
+func stubAz(t *testing.T, stdout string, exitCode int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH stub script not supported on Windows")
+	}
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\ncat <<'JSON'\n%s\nJSON\nexit %d\n", stdout, exitCode)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "az"), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func newTestCLIProvider(t *testing.T, subscriptionID string) *cliProvider {
+	t.Helper()
+	spec := map[string]interface{}{"tenant_id": "tenant-123"}
+	if subscriptionID != "" {
+		spec["subscription_id"] = subscriptionID
+	}
+	p, err := NewCLIProvider("azure-cli", &schema.Provider{Kind: "azure/cli", Spec: spec})
+	require.NoError(t, err)
+	return p
+}
+
+func TestCLIProvider_Authenticate_BuildsCredentialsFromAzOutput(t *testing.T) {
+	expires := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	stubAz(t, fmt.Sprintf(`{"accessToken":"az-token","expiresOn":"%s","tenant":"tenant-123","subscription":"sub-from-az","tokenType":"Bearer"}`, expires), 0)
+
+	p := newTestCLIProvider(t, "")
+
+	creds, err := p.Authenticate(context.Background())
+	require.NoError(t, err)
+
+	azureCreds, ok := creds.(*authTypes.AzureCredentials)
+	require.True(t, ok)
+	assert.Equal(t, "az-token", azureCreds.AccessToken)
+	assert.Equal(t, "tenant-123", azureCreds.TenantID)
+	assert.Equal(t, "sub-from-az", azureCreds.SubscriptionID, "subscription falls back to the az response when not configured")
+	assert.Equal(t, authTypes.AzureAuthMethodCLI, azureCreds.AuthMethod,
+		"CLI-minted credentials must be marked so the az cache write-back is skipped")
+}
+
+func TestCLIProvider_Authenticate_NotLoggedIn(t *testing.T) {
+	stubAz(t, `Please run 'az login' to setup account.`, 1)
+
+	p := newTestCLIProvider(t, "sub-123")
+
+	_, err := p.Authenticate(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrAuthenticationFailed)
+	assert.Contains(t, err.Error(), "az login")
+}
+
+func testJWT(t *testing.T, payload string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"typ":"JWT","alg":"RS256"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".sig"
+}
+
+func newTestDeviceCodeProvider(t *testing.T) *deviceCodeProvider {
+	t.Helper()
+	p, err := NewDeviceCodeProvider("azure-device-code", &schema.Provider{
+		Kind: "azure/device-code",
+		Spec: map[string]interface{}{"tenant_id": "tenant-123"},
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func TestDeviceCodeProvider_CreateCredentials_AllTokens(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+	now := time.Now().UTC()
+
+	creds, err := p.createCredentials(&tokenAcquisitionResult{
+		accessToken:       "mgmt-token",
+		expiresOn:         now.Add(1 * time.Hour),
+		graphToken:        "graph-token",
+		graphExpiresOn:    now.Add(2 * time.Hour),
+		keyVaultToken:     "kv-token",
+		keyVaultExpiresOn: now.Add(3 * time.Hour),
+		homeAccountID:     "home-oid.home-tenant",
+	})
+	require.NoError(t, err)
+
+	azureCreds, ok := creds.(*authTypes.AzureCredentials)
+	require.True(t, ok)
+	assert.Equal(t, "mgmt-token", azureCreds.AccessToken)
+	assert.Equal(t, "graph-token", azureCreds.GraphAPIToken)
+	assert.Equal(t, "kv-token", azureCreds.KeyVaultToken)
+	assert.Equal(t, "home-oid.home-tenant", azureCreds.HomeAccountID,
+		"MSAL home account ID must survive into credentials for correct az cache interop")
+	assert.Equal(t, authTypes.AzureAuthMethodDeviceCode, azureCreds.AuthMethod)
+}
+
+func TestDeviceCodeProvider_CreateCredentials_ManagementOnly(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+
+	creds, err := p.createCredentials(&tokenAcquisitionResult{
+		accessToken: "mgmt-token",
+		expiresOn:   time.Now().UTC().Add(1 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	azureCreds, ok := creds.(*authTypes.AzureCredentials)
+	require.True(t, ok)
+	assert.Empty(t, azureCreds.GraphAPIToken)
+	assert.Empty(t, azureCreds.KeyVaultToken)
+	assert.Empty(t, azureCreds.HomeAccountID)
+}
+
+func newOfflineMSALClient(t *testing.T) public.Client {
+	t.Helper()
+	client, err := public.New(
+		defaultAzureClientID,
+		public.WithAuthority("https://login.microsoftonline.com/tenant-123"),
+		public.WithInstanceDiscovery(false),
+	)
+	require.NoError(t, err)
+	return client
+}
+
+func TestDeviceCodeProvider_TrySilentTokenAcquisition(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+	client := newOfflineMSALClient(t)
+
+	t.Run("no cached accounts", func(t *testing.T) {
+		result := p.trySilentTokenAcquisition(context.Background(), &client, nil)
+		assert.Empty(t, result.accessToken)
+		assert.Empty(t, result.homeAccountID)
+	})
+
+	t.Run("no account for tenant", func(t *testing.T) {
+		accounts := []public.Account{{
+			HomeAccountID:     "oid.other-tenant",
+			Realm:             "other-tenant",
+			PreferredUsername: "user@example.com",
+		}}
+		result := p.trySilentTokenAcquisition(context.Background(), &client, accounts)
+		assert.Empty(t, result.accessToken)
+	})
+
+	t.Run("matching account but silent acquisition fails", func(t *testing.T) {
+		// The account matches the tenant but is not in the MSAL cache, so the
+		// silent call fails locally and the flow falls through to device code.
+		accounts := []public.Account{{
+			HomeAccountID:     "home-oid.home-tenant",
+			Realm:             "tenant-123",
+			PreferredUsername: "user@example.com",
+		}}
+		result := p.trySilentTokenAcquisition(context.Background(), &client, accounts)
+		assert.Empty(t, result.accessToken)
+		assert.Empty(t, result.homeAccountID, "home account id must not be set when silent acquisition fails")
+	})
+}
+
+func TestDeviceCodeProvider_AcquireAdditionalTokens_SilentFailures(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+	client := newOfflineMSALClient(t)
+
+	accounts := []public.Account{{
+		HomeAccountID:     "home-oid.home-tenant",
+		Realm:             "tenant-123",
+		PreferredUsername: "user@example.com",
+	}}
+	result := tokenAcquisitionResult{accessToken: "mgmt-token"}
+
+	// Graph and KeyVault silent acquisitions fail locally (account not in
+	// cache); the result must keep the management token and stay usable.
+	p.acquireAdditionalTokens(context.Background(), &client, accounts, &result)
+	assert.Equal(t, "mgmt-token", result.accessToken)
+	assert.Empty(t, result.graphToken)
+	assert.Empty(t, result.keyVaultToken)
+}
+
+func TestDeviceCodeProvider_Authenticate_Headless(t *testing.T) {
+	// Sandbox HOME so the MSAL cache is created under a temp dir.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	p := newTestDeviceCodeProvider(t)
+
+	// Under `go test` stderr is not a TTY, so after the (empty-cache) silent
+	// attempt the device code flow refuses to start.
+	_, err := p.Authenticate(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrAuthenticationFailed)
+	assert.Contains(t, err.Error(), "interactive terminal")
+}
+
+func TestDeviceCodeProvider_FindAccountForTenant_CapturesHomeAccountID(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+
+	accounts := []public.Account{
+		{HomeAccountID: "oid.other", Realm: "other-tenant"},
+		{HomeAccountID: "home-oid.home-tenant", Realm: "tenant-123"},
+	}
+	account, err := p.findAccountForTenant(accounts)
+	require.NoError(t, err)
+	assert.Equal(t, "home-oid.home-tenant", account.HomeAccountID)
+}
+
+func TestDeviceCodeProvider_CaptureHomeAccountID(t *testing.T) {
+	p := newTestDeviceCodeProvider(t)
+
+	t.Run("matching account captured", func(t *testing.T) {
+		result := tokenAcquisitionResult{}
+		p.captureHomeAccountID([]public.Account{
+			{HomeAccountID: "home-oid.home-tenant", Realm: "tenant-123"},
+		}, &result)
+		assert.Equal(t, "home-oid.home-tenant", result.homeAccountID)
+	})
+
+	t.Run("no matching account leaves result empty", func(t *testing.T) {
+		result := tokenAcquisitionResult{}
+		p.captureHomeAccountID([]public.Account{
+			{HomeAccountID: "oid.other", Realm: "other-tenant"},
+		}, &result)
+		assert.Empty(t, result.homeAccountID)
+	})
+}

--- a/pkg/auth/providers/azure/cli.go
+++ b/pkg/auth/providers/azure/cli.go
@@ -122,7 +122,8 @@ func (p *cliProvider) IsAmbient() bool {
 func (p *cliProvider) Authenticate(ctx context.Context) (authTypes.ICredentials, error) {
 	defer perf.Track(nil, "azure.cliProvider.Authenticate")()
 
-	log.Debug("Authenticating with Azure CLI",
+	log.Debug(
+		"Authenticating with Azure CLI",
 		"provider", p.name,
 		"tenant", p.tenantID,
 	)
@@ -158,9 +159,11 @@ func (p *cliProvider) Authenticate(ctx context.Context) (authTypes.ICredentials,
 		SubscriptionID:   subscriptionID,
 		Location:         p.location,
 		CloudEnvironment: p.cloudEnv.Name,
+		AuthMethod:       authTypes.AzureAuthMethodCLI,
 	}
 
-	log.Debug("Successfully authenticated with Azure CLI",
+	log.Debug(
+		"Successfully authenticated with Azure CLI",
 		"provider", p.name,
 		"tenant", p.tenantID,
 		"subscription", subscriptionID,

--- a/pkg/auth/providers/azure/device_code.go
+++ b/pkg/auth/providers/azure/device_code.go
@@ -376,11 +376,7 @@ func (p *deviceCodeProvider) acquireTokensViaDeviceCode(ctx context.Context, cli
 		return result, nil
 	}
 
-	// Record the MSAL home account ID for correct Azure CLI cache interop
-	// (guest users have a home tenant different from p.tenantID).
-	if account, findErr := p.findAccountForTenant(accounts); findErr == nil {
-		result.homeAccountID = account.HomeAccountID
-	}
+	p.captureHomeAccountID(accounts, &result)
 
 	// Acquire additional API tokens for azuread and azurerm providers.
 	p.acquireAdditionalTokens(ctx, client, accounts, &result)
@@ -431,6 +427,14 @@ func (p *deviceCodeProvider) acquireAdditionalTokens(ctx context.Context, client
 		log.Debug("Successfully obtained KeyVault token",
 			"expiresOn", result.keyVaultExpiresOn,
 			"tokenLength", len(result.keyVaultToken))
+	}
+}
+
+// captureHomeAccountID records the MSAL home account ID for correct Azure CLI
+// cache interop (guest users have a home tenant different from p.tenantID).
+func (p *deviceCodeProvider) captureHomeAccountID(accounts []public.Account, result *tokenAcquisitionResult) {
+	if account, err := p.findAccountForTenant(accounts); err == nil {
+		result.homeAccountID = account.HomeAccountID
 	}
 }
 

--- a/pkg/auth/providers/azure/device_code.go
+++ b/pkg/auth/providers/azure/device_code.go
@@ -252,6 +252,7 @@ func (p *deviceCodeProvider) Authenticate(ctx context.Context) (authTypes.ICrede
 		GraphExpiresAt:    tokens.graphExpiresOn,
 		KeyVaultToken:     tokens.keyVaultToken,
 		KeyVaultExpiresAt: tokens.keyVaultExpiresOn,
+		HomeAccountID:     tokens.homeAccountID,
 	}); err != nil {
 		log.Debug("Failed to update Azure CLI token cache", "error", err)
 	}
@@ -267,6 +268,10 @@ type tokenAcquisitionResult struct {
 	expiresOn         time.Time
 	graphExpiresOn    time.Time
 	keyVaultExpiresOn time.Time
+	// homeAccountID is MSAL's "{home-oid}.{home-tenant-id}" for the authenticated
+	// account. For guest (B2B) users the home tenant differs from p.tenantID, and
+	// the Azure CLI cache write-back must use this value to avoid duplicate accounts.
+	homeAccountID string
 }
 
 // trySilentTokenAcquisition attempts to acquire tokens silently from cached account.
@@ -291,7 +296,8 @@ func (p *deviceCodeProvider) trySilentTokenAcquisition(ctx context.Context, clie
 		azureCloud.LogFieldTenantID, p.tenantID)
 
 	// Try to get management token silently.
-	mgmtResult, err := client.AcquireTokenSilent(ctx,
+	mgmtResult, err := client.AcquireTokenSilent(
+		ctx,
 		[]string{p.cloudEnv.ManagementScope},
 		public.WithSilentAccount(account),
 	)
@@ -302,10 +308,12 @@ func (p *deviceCodeProvider) trySilentTokenAcquisition(ctx context.Context, clie
 
 	result.accessToken = mgmtResult.AccessToken
 	result.expiresOn = mgmtResult.ExpiresOn
+	result.homeAccountID = account.HomeAccountID
 	log.Debug("Successfully acquired management token silently", "expiresOn", result.expiresOn)
 
 	// Try to get Graph token silently.
-	graphResult, err := client.AcquireTokenSilent(ctx,
+	graphResult, err := client.AcquireTokenSilent(
+		ctx,
 		[]string{p.cloudEnv.GraphAPIScope},
 		public.WithSilentAccount(account),
 	)
@@ -318,7 +326,8 @@ func (p *deviceCodeProvider) trySilentTokenAcquisition(ctx context.Context, clie
 	}
 
 	// Try to get KeyVault token silently.
-	kvResult, err := client.AcquireTokenSilent(ctx,
+	kvResult, err := client.AcquireTokenSilent(
+		ctx,
 		[]string{p.cloudEnv.KeyVaultScope},
 		public.WithSilentAccount(account),
 	)
@@ -342,7 +351,8 @@ func (p *deviceCodeProvider) acquireTokensViaDeviceCode(ctx context.Context, cli
 		return result, fmt.Errorf("%w: Azure device code flow requires an interactive terminal (no TTY detected). Use managed identity or service principal authentication in headless environments", errUtils.ErrAuthenticationFailed)
 	}
 
-	log.Debug("Starting Azure device code authentication",
+	log.Debug(
+		"Starting Azure device code authentication",
 		"provider", p.name,
 		"tenant", p.tenantID,
 		"clientID", p.clientID,
@@ -366,6 +376,12 @@ func (p *deviceCodeProvider) acquireTokensViaDeviceCode(ctx context.Context, cli
 		return result, nil
 	}
 
+	// Record the MSAL home account ID for correct Azure CLI cache interop
+	// (guest users have a home tenant different from p.tenantID).
+	if account, findErr := p.findAccountForTenant(accounts); findErr == nil {
+		result.homeAccountID = account.HomeAccountID
+	}
+
 	// Acquire additional API tokens for azuread and azurerm providers.
 	p.acquireAdditionalTokens(ctx, client, accounts, &result)
 
@@ -385,7 +401,8 @@ func (p *deviceCodeProvider) acquireAdditionalTokens(ctx context.Context, client
 
 	// Request Graph API token for azuread provider (silently, using refresh token).
 	log.Debug("Requesting Graph API token for azuread provider")
-	graphResult, err := client.AcquireTokenSilent(ctx,
+	graphResult, err := client.AcquireTokenSilent(
+		ctx,
 		[]string{p.cloudEnv.GraphAPIScope},
 		public.WithSilentAccount(account),
 	)
@@ -401,7 +418,8 @@ func (p *deviceCodeProvider) acquireAdditionalTokens(ctx context.Context, client
 
 	// Request KeyVault token for azurerm provider KeyVault operations (silently).
 	log.Debug("Requesting KeyVault token for azurerm provider")
-	kvResult, err := client.AcquireTokenSilent(ctx,
+	kvResult, err := client.AcquireTokenSilent(
+		ctx,
 		[]string{p.cloudEnv.KeyVaultScope},
 		public.WithSilentAccount(account),
 	)
@@ -429,6 +447,8 @@ func (p *deviceCodeProvider) createCredentials(tokens *tokenAcquisitionResult) (
 		SubscriptionID:   p.subscriptionID,
 		Location:         p.location,
 		CloudEnvironment: p.cloudEnv.Name, // Propagate cloud environment for MSAL cache.
+		AuthMethod:       authTypes.AzureAuthMethodDeviceCode,
+		HomeAccountID:    tokens.homeAccountID,
 	}
 
 	// Add Graph API token if available.

--- a/pkg/auth/providers/azure/device_code_cache.go
+++ b/pkg/auth/providers/azure/device_code_cache.go
@@ -210,6 +210,7 @@ type tokenCacheUpdate struct {
 	GraphExpiresAt    time.Time // Expiration time for graph token, zero value if not available
 	KeyVaultToken     string    // KeyVault API access token (for azurerm provider KeyVault operations), empty string if not available
 	KeyVaultExpiresAt time.Time // Expiration time for KeyVault token, zero value if not available
+	HomeAccountID     string    // MSAL "{home-oid}.{home-tenant-id}"; differs from "{oid}.{tenant}" for guest (B2B) users
 }
 
 // updateAzureCLICache updates the Azure CLI MSAL token cache so Terraform can use it.
@@ -289,9 +290,18 @@ func (p *deviceCodeProvider) populateCLICacheWithTokens(
 	userOID, username string,
 	update *tokenCacheUpdate,
 ) string {
+	// Prefer MSAL's own home account ID: for guest (B2B) users the home tenant
+	// differs from p.tenantID, and deriving "{oid}.{target-tenant}" creates a
+	// duplicate Account entry with the same username, which breaks az
+	// (https://github.com/Azure/azure-cli/issues/20168).
+	homeAccountID := update.HomeAccountID
+	if homeAccountID == "" {
+		homeAccountID = fmt.Sprintf("%s.%s", userOID, p.tenantID)
+	}
+
 	// Create common MSAL identifiers.
 	ids := msalIdentifiers{
-		homeAccountID: fmt.Sprintf("%s.%s", userOID, p.tenantID),
+		homeAccountID: homeAccountID,
 		environment:   p.cloudEnv.LoginEndpoint,
 		clientID:      "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // Azure CLI public client.
 		realm:         p.tenantID,

--- a/pkg/auth/providers/azure/device_code_cache_test.go
+++ b/pkg/auth/providers/azure/device_code_cache_test.go
@@ -740,6 +740,55 @@ func TestDeviceCodeProvider_updateAzureCLICache_Integration(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDeviceCodeProvider_updateAzureCLICache_GuestHomeAccountID(t *testing.T) {
+	// For guest (B2B) users MSAL's home account ID ("{home-oid}.{home-tenant}")
+	// differs from "{oid}.{target-tenant}". The written Account entry must carry
+	// the MSAL value, or az fails with "Found multiple accounts with the same
+	// username" (azure-cli#20168).
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("AZURE_CONFIG_DIR", tmpHome)
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"typ":"JWT","alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"oid":"guest-oid-in-target","upn":"guest@hometenant.com"}`))
+	accessToken := header + "." + payload + ".testsignature"
+
+	provider := &deviceCodeProvider{
+		name:     "test-provider",
+		tenantID: "target-tenant",
+		cloudEnv: azureCloud.GetCloudEnvironment(""),
+		config: &schema.Provider{
+			Kind: "azure/device-code",
+			Spec: map[string]interface{}{
+				"tenant_id": "target-tenant",
+			},
+		},
+	}
+
+	err := provider.updateAzureCLICache(&tokenCacheUpdate{
+		AccessToken:   accessToken,
+		ExpiresAt:     time.Now().UTC().Add(1 * time.Hour),
+		HomeAccountID: "home-oid.home-tenant",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tmpHome, ".azure", "msal_token_cache.json"))
+	require.NoError(t, err)
+
+	var cache map[string]map[string]map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &cache))
+
+	accounts := cache["Account"]
+	require.Len(t, accounts, 1, "exactly one Account entry expected")
+	for key, entry := range accounts {
+		assert.Contains(t, key, "home-oid.home-tenant", "cache key must use the MSAL home account ID")
+		assert.Equal(t, "home-oid.home-tenant", entry[azureCloud.FieldHomeAccountID])
+		assert.Equal(t, "guest-oid-in-target", entry["local_account_id"], "local account id stays the target-tenant OID")
+		assert.Equal(t, "target-tenant", entry[azureCloud.FieldRealm], "realm stays the target tenant")
+	}
+}
+
 func TestLoadAndInitializeCLICache(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/auth/providers/azure/oidc.go
+++ b/pkg/auth/providers/azure/oidc.go
@@ -204,7 +204,8 @@ func (p *oidcProvider) getTokenEndpoint() string {
 func (p *oidcProvider) Authenticate(ctx context.Context) (authTypes.ICredentials, error) {
 	defer perf.Track(nil, "azure.oidcProvider.Authenticate")()
 
-	log.Debug("Authenticating with Azure OIDC",
+	log.Debug(
+		"Authenticating with Azure OIDC",
 		"provider", p.name,
 		"tenant", p.tenantID,
 		"client", p.clientID,
@@ -245,13 +246,15 @@ func (p *oidcProvider) Authenticate(ctx context.Context) (authTypes.ICredentials
 		TokenFilePath:      tokenFilePath,
 		FederatedToken:     federatedToken,  // Store for Azure CLI service_principal_entries.json.
 		CloudEnvironment:   p.cloudEnv.Name, // Propagate cloud environment for MSAL cache.
+		AuthMethod:         authTypes.AzureAuthMethodOIDC,
 	}
 
 	// Acquire additional tokens for Azure CLI and Terraform provider compatibility.
 	// These are acquired in parallel for efficiency.
 	p.acquireAdditionalTokens(ctx, federatedToken, creds)
 
-	log.Debug("Successfully authenticated with Azure OIDC",
+	log.Debug(
+		"Successfully authenticated with Azure OIDC",
 		"provider", p.name,
 		"tenant", p.tenantID,
 		"subscription", p.subscriptionID,
@@ -476,7 +479,8 @@ func (p *oidcProvider) exchangeToken(ctx context.Context, federatedToken, scope 
 		return nil, fmt.Errorf("%w: empty access token in Azure AD response", errUtils.ErrAuthenticationFailed)
 	}
 
-	log.Debug("Successfully exchanged federated token for Azure access token",
+	log.Debug(
+		"Successfully exchanged federated token for Azure access token",
 		"scope", scope,
 		"tokenType", tokenResp.TokenType,
 		"expiresIn", tokenResp.ExpiresIn,
@@ -548,7 +552,8 @@ func (p *oidcProvider) PrepareEnvironment(ctx context.Context, environ map[strin
 		result["AZURE_FEDERATED_TOKEN_FILE"] = tokenFile
 	}
 
-	log.Debug("Azure OIDC environment prepared",
+	log.Debug(
+		"Azure OIDC environment prepared",
 		"ARM_USE_OIDC", "true",
 		"ARM_CLIENT_ID", p.clientID,
 		"subscription", p.subscriptionID,

--- a/pkg/auth/types/azure_credentials.go
+++ b/pkg/auth/types/azure_credentials.go
@@ -40,7 +40,26 @@ type AzureCredentials struct {
 	// CloudEnvironment is the Azure cloud environment name ("public", "usgovernment", "china").
 	// Used to select correct endpoints when writing MSAL cache entries.
 	CloudEnvironment string `json:"cloud_environment,omitempty"`
+	// AuthMethod records which provider kind minted these credentials
+	// (AzureAuthMethodCLI, AzureAuthMethodDeviceCode, AzureAuthMethodOIDC).
+	// Credentials that originated from the Azure CLI must not be written back
+	// into the CLI's own cache files.
+	AuthMethod string `json:"auth_method,omitempty"`
+	// HomeAccountID is the MSAL home account identifier ("{home-oid}.{home-tenant-id}").
+	// For guest (B2B) users the home tenant differs from the tenant being accessed;
+	// deriving the value from the target tenant instead creates a duplicate Azure CLI
+	// cache Account entry with the same username, which breaks every az command
+	// (https://github.com/Azure/azure-cli/issues/20168). Populated by providers that
+	// receive it from MSAL.
+	HomeAccountID string `json:"home_account_id,omitempty"`
 }
+
+// Azure credential auth methods (values of AzureCredentials.AuthMethod).
+const (
+	AzureAuthMethodCLI        = "cli"
+	AzureAuthMethodDeviceCode = "device_code"
+	AzureAuthMethodOIDC       = "oidc"
+)
 
 // IsExpired returns true if the credentials are expired.
 // This implements the ICredentials interface.


### PR DESCRIPTION
## what

- Skip the Azure CLI cache write-back entirely when credentials originated from the `azure/cli` provider — az's own cache is authoritative, and writing back what came from az is what corrupted it.
- Record the originating auth method on `AzureCredentials` (`cli` / `device_code` / `oidc`) so the write-back can be gated per provider kind.
- Capture MSAL's real home account ID in the `azure/device-code` provider (silent and interactive flows) and use it in both Azure CLI cache writers (`UpdateAzureCLIFiles` and the provider-level `updateAzureCLICache`), falling back to the previous `{oid}.{tenant}` derivation when unavailable.
- Replace the `azure/subscription` identity's field-by-field credential copy with a struct copy plus explicit overrides, and add a reflection-based regression test that fails if any future `AzureCredentials` field is dropped by the wrap.
- Isolate `TestNewMSALCache`'s default-path case from the real `~/.azure`.

## why

- After `atmos auth login`, the Azure CLI cache write-back created an MSAL Account entry with `home_account_id` derived as `{oid}.{target-tenant}` and hardcoded `account_source: "device_code"`. For guest (B2B) users the home tenant differs from the target tenant, so az ended up with **two Account entries for the same username** and failed every subsequent command with `Found multiple accounts with the same username` ([azure-cli#20168](https://github.com/Azure/azure-cli/issues/20168)) — including `az account get-access-token`, which the `azure/cli` provider itself shells out to. In other words, one `atmos auth login` broke both az and the next atmos login for any guest user.
- Reproduced and verified end to end against a real tenant where the operator is a B2B guest: before the fix, `az login` → `atmos auth login` → az broken; after the fix, az stays healthy, the cache keeps exactly one Account entry, and the persisted credentials carry `auth_method` so the gate holds across credential caching.
- The subscription identity's field-by-field copy silently dropped the new fields before they reached the cache writer (found only by the end-to-end test), which is why the copy is now structural and guarded by a reflection test.

## references

- https://github.com/Azure/azure-cli/issues/20168 (the az failure mode this triggered)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Azure credentials now retain authentication method and account identity details.
- Improved support for guest and cross-tenant Azure accounts during authentication and token caching.
- Subscription-based authentication preserves provider credential settings while applying subscription-specific values.

## Bug Fixes
- Azure CLI authentication no longer unexpectedly modifies CLI credential cache files.
- Corrected account identification and tenant details for guest-user authentication.
- Improved cache path handling across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->