### PR TITLE
fix(scaffold): preserve source in scaffold config

### DIFF
--- a/docs/fixes/2026-08-10-scaffold-remote-source-provenance.md
+++ b/docs/fixes/2026-08-10-scaffold-remote-source-provenance.md
@@ -1,0 +1,52 @@
+# Fix: remote scaffold sources no longer record a dangling temp-dir path in `spec.source`
+
+**Date:** 2026-08-10
+
+## Summary
+
+`atmos scaffold generate`/`atmos init` recorded a dangling, already-deleted temp-directory path in
+`spec.source` of `.atmos/scaffold.yaml` whenever the template source was remote (`git::...` or a bare
+`https://...` URL). `resolveRemote()` in `pkg/generator/source/resolver.go` now restores
+`Configuration.Source` to the original source string the caller passed in after loading the template
+config from the temporary download directory.
+
+## Context
+
+- For a remote scaffold source, `resolveRemote()` downloads the template into
+  `os.MkdirTemp("", "atmos-scaffold-")`, then loads the config with that temp dir passed in as the
+  "source." `Configuration.Source` — and therefore the persisted `spec.source` — ended up holding
+  something like `/var/folders/xx/.../atmos-scaffold-1234567890`. `cleanup()` removes that directory
+  immediately after the command finishes, so the recorded provenance was a dangling reference to nothing
+  as soon as generation completed, contradicting `SaveProjectRecord`'s own doc comment: "spec.source and
+  spec.baseRef record provenance for future updates."
+- Local sources (a relative/absolute path, or `file://...`) were already correct, but only by accident of
+  `resolveLocal` having no temp-dir indirection step, not because anything special-cased provenance for
+  them.
+- Reproduced directly: `atmos scaffold generate "git::https://.../scaffold-template.git" ./out --defaults`,
+  then `cat ./out/.atmos/scaffold.yaml` showed a `/var/folders/...`/`/tmp/...` path for `spec.source` that
+  no longer existed on disk.
+- No upstream GitHub issue; PR https://github.com/cloudposse/atmos/pull/2869 was opened directly.
+
+## Changes
+
+- `pkg/generator/source/resolver.go`: in `resolveRemote()`, set `conf.Source = src` (the original source
+  string the caller passed in) after loading the template configuration from the temporary download
+  directory, instead of leaving `Configuration.Source` as whatever `LoadConfigurationFromDir` was given
+  (the temp dir itself). No change to `resolveLocal`, which already recorded the correct value.
+- `pkg/generator/source/resolver_test.go`: added assertions that `Configuration.Source` holds the original
+  source for both local (`TestResolve_LocalPath`, `TestHydrate_LocalStub`) and remote paths, plus a
+  dedicated regression test, `TestResolve_RemoteRecordsOriginalSource`, that fails on the pre-fix code and
+  passes after. The remote case is exercised by serving an in-memory ZIP archive from an `httptest.Server`
+  rather than a git fixture — go-getter's HTTP getter unpacks the `.zip` extension on its own, so the test
+  never shells out to git or any other external binary and stays hermetic/cross-platform.
+
+## Validation
+
+- `go test ./pkg/generator/source/...` — passes, including `TestResolve_RemoteRecordsOriginalSource`.
+- Manual repro: `atmos scaffold generate "git::https://.../scaffold-template.git" ./out --defaults` followed
+  by `cat ./out/.atmos/scaffold.yaml` now shows the original `git::...` source string in `spec.source`
+  instead of the removed temp directory.
+
+## Follow-ups
+
+None.

--- a/pkg/generator/source/resolver.go
+++ b/pkg/generator/source/resolver.go
@@ -118,6 +118,10 @@ func resolveRemote(atmosConfig *schema.AtmosConfiguration, name, src string, tim
 		cleanup()
 		return nil, noop, err
 	}
+	// tempDir only exists to read files off disk and is removed by cleanup()
+	// once generation finishes; the recorded provenance must be the original
+	// source the caller passed in, not that ephemeral fetch destination.
+	conf.Source = src
 	return conf, cleanup, nil
 }
 

--- a/pkg/generator/source/resolver_test.go
+++ b/pkg/generator/source/resolver_test.go
@@ -1,6 +1,10 @@
 package source
 
 import (
+	"archive/zip"
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
@@ -235,20 +239,50 @@ func TestResolve_RemoteGitSubdirSuccess(t *testing.T) {
 	assert.True(t, hasSampleFile(cfg.Files), "remote git subdir template files must be loaded")
 }
 
+// zipArchive builds an in-memory ZIP archive containing the given files.
+// go-getter's HTTP getter unpacks a recognized archive extension (.zip
+// included) directly, so serving one over httptest.Server exercises a real
+// remote (ClientModeDir) fetch through resolveRemote without needing git or
+// any other external binary.
+func zipArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
 // TestResolve_RemoteRecordsOriginalSource pins the bug where a remote
 // (git::/https://) scaffold source ended up with Configuration.Source (and
 // therefore the persisted spec.source in .atmos/scaffold.yaml) set to the
 // ephemeral os.MkdirTemp download directory instead of the original source
 // string. That tempdir is removed by cleanup() as soon as the command
 // finishes, leaving spec.source pointing at nothing.
+//
+// Serves a ZIP archive from a local httptest.Server rather than using a git
+// fixture: the ".zip" extension is enough for go-getter's HTTP getter to
+// unpack it into the temp dir on its own, so this test never shells out to
+// git (or any other external binary) and stays hermetic/cross-platform.
 func TestResolve_RemoteRecordsOriginalSource(t *testing.T) {
-	requireGit(t)
-
-	repoDir := initSourceTestGitRepo(t, map[string]string{
+	archive := zipArchive(t, map[string]string{
 		"scaffold.yaml": sampleScaffold,
 		"file.txt":      "hello",
 	})
-	src := "git::" + sourceTestGitFileURI(repoDir) + "?ref=main"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+
+	src := server.URL + "/template.zip"
 
 	cfg, cleanup, err := Resolve(&schema.AtmosConfiguration{}, "sample", src, time.Minute)
 	require.NoError(t, err)
@@ -256,6 +290,7 @@ func TestResolve_RemoteRecordsOriginalSource(t *testing.T) {
 	defer cleanup()
 	require.NotNil(t, cfg)
 
+	assert.True(t, hasSampleFile(cfg.Files), "remote archive template files must be loaded")
 	assert.Equal(t, src, cfg.Source, "remote sources must record the original source string, not the ephemeral fetch tempdir")
 }
 

--- a/pkg/generator/source/resolver_test.go
+++ b/pkg/generator/source/resolver_test.go
@@ -71,6 +71,7 @@ func TestResolve_LocalPath(t *testing.T) {
 	defer cleanup()
 	require.NotNil(t, cfg)
 	assert.True(t, hasSampleFile(cfg.Files), "local template files must be loaded")
+	assert.Equal(t, dir, cfg.Source, "local sources must record the original path")
 }
 
 func TestResolve_LocalPathDefaultTimeout(t *testing.T) {
@@ -152,6 +153,7 @@ func TestHydrate_LocalStub(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	assert.True(t, hasSampleFile(stub.Files), "local stub must be hydrated from its source")
+	assert.Equal(t, dir, stub.Source, "hydrate's *stub = *resolved copy must preserve the original source")
 }
 
 func TestHydrate_LocalStubError(t *testing.T) {
@@ -231,6 +233,30 @@ func TestResolve_RemoteGitSubdirSuccess(t *testing.T) {
 	defer cleanup()
 	require.NotNil(t, cfg)
 	assert.True(t, hasSampleFile(cfg.Files), "remote git subdir template files must be loaded")
+}
+
+// TestResolve_RemoteRecordsOriginalSource pins the bug where a remote
+// (git::/https://) scaffold source ended up with Configuration.Source (and
+// therefore the persisted spec.source in .atmos/scaffold.yaml) set to the
+// ephemeral os.MkdirTemp download directory instead of the original source
+// string. That tempdir is removed by cleanup() as soon as the command
+// finishes, leaving spec.source pointing at nothing.
+func TestResolve_RemoteRecordsOriginalSource(t *testing.T) {
+	requireGit(t)
+
+	repoDir := initSourceTestGitRepo(t, map[string]string{
+		"scaffold.yaml": sampleScaffold,
+		"file.txt":      "hello",
+	})
+	src := "git::" + sourceTestGitFileURI(repoDir) + "?ref=main"
+
+	cfg, cleanup, err := Resolve(&schema.AtmosConfiguration{}, "sample", src, time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	defer cleanup()
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, src, cfg.Source, "remote sources must record the original source string, not the ephemeral fetch tempdir")
 }
 
 // TestResolve_RemoteGitSubdirMissing pins the exact failure mode reported for


### PR DESCRIPTION
## what

- Fix `atmos scaffold generate`/`atmos init` recording a dangling, already-deleted temp-directory path in `spec.source` of `.atmos/scaffold.yaml` whenever the template source is remote (`git::...` or a bare `https://...` URL).
- In the file`pkg/generator/source/resolver.go`: in `resolveRemote()`, set `conf.Source = src` (the original source string the caller passed in) after loading the template configuration from the temporary download directory, instead of leaving `Configuration.Source` as whatever `LoadConfigurationFromDir` was given (the temp dir itself).
- `pkg/generator/source/resolver_test.go`: added/extended tests asserting `Configuration.Source` holds the original source for both local and remote paths, plus a dedicated regression test (`TestResolve_RemoteRecordsOriginalSource`) that fails on the pre-fix code and passes after.
- No change to local source handling (`resolveLocal`), which already recorded the correct value.

## why

- For a **remote** scaffold source, `resolveRemote()` downloads the template into `os.MkdirTemp("", "atmos-scaffold-")`, then loaded the config with that temp dir passed in as the "source" — so `Configuration.Source`, and
  therefore the persisted `spec.source`, ended up holding something like `/var/folders/xx/.../atmos-scaffold-1234567890`. That directory is removed by `cleanup()` immediately after the command finishes, so the recorded provenance is a dangling reference to nothing as soon as generation completes — useless for anything that might want to read it back later (e.g. a future `--update`/re-resolve flow), and directly contradicts `SaveProjectRecord`'s own doc comment: *"spec.source and spec.baseRef record provenance for future updates."*
- Local sources (a relative/absolute path, or `file://...`) were correct only by accident of not having a temp-dir indirection step in `resolveLocal`, not because anything special-cased provenance for them.
- Reproduced directly: `atmos scaffold generate "git::https://.../scaffold-template.git" ./out --defaults`, then `cat ./out/.atmos/scaffold.yaml` shows a `/var/folders/...`/`/tmp/...` path for `spec.source`, and that path no longer exists on disk.

## references

- No upstream GitHub issue — checked issue search and the web for `cloudposse/atmos` + `spec.source`/`scaffold`, nothing matched as of 2026-08.
