### PR TITLE
fix(ci): resolve merge_commit_sha^1 as diff base for merged PRs

### DIFF
--- a/docs/fixes/2026-08-06-github-merged-pr-diff-base.md
+++ b/docs/fixes/2026-08-06-github-merged-pr-diff-base.md
@@ -1,0 +1,77 @@
+# Fix: `resolvePRBase` no longer returns a degenerate base for merged PRs
+
+**Date:** 2026-08-06
+
+## Summary
+
+For merged pull requests, `atmos describe affected --upload` running in GitHub
+Actions with `ci.enabled: true` could resolve a self-referential diff base when
+the workflow's checkout wasn't pinned to `pull_request.head.sha`. This caused
+every commit that landed on the target branch between when the PR branch was
+cut and when it merged to be misreported as part of that PR — up to 510
+false-positive "affected" components in one confirmed production incident.
+
+## Context
+
+`resolvePRBase` in `pkg/ci/providers/github/base.go` auto-resolves the diff
+base for `pull_request` events via a fallback chain (merge-base, then
+`HEAD~1`, then the payload's `base.sha`, then a ref to the target branch tip).
+For a merged PR (`action == "closed"`, `pull_request.merged == true`), if
+`HEAD` isn't pinned to the PR's own head SHA, it can end up on or past the
+target branch's post-merge tip. In that state, the existing tiers can produce
+a base that is effectively `HEAD` itself (in one incident, the resolved
+`--base` exactly equaled `merge_commit_sha`), instead of the PR's true fork
+point. Diffing that degenerate base against the PR's actual head SHA then
+surfaces every unrelated commit that landed on the target branch in the
+interim as "affected."
+
+## Changes
+
+- `pkg/ci/providers/github/base.go`: added a new tier 0 to `resolvePRBase`,
+  gated on `action == "closed" && pull_request.merged == true`, that resolves
+  `pull_request.merge_commit_sha`'s first parent via git (fetching the commit
+  from `origin` first if it isn't present locally) and returns it as the base.
+  This is derived from the merge commit GitHub itself created, so it's correct
+  regardless of what the workflow checked out. Any failure (field missing,
+  fetch failure, no parent) falls through unchanged to the existing 4-tier
+  chain — no behavior change for any other event/action.
+- Added a secondary guard in the existing tier 1 (merge-base): for closed PRs,
+  if the resolved merge-base equals the currently checked-out `HEAD`, it's now
+  treated as a failed/degenerate resolution and falls through to the rest of
+  the chain, instead of being accepted as a valid "success." This closes the
+  same failure class even when `merge_commit_sha` is unavailable in the
+  payload.
+- `pkg/ci/providers/github/base_test.go`: added
+  `TestResolveBase_PullRequest_Merged_UsesMergeCommitParent` (deterministic
+  git fixture reproducing the incident: a real merge commit with two parents,
+  checkout left at the merge commit, asserting the resolved base is the merge
+  commit's parent and not `HEAD` itself),
+  `TestResolveBase_PullRequest_Merged_NoMergeCommitSHA_FallsThroughUnchanged`
+  (regression guard: identical behavior to the pre-fix code when
+  `merge_commit_sha` is absent from the payload), and
+  `TestResolveBase_PullRequest_OpenedOrSynchronize_Unaffected` (regression
+  guard: the new tier never fires for non-`closed` actions, even if a payload
+  carries `merged: true` and a `merge_commit_sha`).
+
+## Validation
+
+- `go build ./...` — clean.
+- `go test ./pkg/ci/providers/github/... -run TestResolveBase -v` — all tests
+  pass, including the three new ones and every pre-existing test in the file
+  (unmodified).
+- `go vet ./pkg/ci/...` and `go test ./pkg/ci/...` — all packages pass.
+- `atmos lint --changed` — 0 issues (after extracting tier 0 into
+  `resolveMergedPRTier` to satisfy `nestif`, and introducing the
+  `payloadKeySHA` constant to satisfy `revive`'s `add-constant` check on the
+  repeated `"sha"` literal).
+- `atmos test` (short suite): `tests/testhelpers` and
+  `tests/testhelpers/httpmock` pass; `tests` (the `TestCLICommands` golden-
+  snapshot suite) times out locally in this environment. Confirmed
+  pre-existing and unrelated to this change: at the time of this run, this
+  branch's `HEAD` was identical to `origin/main` aside from the two edited
+  files and this doc, and the touched code (`pkg/ci/providers/github`) is
+  nowhere near the CLI/emulator-preflight code path that hangs.
+
+## Follow-ups
+
+None.

--- a/pkg/ci/providers/github/base.go
+++ b/pkg/ci/providers/github/base.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/cloudposse/atmos/pkg/ci/internal/provider"
 	"github.com/cloudposse/atmos/pkg/git"
@@ -34,10 +37,15 @@ const (
 	sourceMergeGroupBaseSHA = "event.merge_group.base_sha"
 	// SourceMergeGroupBaseRef is the source label when falling back to event.merge_group.base_ref.
 	sourceMergeGroupBaseRef = "event.merge_group.base_ref"
+	// SourceMergeCommitParent is the source label when resolving from merge_commit_sha^1 for a merged PR.
+	sourceMergeCommitParent = "merge_commit_sha^1 (merged PR)"
 	// EventMergeGroup is the GitHub Actions merge_group event name.
 	eventMergeGroup = "merge_group"
 	// RefsHeadsPrefix is the prefix on fully-qualified branch refs in event payloads.
 	refsHeadsPrefix = "refs/heads/"
+	// PayloadKeySHA is the JSON key for a commit SHA field in event payloads,
+	// and doubles as the structured-log key used when logging a SHA value.
+	payloadKeySHA = "sha"
 )
 
 // ErrEventPathNotSet is returned when $GITHUB_EVENT_PATH is not set.
@@ -80,9 +88,17 @@ func (p *Provider) ResolveBase() (*provider.BaseResolution, error) {
 // resolvePRBase resolves the base commit for pull request events.
 //
 // Strategy chain (first success wins):
-//  1. merge-base(HEAD, origin/<target>) — gold standard. Self-heals from
-//     shallow CI checkouts via MergeBaseWithAutoFetch (fetches the target
-//     branch and deepens history when needed).
+//  0. merge_commit_sha^1 — for closed/merged PRs only. The gold standard for
+//     merged PRs specifically: derived from the merge commit GitHub itself
+//     created, so it's correct regardless of what the workflow checked out.
+//     This matters because an unpinned checkout (no `ref: head.sha`) can
+//     leave HEAD on or past the target branch's post-merge tip, which makes
+//     tier 1 below degenerate (see its self-referential guard).
+//  1. merge-base(HEAD, origin/<target>) — gold standard for open/synced PRs.
+//     Self-heals from shallow CI checkouts via MergeBaseWithAutoFetch
+//     (fetches the target branch and deepens history when needed). For
+//     closed PRs, a result equal to the checked-out HEAD is treated as a
+//     failed/degenerate resolution rather than accepted.
 //  2. HEAD~1 — only for closed/merged PRs when merge-base is unavailable.
 //     Correct when the merge commit is checked out with merge/squash
 //     strategy.
@@ -105,17 +121,28 @@ func resolvePRBase(eventName string) (*provider.BaseResolution, error) {
 	targetBranch := extractTargetBranch(payload)
 	action, _ := payload["action"].(string)
 
+	// 0) Merged PRs: merge_commit_sha^1. See the tier-0 note in the doc
+	// comment above — this is only ever a *preferred* first attempt; any
+	// failure (field missing, fetch failure, no parent) falls through to
+	// the unchanged tier 1-4 chain below.
+	if res := resolveMergedPRTier(payload, action, headSHA, targetBranch, eventName); res != nil {
+		return res, nil
+	}
+
 	// 1) merge-base — the gold standard. Works regardless of what's
 	// checked out, merge strategy, or number of commits on the PR.
 	if targetBranch != "" {
 		if sha, mbErr := git.MergeBaseWithAutoFetch(".", targetBranch); mbErr == nil {
-			return &provider.BaseResolution{
-				SHA:          sha,
-				HeadSHA:      headSHA,
-				TargetBranch: targetBranch,
-				Source:       "merge-base(HEAD, origin/" + targetBranch + ")",
-				EventType:    eventName,
-			}, nil
+			if action != "closed" || !mergeBaseIsSelfReferential(sha) {
+				return &provider.BaseResolution{
+					SHA:          sha,
+					HeadSHA:      headSHA,
+					TargetBranch: targetBranch,
+					Source:       "merge-base(HEAD, origin/" + targetBranch + ")",
+					EventType:    eventName,
+				}, nil
+			}
+			log.Debug("merge-base equals current HEAD for a closed PR, treating as degenerate", "target", targetBranch, payloadKeySHA, sha)
 		} else {
 			log.Debug("merge-base failed, trying fallbacks", "target", targetBranch, "error", mbErr)
 		}
@@ -201,7 +228,62 @@ func extractPRHeadSHA(payload map[string]any) string {
 		return ""
 	}
 
-	sha, _ := head["sha"].(string)
+	sha, _ := head[payloadKeySHA].(string)
+	return sha
+}
+
+// resolveMergedPRTier attempts tier 0 of resolvePRBase's strategy chain:
+// resolving merge_commit_sha^1 for a closed, merged PR. Returns nil if the
+// tier doesn't apply (not a closed/merged PR, or no merge_commit_sha in the
+// payload) or fails to resolve, so the caller falls through to the unchanged
+// tier 1-4 chain.
+func resolveMergedPRTier(payload map[string]any, action, headSHA, targetBranch, eventName string) *provider.BaseResolution {
+	if action != "closed" || !isPRMerged(payload) {
+		return nil
+	}
+
+	mergeCommitSHA := extractMergeCommitSHA(payload)
+	if mergeCommitSHA == "" {
+		return nil
+	}
+
+	sha, err := resolveMergeCommitParent(mergeCommitSHA)
+	if err != nil {
+		log.Debug("merge_commit_sha^1 failed, trying fallbacks", "merge_commit_sha", mergeCommitSHA, "error", err)
+		return nil
+	}
+
+	return &provider.BaseResolution{
+		SHA:          sha,
+		HeadSHA:      headSHA,
+		TargetBranch: targetBranch,
+		Source:       sourceMergeCommitParent,
+		EventType:    eventName,
+	}
+}
+
+// isPRMerged reports whether the pull request event payload indicates the PR
+// was actually merged (event.pull_request.merged == true), as opposed to
+// closed without merging.
+func isPRMerged(payload map[string]any) bool {
+	pr, _ := payload[payloadKeyPullRequest].(map[string]any)
+	if pr == nil {
+		return false
+	}
+
+	merged, _ := pr["merged"].(bool)
+	return merged
+}
+
+// extractMergeCommitSHA extracts the merge commit SHA GitHub created when the
+// PR was merged, from event.pull_request.merge_commit_sha.
+func extractMergeCommitSHA(payload map[string]any) string {
+	pr, _ := payload[payloadKeyPullRequest].(map[string]any)
+	if pr == nil {
+		return ""
+	}
+
+	sha, _ := pr["merge_commit_sha"].(string)
 	return sha
 }
 
@@ -220,7 +302,7 @@ func extractBaseSHA(payload map[string]any) string {
 		return ""
 	}
 
-	sha, _ := base["sha"].(string)
+	sha, _ := base[payloadKeySHA].(string)
 	return sha
 }
 
@@ -434,4 +516,101 @@ func resolveParentCommit() (string, error) {
 	}
 
 	return parent.Hash.String(), nil
+}
+
+// currentHeadSHA resolves the SHA of the currently checked-out HEAD commit.
+func currentHeadSHA() (string, error) {
+	repo, err := git.GetLocalRepo()
+	if err != nil {
+		return "", fmt.Errorf("opening local repo: %w", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("getting HEAD: %w", err)
+	}
+
+	return head.Hash().String(), nil
+}
+
+// mergeBaseIsSelfReferential reports whether sha equals the currently
+// checked-out HEAD commit. For closed/merged PRs, this indicates the
+// workflow's checkout was not pinned to pull_request.head.sha: HEAD already
+// sits on (or past) the target branch's post-merge tip, so
+// merge-base(HEAD, origin/<target>) degenerates to HEAD itself instead of
+// the PR's true fork point. On any error resolving HEAD, this returns false
+// so the caller falls back to accepting the merge-base result unchanged.
+func mergeBaseIsSelfReferential(sha string) bool {
+	head, err := currentHeadSHA()
+	if err != nil {
+		return false
+	}
+
+	return sha == head
+}
+
+// resolveMergeCommitParent resolves the first parent of a merge commit SHA,
+// fetching the commit from origin first if it is not present locally. Mirrors
+// the try-then-fetch-then-retry-once shape of git.MergeBaseWithAutoFetch, but
+// targets a single commit SHA rather than a branch ref: a merge commit's SHA
+// is known from the event payload but is not necessarily reachable from any
+// local ref when the workflow's checkout wasn't pinned to the PR head.
+func resolveMergeCommitParent(mergeCommitSHA string) (string, error) {
+	defer perf.Track(nil, "github.resolveMergeCommitParent")()
+
+	sha, err := commitParentSHA(mergeCommitSHA)
+	if err == nil {
+		return sha, nil
+	}
+
+	if fetchErr := fetchCommitSHA(mergeCommitSHA); fetchErr != nil {
+		log.Debug("fetching merge commit failed", "merge_commit_sha", mergeCommitSHA, "error", fetchErr)
+		return "", err
+	}
+
+	return commitParentSHA(mergeCommitSHA)
+}
+
+// commitParentSHA resolves the first parent of an arbitrary commit SHA using
+// the local repository. Same shape as resolveParentCommit, but for a commit
+// specified by SHA rather than HEAD.
+func commitParentSHA(sha string) (string, error) {
+	repo, err := git.GetLocalRepo()
+	if err != nil {
+		return "", fmt.Errorf("opening local repo: %w", err)
+	}
+
+	commit, err := repo.CommitObject(plumbing.NewHash(sha))
+	if err != nil {
+		return "", fmt.Errorf("getting commit %s: %w", sha, err)
+	}
+
+	if commit.NumParents() == 0 {
+		return "", ErrNoParentCommit
+	}
+
+	parent, err := commit.Parent(0)
+	if err != nil {
+		return "", fmt.Errorf("getting parent commit: %w", err)
+	}
+
+	return parent.Hash.String(), nil
+}
+
+// fetchCommitSHA fetches a single commit SHA from the "origin" remote,
+// making it available locally even if it isn't reachable from any local
+// remote-tracking ref.
+func fetchCommitSHA(sha string) error {
+	defer perf.Track(nil, "github.fetchCommitSHA")()
+
+	cmd := exec.Command("git", "fetch", "origin", sha, "--no-tags", "--depth=1")
+	cmd.Dir = "."
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("fetching commit %s from origin: %w\n%s", sha, err, string(output))
+	}
+
+	log.Debug("Fetched commit", payloadKeySHA, sha)
+
+	return nil
 }

--- a/pkg/ci/providers/github/base_test.go
+++ b/pkg/ci/providers/github/base_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -691,4 +692,205 @@ func writeEventPayload(t *testing.T, payload map[string]any) string {
 	require.NoError(t, err)
 
 	return path
+}
+
+// runGit runs a git command in dir, failing the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(output))
+}
+
+// runGitOutput runs a git command in dir and returns trimmed stdout.
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err, "git %v failed", args)
+	return strings.TrimSpace(string(out))
+}
+
+// TestResolveBase_PullRequest_Merged_UsesMergeCommitParent reproduces the
+// production incident at the unit-test level: the workflow's checkout was
+// not pinned to pull_request.head.sha, so HEAD ends up on the target
+// branch's post-merge tip (the merge commit itself) instead of the PR's
+// original branch. Without the fix, this degenerates tier 1's
+// merge-base(HEAD, origin/<target>) into a self-referential, meaningless
+// base. The fix must instead resolve merge_commit_sha^1 -- the merge
+// commit's first parent, which is always the target branch's pre-merge
+// tip (verified: `git merge --no-ff` always parents a merge commit as
+// [previous-tip-of-current-branch, merged-branch-tip], never the fork
+// point) -- giving downstream merge-base-aware diffing a real commit on
+// the target branch's mainline to work from, instead of HEAD itself.
+func TestResolveBase_PullRequest_Merged_UsesMergeCommitParent(t *testing.T) {
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "a.txt"), []byte("a"), 0o644))
+	runGit(t, repoDir, "add", "a.txt")
+	runGit(t, repoDir, "commit", "-q", "-m", "A: initial commit")
+
+	runGit(t, repoDir, "checkout", "-q", "-b", "pr-branch")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "f1.txt"), []byte("f1"), 0o644))
+	runGit(t, repoDir, "add", "f1.txt")
+	runGit(t, repoDir, "commit", "-q", "-m", "F1: the PR's own change")
+	prHeadSHA := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	runGit(t, repoDir, "checkout", "-q", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "b.txt"), []byte("b"), 0o644))
+	runGit(t, repoDir, "add", "b.txt")
+	runGit(t, repoDir, "commit", "-q", "-m", "B: unrelated commit landed on main after the PR branch was cut")
+	mainTipBeforeMergeSHA := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	runGit(t, repoDir, "merge", "-q", "--no-ff", "pr-branch", "-m", "Merge pull request from pr-branch")
+	mergeCommitSHA := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	// HEAD is now the merge commit on main -- reproduces "checkout already
+	// at post-merge HEAD."
+	t.Chdir(repoDir)
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+
+	eventPayload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged": true,
+			"head": map[string]any{
+				"sha": prHeadSHA,
+			},
+			"base": map[string]any{
+				"ref": "main",
+			},
+			"merge_commit_sha": mergeCommitSHA,
+		},
+	}
+	eventPath := writeEventPayload(t, eventPayload)
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	p := NewProvider()
+	res, err := p.ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, mainTipBeforeMergeSHA, res.SHA, "must resolve to the merge commit's first parent")
+	assert.NotEqual(t, mergeCommitSHA, res.SHA, "must not be the degenerate merge commit itself (== checked-out HEAD)")
+	assert.Equal(t, sourceMergeCommitParent, res.Source)
+	assert.Equal(t, prHeadSHA, res.HeadSHA)
+	assert.Equal(t, "main", res.TargetBranch)
+	assert.Equal(t, "pull_request", res.EventType)
+}
+
+// TestResolveBase_PullRequest_Merged_NoMergeCommitSHA_FallsThroughUnchanged
+// is a regression guard: when the payload has no merge_commit_sha (e.g. an
+// older GitHub Actions runner, or a hand-crafted payload), tier 0 must be a
+// no-op and resolution must fall through to the pre-existing chain exactly
+// as it did before this fix -- mirrors TestResolveBase_PullRequest_Closed.
+func TestResolveBase_PullRequest_Merged_NoMergeCommitSHA_FallsThroughUnchanged(t *testing.T) {
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+
+	eventPayload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged": true,
+			"head": map[string]any{
+				"sha": "headsha123456789012345678901234567890ab",
+			},
+			"base": map[string]any{
+				"ref": "main",
+				"sha": "abc123def456789012345678901234567890abcd",
+			},
+		},
+	}
+	eventPath := writeEventPayload(t, eventPayload)
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	p := NewProvider()
+	res, err := p.ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "pull_request", res.EventType)
+	assert.Equal(t, "headsha123456789012345678901234567890ab", res.HeadSHA)
+	assert.NotContains(t, res.Source, "merge_commit_sha", "tier 0 must not fire when the payload has no merge_commit_sha")
+	// Same nondeterministic-but-bounded assertion as TestResolveBase_PullRequest_Closed:
+	// in the test environment, merge-base and HEAD~1 may or may not work.
+	if res.SHA != "" {
+		validSources := []string{
+			"merge-base",
+			"HEAD~1",
+			"event.pull_request.base.sha",
+		}
+		matched := false
+		for _, want := range validSources {
+			if strings.Contains(res.Source, want) {
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched,
+			"Source %q must contain one of %v", res.Source, validSources)
+	} else {
+		assert.Equal(t, "refs/remotes/origin/main", res.Ref)
+	}
+}
+
+// TestResolveBase_PullRequest_OpenedOrSynchronize_Unaffected is a direct
+// regression guard: tier 0 must only ever run for action == "closed". Even
+// if a payload somehow carries "merged": true and a merge_commit_sha on a
+// "synchronize" action (which shouldn't happen in real GitHub payloads, but
+// nothing stops a malformed/replayed event from having it), it must be
+// ignored. Uses a nonexistent target branch so tier 1 (merge-base) is
+// guaranteed to fail and tier 3 (payload base.sha) fires deterministically.
+func TestResolveBase_PullRequest_OpenedOrSynchronize_Unaffected(t *testing.T) {
+	const target = "nonexistent-target-for-merged-pr-tier0-guard"
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", target)
+
+	eventPayload := map[string]any{
+		"action": "synchronize",
+		"pull_request": map[string]any{
+			"merged": true,
+			"head": map[string]any{
+				"sha": "headsha123456789012345678901234567890ab",
+			},
+			"base": map[string]any{
+				"ref": target,
+				"sha": "stalebasesha789012345678901234567890abcd",
+			},
+			"merge_commit_sha": "shouldneverbeusedsha123456789012345678ab",
+		},
+	}
+	eventPath := writeEventPayload(t, eventPayload)
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	p := NewProvider()
+	res, err := p.ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "stalebasesha789012345678901234567890abcd", res.SHA)
+	assert.Equal(t, "event.pull_request.base.sha", res.Source, "tier 0 must never fire for a non-closed action")
+	assert.NotContains(t, res.Source, "merge_commit_sha")
 }


### PR DESCRIPTION
## what

- `resolvePRBase` (`pkg/ci/providers/github/base.go`) now resolves `merge_commit_sha^1` as a preferred first step for closed/merged `pull_request` events, before falling into the existing `merge-base(HEAD, origin/<target>)` → `HEAD~1` → `event.pull_request.base.sha` → ref fallback chain.
- The existing `merge-base` tier now treats a result equal to the checked-out `HEAD` as a failed resolution for closed PRs (instead of accepting it as a valid base), as a secondary guard against the same failure class when `merge_commit_sha` is unavailable.
- Any failure in the new step (field missing, fetch failure, no parent) falls through unchanged to the pre-existing fallback chain — no behavior change for open/synchronize PR events, push events, or merge_group events.
- Added `docs/fixes/2026-08-06-github-merged-pr-diff-base.md` recording the fix per repo convention.

## why

- `atmos describe affected --upload` in GitHub Actions with `ci.enabled: true` auto-resolves the diff base for merged PRs. If the workflow's checkout isn't pinned to `pull_request.head.sha`, `HEAD` can end up on or past the target branch's post-merge tip, causing the existing merge-base tier to resolve a degenerate, self-referential base.
- This has caused two confirmed customer incidents, including one with 510 false-positive "affected" components after a single merge, traced through months of smaller occurrences. In that incident, the resolved `--base` exactly equaled the PR's `merge_commit_sha` — the fingerprint of this exact degeneracy.
- `merge_commit_sha^1` (the merge commit's first parent) is derived from the merge commit GitHub itself created when the PR was merged, so it's correct regardless of what the workflow happened to check out.

## references

- N/A — reported directly, no tracking issue per this task's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved base commit detection for merged GitHub pull requests.
  - Correctly resolves the merge commit’s first parent when available.
  - Avoids using invalid merge-base results that match the current commit.
  - Preserves existing fallback behavior when merge information is unavailable.
  - Ensures merge-specific handling does not affect opened or synchronized pull requests.

- **Documentation**
  - Added documentation describing the GitHub merged pull request base-resolution fix and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->