### PR TITLE
fix(schema): allow http as a valid terraform backend_type

### DIFF
--- a/internal/exec/validate_stacks_test.go
+++ b/internal/exec/validate_stacks_test.go
@@ -237,36 +237,54 @@ func TestValidateStacksSchemaValidationHasTeeth(t *testing.T) {
 }
 
 // TestValidateStacksAllowsHttpBackendType guards against a regression of the schema gap
-// where `backend_type: http` (OpenTofu/Terraform's generic HTTP backend, used e.g. for
-// GitLab-managed Terraform state) failed schema validation even though backend generation
-// itself (generateComponentBackendConfig) has always handled it as a plain passthrough,
-// the same as any backend type other than "cloud".
+// where `backend_type: http` / `remote_state_backend_type: http` (OpenTofu/Terraform's
+// generic HTTP backend, used e.g. for GitLab-managed Terraform state) failed schema
+// validation even though backend generation itself (generateComponentBackendConfig) has
+// always handled it as a plain passthrough, the same as any backend type other than
+// "cloud". Both `backend`/`backend_type` and the separate `remote_state_backend`/
+// `remote_state_backend_type` pair are covered since they're distinct schema definitions.
 func TestValidateStacksAllowsHttpBackendType(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "stacks", "deploy"), 0o755))
+	httpBlock := func(key string) string {
+		return "      " + key + "_type: http\n" +
+			"      " + key + ":\n" +
+			"        http:\n" +
+			"          address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc\"\n" +
+			"          lock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
+			"          unlock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
+			"          lock_method: POST\n" +
+			"          unlock_method: DELETE\n"
+	}
 
-	atmosYAML := "base_path: \".\"\n" +
-		"stacks:\n  base_path: \"stacks\"\n  included_paths: [\"deploy/**/*\"]\n  name_pattern: \"{stage}\"\n" +
-		"logs:\n  level: \"Warning\"\n"
-	manifest := "vars:\n  stage: dev\n" +
-		"components:\n  terraform:\n    vpc:\n      vars:\n        name: vpc\n" +
-		"      backend_type: http\n" +
-		"      backend:\n" +
-		"        http:\n" +
-		"          address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc\"\n" +
-		"          lock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
-		"          unlock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
-		"          lock_method: POST\n" +
-		"          unlock_method: DELETE\n"
+	cases := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "backend_type", fragment: httpBlock("backend")},
+		{name: "remote_state_backend_type", fragment: httpBlock("remote_state_backend")},
+	}
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "atmos.yaml"), []byte(atmosYAML), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "stacks", "deploy", "stack.yaml"), []byte(manifest), 0o644))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "stacks", "deploy"), 0o755))
 
-	t.Chdir(dir)
-	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
-	require.NoError(t, err)
+			atmosYAML := "base_path: \".\"\n" +
+				"stacks:\n  base_path: \"stacks\"\n  included_paths: [\"deploy/**/*\"]\n  name_pattern: \"{stage}\"\n" +
+				"logs:\n  level: \"Warning\"\n"
+			manifest := "vars:\n  stage: dev\n" +
+				"components:\n  terraform:\n    vpc:\n      vars:\n        name: vpc\n" +
+				tc.fragment
 
-	require.NoError(t, ValidateStacks(&atmosConfig), "backend_type: http must pass schema validation")
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "atmos.yaml"), []byte(atmosYAML), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "stacks", "deploy", "stack.yaml"), []byte(manifest), 0o644))
+
+			t.Chdir(dir)
+			atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
+			require.NoError(t, err)
+
+			require.NoError(t, ValidateStacks(&atmosConfig), tc.name+": http must pass schema validation")
+		})
+	}
 }
 
 func TestValidateStacksRejectsUnsupportedYamlFunction(t *testing.T) {

--- a/internal/exec/validate_stacks_test.go
+++ b/internal/exec/validate_stacks_test.go
@@ -236,6 +236,39 @@ func TestValidateStacksSchemaValidationHasTeeth(t *testing.T) {
 	require.NoError(t, validate(validManifest), "valid manifest must pass validation")
 }
 
+// TestValidateStacksAllowsHttpBackendType guards against a regression of the schema gap
+// where `backend_type: http` (OpenTofu/Terraform's generic HTTP backend, used e.g. for
+// GitLab-managed Terraform state) failed schema validation even though backend generation
+// itself (generateComponentBackendConfig) has always handled it as a plain passthrough,
+// the same as any backend type other than "cloud".
+func TestValidateStacksAllowsHttpBackendType(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "stacks", "deploy"), 0o755))
+
+	atmosYAML := "base_path: \".\"\n" +
+		"stacks:\n  base_path: \"stacks\"\n  included_paths: [\"deploy/**/*\"]\n  name_pattern: \"{stage}\"\n" +
+		"logs:\n  level: \"Warning\"\n"
+	manifest := "vars:\n  stage: dev\n" +
+		"components:\n  terraform:\n    vpc:\n      vars:\n        name: vpc\n" +
+		"      backend_type: http\n" +
+		"      backend:\n" +
+		"        http:\n" +
+		"          address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc\"\n" +
+		"          lock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
+		"          unlock_address: \"https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock\"\n" +
+		"          lock_method: POST\n" +
+		"          unlock_method: DELETE\n"
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "atmos.yaml"), []byte(atmosYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stacks", "deploy", "stack.yaml"), []byte(manifest), 0o644))
+
+	t.Chdir(dir)
+	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
+	require.NoError(t, err)
+
+	require.NoError(t, ValidateStacks(&atmosConfig), "backend_type: http must pass schema validation")
+}
+
 func TestValidateStacksRejectsUnsupportedYamlFunction(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "stacks", "deploy"), 0o755))

--- a/pkg/datafetcher/schema/atmos/manifest/1.0.json
+++ b/pkg/datafetcher/schema/atmos/manifest/1.0.json
@@ -2079,7 +2079,8 @@
             "static",
             "azurerm",
             "gcs",
-            "cloud"
+            "cloud",
+            "http"
           ]
         }
       ]
@@ -2107,7 +2108,8 @@
             "static",
             "azurerm",
             "gcs",
-            "cloud"
+            "cloud",
+            "http"
           ]
         }
       ]
@@ -2214,6 +2216,18 @@
               ]
             },
             "cloud": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^!include"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "http": {
               "oneOf": [
                 {
                   "type": "string",

--- a/tests/fixtures/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
+++ b/tests/fixtures/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json
@@ -1055,7 +1055,8 @@
             "static",
             "azurerm",
             "gcs",
-            "cloud"
+            "cloud",
+            "http"
           ]
         }
       ]
@@ -1083,7 +1084,8 @@
             "static",
             "azurerm",
             "gcs",
-            "cloud"
+            "cloud",
+            "http"
           ]
         }
       ]
@@ -1190,6 +1192,18 @@
               ]
             },
             "cloud": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^!include"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "http": {
               "oneOf": [
                 {
                   "type": "string",

--- a/website/docs/stacks/_partials/_backend-config.mdx
+++ b/website/docs/stacks/_partials/_backend-config.mdx
@@ -272,6 +272,47 @@ For development or single-user scenarios:
   </TabItem>
 </Tabs>
 
+### HTTP Backend
+
+For state stored behind a generic HTTP endpoint, such as [GitLab-managed Terraform state](https://docs.gitlab.com/user/infrastructure/iac/terraform_state/):
+
+<Tabs>
+  <TabItem value="yaml" label="Stack Configuration" default>
+    ```yaml
+    terraform:
+      backend_type: http
+      backend:
+        http:
+          address: "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc"
+          lock_address: "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock"
+          unlock_address: "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock"
+          lock_method: POST
+          unlock_method: DELETE
+          username: gitlab-ci-token
+          password: "{{ .env.CI_JOB_TOKEN }}"
+    ```
+  </TabItem>
+  <TabItem value="json" label="Generated File">
+    ```json title="components/terraform/vpc/backend.tf.json"
+    {
+      "terraform": {
+        "backend": {
+          "http": {
+            "address": "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc",
+            "lock_address": "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock",
+            "unlock_address": "https://gitlab.example.com/api/v4/projects/123/terraform/state/vpc/lock",
+            "lock_method": "POST",
+            "unlock_method": "DELETE",
+            "username": "gitlab-ci-token",
+            "password": "glcbt-..."
+          }
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
 ## Remote State Backend
 
 The `remote_state_backend` configuration is separate from `backend` and controls how other components can read this component's state:

--- a/website/docs/stacks/_partials/_backend-config.mdx
+++ b/website/docs/stacks/_partials/_backend-config.mdx
@@ -289,7 +289,7 @@ For state stored behind a generic HTTP endpoint, such as [GitLab-managed Terrafo
           lock_method: POST
           unlock_method: DELETE
           username: gitlab-ci-token
-          password: "{{ .env.CI_JOB_TOKEN }}"
+          password: !env CI_JOB_TOKEN
     ```
   </TabItem>
   <TabItem value="json" label="Generated File">
@@ -312,6 +312,13 @@ For state stored behind a generic HTTP endpoint, such as [GitLab-managed Terrafo
     ```
   </TabItem>
 </Tabs>
+
+:::warning
+`backend.tf.json` is generated with credentials expanded in plain text — in the example
+above, the resolved `CI_JOB_TOKEN` value. Never commit this file, log its contents, or
+upload it as a CI artifact. It should be excluded via `.gitignore` (Atmos regenerates it
+on demand when `auto_generate_backend_file` is enabled).
+:::
 
 ## Remote State Backend
 


### PR DESCRIPTION
The atmos-manifest JSON Schema's backend_type/remote_state_backend_type enum and backend_manifest properties hardcoded 8 backend types (local, s3, remote, vault, static, azurerm, gcs, cloud) and rejected Terraform/ OpenTofu's generic `http` backend, used e.g. for GitLab-managed Terraform state. Since schema validation of imported/mixin files was recently fixed to actually run, any manifest using `backend_type: http` now fails `atmos describe stacks` (and anything that calls it, e.g. `terraform plan/apply`) outright, even though backend generation itself (generateComponentBackendConfig) has always handled arbitrary backend types generically.

Add "http" to both enums and to backend_manifest.properties, mirroring the existing entries. Also update the test fixture copy of the schema to keep it in sync, document the HTTP backend in the backend-config docs partial, and add a regression test proving backend_type: http now passes validation with the default embedded schema.

closes #2919 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring HTTP backends for Terraform and remote state.
  - HTTP backend settings can be provided inline or through included configuration files.
  - Added support for state, locking, and unlock endpoints, request methods, and GitLab token credentials.

- **Documentation**
  - Added YAML and JSON configuration examples for HTTP backends.
  - Warned that generated backend files may contain plaintext credentials and should not be committed, logged, or uploaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->