### PR TITLE
ci(test): make macOS k3s reliable by fixing the colima timeout budget

### DIFF
--- a/.github/actions/setup-colima/action.yml
+++ b/.github/actions/setup-colima/action.yml
@@ -36,9 +36,9 @@ runs:
 
         diagnose_colima() {
           echo "::group::Colima diagnostics"
-          colima status || true
-          limactl list || true
-          pgrep -fl 'colima|lima|qemu' || true
+          run_with_timeout 30 colima status || true
+          run_with_timeout 30 limactl list || true
+          pgrep -fl 'colima|lima' || true
           for log in "$HOME"/.colima/_lima/colima/serial*.log "$HOME"/.colima/_lima/colima/ha.stderr.log; do
             if [ -f "$log" ]; then
               echo "---- $log ----"
@@ -55,7 +55,7 @@ runs:
         run_with_timeout 420 brew install colima docker
 
         # Colima/Lima occasionally leaves the VM half-started on macOS runners
-        # (SSH/DHCP timeout while QEMU is still exiting). Start from a clean
+        # (SSH/DHCP timeout while the previous VM is still exiting). Start from a clean
         # instance and retry before failing the job. The k3s image is pulled
         # once after the runtime verifies (below), not inside this retry loop,
         # so a slow or rate-limited Docker Hub pull cannot masquerade as a
@@ -63,42 +63,35 @@ runs:
         start_colima() {
           local status=1
 
-          run_with_timeout 180 colima delete --data --force || true
+          run_with_timeout 90 colima delete --data --force || true
 
-          # vz (Virtualization.framework) does not come up on GitHub's Intel
-          # macOS runners, and the k3s job runs on macos-15-intel precisely
-          # because the M-series runners lack the virtualization path Colima
-          # needs (see the build matrix note in test.yml). Trying vz there
-          # burns up to two full attempts (~27 minutes of caps) before qemu,
-          # the runtime that actually works, is tried. Go straight to qemu
-          # on x86_64; keep the vz-first ladder on arm64.
-          local vm_types
-          if [ "$(uname -m)" = "x86_64" ]; then
-            vm_types=(qemu)
-          else
-            vm_types=(vz qemu)
-          fi
-
-          for vm_type in "${vm_types[@]}"; do
-            if [ "$vm_type" = "qemu" ]; then
-              run_with_timeout 420 brew install qemu
-            fi
-
-            for attempt in 1 2; do
-              echo "::group::Start Colima (${vm_type}) attempt ${attempt}"
-              if run_with_timeout 480 colima start --runtime docker --vm-type "$vm_type" --cpu 2 --memory 4 --disk 20 \
-                && run_with_timeout 120 docker info; then
-                echo "::endgroup::"
-                return 0
-              fi
-
-              status=$?
+          # vz (Virtualization.framework) is the runtime that works on the
+          # macos-15-intel runner this job targets; the former qemu fallback
+          # never came up there (usernet SSH-forwarding failure, see
+          # docs/fixes/2026-07-01-macos-k3s-runner-research.md), so it was a
+          # dead rung that only added minutes to the failure path. vz only,
+          # two bounded attempts.
+          for attempt in 1 2; do
+            echo "::group::Start Colima (vz) attempt ${attempt}"
+            if run_with_timeout 480 colima start --runtime docker --vm-type vz --cpu 2 --memory 4 --disk 20 \
+              && run_with_timeout 120 docker info; then
               echo "::endgroup::"
-              diagnose_colima
+              return 0
+            else
+              # Capture inside the else: after a completed `if` with no branch
+              # taken, $? is the if statement's own zero, so a post-if capture
+              # makes start_colima report success after every attempt failed.
+              status=$?
+            fi
+            echo "::endgroup::"
+            diagnose_colima
 
-              run_with_timeout 180 colima delete --data --force || true
-              sleep $((attempt * 20))
-            done
+            # Teardown and backoff only between attempts; after the final
+            # failure the runner is discarded, so cleanup is dead time.
+            if [ "$attempt" -lt 2 ]; then
+              run_with_timeout 90 colima delete --data --force || true
+              sleep 20
+            fi
           done
 
           return "$status"
@@ -107,7 +100,7 @@ runs:
         start_colima
 
         docker context use colima || true
-        run_with_timeout 120 docker version
+        run_with_timeout 60 docker version
 
         # Pre-pull the k3s image the Kubernetes emulator drives
         # (pkg/emulator/driver/k3s.go), once, now that the runtime is healthy.
@@ -115,13 +108,13 @@ runs:
         # pull cannot trigger a VM rebuild, but retried on its own: a
         # transient registry failure should not fail the job after the VM
         # came up successfully.
-        for attempt in 1 2 3; do
-          if run_with_timeout 600 docker pull rancher/k3s:latest; then
+        for attempt in 1 2; do
+          if run_with_timeout 300 docker pull rancher/k3s:latest; then
             break
           fi
-          if [ "$attempt" = 3 ]; then
+          if [ "$attempt" = 2 ]; then
             echo "::error::Failed to pull rancher/k3s:latest after ${attempt} attempts"
             exit 1
           fi
-          sleep $((attempt * 30))
+          sleep 30
         done

--- a/.github/actions/setup-colima/action.yml
+++ b/.github/actions/setup-colima/action.yml
@@ -65,7 +65,21 @@ runs:
 
           run_with_timeout 180 colima delete --data --force || true
 
-          for vm_type in vz qemu; do
+          # vz (Virtualization.framework) does not come up on GitHub's Intel
+          # macOS runners, and the k3s job runs on macos-15-intel precisely
+          # because the M-series runners lack the virtualization path Colima
+          # needs (see the build matrix note in test.yml). Trying vz there
+          # burns up to two full attempts (~27 minutes of caps) before qemu,
+          # the runtime that actually works, is tried. Go straight to qemu
+          # on x86_64; keep the vz-first ladder on arm64.
+          local vm_types
+          if [ "$(uname -m)" = "x86_64" ]; then
+            vm_types=(qemu)
+          else
+            vm_types=(vz qemu)
+          fi
+
+          for vm_type in "${vm_types[@]}"; do
             if [ "$vm_type" = "qemu" ]; then
               run_with_timeout 420 brew install qemu
             fi
@@ -98,5 +112,16 @@ runs:
         # Pre-pull the k3s image the Kubernetes emulator drives
         # (pkg/emulator/driver/k3s.go), once, now that the runtime is healthy.
         # Kept out of the colima start/retry loop above so a slow Docker Hub
-        # pull cannot trigger a VM rebuild.
-        run_with_timeout 600 docker pull rancher/k3s:latest
+        # pull cannot trigger a VM rebuild, but retried on its own: a
+        # transient registry failure should not fail the job after the VM
+        # came up successfully.
+        for attempt in 1 2 3; do
+          if run_with_timeout 600 docker pull rancher/k3s:latest; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::Failed to pull rancher/k3s:latest after ${attempt} attempts"
+            exit 1
+          fi
+          sleep $((attempt * 30))
+        done

--- a/.github/actions/setup-colima/action.yml
+++ b/.github/actions/setup-colima/action.yml
@@ -56,9 +56,10 @@ runs:
 
         # Colima/Lima occasionally leaves the VM half-started on macOS runners
         # (SSH/DHCP timeout while QEMU is still exiting). Start from a clean
-        # instance and retry before failing the job. Also preflight Docker
-        # and pull the k3s image here so emulator startup does not discover a
-        # broken runtime halfway through `atmos test`.
+        # instance and retry before failing the job. The k3s image is pulled
+        # once after the runtime verifies (below), not inside this retry loop,
+        # so a slow or rate-limited Docker Hub pull cannot masquerade as a
+        # runtime-start failure and force a full VM delete + rebuild.
         start_colima() {
           local status=1
 
@@ -72,8 +73,7 @@ runs:
             for attempt in 1 2; do
               echo "::group::Start Colima (${vm_type}) attempt ${attempt}"
               if run_with_timeout 480 colima start --runtime docker --vm-type "$vm_type" --cpu 2 --memory 4 --disk 20 \
-                && run_with_timeout 120 docker info \
-                && run_with_timeout 600 docker pull rancher/k3s:latest; then
+                && run_with_timeout 120 docker info; then
                 echo "::endgroup::"
                 return 0
               fi
@@ -94,3 +94,9 @@ runs:
 
         docker context use colima || true
         run_with_timeout 120 docker version
+
+        # Pre-pull the k3s image the Kubernetes emulator drives
+        # (pkg/emulator/driver/k3s.go), once, now that the runtime is healthy.
+        # Kept out of the colima start/retry loop above so a slow Docker Hub
+        # pull cannot trigger a VM rebuild.
+        run_with_timeout 600 docker pull rancher/k3s:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -605,14 +605,18 @@ jobs:
 
       - name: Start Docker-compatible runtime on macOS
         if: matrix.flavor.target == 'macos'
-        # setup-colima goes straight to qemu on the Intel runner (vz cannot come
-        # up there), so the ladder this cap must exceed is: brew installs (7m of
-        # caps) + initial delete (3m) + two qemu attempts (10m of caps each,
-        # plus teardown between) + docker verify and k3s image pull with
-        # retries. A realistic pass is 10-15 minutes; 35 gives 2x headroom and,
-        # unlike a cap equal to the job's 60-minute budget, leaves the balance
-        # of the job for the k3s tests this step exists to enable.
-        timeout-minutes: 35
+        # setup-colima is vz-only: qemu never came up on this Intel runner
+        # (usernet failure, docs/fixes/2026-07-01-macos-k3s-runner-research.md),
+        # and a green run shows vz starting on the first attempt with the whole
+        # step under 6 minutes. Caps: brew 7m + initial cleanup 1.5m + two vz
+        # start/info attempts 10m each + bounded diagnostics and intermediate
+        # cleanup ~3m + verify 1m + two 5m pull attempts with backoff. Every
+        # cap hit simultaneously sums to ~43m; 40 deliberately undercuts that.
+        # A pass surviving one full attempt timeout, a full second attempt, and
+        # one failed pull (~33m) still fits, so anything past 40 is treated as
+        # pathological. The job-level 60m cap stays, leaving room for the two
+        # 15-minute test attempts.
+        timeout-minutes: 40
         uses: ./.github/actions/setup-colima
 
       - name: Configure Docker Hub mirror on Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -605,7 +605,11 @@ jobs:
 
       - name: Start Docker-compatible runtime on macOS
         if: matrix.flavor.target == 'macos'
-        timeout-minutes: 45
+        # Must exceed the setup-colima vz -> qemu fallback ladder. At 45 minutes
+        # the step was guillotined partway through the vz retries, so the qemu
+        # fallback (the runtime that actually comes up on the Intel runner) never
+        # ran and every failure cost the full 45 minutes.
+        timeout-minutes: 60
         uses: ./.github/actions/setup-colima
 
       - name: Configure Docker Hub mirror on Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -612,10 +612,10 @@ jobs:
         # start/info attempts 10m each + bounded diagnostics and intermediate
         # cleanup ~3m + verify 1m + two 5m pull attempts with backoff. Every
         # cap hit simultaneously sums to ~43m; 40 deliberately undercuts that.
-        # A pass surviving one full attempt timeout, a full second attempt, and
-        # one failed pull (~33m) still fits, so anything past 40 is treated as
-        # pathological. The job-level 60m cap stays, leaving room for the two
-        # 15-minute test attempts.
+        # The recovery path fits when the final image pull completes normally;
+        # anything past 40 is treated as pathological. The job-level 60m cap
+        # preserves fail-fast behavior; the observed healthy setup leaves ample
+        # time for both 15-minute test attempts.
         timeout-minutes: 40
         uses: ./.github/actions/setup-colima
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -605,11 +605,14 @@ jobs:
 
       - name: Start Docker-compatible runtime on macOS
         if: matrix.flavor.target == 'macos'
-        # Must exceed the setup-colima vz -> qemu fallback ladder. At 45 minutes
-        # the step was guillotined partway through the vz retries, so the qemu
-        # fallback (the runtime that actually comes up on the Intel runner) never
-        # ran and every failure cost the full 45 minutes.
-        timeout-minutes: 60
+        # setup-colima goes straight to qemu on the Intel runner (vz cannot come
+        # up there), so the ladder this cap must exceed is: brew installs (7m of
+        # caps) + initial delete (3m) + two qemu attempts (10m of caps each,
+        # plus teardown between) + docker verify and k3s image pull with
+        # retries. A realistic pass is 10-15 minutes; 35 gives 2x headroom and,
+        # unlike a cap equal to the job's 60-minute budget, leaves the balance
+        # of the job for the k3s tests this step exists to enable.
+        timeout-minutes: 35
         uses: ./.github/actions/setup-colima
 
       - name: Configure Docker Hub mirror on Linux


### PR DESCRIPTION
## Why

`[k3s-macos]` is a required check (via `[k3s] demo-helmfile`) and flakes on unrelated PRs, costing the full step budget each time and blocking merge. The failure is entirely in CI setup: the job dies at "Start Docker-compatible runtime on macOS" without running a single helm test. Closes #2935.

## What

The colima setup ladder was longer than the step cap that contained it, so the step was guillotined before the ladder could finish, and a status-propagation bug hid which rung actually failed. This PR makes the ladder shorter than its cap instead of growing the cap:

- **vz only; the qemu fallback is removed.** `docs/fixes/2026-07-01-macos-k3s-runner-research.md` already selected vz for `macos-15-intel` and records qemu failing there on `usernet unable to resolve IP for SSH forwarding` before any test ran, and a green run (31723563772) confirms vz starting on attempt 1 with the whole setup step under 6 minutes. The qemu rung (plus its 7-minute `brew install qemu` cap) was a dead rung that only added minutes to the failure path. Two bounded vz attempts remain as the half-started-VM mitigation.
- **Fix failure propagation in `start_colima`.** `status=$?` ran after the completed `if`, which reads the `if` statement's own zero when no branch executes, so the function returned success after every attempt had failed and the job died later at `docker version` with a misleading error. The status is now captured in the `else` branch.
- **`docker pull rancher/k3s:latest` moves out of the start/retry loop and retries on its own** (two independent 5-minute attempts). In the loop, a slow or rate-limited Docker Hub pull counted as a runtime-start failure and forced a full VM delete + rebuild, so registry flakiness masqueraded as hypervisor flakiness.
- **Diagnostics are kept after every failed attempt, including the last, and bounded** (`colima status` and `limactl list` capped at 30s so they cannot hang the step). Teardown and backoff run only between attempts; after the final failure the runner is discarded, so cleanup is dead time.
- **Step cap 40 minutes; the job-level 60-minute cap is unchanged**, preserving fail-fast behavior; the observed healthy setup leaves ample time for both 15-minute test attempts.

## Timeout arithmetic

Caps on the setup path: brew installs 7m + initial cleanup 1.5m + two vz start/info attempts 10m each + bounded diagnostics and intermediate cleanup ~3m + docker verify 1m + two 5-minute pull attempts with backoff. Every cap hit simultaneously sums to ~43 minutes; the 40-minute cap deliberately undercuts that. The recovery path fits when the final image pull completes normally; anything past 40 is treated as pathological. The observed healthy path is under 6 minutes.

## Cost of merge

CI-only; no product code changes. The failure mode changes shape: instead of a slow crawl through a dead qemu rung, a runner where vz cannot start now fails hard after two bounded attempts, with diagnostics captured both times.

## Out of scope (raised in #2935)

Pinning the k3s image would need a change to `pkg/emulator/driver/k3s.go` (the ref is hardcoded there), so this PR keeps `:latest` to stay CI-only. And `macos-15-intel` is on GitHub's deprecation path; a longer-term plan for `[k3s-macos]` is noted in the issue.
