### PR TITLE
docs(ci): document PR plan comments

### DIFF
--- a/website/docs/ci/ci.mdx
+++ b/website/docs/ci/ci.mdx
@@ -15,8 +15,8 @@ import Experimental from '@site/src/components/Experimental'
 
 <Intro>
 Atmos brings first-class CI/CD support directly into the CLI. Run Atmos commands in
-GitHub Actions and get rich job summaries, status checks, output variables, and stored planfile
-verification — no extra actions required. And because every command is **git-aware**, the same
+GitHub Actions and get rich job summaries, status checks, output variables, pull-request plan
+comments, and stored planfile verification — no extra actions required. And because every command is **git-aware**, the same
 CLI powers GitOps end to end: plan and apply only what changed, vendor reusable catalogs across
 repositories, and commit results back to your source of truth. Kubernetes components also write
 native job summaries, with a deliberately smaller v1 surface.
@@ -29,6 +29,7 @@ anymore. The `atmos` CLI now does this work:
 - It writes job summaries.
 - It posts status checks.
 - It sets output variables.
+- It posts pull-request plan summaries.
 - It manages planfiles.
 
 Do not use the old Actions in new workflows. Existing workflows that use them still work. `actions/checkout`
@@ -57,6 +58,9 @@ ci:
       - plan_summary
   checks:
     enabled: true
+  comments:
+    enabled: true
+    behavior: upsert
 ```
 </File>
 
@@ -75,7 +79,7 @@ ci:
 </Terminal>
 
 <ActionCard title="CI Configuration">
-    Configure CI providers, job summaries, output variables, status checks, planfile storage, and templates in your `atmos.yaml`.
+    Configure CI providers, job summaries, output variables, status checks, pull-request plan comments, planfile storage, and templates in your `atmos.yaml`.
     <div>
       <PrimaryCTA to="/cli/configuration/ci">Configuration Reference</PrimaryCTA>
     </div>
@@ -481,6 +485,14 @@ output variables in v1.
 
 Live commit status checks showing real-time operation progress — "Plan in progress" while
 running and "3 to add, 1 to change, 0 to destroy" when complete.
+
+### [PR Comments](/cli/configuration/ci/comments)
+
+When `ci.comments.enabled: true`, Terraform plans running in a pull-request context can post their
+rendered plan summary as a PR comment. The comment uses the same template as the job summary and,
+with the default `upsert` behavior, updates one comment per command, component, and stack on later
+runs. This requires GitHub Actions `pull-requests: write`; comments are not posted for non-PR runs,
+when no summary is available, or by apply, deploy, Kubernetes, Helm, or Helmfile commands.
 
 ### [Planfile Storage](/ci/planfile-storage)
 

--- a/website/docs/ci/ci.mdx
+++ b/website/docs/ci/ci.mdx
@@ -16,10 +16,11 @@ import Experimental from '@site/src/components/Experimental'
 <Intro>
 Atmos brings first-class CI/CD support directly into the CLI. Run Atmos commands in
 GitHub Actions and get rich job summaries, status checks, output variables, pull-request plan
-comments, and stored planfile verification — no extra actions required. And because every command is **git-aware**, the same
-CLI powers GitOps end to end: plan and apply only what changed, vendor reusable catalogs across
-repositories, and commit results back to your source of truth. Kubernetes components also write
-native job summaries, with a deliberately smaller v1 surface.
+comments, and stored planfile verification without wrapper actions. PR comments require
+`ci.comments.enabled: true` and `pull-requests: write`. And because every command is **git-aware**,
+the same CLI powers GitOps end to end: plan and apply only what changed, vendor reusable catalogs
+across repositories, and commit results back to your source of truth. Kubernetes components also
+write native job summaries, with a deliberately smaller v1 surface.
 </Intro>
 
 :::note Replaces the old `cloudposse/github-action-*` Actions

--- a/website/docs/cli/commands/terraform/terraform-plan.mdx
+++ b/website/docs/cli/commands/terraform/terraform-plan.mdx
@@ -482,6 +482,9 @@ When running in CI mode (`--ci` flag or auto-detected), Atmos produces rich CI a
 - **Job summaries** with resource badges, collapsible diffs, and warnings written to `$GITHUB_STEP_SUMMARY`
 - **Output variables** (`has_changes`, `has_errors`, `exit_code`, etc.) written to `$GITHUB_OUTPUT`
 - **Status checks** showing plan progress and results (requires `ci.checks.enabled: true`)
+- **PR plan-summary comments** when `ci.comments.enabled: true`, the run is for a pull request, and
+  the workflow grants `pull-requests: write`; comments reuse the job-summary template and are
+  updated by default on later runs for the same command, component, and stack
 
 ```shell
 # In GitHub Actions (auto-detected)
@@ -492,7 +495,7 @@ atmos terraform plan vpc -s dev --ci
 ```
 
 :::info
-See [CI Configuration](/cli/configuration/ci) for full configuration options including custom templates, status checks, and output variables.
+See [CI Configuration](/cli/configuration/ci) for full configuration options including custom templates, status checks, and output variables. See [CI Pull Request Comments](/cli/configuration/ci/comments) to opt into plan-summary comments.
 :::
 
 ## Related Commands

--- a/website/docs/cli/configuration/ci/comments.mdx
+++ b/website/docs/cli/configuration/ci/comments.mdx
@@ -1,8 +1,8 @@
 ---
-title: CI PR Comments
+title: CI Pull Request Comments
 sidebar_label: comments
 sidebar_class_name: command
-description: Configure PR/MR comments with plan summaries
+description: Configure GitHub pull-request comments with Terraform plan summaries
 ---
 
 import Intro from '@site/src/components/Intro'
@@ -10,8 +10,9 @@ import File from '@site/src/components/File'
 import Experimental from '@site/src/components/Experimental'
 
 <Intro>
-The `ci.comments` section configures automatic comments on pull requests (GitHub) or merge requests
-(GitLab) with plan summaries, similar to tools like tfcmt and atlantis.
+The `ci.comments` section configures automatic GitHub pull-request comments with Terraform plan
+summaries, similar to tools like tfcmt and Atlantis. Comments are opt-in and are posted only when
+`atmos terraform plan` runs in a pull-request context with a rendered summary available.
 </Intro>
 
 <Experimental />
@@ -30,11 +31,12 @@ ci:
 <dl>
   <dt>`ci.comments.enabled`</dt>
   <dd>
-    Post or update comments on PRs (GitHub) or MRs (GitLab) with plan summaries.
+    Post or update GitHub pull-request comments with Terraform plan summaries. Atmos skips comments
+    outside a pull-request context or when it cannot render a summary to post.
 
-    **Requires:** `pull-requests: write` permission (GitHub) or API token with MR notes scope (GitLab)
+    **Requires:** GitHub Actions `pull-requests: write` permission
 
-    **Default:** `true`
+    **Default:** `false` (explicit opt-in)
 
     **Environment variable:** `ATMOS_CI_COMMENTS_ENABLED` — overrides this setting when set.
   </dd>
@@ -47,8 +49,8 @@ ci:
     - `update` — Update existing comment or fail if none exists
     - `upsert` — Update existing comment or create new one (recommended)
 
-    Comments are identified by an HTML marker for the component/stack combination, so each
-    component gets its own comment that is updated on subsequent runs.
+    Comments are identified by an HTML marker for the command, component, and stack combination,
+    so each target gets its own comment that can be updated on subsequent plan runs.
 
     **Default:** `upsert`
   </dd>
@@ -71,8 +73,8 @@ permissions:
 
 ## Custom Templates
 
-Override the default comment templates with your own Markdown. See [Templates](/cli/configuration/ci/templates)
-for configuration and template variables.
+Comments reuse the rendered Terraform plan-summary template. Override that template with your own
+Markdown through [Templates](/cli/configuration/ci/templates).
 
 ## Related
 


### PR DESCRIPTION
## what

- Make Terraform PR plan-summary comments discoverable from the Native CI overview and plan command documentation.
- Correct the CI comments reference to describe GitHub-only, Terraform-plan-only, explicit opt-in behavior.

## why

- Users could not discover this capability in high-traffic Native CI docs, and the reference incorrectly claimed comments were enabled by default.

## references

- N/A
