### PR TITLE
fix(helm): native Helm UX fixes (repo isolation, status output, default identity, namespace)

### DIFF
--- a/docs/fixes/2026-08-14-native-helm-ux-fixes.md
+++ b/docs/fixes/2026-08-14-native-helm-ux-fixes.md
@@ -6,10 +6,11 @@
 ## Summary
 
 Four related usability/correctness issues in the experimental native Helm implementation, all
-surfaced while deploying real charts to an AKS cluster. They are grouped in one change because they
-share a common shape: Atmos was configuring the Helm *action* objects but not the Helm `EnvSettings`
-that Helm actually reads for repository resolution, namespacing, and identity. Each fix is small and
-backward compatible.
+surfaced while deploying real charts to an AKS cluster. Each fix is small and backward compatible.
+Two of them (repository resolution and namespacing) come from Atmos configuring the Helm *action*
+objects but not the Helm `EnvSettings` that Helm actually reads; one adds missing operation output;
+and the default-identity fix is in Atmos's own authentication setup (`processStacksWithAuth` /
+`setupComponentAuthForCLI`), not Helm settings.
 
 1. Repository config/cache inherited (and mutated) the user's global Helm config.
 2. `atmos helm apply` / `delete` succeeded silently (no status output).

--- a/docs/fixes/2026-08-14-native-helm-ux-fixes.md
+++ b/docs/fixes/2026-08-14-native-helm-ux-fixes.md
@@ -1,143 +1,81 @@
 # Fix: native Helm UX fixes (repo isolation, status output, default identity, namespace)
 
 **Date:** 2026-08-14
-**Area:** `pkg/component/helm` (experimental native Helm components: `atmos helm template/diff/apply/delete`)
 
 ## Summary
 
-Four related usability/correctness issues in the experimental native Helm implementation, all
-surfaced while deploying real charts to an AKS cluster. Each fix is small and backward compatible.
-Two of them (repository resolution and namespacing) come from Atmos configuring the Helm *action*
-objects but not the Helm `EnvSettings` that Helm actually reads; one adds missing operation output;
-and the default-identity fix is in Atmos's own authentication setup (`processStacksWithAuth` /
-`setupComponentAuthForCLI`), not Helm settings.
+Four related usability/correctness fixes in the experimental native Helm implementation
+(`pkg/component/helm`; `atmos helm template/diff/apply/delete`), all surfaced while deploying real charts
+to an AKS cluster:
 
-1. Repository config/cache inherited (and mutated) the user's global Helm config.
-2. `atmos helm apply` / `delete` succeeded silently (no status output).
-3. `atmos helm` ignored the stack's default-identity binding, forcing an explicit `--identity`.
-4. Charts whose manifests omit `metadata.namespace` installed into the kubeconfig-default namespace.
+1. **Repository config/cache isolation** - stop inheriting (and mutating) the user's global Helm config.
+2. **Status output** - `apply`/`delete` print a status line instead of succeeding silently.
+3. **Default identity** - cluster operations resolve the stack's default identity, so `--identity` is no
+   longer required.
+4. **Namespace** - namespace-less charts install into the configured namespace, not the kubeconfig default.
 
----
+Each fix is small and backward compatible. Fixes 1 and 4 share a root cause (Atmos set the Helm *action*
+fields but not the Helm `EnvSettings`); fix 2 was missing output; fix 3 is in Atmos auth setup.
 
-## Issue 1: repository config/cache inherited the user's global Helm config
+## Context
 
-### Root cause
+**1. Repo config inherited the global Helm config.** `newSettings` was `cli.New`, so
+`EnvSettings.RepositoryConfig`/`RepositoryCache` defaulted to the user's global Helm config. Resolving a
+declared `repo/name` chart sets `ChartPathOptions.RepoURL`, which sends Helm down
+`downloader.(*ChartDownloader).scanReposForURL` - it iterates **every** repo in the user's global
+`repositories.yaml` and fails on the first one whose index is not cached (e.g. a stale `bitnami` entry:
+`no cached repo found ... bitnami-index.yaml`). `setupHelmRepositories` also wrote the declared repos into
+that global config.
 
-`newSettings` was `cli.New`, so Helm's `EnvSettings.RepositoryConfig` / `RepositoryCache` defaulted to
-the user's global Helm config (`~/.config/helm/repositories.yaml`, `~/Library/Caches/helm/...`, etc.).
-Two consequences:
+**2. Apply/delete were silent.** `runOperation` built a summary map for apply/delete but only returned it
+(it feeds the CI job summary); nothing reached the terminal, so a successful `apply`/`delete` printed
+nothing (`template`/`diff` print their own output).
 
-- When resolving a declared `repo/name` chart, Atmos sets `ChartPathOptions.RepoURL`, which sends Helm
-  down `downloader.(*ChartDownloader).scanReposForURL`. That function iterates **every** repository in
-  the user's global `repositories.yaml` and `LoadIndexFile`s each one, failing on the first repo whose
-  index is not cached (e.g. a stale `bitnami` entry: `no cached repo found ... bitnami-index.yaml`).
-  A completely unrelated repository in the user's global config would break an Atmos chart render.
-- `setupHelmRepositories` writes the components' declared repositories into that same global config,
-  mutating the user's personal Helm setup.
+**3. `--identity` was always required.** `processStacksWithAuth` set up component auth only when an
+explicit identity was given, so without `--identity` no auth manager was created, no `KUBECONFIG` was
+injected, and the command could not reach the cluster - unlike `atmos terraform`/`helmfile`, which resolve
+the stack's `default: true` identity.
 
-### Fix
+**4. Namespace-less charts landed in `default`.** Helm derives the namespace for namespace-less objects
+from the settings/`RESTClientGetter`, which Atmos left at the kubeconfig context default. `newActionContext`
+passed the namespace to `cfg.Init` and `installRelease` set `action.Install.Namespace`, but the
+`EnvSettings` namespace was never set.
 
-`newSettings` is now `defaultSettings`, which calls `cli.New()` and then `isolateRepositoryConfig`:
-when the user has **not** set `HELM_REPOSITORY_CONFIG` / `HELM_REPOSITORY_CACHE`, the config and cache
-are pointed at an Atmos-managed XDG location (`<xdg-config>/atmos/helm/repositories.yaml`,
-`<xdg-cache>/atmos/helm/repository`) via `pkg/xdg`. This mirrors how Atmos already isolates the
-kubeconfig (`pkg/auth/cloud/kube`). Explicit `HELM_REPOSITORY_*` env vars are respected unchanged.
+## Changes
 
-Result: chart resolution depends only on the repositories the components declare, is reproducible on
-any workstation/CI, and never touches the user's global Helm config.
+All in `pkg/component/helm`:
 
-## Issue 2: `apply` / `delete` succeeded silently
+1. **Isolation.** `newSettings` is now `defaultSettings` = `cli.New()` + `isolateRepositoryConfig`, which
+   points `RepositoryConfig`/`RepositoryCache` at an Atmos-managed XDG location (`<xdg-config>/atmos/helm`,
+   `<xdg-cache>/atmos/helm/repository`) unless `HELM_REPOSITORY_CONFIG`/`HELM_REPOSITORY_CACHE` is set.
+   Mirrors the existing kubeconfig isolation; explicit env vars still win.
+2. **Status output.** `runOperation` calls `emitOperationStatus` after a successful apply/delete, which
+   writes a one-line status via `ui.Success` - the UI channel (stderr), per `docs/io-and-ui-output.md`; the
+   data channel (stdout) is reserved for pipeable output. `ui.Success` renders markdown inline, so the
+   release/namespace/chart are backticked and the chart note uses `((muted))` styling.
+   `formatOperationStatus` returns empty for template/diff, so nothing is emitted there or on error.
+3. **Default identity.** `processStacksWithAuth` takes the operation and calls `setupComponentAuthForCLI`
+   when `shouldSetupComponentAuth` is true: for an explicit identity, or any cluster operation
+   (`operationRequiresCluster`, an explicit allowlist of apply/diff/delete so an unsupported operation
+   surfaces `ErrHelmUnsupportedOperation` instead of an auth error). `setupTerraformAuth` auto-detects the
+   stack default identity. Template stays offline; a component with no auth keeps the ambient `KUBECONFIG`.
+4. **Namespace.** `newActionContext` calls `settings.SetNamespace(namespace)` before building the
+   `RESTClientGetter`, so namespace-less manifests install into the component's configured namespace. An
+   empty namespace leaves Helm's own default untouched; charts with an explicit namespace are unaffected.
 
-### Root cause
+## Validation
 
-`runOperation` builds a summary map for apply/delete but only returns it (it feeds the CI job summary).
-Nothing was written to the terminal, so a successful `atmos helm apply`/`delete` printed nothing and
-the user had to run `kubectl` to confirm anything happened. (`template` and `diff` print their own
-output.)
+- Automated (new tests in `pkg/component/helm`; new functions covered 100%, package total ~89.6%):
+  `repo_isolation_test.go`, `status_output_test.go`, `default_identity_test.go` (incl. an unsupported-op
+  case), `namespace_test.go`, plus an `executor_extra_test.go` case asserting a cluster op resolves auth
+  with no explicit identity. Status output goes through `ui.Success`, which degrades gracefully when the UI
+  formatter is uninitialized; `TestMain` initializes the `data` writer for the `diff` path.
+- `go test ./pkg/component/helm/... -count=1` passes; `gofmt` and `go vet` clean; `go build ./...` OK.
+- Manual: built a binary and deployed a local chart and a public-repo chart to a live AKS cluster -
+  isolation removed the unrelated-global-repo failure and left the global config untouched; apply and
+  delete printed their status line; both charts applied and deleted with no `--identity`; and the public
+  chart (whose manifests set no namespace) installed into the configured namespace rather than `default`.
 
-### Fix
+## Follow-ups
 
-`runOperation` now calls `emitOperationStatus` after a successful apply/delete, which writes a
-one-line summary via `data.Writeln` (the same output path `diff` uses): `Applied Helm release "X" to
-namespace "Y" (chart Z)` / `Deleted Helm release "X" from namespace "Y"`. `formatOperationStatus`
-builds the message and returns empty for operations that need no status line, so nothing is emitted on
-error or for template/diff.
-
-## Issue 3: `atmos helm` ignored the stack default-identity binding
-
-### Root cause
-
-`processStacksWithAuth` set up component auth only `if info.Identity != ""`. With no `--identity`,
-no auth manager was created and `applyAuthEnvironment` returned a no-op, so no `KUBECONFIG` was
-injected and the command could not reach the cluster. Unlike `atmos terraform` /
-`atmos helmfile` (which call `authManager.GetDefaultIdentity`/`storeAutoDetectedIdentity` via
-`setupTerraformAuth`), `atmos helm` never resolved the stack's `default: true` identity, forcing an
-explicit `--identity` on every cluster command.
-
-### Fix
-
-`processStacksWithAuth` now takes the `operation` and calls the shared `setupComponentAuthForCLI`
-(already aliased to `internal/exec.SetupComponentAuthForCLI` -> `setupTerraformAuth`) whenever
-`shouldSetupComponentAuth` is true: for an explicit identity, or for any cluster operation
-(`operationRequiresCluster`: everything except `template`). `setupTerraformAuth` auto-detects the
-stack default identity into `info.Identity`, so `atmos helm apply/diff/delete` honor the per-stack
-`auth.identities: { <id>: { default: true } }` binding with no `--identity`, exactly like terraform.
-
-The offline `template` render never triggers auth (stays fully offline). When no auth is configured,
-`setupComponentAuthForCLI` returns a nil manager and the identity stays empty, so the ambient
-`KUBECONFIG` is used, preserving prior behavior.
-
-## Issue 4: namespace-less charts installed into the kubeconfig-default namespace
-
-### Root cause
-
-For a chart whose manifests omit `metadata.namespace`, Helm assigns the namespace from the kube
-client's `RESTClientGetter`, which derives it from `EnvSettings.Namespace()`. `newActionContext`
-passed the target namespace to `cfg.Init` (the storage driver) and `installRelease` set
-`action.Install.Namespace`, but the `EnvSettings` namespace was never set, so it stayed at the
-kubeconfig context default (usually `default`). Charts that hardcode `namespace: {{ .Release.Namespace }}`
-worked; charts that do not (e.g. the public Ealenn `echo-server`) landed in `default`.
-
-### Fix
-
-`newActionContext` now calls `settings.SetNamespace(namespace)` before building the
-`RESTClientGetter`, so namespace-less manifests install into the component's configured namespace.
-An empty namespace leaves Helm's own default untouched.
-
----
-
-## Backward compatibility
-
-- No config or public API changes. Explicit `HELM_REPOSITORY_CONFIG`/`HELM_REPOSITORY_CACHE` and
-  `--identity`/`ATMOS_IDENTITY` continue to win.
-- `template` remains fully offline (no auth, no cluster).
-- Components with no auth configured continue to use the ambient `KUBECONFIG`.
-- Charts that already set an explicit namespace are unaffected.
-
-## Tests
-
-All in `pkg/component/helm` (new functions covered 100%; package total ~89.6%):
-
-- `repo_isolation_test.go` - `TestNewSettings_IsolatesRepositoryConfigWhenEnvUnset`,
-  `TestNewSettings_RespectsExplicitRepositoryEnv`.
-- `status_output_test.go` - `TestEmitOperationStatus` (writes for apply/delete on success only; silent
-  on error / template / diff), `TestFormatOperationStatus`.
-- `default_identity_test.go` - `TestShouldSetupComponentAuth`, `TestOperationRequiresCluster`;
-  plus `executor_extra_test.go` asserts a cluster op resolves auth with no explicit identity.
-- `namespace_test.go` - `TestNewActionContext_SetsSettingsNamespace`,
-  `TestNewActionContext_EmptyNamespaceKeepsDefault`.
-
-`TestMain` initializes the `data` writer once for the package (apply/delete now emit via `data.Writeln`).
-
-```shell
-go test ./pkg/component/helm/... -count=1
-```
-
-## Expected behavior
-
-- Native Helm no longer breaks on unrelated repos in the user's global Helm config, and no longer
-  mutates that config.
-- `atmos helm apply`/`delete` print a status line on success.
-- `atmos helm apply/diff/delete <component> -s <stack>` work without `--identity` when the stack binds
-  a default identity.
-- Charts without an explicit namespace install into the component's configured `namespace`.
+None.

--- a/docs/fixes/2026-08-14-native-helm-ux-fixes.md
+++ b/docs/fixes/2026-08-14-native-helm-ux-fixes.md
@@ -8,11 +8,11 @@ Four related usability/correctness fixes in the experimental native Helm impleme
 (`pkg/component/helm`; `atmos helm template/diff/apply/delete`), all surfaced while deploying real charts
 to an AKS cluster:
 
-1. **Repository config/cache isolation** - stop inheriting (and mutating) the user's global Helm config.
-2. **Status output** - `apply`/`delete` print a status line instead of succeeding silently.
-3. **Default identity** - cluster operations resolve the stack's default identity, so `--identity` is no
-   longer required.
-4. **Namespace** - namespace-less charts install into the configured namespace, not the kubeconfig default.
+- **1. Repository config/cache isolation** - stop inheriting (and mutating) the user's global Helm config.
+- **2. Status output** - `apply`/`delete` print a status line instead of succeeding silently.
+- **3. Default identity** - cluster operations resolve the stack's default identity, so `--identity` is
+  no longer required.
+- **4. Namespace** - namespace-less charts install into the configured namespace, not the kubeconfig default.
 
 Each fix is small and backward compatible. Fixes 1 and 4 share a root cause (Atmos set the Helm *action*
 fields but not the Helm `EnvSettings`); fix 2 was missing output; fix 3 is in Atmos auth setup.
@@ -45,23 +45,23 @@ passed the namespace to `cfg.Init` and `installRelease` set `action.Install.Name
 
 All in `pkg/component/helm`:
 
-1. **Isolation.** `newSettings` is now `defaultSettings` = `cli.New()` + `isolateRepositoryConfig`, which
-   points `RepositoryConfig`/`RepositoryCache` at an Atmos-managed XDG location (`<xdg-config>/atmos/helm`,
-   `<xdg-cache>/atmos/helm/repository`) unless `HELM_REPOSITORY_CONFIG`/`HELM_REPOSITORY_CACHE` is set.
-   Mirrors the existing kubeconfig isolation; explicit env vars still win.
-2. **Status output.** `runOperation` calls `emitOperationStatus` after a successful apply/delete, which
-   writes a one-line status via `ui.Success` - the UI channel (stderr), per `docs/io-and-ui-output.md`; the
-   data channel (stdout) is reserved for pipeable output. `ui.Success` renders markdown inline, so the
-   release/namespace/chart are backticked and the chart note uses `((muted))` styling.
-   `formatOperationStatus` returns empty for template/diff, so nothing is emitted there or on error.
-3. **Default identity.** `processStacksWithAuth` takes the operation and calls `setupComponentAuthForCLI`
-   when `shouldSetupComponentAuth` is true: for an explicit identity, or any cluster operation
-   (`operationRequiresCluster`, an explicit allowlist of apply/diff/delete so an unsupported operation
-   surfaces `ErrHelmUnsupportedOperation` instead of an auth error). `setupTerraformAuth` auto-detects the
-   stack default identity. Template stays offline; a component with no auth keeps the ambient `KUBECONFIG`.
-4. **Namespace.** `newActionContext` calls `settings.SetNamespace(namespace)` before building the
-   `RESTClientGetter`, so namespace-less manifests install into the component's configured namespace. An
-   empty namespace leaves Helm's own default untouched; charts with an explicit namespace are unaffected.
+- **1. Isolation.** `newSettings` is now `defaultSettings` = `cli.New()` + `isolateRepositoryConfig`,
+  which points `RepositoryConfig`/`RepositoryCache` at an Atmos-managed XDG location
+  (`<xdg-config>/atmos/helm`, `<xdg-cache>/atmos/helm/repository`) unless `HELM_REPOSITORY_CONFIG`/
+  `HELM_REPOSITORY_CACHE` is set. Mirrors the existing kubeconfig isolation; explicit env vars still win.
+- **2. Status output.** `runOperation` calls `emitOperationStatus` after a successful apply/delete, which
+  writes a one-line status via `ui.Success` - the UI channel (stderr), per `docs/io-and-ui-output.md`;
+  the data channel (stdout) is reserved for pipeable output. `ui.Success` renders markdown inline, so the
+  release/namespace/chart are backticked and the chart note uses `((muted))` styling.
+  `formatOperationStatus` returns empty for template/diff, so nothing is emitted there or on error.
+- **3. Default identity.** `processStacksWithAuth` takes the operation and calls `setupComponentAuthForCLI`
+  when `shouldSetupComponentAuth` is true: for an explicit identity, or any cluster operation
+  (`operationRequiresCluster`, an explicit allowlist of apply/diff/delete so an unsupported operation
+  surfaces `ErrHelmUnsupportedOperation` instead of an auth error). `setupTerraformAuth` auto-detects the
+  stack default identity. Template stays offline; a component with no auth keeps the ambient `KUBECONFIG`.
+- **4. Namespace.** `newActionContext` calls `settings.SetNamespace(namespace)` before building the
+  `RESTClientGetter`, so namespace-less manifests install into the component's configured namespace. An
+  empty namespace leaves Helm's own default untouched; charts with an explicit namespace are unaffected.
 
 ## Validation
 

--- a/docs/fixes/2026-08-14-native-helm-ux-fixes.md
+++ b/docs/fixes/2026-08-14-native-helm-ux-fixes.md
@@ -1,0 +1,142 @@
+# Fix: native Helm UX fixes (repo isolation, status output, default identity, namespace)
+
+**Date:** 2026-08-14
+**Area:** `pkg/component/helm` (experimental native Helm components: `atmos helm template/diff/apply/delete`)
+
+## Summary
+
+Four related usability/correctness issues in the experimental native Helm implementation, all
+surfaced while deploying real charts to an AKS cluster. They are grouped in one change because they
+share a common shape: Atmos was configuring the Helm *action* objects but not the Helm `EnvSettings`
+that Helm actually reads for repository resolution, namespacing, and identity. Each fix is small and
+backward compatible.
+
+1. Repository config/cache inherited (and mutated) the user's global Helm config.
+2. `atmos helm apply` / `delete` succeeded silently (no status output).
+3. `atmos helm` ignored the stack's default-identity binding, forcing an explicit `--identity`.
+4. Charts whose manifests omit `metadata.namespace` installed into the kubeconfig-default namespace.
+
+---
+
+## Issue 1: repository config/cache inherited the user's global Helm config
+
+### Root cause
+
+`newSettings` was `cli.New`, so Helm's `EnvSettings.RepositoryConfig` / `RepositoryCache` defaulted to
+the user's global Helm config (`~/.config/helm/repositories.yaml`, `~/Library/Caches/helm/...`, etc.).
+Two consequences:
+
+- When resolving a declared `repo/name` chart, Atmos sets `ChartPathOptions.RepoURL`, which sends Helm
+  down `downloader.(*ChartDownloader).scanReposForURL`. That function iterates **every** repository in
+  the user's global `repositories.yaml` and `LoadIndexFile`s each one, failing on the first repo whose
+  index is not cached (e.g. a stale `bitnami` entry: `no cached repo found ... bitnami-index.yaml`).
+  A completely unrelated repository in the user's global config would break an Atmos chart render.
+- `setupHelmRepositories` writes the components' declared repositories into that same global config,
+  mutating the user's personal Helm setup.
+
+### Fix
+
+`newSettings` is now `defaultSettings`, which calls `cli.New()` and then `isolateRepositoryConfig`:
+when the user has **not** set `HELM_REPOSITORY_CONFIG` / `HELM_REPOSITORY_CACHE`, the config and cache
+are pointed at an Atmos-managed XDG location (`<xdg-config>/atmos/helm/repositories.yaml`,
+`<xdg-cache>/atmos/helm/repository`) via `pkg/xdg`. This mirrors how Atmos already isolates the
+kubeconfig (`pkg/auth/cloud/kube`). Explicit `HELM_REPOSITORY_*` env vars are respected unchanged.
+
+Result: chart resolution depends only on the repositories the components declare, is reproducible on
+any workstation/CI, and never touches the user's global Helm config.
+
+## Issue 2: `apply` / `delete` succeeded silently
+
+### Root cause
+
+`runOperation` builds a summary map for apply/delete but only returns it (it feeds the CI job summary).
+Nothing was written to the terminal, so a successful `atmos helm apply`/`delete` printed nothing and
+the user had to run `kubectl` to confirm anything happened. (`template` and `diff` print their own
+output.)
+
+### Fix
+
+`runOperation` now calls `emitOperationStatus` after a successful apply/delete, which writes a
+one-line summary via `data.Writeln` (the same output path `diff` uses): `Applied Helm release "X" to
+namespace "Y" (chart Z)` / `Deleted Helm release "X" from namespace "Y"`. `formatOperationStatus`
+builds the message and returns empty for operations that need no status line, so nothing is emitted on
+error or for template/diff.
+
+## Issue 3: `atmos helm` ignored the stack default-identity binding
+
+### Root cause
+
+`processStacksWithAuth` set up component auth only `if info.Identity != ""`. With no `--identity`,
+no auth manager was created and `applyAuthEnvironment` returned a no-op, so no `KUBECONFIG` was
+injected and the command could not reach the cluster. Unlike `atmos terraform` /
+`atmos helmfile` (which call `authManager.GetDefaultIdentity`/`storeAutoDetectedIdentity` via
+`setupTerraformAuth`), `atmos helm` never resolved the stack's `default: true` identity, forcing an
+explicit `--identity` on every cluster command.
+
+### Fix
+
+`processStacksWithAuth` now takes the `operation` and calls the shared `setupComponentAuthForCLI`
+(already aliased to `internal/exec.SetupComponentAuthForCLI` -> `setupTerraformAuth`) whenever
+`shouldSetupComponentAuth` is true: for an explicit identity, or for any cluster operation
+(`operationRequiresCluster`: everything except `template`). `setupTerraformAuth` auto-detects the
+stack default identity into `info.Identity`, so `atmos helm apply/diff/delete` honor the per-stack
+`auth.identities: { <id>: { default: true } }` binding with no `--identity`, exactly like terraform.
+
+The offline `template` render never triggers auth (stays fully offline). When no auth is configured,
+`setupComponentAuthForCLI` returns a nil manager and the identity stays empty, so the ambient
+`KUBECONFIG` is used, preserving prior behavior.
+
+## Issue 4: namespace-less charts installed into the kubeconfig-default namespace
+
+### Root cause
+
+For a chart whose manifests omit `metadata.namespace`, Helm assigns the namespace from the kube
+client's `RESTClientGetter`, which derives it from `EnvSettings.Namespace()`. `newActionContext`
+passed the target namespace to `cfg.Init` (the storage driver) and `installRelease` set
+`action.Install.Namespace`, but the `EnvSettings` namespace was never set, so it stayed at the
+kubeconfig context default (usually `default`). Charts that hardcode `namespace: {{ .Release.Namespace }}`
+worked; charts that do not (e.g. the public Ealenn `echo-server`) landed in `default`.
+
+### Fix
+
+`newActionContext` now calls `settings.SetNamespace(namespace)` before building the
+`RESTClientGetter`, so namespace-less manifests install into the component's configured namespace.
+An empty namespace leaves Helm's own default untouched.
+
+---
+
+## Backward compatibility
+
+- No config or public API changes. Explicit `HELM_REPOSITORY_CONFIG`/`HELM_REPOSITORY_CACHE` and
+  `--identity`/`ATMOS_IDENTITY` continue to win.
+- `template` remains fully offline (no auth, no cluster).
+- Components with no auth configured continue to use the ambient `KUBECONFIG`.
+- Charts that already set an explicit namespace are unaffected.
+
+## Tests
+
+All in `pkg/component/helm` (new functions covered 100%; package total ~89.6%):
+
+- `repo_isolation_test.go` - `TestNewSettings_IsolatesRepositoryConfigWhenEnvUnset`,
+  `TestNewSettings_RespectsExplicitRepositoryEnv`.
+- `status_output_test.go` - `TestEmitOperationStatus` (writes for apply/delete on success only; silent
+  on error / template / diff), `TestFormatOperationStatus`.
+- `default_identity_test.go` - `TestShouldSetupComponentAuth`, `TestOperationRequiresCluster`;
+  plus `executor_extra_test.go` asserts a cluster op resolves auth with no explicit identity.
+- `namespace_test.go` - `TestNewActionContext_SetsSettingsNamespace`,
+  `TestNewActionContext_EmptyNamespaceKeepsDefault`.
+
+`TestMain` initializes the `data` writer once for the package (apply/delete now emit via `data.Writeln`).
+
+```shell
+go test ./pkg/component/helm/... -count=1
+```
+
+## Expected behavior
+
+- Native Helm no longer breaks on unrelated repos in the user's global Helm config, and no longer
+  mutates that config.
+- `atmos helm apply`/`delete` print a status line on success.
+- `atmos helm apply/diff/delete <component> -s <stack>` work without `--identity` when the stack binds
+  a default identity.
+- Charts without an explicit namespace install into the component's configured `namespace`.

--- a/pkg/component/helm/chart.go
+++ b/pkg/component/helm/chart.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
@@ -15,7 +16,12 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/cloudposse/atmos/pkg/xdg"
 )
+
+// helmXDGSubdir is the atmos-managed Helm home under the XDG config/cache dirs
+// (e.g. ~/.config/atmos/helm and ~/.cache/atmos/helm/repository).
+const helmXDGSubdir = "helm"
 
 // chartSpec is the resolved input needed to render or deploy a Helm chart.
 type chartSpec struct {
@@ -39,8 +45,34 @@ type chartSpec struct {
 	Repositories []chartRepository
 }
 
-// newSettings builds Helm CLI environment settings honoring ambient HELM_* env.
-var newSettings = cli.New
+// newSettings builds Helm CLI environment settings. It honors ambient HELM_* env, but when the user
+// has NOT set HELM_REPOSITORY_CONFIG / HELM_REPOSITORY_CACHE it isolates Helm's repository config and
+// cache to an atmos-managed location instead of inheriting the user's global Helm config. This keeps
+// chart resolution reproducible (an unrelated repo in the user's global repositories.yaml cannot break
+// it via Helm's scanReposForURL) and stops atmos from mutating the user's global Helm repositories.
+// It is a var so tests can override it. See docs/fixes/2026-08-14-native-helm-ux-fixes.md.
+var newSettings = defaultSettings
+
+func defaultSettings() *cli.EnvSettings {
+	settings := cli.New()
+	isolateRepositoryConfig(settings)
+	return settings
+}
+
+// isolateRepositoryConfig points Helm's repository config/cache at the atmos-managed XDG location,
+// but only for the fields the user has not explicitly overridden via the corresponding HELM_* env var.
+func isolateRepositoryConfig(settings *cli.EnvSettings) {
+	if os.Getenv("HELM_REPOSITORY_CONFIG") == "" {
+		if dir := xdg.LookupXDGConfigDir(helmXDGSubdir); dir != "" {
+			settings.RepositoryConfig = filepath.Join(dir, "repositories.yaml")
+		}
+	}
+	if os.Getenv("HELM_REPOSITORY_CACHE") == "" {
+		if dir := xdg.LookupXDGCacheDir(filepath.Join(helmXDGSubdir, "repository")); dir != "" {
+			settings.RepositoryCache = dir
+		}
+	}
+}
 
 // renderManifest renders the chart to a multi-document manifest string without
 // contacting a cluster (client-side dry run, equivalent to `helm template`).

--- a/pkg/component/helm/client.go
+++ b/pkg/component/helm/client.go
@@ -32,6 +32,15 @@ type actionContext struct {
 var newActionContext = func(namespace string) (*actionContext, error) {
 	settings := newSettings()
 
+	// Set the namespace on the settings so Helm's RESTClientGetter installs namespace-less
+	// manifests into it. Setting only the install/upgrade action's Namespace is not enough:
+	// charts whose manifests omit metadata.namespace inherit the getter's namespace, which
+	// otherwise defaults to the kubeconfig context (usually "default") rather than the
+	// component's configured namespace. See docs/fixes/2026-08-14-native-helm-ux-fixes.md.
+	if namespace != "" {
+		settings.SetNamespace(namespace)
+	}
+
 	cfg := new(action.Configuration)
 	if err := cfg.Init(settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER")); err != nil { //nolint:forbidigo
 		return nil, fmt.Errorf("failed to initialize Helm configuration: %w", err)

--- a/pkg/component/helm/default_identity_test.go
+++ b/pkg/component/helm/default_identity_test.go
@@ -1,0 +1,44 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// Issue #3: `atmos helm` must resolve the stack's default-identity binding (like `atmos terraform`)
+// for cluster operations, instead of requiring an explicit --identity. shouldSetupComponentAuth
+// decides whether to set up component auth (which auto-detects the stack default identity) before
+// processing stacks: always when an explicit identity was given, and for any cluster operation
+// (apply/diff/delete). The offline template render must never trigger auth.
+func TestShouldSetupComponentAuth(t *testing.T) {
+	tests := []struct {
+		name      string
+		identity  string
+		operation Operation
+		want      bool
+	}{
+		{"apply with no identity resolves default", "", OperationApply, true},
+		{"diff with no identity resolves default", "", OperationDiff, true},
+		{"delete with no identity resolves default", "", OperationDelete, true},
+		{"template with no identity stays offline", "", OperationTemplate, false},
+		{"explicit identity always sets up auth (template)", "dev", OperationTemplate, true},
+		{"explicit identity always sets up auth (apply)", "dev", OperationApply, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &schema.ConfigAndStacksInfo{Identity: tc.identity}
+			require.Equal(t, tc.want, shouldSetupComponentAuth(info, tc.operation))
+		})
+	}
+}
+
+func TestOperationRequiresCluster(t *testing.T) {
+	require.False(t, operationRequiresCluster(OperationTemplate))
+	require.True(t, operationRequiresCluster(OperationDiff))
+	require.True(t, operationRequiresCluster(OperationApply))
+	require.True(t, operationRequiresCluster(OperationDelete))
+}

--- a/pkg/component/helm/default_identity_test.go
+++ b/pkg/component/helm/default_identity_test.go
@@ -24,6 +24,7 @@ func TestShouldSetupComponentAuth(t *testing.T) {
 		{"diff with no identity resolves default", "", OperationDiff, true},
 		{"delete with no identity resolves default", "", OperationDelete, true},
 		{"template with no identity stays offline", "", OperationTemplate, false},
+		{"unsupported op with no identity does not need cluster", "", Operation("bogus"), false},
 		{"explicit identity always sets up auth (template)", "dev", OperationTemplate, true},
 		{"explicit identity always sets up auth (apply)", "dev", OperationApply, true},
 	}
@@ -41,4 +42,7 @@ func TestOperationRequiresCluster(t *testing.T) {
 	require.True(t, operationRequiresCluster(OperationDiff))
 	require.True(t, operationRequiresCluster(OperationApply))
 	require.True(t, operationRequiresCluster(OperationDelete))
+	// An unsupported operation must not require cluster auth, so runOperation can surface
+	// ErrHelmUnsupportedOperation instead of an auth error.
+	require.False(t, operationRequiresCluster(Operation("bogus")))
 }

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -427,10 +427,16 @@ func shouldSetupComponentAuth(info *schema.ConfigAndStacksInfo, operation Operat
 	return operationRequiresCluster(operation)
 }
 
-// operationRequiresCluster reports whether an operation contacts the cluster (everything except the
-// offline template render).
+// operationRequiresCluster reports whether an operation contacts the cluster. It uses an explicit
+// allowlist (apply/diff/delete) rather than "not template" so that an unsupported operation does not
+// trigger authentication before runOperation can return ErrHelmUnsupportedOperation.
 func operationRequiresCluster(operation Operation) bool {
-	return operation != OperationTemplate
+	switch operation {
+	case OperationApply, OperationDiff, OperationDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveComponentPath(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -58,6 +58,7 @@ var (
 	applyHelmRelease         = applyRelease
 	deleteHelmRelease        = deleteRelease
 	setupRepositories        = setupHelmRepositories
+	writeStatusLine          = data.Writeln
 )
 
 // renderTimeout bounds a single chart render/locate (which may download remote charts).
@@ -97,7 +98,7 @@ func executeSingle(
 	info *schema.ConfigAndStacksInfo,
 	operation Operation,
 ) error {
-	if err := processStacksWithAuth(atmosConfig, info); err != nil {
+	if err := processStacksWithAuth(atmosConfig, info, operation); err != nil {
 		return err
 	}
 	if !info.ComponentIsEnabled {
@@ -211,9 +212,11 @@ func runOperation(
 	case OperationApply:
 		applySummary, err := deliverApply(atmosConfig, info, ctx.Flags, spec)
 		mergeSummary(summary, applySummary)
+		emitOperationStatus(OperationApply, summary, err)
 		return summary, err
 	case OperationDelete:
 		err := deleteHelmRelease(spec.ReleaseName, spec.Namespace)
+		emitOperationStatus(OperationDelete, summary, err)
 		return summary, err
 	default:
 		return summary, fmt.Errorf("%w: %q", errUtils.ErrHelmUnsupportedOperation, operation)
@@ -391,9 +394,9 @@ func normalizeGlobalConfig(atmosConfig *schema.AtmosConfiguration) {
 	}
 }
 
-func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) error {
+func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, operation Operation) error {
 	var authManager auth.AuthManager
-	if info.Identity != "" {
+	if shouldSetupComponentAuth(info, operation) {
 		var err error
 		authManager, err = setupComponentAuthForCLI(atmosConfig, info)
 		if err != nil {
@@ -408,6 +411,26 @@ func processStacksWithAuth(atmosConfig *schema.AtmosConfiguration, info *schema.
 
 	*info = processedInfo
 	return nil
+}
+
+// shouldSetupComponentAuth reports whether to resolve component auth (which auto-detects the stack's
+// `default: true` identity) before processing stacks. It runs when an explicit identity was requested,
+// or for any cluster operation (apply/diff/delete) so those resolve the stack's default-identity
+// binding automatically - matching `atmos terraform`, which never needs an explicit --identity for a
+// stack that binds one. The offline template render never triggers auth. When no auth is configured,
+// setupComponentAuthForCLI returns a nil manager and the identity stays empty (ambient KUBECONFIG is
+// used, preserving prior behavior). See docs/fixes/2026-08-14-native-helm-ux-fixes.md.
+func shouldSetupComponentAuth(info *schema.ConfigAndStacksInfo, operation Operation) bool {
+	if info.Identity != "" {
+		return true
+	}
+	return operationRequiresCluster(operation)
+}
+
+// operationRequiresCluster reports whether an operation contacts the cluster (everything except the
+// offline template render).
+func operationRequiresCluster(operation Operation) bool {
+	return operation != OperationTemplate
 }
 
 func resolveComponentPath(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo) (string, error) {
@@ -487,6 +510,39 @@ func runHelmCIHook(p helmCIHookParams) {
 		Aggregate:    summary,
 	}); err != nil {
 		log.Warn("CI hook execution failed", "component", p.info.ComponentFromArg, "error", err)
+	}
+}
+
+// emitOperationStatus prints a human-readable status line for a completed cluster operation so
+// apply/delete do not succeed silently. It writes only for apply/delete and only on success; the
+// template/diff operations already produce their own output. See docs/fixes/2026-08-14-native-helm-ux-fixes.md.
+func emitOperationStatus(operation Operation, summary map[string]any, opErr error) {
+	if opErr != nil {
+		return
+	}
+	msg := formatOperationStatus(operation, summary)
+	if msg == "" {
+		return
+	}
+	_ = writeStatusLine(msg)
+}
+
+// formatOperationStatus builds the one-line status message for apply/delete from the operation
+// summary. It returns an empty string for operations that need no status line (template, diff).
+func formatOperationStatus(operation Operation, summary map[string]any) string {
+	release, _ := summary["release_name"].(string)
+	namespace, _ := summary["namespace"].(string)
+	switch operation {
+	case OperationApply:
+		msg := fmt.Sprintf("Applied Helm release %q to namespace %q", release, namespace)
+		if chart, ok := summary["chart"].(string); ok && chart != "" {
+			msg += fmt.Sprintf(" (chart %s)", chart)
+		}
+		return msg
+	case OperationDelete:
+		return fmt.Sprintf("Deleted Helm release %q from namespace %q", release, namespace)
+	default:
+		return ""
 	}
 }
 

--- a/pkg/component/helm/executor.go
+++ b/pkg/component/helm/executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/provisioner/target"
 	"github.com/cloudposse/atmos/pkg/schema"
 	tfgenerate "github.com/cloudposse/atmos/pkg/terraform/generate"
+	"github.com/cloudposse/atmos/pkg/ui"
 	u "github.com/cloudposse/atmos/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -58,7 +59,10 @@ var (
 	applyHelmRelease         = applyRelease
 	deleteHelmRelease        = deleteRelease
 	setupRepositories        = setupHelmRepositories
-	writeStatusLine          = data.Writeln
+	// writeStatusLine emits human-readable apply/delete status on the UI channel (stderr) via the ui
+	// layer - not data.Write (stdout), which is reserved for pipeable command data. See
+	// docs/io-and-ui-output.md. ui.Success renders markdown inline (backticks, `((muted))`).
+	writeStatusLine = ui.Success
 )
 
 // renderTimeout bounds a single chart render/locate (which may download remote charts).
@@ -530,7 +534,7 @@ func emitOperationStatus(operation Operation, summary map[string]any, opErr erro
 	if msg == "" {
 		return
 	}
-	_ = writeStatusLine(msg)
+	writeStatusLine(msg)
 }
 
 // formatOperationStatus builds the one-line status message for apply/delete from the operation
@@ -540,13 +544,13 @@ func formatOperationStatus(operation Operation, summary map[string]any) string {
 	namespace, _ := summary["namespace"].(string)
 	switch operation {
 	case OperationApply:
-		msg := fmt.Sprintf("Applied Helm release %q to namespace %q", release, namespace)
+		msg := fmt.Sprintf("Applied Helm release `%s` to namespace `%s`", release, namespace)
 		if chart, ok := summary["chart"].(string); ok && chart != "" {
-			msg += fmt.Sprintf(" (chart %s)", chart)
+			msg += fmt.Sprintf(" ((chart `%s`))", chart)
 		}
 		return msg
 	case OperationDelete:
-		return fmt.Sprintf("Deleted Helm release %q from namespace %q", release, namespace)
+		return fmt.Sprintf("Deleted Helm release `%s` from namespace `%s`", release, namespace)
 	default:
 		return ""
 	}

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -41,7 +41,7 @@ func TestExecuteSingle_HappyPath(t *testing.T) {
 	originalWriteStatus := writeStatusLine
 	// The delete operation now emits a status line; stub the writer so the test does not depend on
 	// the data package writer being initialized.
-	writeStatusLine = func(string) error { return nil }
+	writeStatusLine = func(string) {}
 	t.Cleanup(func() {
 		initCliConfig = originalInit
 		processStacks = originalProcess

--- a/pkg/component/helm/executor_extra_test.go
+++ b/pkg/component/helm/executor_extra_test.go
@@ -38,6 +38,10 @@ func TestExecuteSingle_HappyPath(t *testing.T) {
 	originalHooks := getHooks
 	originalCI := runCIHooks
 	originalDelete := deleteHelmRelease
+	originalWriteStatus := writeStatusLine
+	// The delete operation now emits a status line; stub the writer so the test does not depend on
+	// the data package writer being initialized.
+	writeStatusLine = func(string) error { return nil }
 	t.Cleanup(func() {
 		initCliConfig = originalInit
 		processStacks = originalProcess
@@ -46,6 +50,7 @@ func TestExecuteSingle_HappyPath(t *testing.T) {
 		getHooks = originalHooks
 		runCIHooks = originalCI
 		deleteHelmRelease = originalDelete
+		writeStatusLine = originalWriteStatus
 	})
 
 	initCliConfig = func(info schema.ConfigAndStacksInfo, _ bool) (schema.AtmosConfiguration, error) {
@@ -357,22 +362,32 @@ func TestProcessStacksWithAuth(t *testing.T) {
 		setupComponentAuthForCLI = originalAuth
 	})
 
-	// Without an identity, no auth manager is created and processStacks runs.
+	// Without an identity, an offline template render creates no auth manager and processStacks runs.
 	processStacks = func(_ *schema.AtmosConfiguration, info schema.ConfigAndStacksInfo, _, _, _ bool, _ []string, authManager auth.AuthManager) (schema.ConfigAndStacksInfo, error) {
 		assert.Nil(t, authManager)
 		info.ComponentIsEnabled = true
 		return info, nil
 	}
 	info := &schema.ConfigAndStacksInfo{ComponentFromArg: "app"}
-	require.NoError(t, processStacksWithAuth(&schema.AtmosConfiguration{}, info))
+	require.NoError(t, processStacksWithAuth(&schema.AtmosConfiguration{}, info, OperationTemplate))
 	assert.True(t, info.ComponentIsEnabled)
+
+	// Issue #3: a cluster operation resolves component auth even without an explicit identity, so the
+	// stack's default-identity binding is honored (like `atmos terraform`).
+	authSetupCalled := false
+	setupComponentAuthForCLI = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (auth.AuthManager, error) {
+		authSetupCalled = true
+		return nil, nil
+	}
+	require.NoError(t, processStacksWithAuth(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{ComponentFromArg: "app"}, OperationApply))
+	assert.True(t, authSetupCalled, "cluster ops must resolve component auth even without --identity")
 
 	// With an identity, a setup failure propagates before processStacks runs.
 	sentinel := errors.New("auth failed")
 	setupComponentAuthForCLI = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (auth.AuthManager, error) {
 		return nil, sentinel
 	}
-	err := processStacksWithAuth(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{Identity: "admin"})
+	err := processStacksWithAuth(&schema.AtmosConfiguration{}, &schema.ConfigAndStacksInfo{Identity: "admin"}, OperationApply)
 	require.ErrorIs(t, err, sentinel)
 }
 

--- a/pkg/component/helm/executor_test.go
+++ b/pkg/component/helm/executor_test.go
@@ -17,10 +17,8 @@ import (
 	"github.com/cloudposse/atmos/pkg/auth"
 	"github.com/cloudposse/atmos/pkg/component"
 	cfg "github.com/cloudposse/atmos/pkg/config"
-	"github.com/cloudposse/atmos/pkg/data"
 	"github.com/cloudposse/atmos/pkg/dependencies"
 	"github.com/cloudposse/atmos/pkg/hooks"
-	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -34,11 +32,8 @@ data:
 `
 
 func TestRunOperationDispatchesWithSummaries(t *testing.T) {
-	ioCtx, err := iolib.NewContext()
-	require.NoError(t, err)
-	data.InitWriter(ioCtx)
-	t.Cleanup(data.Reset)
-
+	// The data writer is initialized once for the package in TestMain; do not reset it here, or
+	// later tests that emit an apply/delete status line would panic on an uninitialized writer.
 	originalRender := renderChartManifest
 	originalApply := applyHelmRelease
 	originalDelete := deleteHelmRelease

--- a/pkg/component/helm/main_test.go
+++ b/pkg/component/helm/main_test.go
@@ -1,0 +1,21 @@
+package helm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudposse/atmos/pkg/data"
+	iolib "github.com/cloudposse/atmos/pkg/io"
+)
+
+// TestMain initializes the data-package writer once for the whole package. Apply/delete now emit a
+// status line via data.Writeln (issue #2), which panics if the writer was never initialized; doing it
+// here keeps every test that exercises those operations working without per-test setup.
+func TestMain(m *testing.M) {
+	ioCtx, err := iolib.NewContext()
+	if err != nil {
+		panic(err)
+	}
+	data.InitWriter(ioCtx)
+	os.Exit(m.Run())
+}

--- a/pkg/component/helm/namespace_test.go
+++ b/pkg/component/helm/namespace_test.go
@@ -1,0 +1,25 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #4: a chart whose manifests carry no metadata.namespace must install into the
+// component's configured namespace, not the kubeconfig-default namespace. Helm derives the
+// namespace for namespace-less objects from the settings/RESTClientGetter, so the action
+// context must set the namespace on the settings (not only on the install action).
+func TestNewActionContext_SetsSettingsNamespace(t *testing.T) {
+	actx, err := newActionContext("echo-server-public")
+	require.NoError(t, err)
+	require.Equal(t, "echo-server-public", actx.settings.Namespace(),
+		"newActionContext must set the namespace on the Helm settings so namespace-less manifests install into it")
+}
+
+// An empty namespace must leave the settings namespace at Helm's own default (no override).
+func TestNewActionContext_EmptyNamespaceKeepsDefault(t *testing.T) {
+	actx, err := newActionContext("")
+	require.NoError(t, err)
+	require.Equal(t, "default", actx.settings.Namespace())
+}

--- a/pkg/component/helm/repo_isolation_test.go
+++ b/pkg/component/helm/repo_isolation_test.go
@@ -1,0 +1,42 @@
+package helm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1: when the user has not set HELM_REPOSITORY_CONFIG / HELM_REPOSITORY_CACHE, atmos must
+// isolate Helm's repository config and cache to an atmos-managed location instead of inheriting the
+// user's GLOBAL Helm config. Otherwise Helm's chart resolution (scanReposForURL) iterates every repo
+// in the user's global repositories.yaml and fails on the first one whose index is not cached, and
+// atmos also mutates the user's global Helm config by adding the components' declared repositories.
+func TestNewSettings_IsolatesRepositoryConfigWhenEnvUnset(t *testing.T) {
+	t.Setenv("HELM_REPOSITORY_CONFIG", "")
+	t.Setenv("HELM_REPOSITORY_CACHE", "")
+	t.Setenv("ATMOS_XDG_CONFIG_HOME", "")
+	t.Setenv("ATMOS_XDG_CACHE_HOME", "")
+	cfgHome := t.TempDir()
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	s := newSettings()
+
+	require.Equal(t, filepath.Join(cfgHome, "atmos", "helm", "repositories.yaml"), s.RepositoryConfig,
+		"repository config must be isolated to the atmos-managed XDG config dir")
+	require.Equal(t, filepath.Join(cacheHome, "atmos", "helm", "repository"), s.RepositoryCache,
+		"repository cache must be isolated to the atmos-managed XDG cache dir")
+}
+
+// When the user explicitly sets the HELM_REPOSITORY_* env vars, atmos must not override them.
+func TestNewSettings_RespectsExplicitRepositoryEnv(t *testing.T) {
+	t.Setenv("HELM_REPOSITORY_CONFIG", "/custom/repositories.yaml")
+	t.Setenv("HELM_REPOSITORY_CACHE", "/custom/cache")
+
+	s := newSettings()
+
+	require.Equal(t, "/custom/repositories.yaml", s.RepositoryConfig)
+	require.Equal(t, "/custom/cache", s.RepositoryCache)
+}

--- a/pkg/component/helm/repo_isolation_test.go
+++ b/pkg/component/helm/repo_isolation_test.go
@@ -32,11 +32,13 @@ func TestNewSettings_IsolatesRepositoryConfigWhenEnvUnset(t *testing.T) {
 
 // When the user explicitly sets the HELM_REPOSITORY_* env vars, atmos must not override them.
 func TestNewSettings_RespectsExplicitRepositoryEnv(t *testing.T) {
-	t.Setenv("HELM_REPOSITORY_CONFIG", "/custom/repositories.yaml")
-	t.Setenv("HELM_REPOSITORY_CACHE", "/custom/cache")
+	configPath := filepath.Join(t.TempDir(), "repositories.yaml")
+	cachePath := filepath.Join(t.TempDir(), "repository")
+	t.Setenv("HELM_REPOSITORY_CONFIG", configPath)
+	t.Setenv("HELM_REPOSITORY_CACHE", cachePath)
 
 	s := newSettings()
 
-	require.Equal(t, "/custom/repositories.yaml", s.RepositoryConfig)
-	require.Equal(t, "/custom/cache", s.RepositoryCache)
+	require.Equal(t, configPath, s.RepositoryConfig)
+	require.Equal(t, cachePath, s.RepositoryCache)
 }

--- a/pkg/component/helm/repository_test.go
+++ b/pkg/component/helm/repository_test.go
@@ -181,11 +181,19 @@ func TestSetupHelmRepositories_NoRepositoriesReturnsNil(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestSetupHelmRepositories_EmptyRepoFileConfigReturnsNil verifies that an
-// empty (but explicitly set) HELM_REPOSITORY_CONFIG short-circuits before any
-// filesystem access, per the "if repoFile == \"\" { return nil }" guard.
+// TestSetupHelmRepositories_EmptyRepoFileConfigReturnsNil verifies that an empty
+// RepositoryConfig short-circuits before any filesystem access, per the
+// "if repoFile == \"\" { return nil }" guard. Because newSettings now isolates the
+// repository config to an atmos-managed path (issue #1), the empty config is produced by
+// stubbing newSettings rather than by an empty HELM_REPOSITORY_CONFIG env var.
 func TestSetupHelmRepositories_EmptyRepoFileConfigReturnsNil(t *testing.T) {
-	t.Setenv("HELM_REPOSITORY_CONFIG", "")
+	orig := newSettings
+	t.Cleanup(func() { newSettings = orig })
+	newSettings = func() *cli.EnvSettings {
+		s := cli.New()
+		s.RepositoryConfig = ""
+		return s
+	}
 
 	err := setupHelmRepositories([]chartRepository{{Name: "example", URL: "https://example.com"}})
 	assert.NoError(t, err)

--- a/pkg/component/helm/status_output_test.go
+++ b/pkg/component/helm/status_output_test.go
@@ -1,0 +1,70 @@
+package helm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #2: cluster-mutating commands (apply, delete) must print a status line instead of
+// succeeding silently. emitOperationStatus writes a human-readable summary via the status
+// writer for apply/delete on success only (never on error, never for template/diff which
+// produce their own output).
+func TestEmitOperationStatus(t *testing.T) {
+	summary := map[string]any{
+		"release_name": "echo-server-public",
+		"namespace":    "echo-server-public",
+		"chart":        "ealenn/echo-server",
+	}
+
+	tests := []struct {
+		name      string
+		operation Operation
+		opErr     error
+		wantWrite bool
+	}{
+		{"apply success writes", OperationApply, nil, true},
+		{"delete success writes", OperationDelete, nil, true},
+		{"apply error is silent", OperationApply, assert.AnError, false},
+		{"template is silent", OperationTemplate, nil, false},
+		{"diff is silent", OperationDiff, nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured string
+			var called bool
+			orig := writeStatusLine
+			writeStatusLine = func(s string) error { called = true; captured = s; return nil }
+			t.Cleanup(func() { writeStatusLine = orig })
+
+			emitOperationStatus(tc.operation, summary, tc.opErr)
+
+			require.Equal(t, tc.wantWrite, called)
+			if tc.wantWrite {
+				require.Contains(t, captured, "echo-server-public")
+			}
+		})
+	}
+}
+
+// formatOperationStatus names the release and namespace for apply/delete and is empty otherwise.
+func TestFormatOperationStatus(t *testing.T) {
+	summary := map[string]any{
+		"release_name": "echo-server",
+		"namespace":    "echo-server",
+		"chart":        "./",
+	}
+
+	apply := formatOperationStatus(OperationApply, summary)
+	require.Contains(t, apply, "echo-server")
+	require.Contains(t, strings.ToLower(apply), "namespace")
+
+	del := formatOperationStatus(OperationDelete, summary)
+	require.Contains(t, del, "echo-server")
+
+	require.Empty(t, formatOperationStatus(OperationTemplate, summary))
+	require.Empty(t, formatOperationStatus(OperationDiff, summary))
+}

--- a/pkg/component/helm/status_output_test.go
+++ b/pkg/component/helm/status_output_test.go
@@ -37,7 +37,7 @@ func TestEmitOperationStatus(t *testing.T) {
 			var captured string
 			var called bool
 			orig := writeStatusLine
-			writeStatusLine = func(s string) error { called = true; captured = s; return nil }
+			writeStatusLine = func(s string) { called = true; captured = s }
 			t.Cleanup(func() { writeStatusLine = orig })
 
 			emitOperationStatus(tc.operation, summary, tc.opErr)
@@ -61,9 +61,11 @@ func TestFormatOperationStatus(t *testing.T) {
 	apply := formatOperationStatus(OperationApply, summary)
 	require.Contains(t, apply, "echo-server")
 	require.Contains(t, strings.ToLower(apply), "namespace")
+	// The release/namespace are markdown-backticked so ui.Success renders them as inline code.
+	require.Contains(t, apply, "`echo-server`")
 
 	del := formatOperationStatus(OperationDelete, summary)
-	require.Contains(t, del, "echo-server")
+	require.Contains(t, del, "`echo-server`")
 
 	require.Empty(t, formatOperationStatus(OperationTemplate, summary))
 	require.Empty(t, formatOperationStatus(OperationDiff, summary))


### PR DESCRIPTION
## what

Four independent fixes to the native Helm implementation (`pkg/component/helm`):

- **1. Repository config/cache isolation.** `newSettings` now points Helm's `RepositoryConfig` and
  `RepositoryCache` at an atmos-managed XDG location (`<xdg-config>/atmos/helm/repositories.yaml`,
  `<xdg-cache>/atmos/helm/repository`) unless `HELM_REPOSITORY_CONFIG` / `HELM_REPOSITORY_CACHE` is set,
  instead of inheriting the user's global Helm config.

- **2. Status output on apply/delete.** `atmos helm apply` and `atmos helm delete` now print a one-line
  status (release name, namespace, chart) instead of succeeding silently.

- **3. Stack default-identity resolution.** `atmos helm apply/diff/delete` resolve the stack's
  `default: true` identity binding the same way `atmos terraform` does, so an explicit `--identity` is
  no longer required for cluster operations. The offline `template` render never triggers auth.

- **4. Namespace for namespace-less charts.** `newActionContext` now sets the namespace on the Helm
  `EnvSettings` (`SetNamespace`), so charts whose manifests omit `metadata.namespace` install into the
  component's configured namespace instead of the kubeconfig-default namespace.

## why

- **1.** Because settings inherited the user's global Helm config, resolving a declared `repo/name`
  chart sent Helm down `downloader.(*ChartDownloader).scanReposForURL`, which iterates every repository
  in the user's global `repositories.yaml` and fails on the first one whose index is not cached
  (e.g. `no cached repo found ... <repo>-index.yaml`). An unrelated repository in the user's global
  config could break an atmos chart render, and `setupHelmRepositories` also mutated the user's global
  config. Isolation makes chart resolution depend only on the repositories the components declare, keeps
  it reproducible across workstations/CI, and mirrors how the kubeconfig is already isolated under the
  atmos XDG dir.

- **2.** A successful apply/delete produced no output, so there was no confirmation of what happened
  (release, namespace, chart) without separately querying the cluster. `template`/`diff` already emit
  their own output; apply/delete now do too.

- **3.** The helm exec path set up auth only when an explicit identity was given, so without `--identity`
  no auth manager was created, no `KUBECONFIG` was injected, and the command could not reach the cluster.
  Terraform/helmfile already auto-resolve the stack default identity; helm now matches them for cluster
  operations while keeping `template` fully offline. When no auth is configured, the identity stays empty
  and the ambient `KUBECONFIG` is used, preserving prior behavior.

- **4.** Helm derives the namespace for namespace-less objects from the settings/`RESTClientGetter`,
  which atmos left at the kubeconfig context default; only the install action's namespace was set. Charts
  that hardcode `namespace: {{ .Release.Namespace }}` worked, but charts that do not landed in `default`.

## testing

### Automated (in-code, `pkg/component/helm`)

- `repo_isolation_test.go` - isolation is applied when the `HELM_REPOSITORY_*` env vars are unset;
  explicit values are respected unchanged.
- `status_output_test.go` - a status line is written for apply/delete on success only (silent on error
  and for template/diff), and the message names the release and namespace.
- `default_identity_test.go` - the decision logic (`shouldSetupComponentAuth`, `operationRequiresCluster`),
  plus an executor test asserting a cluster operation resolves component auth with no explicit identity
  while `template` stays offline.
- `namespace_test.go` - `newActionContext` sets the settings namespace; an empty namespace leaves Helm's
  default untouched.

New functions are covered at 100%; package total is ~89.6%. `gofmt` and `go vet` are clean, and the full
module builds. `TestMain` initializes the `data` writer once for the package since apply/delete now emit
output.

### Manual (against a live AKS cluster)

Built a binary and deployed two native Helm components: one local chart (files in the repo) and one chart
pulled from a public Helm repository.

- **1.** With the global Helm config holding unrelated, uncached repositories, apply previously failed on
  an unrelated repo's index; after the fix it succeeds, writes only to the atmos-managed repository config
  (which then contains only the declared repository), and leaves the user's global config untouched.
- **2.** apply and delete both print their status line.
- **3.** both charts were applied and deleted with no `--identity`, resolving the stack's default identity.
- **4.** the public chart (whose manifests set no namespace) installed into the configured namespace
  instead of `default`.

## references

- `docs/fixes/2026-08-14-native-helm-ux-fixes.md`
