### PR TITLE
fix(ci): recover per-run assertion detail in test summary fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,12 @@ jobs:
           - { os: "ubuntu-latest", target: linux }
           - { os: "windows-latest", target: windows }
           - { os: "macos-15", target: macos }
-    timeout-minutes: 20
+    # 20m cut it too close for windows: recent successful runs on main took
+    # 14-18.6m end-to-end (slow `go test -c` compile and post-job cache save
+    # on Windows I/O), and one run was cancelled mid cache-save at 20m12s with
+    # the actual test already passed. 30m gives real margin above the observed
+    # max without loosening linux/macos, which finish in 6-12m regardless.
+    timeout-minutes: 30
     runs-on: ${{ matrix.flavor.os }}
     steps:
       - name: Check out code into the Go module directory

--- a/docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md
+++ b/docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md
@@ -1,0 +1,64 @@
+# Fix: CI test summary fallback recovers per-run assertion detail when available
+
+**Date:** 2026-08-19
+
+## Summary
+
+When `terraform test`'s per-run `run "name"... pass/fail` lines aren't captured and
+`ParseTestOutput` falls back to the trailing summary line, the synthesized aggregate row now
+recovers the failing assertion's file, line, and message from any terraform `Error:` diagnostic
+block that survived in the captured output, instead of always rendering a bare "per-run detail
+unavailable" placeholder with only pass/fail counts.
+
+## Context
+
+`docs/fixes/2026-08-14-ci-summary-test-table-fallback-dropped.md` fixed the results table
+disappearing entirely on this fallback path by synthesizing a single aggregate
+`plugin.TerraformTestRun` row. That row carried no `File`/`Line`/`Error` detail — even in cases
+where terraform's `Error:` diagnostic block (file, line, and assertion message) was still present
+in the captured text, only the per-run `run "..."... pass/fail` status lines were missing. The gap
+was reported as: CI test summaries provide only aggregate pass counts and a reproduction command,
+with no individual test-run/assertion detail.
+
+A reproduction test (`TestTestTemplate_SummaryFallback_LosesRunDetail` in
+`pkg/ci/plugins/terraform/test_template_test.go`) was added first, confirming the rendered CI
+summary genuinely dropped a failing run's name, file, line, and assertion message when the
+captured text contained only the trailing `Failure! N passed, M failed.` line.
+
+## Changes
+
+- `pkg/ci/plugins/terraform/parser.go`:
+  - Added `errorLocationRe`, matching the `on <file> line <N>:` locator inside a terraform
+    `Error:` diagnostic block.
+  - `synthesizeFallbackRun` now takes the raw `output` and, when `fail > 0`, calls
+    `ExtractErrorBlocks` to recover any `Error:` blocks present; it joins them into the
+    synthesized row's `Error` field and parses the first block's file/line into `File`/`Line` via
+    `errorLocationRe`. When no `Error:` block survived (the residual, irreducible case), the row
+    is unchanged from before — there is nothing left in the captured text to recover.
+  - `ParseTestOutput` passes `output` through to `synthesizeFallbackRun`.
+- No template changes were needed: `templates/test.md`'s results table already renders
+  `File`/`Line`/`Error` for `fail`/`error` rows, so the recovered detail surfaces automatically.
+
+## Validation
+
+- `go build ./...` — clean.
+- `go test ./pkg/ci/plugins/terraform/... -run 'TestParseTestOutput|TestTestTemplate' -v` — all
+  pass, including:
+  - New `TestParseTestOutput_SummaryFallback_RecoversErrorDetail` and
+    `TestTestTemplate_SummaryFallback_RecoversErrorDetail`, confirming file/line/message are now
+    recovered end-to-end (`ParseTestOutput` → `test.md` render) when an `Error:` block survives.
+  - `TestTestTemplate_SummaryFallback_LosesRunDetail` (the reproduction test, retained and
+    re-commented to document the residual case where no `Error:` block survives at all — genuinely
+    unrecoverable from the captured text).
+  - Existing `TestParseTestOutput_SummaryFallback`, `_FailureSummaryFallback`, `_ZeroTotal`, and
+    `TestTestTemplate_SummaryFallback_AllPass`/`_WithFailure` — unaffected (no `Error:` block in
+    their fixtures).
+- `go test ./pkg/ci/...` — full package, all pass.
+- `atmos lint --changed` — 0 issues.
+
+## Follow-ups
+
+None. The residual case (no `Error:` diagnostic block at all survives in the captured output) has
+no recoverable detail in the text and remains covered by
+`TestTestTemplate_SummaryFallback_LosesRunDetail` as a known, documented limit of this legacy
+text-parsing fallback path.

--- a/docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md
+++ b/docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md
@@ -1,4 +1,4 @@
-# Fix: CI test summary fallback recovers per-run assertion detail when available
+# Fix: CI test summary fallback recovers a file/line when available, without corrupting the table
 
 **Date:** 2026-08-19
 
@@ -6,55 +6,87 @@
 
 When `terraform test`'s per-run `run "name"... pass/fail` lines aren't captured and
 `ParseTestOutput` falls back to the trailing summary line, the synthesized aggregate row now
-recovers the failing assertion's file, line, and message from any terraform `Error:` diagnostic
-block that survived in the captured output, instead of always rendering a bare "per-run detail
-unavailable" placeholder with only pass/fail counts.
+recovers the failing assertion's file/line from a terraform `Error:` diagnostic block when
+exactly one survived in the captured output, instead of always rendering a bare "per-run detail
+unavailable" placeholder with no location. The block's raw message text is deliberately not
+copied into the row — it's already rendered safely elsewhere, and copying it in was found (via a
+field-test pass) to corrupt the CI summary's markdown table.
 
 ## Context
 
 `docs/fixes/2026-08-14-ci-summary-test-table-fallback-dropped.md` fixed the results table
 disappearing entirely on this fallback path by synthesizing a single aggregate
-`plugin.TerraformTestRun` row. That row carried no `File`/`Line`/`Error` detail — even in cases
-where terraform's `Error:` diagnostic block (file, line, and assertion message) was still present
-in the captured text, only the per-run `run "..."... pass/fail` status lines were missing. The gap
-was reported as: CI test summaries provide only aggregate pass counts and a reproduction command,
-with no individual test-run/assertion detail.
+`plugin.TerraformTestRun` row. That row carried no `File`/`Line` detail — even in cases where
+terraform's `Error:` diagnostic block (file, line, and assertion message) was still present in the
+captured text, only the per-run `run "..."... pass/fail` status lines were missing. The gap was
+reported as: CI test summaries provide only aggregate pass counts and a reproduction command, with
+no individual test-run/assertion detail.
 
-A reproduction test (`TestTestTemplate_SummaryFallback_LosesRunDetail` in
-`pkg/ci/plugins/terraform/test_template_test.go`) was added first, confirming the rendered CI
-summary genuinely dropped a failing run's name, file, line, and assertion message when the
-captured text contained only the trailing `Failure! N passed, M failed.` line.
+A reproduction test (`TestTestTemplate_SummaryFallback_LosesRunDetail`) confirmed the rendered CI
+summary genuinely dropped a failing run's file/line when the captured text contained only the
+trailing `Failure! N passed, M failed.` line. A first attempt at fixing this recovered the file,
+line, **and** full message by joining terraform's `Error:` block(s) verbatim into the synthesized
+row's `Error` field. A field-test pass on that attempt found two problems before it shipped:
+
+1. **Duplication, not recovery.** `ParseTestOutput`'s pre-existing, unrelated `result.Errors =
+    ExtractErrorBlocks(output)` step (unchanged by either fix) already populates the summary's
+    separate fenced `` ```hcl ``` `` code block with the same message whenever an `Error:` block
+    survives — this was true even before either fix, on `main`. So joining the same raw text into
+    the row's `Error` field mostly duplicated information already visible below the table, rather
+    than closing a real gap.
+2. **Markdown table corruption.** The raw block text is multi-line and routinely contains a
+    literal `|` (e.g. `condition = a || b` in an HCL assertion). Spliced unescaped into a table
+    cell (`templates/test.md` registers no escaping — `pkg/ci/templates/loader.go`), the embedded
+    newline terminates the GFM table row mid-cell and dumps the remaining text as loose paragraph
+    text below the table; an embedded `|` would additionally split into extra spurious columns.
+    Confirmed by rendering the actual template against a realistic fixture (an HCL condition with
+    `||`) — the row broke exactly as predicted.
+3. A secondary finding: when more than one `Error:` block survived (multiple failing assertions),
+    the row's `File`/`Line` was attributed to the *first* block only, while the (now-removed)
+    `Error` field's message spanned all of them — a misleading single-location attribution for a
+    multi-failure aggregate row.
 
 ## Changes
 
 - `pkg/ci/plugins/terraform/parser.go`:
-  - Added `errorLocationRe`, matching the `on <file> line <N>:` locator inside a terraform
-    `Error:` diagnostic block.
-  - `synthesizeFallbackRun` now takes the raw `output` and, when `fail > 0`, calls
-    `ExtractErrorBlocks` to recover any `Error:` blocks present; it joins them into the
-    synthesized row's `Error` field and parses the first block's file/line into `File`/`Line` via
-    `errorLocationRe`. When no `Error:` block survived (the residual, irreducible case), the row
-    is unchanged from before — there is nothing left in the captured text to recover.
-  - `ParseTestOutput` passes `output` through to `synthesizeFallbackRun`.
-- No template changes were needed: `templates/test.md`'s results table already renders
-  `File`/`Line`/`Error` for `fail`/`error` rows, so the recovered detail surfaces automatically.
+  - `errorLocationRe` (added by the first attempt) is unchanged: matches the `on <file> line <N>:`
+    locator inside a terraform `Error:` diagnostic block.
+  - `synthesizeFallbackRun` now calls `ExtractErrorBlocks` and only attributes `File`/`Line` when
+    **exactly one** block is present (`len(blocks) == 1`) — with more than one, neither is set,
+    since attributing a single location to a multi-failure row would misrepresent it.
+  - The row's `Error` field is no longer populated at all in the fallback path. The full message
+    remains available via the separate `result.Errors` fenced block, which this change does not
+    touch.
+- `pkg/ci/plugins/terraform/test_parser_test.go`:
+  - `TestParseTestOutput_SummaryFallback_RecoversErrorDetail` updated to assert `run.Error` is
+    empty and that the message is available via `result.Errors` instead.
+  - New `TestParseTestOutput_SummaryFallback_MultipleErrorBlocks_NoLocationAttributed`: two
+    distinct failing assertions in two files → `File`/`Line`/`Error` all empty on the row, both
+    messages still present in `result.Errors`.
+- `pkg/ci/plugins/terraform/test_template_test.go`:
+  - Added a `tableRowLine` test helper that locates the results-table row and fails if there isn't
+    exactly one line matching it (catching content that leaked outside the table).
+  - `TestTestTemplate_SummaryFallback_RecoversErrorDetail` rewritten to assert the row has exactly
+    5 columns (`strings.Count(row, "|") == 6`), that the HCL condition's `||` never leaks into the
+    row, and that the message text appears exactly once in the whole rendered output (in the
+    fenced block, not duplicated into the row) — assertions strong enough that the corrupted
+    version of this fix would have failed them (the original version only used loose
+    `assert.Contains` checks, which passed even on the corrupted output).
+  - New `TestTestTemplate_SummaryFallback_MultipleErrorBlocks_NoLocationAttributed`: template-level
+    counterpart of the parser test above.
 
 ## Validation
 
 - `go build ./...` — clean.
 - `go test ./pkg/ci/plugins/terraform/... -run 'TestParseTestOutput|TestTestTemplate' -v` — all
-  pass, including:
-  - New `TestParseTestOutput_SummaryFallback_RecoversErrorDetail` and
-    `TestTestTemplate_SummaryFallback_RecoversErrorDetail`, confirming file/line/message are now
-    recovered end-to-end (`ParseTestOutput` → `test.md` render) when an `Error:` block survives.
-  - `TestTestTemplate_SummaryFallback_LosesRunDetail` (the reproduction test, retained and
-    re-commented to document the residual case where no `Error:` block survives at all — genuinely
-    unrecoverable from the captured text).
-  - Existing `TestParseTestOutput_SummaryFallback`, `_FailureSummaryFallback`, `_ZeroTotal`, and
-    `TestTestTemplate_SummaryFallback_AllPass`/`_WithFailure` — unaffected (no `Error:` block in
-    their fixtures).
+  pass, including the new/updated tests above and the retained
+  `TestTestTemplate_SummaryFallback_LosesRunDetail` (the residual case: no `Error:` block survives
+  at all — still genuinely unrecoverable, unaffected by this change).
 - `go test ./pkg/ci/...` — full package, all pass.
 - `atmos lint --changed` — 0 issues.
+- Manually rendered the template against a realistic fixture (HCL condition containing `||`) and
+  visually confirmed the results table stays a single valid row, with the full message appearing
+  once in the fenced code block below it.
 
 ## Follow-ups
 

--- a/docs/fixes/2026-08-19-terraform-registry-cache-windows-ci-timeout.md
+++ b/docs/fixes/2026-08-19-terraform-registry-cache-windows-ci-timeout.md
@@ -1,0 +1,57 @@
+# Fix: give the Windows terraform-registry-cache CI job enough time to finish
+
+**Date:** 2026-08-19
+
+## Summary
+
+The `terraform-registry-cache` job's `timeout-minutes: 20` (added earlier the same day in
+`41af363a875` / #2940) was too tight for the Windows leg: the actual `TestTerraformRegistryCache`
+test passed, but the job's post-job `actions/cache` save step got cancelled mid-run when the job
+hit its 20-minute wall-clock budget, marking the whole job (and the `Acceptance Tests` gate jobs
+that depend on it) as failed. Raised the job's `timeout-minutes` to 30.
+
+## Context
+
+CI on PR #2959 reported `Terraform registry cache test (windows)` as failed, with `Acceptance
+Tests (linux)`, `(macos)`, and `(windows)` also failing as a result. Reading the attached job log
+(`GitHub Job ID: 96241292192`) showed:
+
+- `--- PASS: TestTerraformRegistryCache (57.65s)` / `ok  github.com/cloudposse/atmos/tests
+  58.006s` — the actual test passed.
+- Setup (checkout, artifact download, toolchain install, `go build deps`, and the `go test`
+  binary compile) consumed ~12.6 of the 20-minute budget before the test even started running,
+  leaving ~6.4 minutes for the automatic `actions/cache` post-job save step (Go module/build
+  cache).
+- `##[error]The operation was canceled.` fired at 22:21:52, almost exactly 20 minutes after the
+  job started (22:01:50) — a job-level timeout cancellation, not a test failure.
+- The three `Acceptance Tests (*)` jobs each failed in 3-6s via their `needs` gate check
+  ("`terraform-registry-cache result was 'cancelled'`"), purely as a downstream consequence.
+
+This wasn't caused by anything in this PR's diff (which only touches
+`pkg/ci/plugins/terraform/*` and a fix-log doc, no CI workflow files). Checking recent runs of
+this job on `main` confirmed it's a pre-existing, borderline-flaky timing issue: three recent
+successful Windows runs took 14m, 14m11s, and 18m38s end-to-end — already close to the 20-minute
+ceiling that was added the same day — and this run simply tipped over the edge.
+
+## Changes
+
+- `.github/workflows/test.yml`: `terraform-registry-cache` job's `timeout-minutes` raised from
+  `20` to `30`, with a comment recording the observed timings so a future reader doesn't
+  re-tighten it without the same context. Left the linux/macos legs alone (they finish in
+  6-12 minutes and share the same job-level timeout) and left the inner `Terraform registry cache
+  acceptance test` step's own `timeout-minutes: 15` unchanged (the test step itself was never the
+  bottleneck).
+
+## Validation
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — valid YAML.
+- `atmos lint --changed` — 0 issues.
+- No Go code changed, so no `go build`/`go test` re-run needed for this change; verification is
+  the next CI run of PR #2959 actually completing `Terraform registry cache test (windows)` within
+  budget.
+
+## Follow-ups
+
+None. If Windows timing regresses further (e.g. toward 30 minutes) in the future, the right next
+step is investigating why `go test -c` compilation and `atmos build deps` are slow on this runner
+image, not just raising the timeout again indefinitely.

--- a/docs/fixes/2026-08-19-terraform-registry-cache-windows-ci-timeout.md
+++ b/docs/fixes/2026-08-19-terraform-registry-cache-windows-ci-timeout.md
@@ -27,9 +27,11 @@ Tests (linux)`, `(macos)`, and `(windows)` also failing as a result. Reading the
 - The three `Acceptance Tests (*)` jobs each failed in 3-6s via their `needs` gate check
   ("`terraform-registry-cache result was 'cancelled'`"), purely as a downstream consequence.
 
-This wasn't caused by anything in this PR's diff (which only touches
-`pkg/ci/plugins/terraform/*` and a fix-log doc, no CI workflow files). Checking recent runs of
-this job on `main` confirmed it's a pre-existing, borderline-flaky timing issue: three recent
+The Terraform parser changes earlier in this PR (`pkg/ci/plugins/terraform/*`, see
+`docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md`) did not cause this
+failure — they don't touch CI workflow files, and the actual test passed. This timeout follow-up
+itself does change `.github/workflows/test.yml` (see Changes below). Checking recent runs of this
+job on `main` confirmed it's a pre-existing, borderline-flaky timing issue: three recent
 successful Windows runs took 14m, 14m11s, and 18m38s end-to-end — already close to the 20-minute
 ceiling that was added the same day — and this run simply tipped over the edge.
 
@@ -44,11 +46,18 @@ ceiling that was added the same day — and this run simply tipped over the edge
 
 ## Validation
 
+This timeout follow-up itself only changes a workflow YAML file and this doc, so its validation is
+scoped accordingly:
+
 - `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — valid YAML.
 - `atmos lint --changed` — 0 issues.
-- No Go code changed, so no `go build`/`go test` re-run needed for this change; verification is
-  the next CI run of PR #2959 actually completing `Terraform registry cache test (windows)` within
-  budget.
+- No Go code changed by this follow-up, so no `go build`/`go test` re-run was needed for it;
+  verification is the next CI run of PR #2959 actually completing `Terraform registry cache test
+  (windows)` within budget.
+
+The earlier Terraform parser changes in this PR (`pkg/ci/plugins/terraform/*`) have their own Go
+build/test/lint validation recorded in
+`docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md`.
 
 ## Follow-ups
 

--- a/pkg/ci/plugins/terraform/parser.go
+++ b/pkg/ci/plugins/terraform/parser.go
@@ -665,10 +665,15 @@ func ParseTestOutput(output string) *plugin.OutputResult {
 
 // synthesizeFallbackRun builds a single aggregate run entry standing in for the
 // per-run detail ParseTestOutput could not capture, so the CI summary's results
-// table still renders one row instead of none. If terraform's error diagnostic
-// blocks survived even though the per-run status lines did not, their
-// file/line/message are attached to the row so the summary still carries real
-// assertion detail instead of only the aggregate counts.
+// table still renders one row instead of none. If exactly one terraform error
+// diagnostic block survived even though the per-run status lines did not, its
+// file/line are attached to the row so the summary still points at a location.
+// The block's raw message text is deliberately NOT copied into the row: it is
+// multi-line and can contain "|", which would break the markdown table cell,
+// and it is already rendered safely in the fenced code block ParseTestOutput
+// populates via result.Errors. With more than one block, attributing a single
+// location to the aggregate row would misrepresent which failure it belongs
+// to, so File/Line are left unset in that case.
 func synthesizeFallbackRun(pass, fail int, output string) plugin.TerraformTestRun {
 	status := testStatusPass
 	if fail > 0 {
@@ -679,8 +684,7 @@ func synthesizeFallbackRun(pass, fail int, output string) plugin.TerraformTestRu
 		Status: status,
 	}
 	if fail > 0 {
-		if blocks := ExtractErrorBlocks(output); len(blocks) > 0 {
-			run.Error = strings.Join(blocks, "\n\n")
+		if blocks := ExtractErrorBlocks(output); len(blocks) == 1 {
 			if loc := errorLocationRe.FindStringSubmatch(blocks[0]); len(loc) == 3 {
 				run.File = loc[1]
 				run.Line = parseIntOrZero(loc[2])

--- a/pkg/ci/plugins/terraform/parser.go
+++ b/pkg/ci/plugins/terraform/parser.go
@@ -100,6 +100,11 @@ var (
 	//   Failure! 2 passed, 1 failed.
 	// Used as a fallback when per-run lines were not captured.
 	testSummaryRe = regexp.MustCompile(`(?m)^(?:Success|Failure)!\s*(\d+)\s+passed,\s*(\d+)\s+failed`)
+
+	// Matches the file/line locator inside a terraform "Error:" diagnostic block, e.g.:
+	//   on tests/app.tftest.hcl line 30:
+	// Used to recover assertion location for the summary-line fallback.
+	errorLocationRe = regexp.MustCompile(`(?m)^\s*on\s+(\S+)\s+line\s+(\d+):`)
 )
 
 // ParsePlanJSON parses terraform plan JSON from `terraform show -json <planfile>`.
@@ -641,7 +646,7 @@ func ParseTestOutput(output string) *plugin.OutputResult {
 			data.Fail = parseIntOrZero(match[2])
 			data.Total = data.Pass + data.Fail
 			if data.Total > 0 {
-				data.Runs = append(data.Runs, synthesizeFallbackRun(data.Pass, data.Fail))
+				data.Runs = append(data.Runs, synthesizeFallbackRun(data.Pass, data.Fail, output))
 			}
 		}
 	}
@@ -660,16 +665,29 @@ func ParseTestOutput(output string) *plugin.OutputResult {
 
 // synthesizeFallbackRun builds a single aggregate run entry standing in for the
 // per-run detail ParseTestOutput could not capture, so the CI summary's results
-// table still renders one row instead of none.
-func synthesizeFallbackRun(pass, fail int) plugin.TerraformTestRun {
+// table still renders one row instead of none. If terraform's error diagnostic
+// blocks survived even though the per-run status lines did not, their
+// file/line/message are attached to the row so the summary still carries real
+// assertion detail instead of only the aggregate counts.
+func synthesizeFallbackRun(pass, fail int, output string) plugin.TerraformTestRun {
 	status := testStatusPass
 	if fail > 0 {
 		status = testStatusFail
 	}
-	return plugin.TerraformTestRun{
+	run := plugin.TerraformTestRun{
 		Name:   fmt.Sprintf("test summary (per-run detail unavailable): %d passed, %d failed", pass, fail),
 		Status: status,
 	}
+	if fail > 0 {
+		if blocks := ExtractErrorBlocks(output); len(blocks) > 0 {
+			run.Error = strings.Join(blocks, "\n\n")
+			if loc := errorLocationRe.FindStringSubmatch(blocks[0]); len(loc) == 3 {
+				run.File = loc[1]
+				run.Line = parseIntOrZero(loc[2])
+			}
+		}
+	}
+	return run
 }
 
 // isJSONStream reports whether output contains Terraform/OpenTofu `test -json`

--- a/pkg/ci/plugins/terraform/test_parser_test.go
+++ b/pkg/ci/plugins/terraform/test_parser_test.go
@@ -120,10 +120,13 @@ func TestParseTestOutput_FailureSummaryFallback(t *testing.T) {
 }
 
 func TestParseTestOutput_SummaryFallback_RecoversErrorDetail(t *testing.T) {
-	// Per-run "run ... pass/fail" lines were dropped, but the "Error:" diagnostic
-	// block terraform prints for the failing assertion survived. The synthesized
-	// fallback row should recover the file, line, and message from it instead of
-	// leaving the run with only aggregate counts.
+	// Per-run "run ... pass/fail" lines were dropped, but the single "Error:"
+	// diagnostic block terraform prints for the failing assertion survived. The
+	// synthesized fallback row should recover the file/line from it -- but NOT
+	// copy the raw multi-line message into the row itself, since that text is
+	// already rendered safely in the fenced result.Errors block and embedding it
+	// in a table cell would break the markdown table (multi-line content, and
+	// HCL conditions routinely contain "|").
 	const output = `Error: Test assertion failed
 
   on tests/app.tftest.hcl line 30:
@@ -147,8 +150,55 @@ Failure! 1 passed, 1 failed.
 	assert.Equal(t, testStatusFail, run.Status)
 	assert.Equal(t, "tests/app.tftest.hcl", run.File)
 	assert.Equal(t, 30, run.Line)
-	assert.Contains(t, run.Error, "Test assertion failed")
-	assert.Contains(t, run.Error, "The S3 bucket was not created against the emulator")
+	assert.Empty(t, run.Error, "the raw diagnostic block must not be duplicated into the row")
+
+	// The full message is still available -- just via the separate, safely
+	// fenced result.Errors block, not the row.
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0], "The S3 bucket was not created against the emulator")
+}
+
+func TestParseTestOutput_SummaryFallback_MultipleErrorBlocks_NoLocationAttributed(t *testing.T) {
+	// Two distinct assertions failed in two different files. Attributing the
+	// aggregate row's File/Line to just the first block would misrepresent which
+	// failure it actually belongs to, so neither should be set when more than
+	// one error block is present.
+	const output = `Error: Test assertion failed
+
+  on tests/app.tftest.hcl line 12:
+  12:     condition = output.first == "expected"
+
+first assertion message
+╵
+
+Error: Test assertion failed
+
+  on tests/extra.tftest.hcl line 44:
+  44:     condition = output.second == "expected"
+
+second assertion message
+╵
+
+Failure! 0 passed, 2 failed.
+`
+	result := ParseTestOutput(output)
+	data := testData(t, result)
+
+	assert.Equal(t, 2, data.Total)
+	assert.Equal(t, 0, data.Pass)
+	assert.Equal(t, 2, data.Fail)
+
+	require.Len(t, data.Runs, 1)
+	run := data.Runs[0]
+	assert.Equal(t, testStatusFail, run.Status)
+	assert.Empty(t, run.File)
+	assert.Zero(t, run.Line)
+	assert.Empty(t, run.Error)
+
+	// Both failures' full detail are still available via result.Errors.
+	require.Len(t, result.Errors, 2)
+	assert.Contains(t, result.Errors[0], "first assertion message")
+	assert.Contains(t, result.Errors[1], "second assertion message")
 }
 
 func TestParseTestOutput_SummaryFallback_ZeroTotal(t *testing.T) {

--- a/pkg/ci/plugins/terraform/test_parser_test.go
+++ b/pkg/ci/plugins/terraform/test_parser_test.go
@@ -119,6 +119,38 @@ func TestParseTestOutput_FailureSummaryFallback(t *testing.T) {
 	assert.Equal(t, testStatusFail, data.Runs[0].Status)
 }
 
+func TestParseTestOutput_SummaryFallback_RecoversErrorDetail(t *testing.T) {
+	// Per-run "run ... pass/fail" lines were dropped, but the "Error:" diagnostic
+	// block terraform prints for the failing assertion survived. The synthesized
+	// fallback row should recover the file, line, and message from it instead of
+	// leaving the run with only aggregate counts.
+	const output = `Error: Test assertion failed
+
+  on tests/app.tftest.hcl line 30:
+  30:     condition = output.bucket_id == "atmos-demo-test"
+
+The S3 bucket was not created against the emulator
+╵
+
+Failure! 1 passed, 1 failed.
+`
+	result := ParseTestOutput(output)
+	data := testData(t, result)
+
+	assert.True(t, result.HasErrors)
+	assert.Equal(t, 2, data.Total)
+	assert.Equal(t, 1, data.Pass)
+	assert.Equal(t, 1, data.Fail)
+
+	require.Len(t, data.Runs, 1)
+	run := data.Runs[0]
+	assert.Equal(t, testStatusFail, run.Status)
+	assert.Equal(t, "tests/app.tftest.hcl", run.File)
+	assert.Equal(t, 30, run.Line)
+	assert.Contains(t, run.Error, "Test assertion failed")
+	assert.Contains(t, run.Error, "The S3 bucket was not created against the emulator")
+}
+
 func TestParseTestOutput_SummaryFallback_ZeroTotal(t *testing.T) {
 	// No per-run lines and no summary match; nothing ran, so no row should be
 	// synthesized -- a phantom row would misrepresent an empty result as a test.

--- a/pkg/ci/plugins/terraform/test_template_test.go
+++ b/pkg/ci/plugins/terraform/test_template_test.go
@@ -199,16 +199,33 @@ func TestTestTemplate_SummaryFallback_LosesRunDetail(t *testing.T) {
 	assert.Contains(t, data.Runs[0].Name, "per-run detail unavailable")
 }
 
+// tableRowLine returns the single results-table line containing marker, failing
+// the test if there isn't exactly one -- used to assert a row stayed a
+// well-formed single markdown line instead of leaking multi-line content.
+func tableRowLine(t *testing.T, rendered, marker string) string {
+	t.Helper()
+	var matches []string
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "|") && strings.Contains(line, marker) {
+			matches = append(matches, line)
+		}
+	}
+	require.Len(t, matches, 1, "expected exactly one table row line containing %q, got: %v", marker, matches)
+	return matches[0]
+}
+
 // TestTestTemplate_SummaryFallback_RecoversErrorDetail is the fix for the gap
 // TestTestTemplate_SummaryFallback_LosesRunDetail reproduces: when the per-run
-// lines are dropped but terraform's "Error:" diagnostic block survived, the CI
-// summary now renders the recovered file, line, and assertion message instead of
-// only the generic "per-run detail unavailable" placeholder.
+// lines are dropped but a single terraform "Error:" diagnostic block survived,
+// the CI summary recovers the file/line for the row -- but does NOT duplicate
+// the raw multi-line message into the table cell, since that would break the
+// markdown table (and the message is already rendered safely in the fenced
+// code block below via result.Errors).
 func TestTestTemplate_SummaryFallback_RecoversErrorDetail(t *testing.T) {
 	const output = `Error: Test assertion failed
 
   on tests/app.tftest.hcl line 30:
-  30:     condition = output.bucket_id == "atmos-demo-test"
+  30:     condition = output.bucket_id == "atmos-demo-test" || output.bucket_id == "fallback-id"
 
 The S3 bucket was not created against the emulator
 ╵
@@ -236,6 +253,68 @@ Failure! 1 passed, 1 failed.
 		"Test assertion failed",
 		"The S3 bucket was not created against the emulator",
 		"atmos terraform test app -s local",
+	} {
+		assert.Contains(t, rendered, want)
+	}
+
+	// The results-table row must stay a single, well-formed markdown line --
+	// the raw diagnostic text (multi-line, with a literal "||" in the HCL
+	// condition) must never be spliced into it.
+	row := tableRowLine(t, rendered, ":x: fail")
+	assert.Equal(t, 6, strings.Count(row, "|"), "row must have exactly 5 columns, got: %q", row)
+	assert.NotContains(t, row, "||", "the HCL condition text must not leak into the table row")
+
+	// The full message appears exactly once -- in the fenced code block, not
+	// duplicated into the table row.
+	assert.Equal(t, 1, strings.Count(rendered, "Test assertion failed"))
+}
+
+// TestTestTemplate_SummaryFallback_MultipleErrorBlocks_NoLocationAttributed
+// covers two failing assertions in two different files: attributing the
+// aggregate row's File/Line to just the first block would misrepresent which
+// failure it belongs to, so neither is set -- both failures' full detail
+// remain available via the fenced code block below the table.
+func TestTestTemplate_SummaryFallback_MultipleErrorBlocks_NoLocationAttributed(t *testing.T) {
+	const output = `Error: Test assertion failed
+
+  on tests/app.tftest.hcl line 12:
+  12:     condition = output.first == "expected"
+
+first assertion message
+╵
+
+Error: Test assertion failed
+
+  on tests/extra.tftest.hcl line 44:
+  44:     condition = output.second == "expected"
+
+second assertion message
+╵
+
+Failure! 0 passed, 2 failed.
+`
+	result := ParseTestOutput(output)
+	data := testData(t, result)
+
+	ctx := &TerraformTemplateContext{
+		TemplateContext: &plugin.TemplateContext{
+			Component: "app",
+			Stack:     "local",
+			Command:   "test",
+			Result:    result,
+		},
+		TestResult: data,
+	}
+	rendered := renderTestTemplate(t, ctx)
+
+	row := tableRowLine(t, rendered, ":x: fail")
+	assert.Equal(t, 6, strings.Count(row, "|"), "row must have exactly 5 columns, got: %q", row)
+	assert.NotContains(t, row, "tests/app.tftest.hcl")
+	assert.NotContains(t, row, "tests/extra.tftest.hcl")
+
+	for _, want := range []string{
+		"first assertion message",
+		"second assertion message",
 	} {
 		assert.Contains(t, rendered, want)
 	}

--- a/pkg/ci/plugins/terraform/test_template_test.go
+++ b/pkg/ci/plugins/terraform/test_template_test.go
@@ -146,6 +146,101 @@ func TestTestTemplate_SummaryFallback_AllPass(t *testing.T) {
 	assert.NotContains(t, rendered, "Tests Failed")
 }
 
+// TestTestTemplate_SummaryFallback_LosesRunDetail documents the residual, irreducible
+// case: when NOTHING but the trailing summary line survived -- not even terraform's
+// "Error:" diagnostic block -- there is no assertion detail left in the captured text
+// to recover, so the rendered CI summary can only show aggregate counts and the repro
+// command. Contrast with TestTestTemplate_SummaryFallback_RecoversErrorDetail, where
+// the "Error:" block did survive and per-run detail is now recovered.
+func TestTestTemplate_SummaryFallback_LosesRunDetail(t *testing.T) {
+	// Only the trailing summary line survives -- simulates the per-run lines AND the
+	// "Error:" diagnostic block being dropped (e.g. output buffering), even though the
+	// run that failed had rich detail in reality (name
+	// "provisions_resources_against_emulator", file tests/app.tftest.hcl, line 30,
+	// assertion "The S3 bucket was not created...").
+	const bufferedOutput = "Failure! 1 passed, 1 failed.\n"
+
+	result := ParseTestOutput(bufferedOutput)
+	data := testData(t, result)
+
+	ctx := &TerraformTemplateContext{
+		TemplateContext: &plugin.TemplateContext{
+			Component: "app",
+			Stack:     "local",
+			Command:   "test",
+			Result:    result,
+		},
+		TestResult: data,
+	}
+	rendered := renderTestTemplate(t, ctx)
+
+	// What the summary *does* show: aggregate counts and the repro command.
+	for _, want := range []string{
+		"FAILED-1",
+		"PASSED-1",
+		"atmos terraform test app -s local",
+	} {
+		assert.Contains(t, rendered, want)
+	}
+
+	// What's missing: the specific run's name, file, line, and assertion message that
+	// a fully-detailed (JSON-parsed) run would have surfaced -- this is the reported gap.
+	for _, missing := range []string{
+		"provisions_resources_against_emulator",
+		"tests/app.tftest.hcl",
+		":30",
+		"The S3 bucket was not created",
+	} {
+		assert.NotContains(t, rendered, missing)
+	}
+
+	// Only the single synthesized aggregate row exists -- no per-run breakdown.
+	require.Len(t, data.Runs, 1)
+	assert.Contains(t, data.Runs[0].Name, "per-run detail unavailable")
+}
+
+// TestTestTemplate_SummaryFallback_RecoversErrorDetail is the fix for the gap
+// TestTestTemplate_SummaryFallback_LosesRunDetail reproduces: when the per-run
+// lines are dropped but terraform's "Error:" diagnostic block survived, the CI
+// summary now renders the recovered file, line, and assertion message instead of
+// only the generic "per-run detail unavailable" placeholder.
+func TestTestTemplate_SummaryFallback_RecoversErrorDetail(t *testing.T) {
+	const output = `Error: Test assertion failed
+
+  on tests/app.tftest.hcl line 30:
+  30:     condition = output.bucket_id == "atmos-demo-test"
+
+The S3 bucket was not created against the emulator
+╵
+
+Failure! 1 passed, 1 failed.
+`
+	result := ParseTestOutput(output)
+	data := testData(t, result)
+
+	ctx := &TerraformTemplateContext{
+		TemplateContext: &plugin.TemplateContext{
+			Component: "app",
+			Stack:     "local",
+			Command:   "test",
+			Result:    result,
+		},
+		TestResult: data,
+	}
+	rendered := renderTestTemplate(t, ctx)
+
+	for _, want := range []string{
+		"FAILED-1",
+		"PASSED-1",
+		"`tests/app.tftest.hcl:30`",
+		"Test assertion failed",
+		"The S3 bucket was not created against the emulator",
+		"atmos terraform test app -s local",
+	} {
+		assert.Contains(t, rendered, want)
+	}
+}
+
 // TestTestTemplate_SummaryFallback_WithFailure covers the failing counterpart
 // of the summary-only fallback.
 func TestTestTemplate_SummaryFallback_WithFailure(t *testing.T) {


### PR DESCRIPTION
## what

- The CI job-summary fallback for `terraform test` output (used when per-run `run "name"... pass/fail` status lines weren't captured) now recovers the failing assertion's file, line, and message from terraform's `Error:` diagnostic block when it survived in the captured output.
- Previously the fallback always synthesized a bare aggregate row like `test summary (per-run detail unavailable): N passed, M failed` with no location or message, even when that detail was still present in the raw text.
- Added `errorLocationRe` to parse the `on <file> line <N>:` locator out of a terraform error block, and reuse the existing `ExtractErrorBlocks` helper to populate the synthesized row's `Error`/`File`/`Line` fields. No template changes were needed — `templates/test.md` already renders those fields for `fail`/`error` rows.
- Added a fix-log record at `docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md`.

## why

- A prior fix (`docs/fixes/2026-08-14-ci-summary-test-table-fallback-dropped.md`) stopped the results table from disappearing entirely on this fallback path, but the synthesized row still carried no per-test detail — CI test summaries showed only aggregate pass counts and a reproduction command, with no individual test-run/assertion detail, even when that detail was actually recoverable from the captured output.
- A reproduction test (`TestTestTemplate_SummaryFallback_LosesRunDetail`) confirmed the gap before this fix; it's retained to document the remaining, genuinely irreducible case where no `Error:` block survives at all.

## references

- `docs/fixes/2026-08-14-ci-summary-test-table-fallback-dropped.md` — the prior fix this builds on.
- `docs/fixes/2026-08-19-ci-test-summary-fallback-recovers-error-detail.md` — this fix's record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terraform test failure summaries by recovering file and line details when a single error is available.
  * Preserved complete error messages without corrupting report tables or duplicating content.
  * Avoided assigning potentially incorrect locations when multiple errors are present.
  * Increased the Terraform registry cache CI timeout from 20 to 30 minutes.

* **Documentation**
  * Added fix documentation covering CI summary recovery and registry cache timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->