### PR TITLE
fix(emulator): join Atmos's container to the shared network when reuse fails

### DIFF
--- a/docs/fixes/2026-08-19-emulator-endpoint-job-container-network-join.md
+++ b/docs/fixes/2026-08-19-emulator-endpoint-job-container-network-join.md
@@ -73,7 +73,7 @@ real CI job container that doesn't explicitly join a custom Docker network.
   the bug rather than passing vacuously.
 - `atmos lint --changed` -- 0 issues.
 - Manual reproduction: disposable copy of the affected application repository, run as a
-  socket-mounted `docker:cli` job container (`docker run --rm -v /var/run/docker.sock:... -v
+  socket-mounted `docker:cli` job container (`docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v
   "$APP_COPY:/workspace" -e CI=true docker:cli sh -c 'atmos terraform test app -s fixtures
   --ci'`) with a locally built `atmos` binary. Before the fix: `emulator aws is up at
   http://172.17.0.1:<port>` followed by `connection refused`. After the fix: `emulator aws is up

--- a/docs/fixes/2026-08-19-emulator-endpoint-job-container-network-join.md
+++ b/docs/fixes/2026-08-19-emulator-endpoint-job-container-network-join.md
@@ -1,0 +1,92 @@
+# Fix: Emulator endpoint unreachable from a socket-mounted job container
+
+**Date:** 2026-08-19
+
+## Summary
+
+`atmos terraform test --ci`, run inside a CI job container that talks to Docker only through a
+mounted host socket, started the AWS emulator successfully but handed Terraform/OpenTofu an
+endpoint (`http://172.17.0.1:<port>`) that was not reachable from that same job container. The
+AWS provider's `GetCallerIdentity` call failed with `connect: connection refused` after nine
+retries. Atmos now actively joins its own container to the emulator's dedicated network instead
+of guessing a reachable IP, so the emulator is addressed by DNS alias, not by IP.
+
+## Context
+
+`pkg/emulator/manager.go`'s `endpoint()` prefers a DNS-alias endpoint when Atmos's own container
+can reuse its *existing* network (`container.CurrentContainerNetwork`). A job container started
+with a plain `docker run` (no `--network`) sits on Docker's default bridge network, which is
+correctly excluded from reuse because it doesn't support embedded DNS/aliases. When reuse failed,
+`pkg/emulator/endpoint_host.go`'s `reachableHostForPublishedPorts()` fell back to parsing the
+container's own default gateway out of `/proc/net/route` -- Docker's classic bridge-gateway IP.
+That heuristic assumes the caller and the emulator container share one Linux host's `docker0`
+bridge. Under Docker Desktop for macOS the daemon runs inside a VM; the bridge-gateway address
+there is not where the host's published-port forwarding actually listens for sibling containers,
+so nothing answered -- "connection refused," exactly as reported.
+
+This closes a gap left open by PR #2942 ("Shared per-stack networking for containers, emulators &
+run steps"), which introduced the current-container-network-reuse mechanism but only reused an
+*existing* usable network -- it never made an unusable one (the default bridge) usable.
+
+Reported and reproduced via a disposable copy of an internal application repository's
+`bugs.md` item 8 ("Emulator identity loopback endpoints fail inside GitHub job containers"),
+using a socket-mounted `docker:cli` job container with no `--network` flag -- the same shape as a
+real CI job container that doesn't explicitly join a custom Docker network.
+
+## Changes
+
+- `pkg/container/network.go`: new `NetworkConnector` interface (`ConnectNetwork`) and
+  `networkConnectResult` idempotency helper, alongside the existing `NetworkEnsurer`.
+- `pkg/container/docker.go`, `pkg/container/podman.go`: `ConnectNetwork` implementations via
+  `docker network connect` / `podman network connect`, using a new shared
+  `buildNetworkConnectArgs` helper in `pkg/container/common.go`.
+- `pkg/container/stack_network.go`: `AttachSharedNetwork` now calls
+  `joinCurrentContainerToNetwork` when reuse fails -- best-effort connecting Atmos's own
+  container to the dedicated per-stack network it just ensured for the new container, gated on
+  `PreferCurrentContainerNetwork()` (so host-native/opted-out runs are unaffected). Once that
+  real network attachment exists, every subsequent `CurrentContainerNetwork` call (in this or any
+  later Atmos process in the same container) picks it up automatically -- no changes were needed
+  in `pkg/emulator/manager.go`.
+- `pkg/emulator/endpoint_host.go`: `reachableHostForPublishedPorts()` now prefers
+  `host.docker.internal` (only when it actually resolves, via a 2s-bounded
+  `net.Resolver.LookupHost`) before the raw default-gateway guess, as a secondary hardening for
+  the last-resort fallback path.
+- New tests: `pkg/container/sibling_network_test.go` (`TestSiblingContainerNetworking_Real`, an
+  unstubbed regression test that exercises the real self-detection/join mechanism when actually
+  run inside a container) and `pkg/container/sibling_network_docker_test.go`
+  (`TestSiblingContainerNetworking_Docker`, opt-in via `ATMOS_TEST_SIBLING_CONTAINER=1`, which
+  drives the above by running `go test` itself inside a nested container with no `--network` and
+  the host socket mounted -- the exact reported topology).
+- Unit test coverage added/extended in `pkg/container/{network,common,stack_network}_test.go` and
+  `pkg/container/{docker,podman}_unit_test.go`, and `pkg/emulator/endpoint_host_test.go`.
+
+## Validation
+
+- `go build ./...` -- clean.
+- `go test ./pkg/container/... ./pkg/emulator/...` -- all passing, including the new real-Docker
+  integration test (`TestDockerRuntime_SharedNetworkAliasReachable_Integration`) and the
+  unstubbed self-detection test.
+- `ATMOS_TEST_SIBLING_CONTAINER=1 go test ./pkg/container/ -run TestSiblingContainerNetworking_Docker`
+  -- passes with the fix in place. Verified it's a genuine regression test by temporarily
+  reverting the `joinCurrentContainerToNetwork` call and re-running: fails with
+  `dial tcp: lookup siblingtest-probe on ...: no such host`, confirming the test actually catches
+  the bug rather than passing vacuously.
+- `atmos lint --changed` -- 0 issues.
+- Manual reproduction: disposable copy of the affected application repository, run as a
+  socket-mounted `docker:cli` job container (`docker run --rm -v /var/run/docker.sock:... -v
+  "$APP_COPY:/workspace" -e CI=true docker:cli sh -c 'atmos terraform test app -s fixtures
+  --ci'`) with a locally built `atmos` binary. Before the fix: `emulator aws is up at
+  http://172.17.0.1:<port>` followed by `connection refused`. After the fix: `emulator aws is up
+  at http://fixtures-aws:4566` (DNS alias), and the run completes fully --
+  `Success! 1 passed, 0 failed, 0 skipped.` -- with zero `connection refused`/`dial tcp` occurrences
+  across the full ~800-line log, including two real `terraform apply`/`destroy` cycles against
+  the emulator.
+- Addressed CodeRabbit review feedback on cloudposse/atmos#2960: removed an overly broad
+  `"already in"` idempotency substring match (would have masked genuine failures like "port
+  already in use"), bounded the `host.docker.internal` DNS lookup with a timeout, and tightened
+  the corresponding test's timing assertion against the actual configured constant instead of a
+  loose bound.
+
+## Follow-ups
+
+None.

--- a/pkg/container/common.go
+++ b/pkg/container/common.go
@@ -433,6 +433,20 @@ func buildStopArgs(containerID string, timeoutSecs int) []string {
 	return []string{"stop", "-t", fmt.Sprintf("%d", timeoutSecs), containerID}
 }
 
+// buildNetworkConnectArgs builds the arguments for a `network connect` operation,
+// attaching containerID to network with each alias registered as a DNS name on
+// it. This function is shared between Docker and Podman runtimes to avoid
+// duplication. Extracted to allow testing the argument building logic without
+// executing commands.
+func buildNetworkConnectArgs(network, containerID string, aliases []string) []string {
+	args := []string{"network", "connect"}
+	for _, alias := range aliases {
+		args = append(args, "--alias", alias)
+	}
+	args = append(args, network, containerID)
+	return args
+}
+
 // buildLogsArgs builds the arguments for a container logs operation.
 // This function is shared between Docker and Podman runtimes to avoid duplication.
 // Extracted to allow testing the argument building logic without executing commands.

--- a/pkg/container/common_test.go
+++ b/pkg/container/common_test.go
@@ -1320,6 +1320,49 @@ func TestBuildStopArgs(t *testing.T) {
 	}
 }
 
+func TestBuildNetworkConnectArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		network     string
+		containerID string
+		aliases     []string
+		expected    []string
+	}{
+		{
+			name:        "no aliases",
+			network:     "atmos-fixtures",
+			containerID: "abc123",
+			expected:    []string{"network", "connect", "atmos-fixtures", "abc123"},
+		},
+		{
+			name:        "single alias",
+			network:     "atmos-fixtures",
+			containerID: "abc123",
+			aliases:     []string{"fixtures-aws"},
+			expected:    []string{"network", "connect", "--alias", "fixtures-aws", "atmos-fixtures", "abc123"},
+		},
+		{
+			name:        "multiple aliases preserve order",
+			network:     "atmos-fixtures",
+			containerID: "abc123",
+			aliases:     []string{"fixtures-aws", "fixtures-aws-alt"},
+			expected: []string{
+				"network", "connect",
+				"--alias", "fixtures-aws",
+				"--alias", "fixtures-aws-alt",
+				"atmos-fixtures", "abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildNetworkConnectArgs(tt.network, tt.containerID, tt.aliases)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestBuildLogsArgs(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -151,6 +151,18 @@ func (d *DockerRuntime) EnsureNetwork(ctx context.Context, name string) error {
 	return networkCreateResult(err, string(output))
 }
 
+// ConnectNetwork attaches an already running container to a user-defined docker
+// network, registering aliases as its DNS names on that network. It implements
+// NetworkConnector so Atmos's own container can join a dedicated stack network
+// it didn't start on.
+func (d *DockerRuntime) ConnectNetwork(ctx context.Context, network, containerID string, aliases []string) error {
+	defer perf.Track(nil, "container.DockerRuntime.ConnectNetwork")()
+
+	cmd := d.command(ctx, buildNetworkConnectArgs(network, containerID, aliases)...)
+	output, err := cmd.CombinedOutput()
+	return networkConnectResult(err, string(output))
+}
+
 // Start starts a container.
 func (d *DockerRuntime) Start(ctx context.Context, containerID string) error {
 	defer perf.Track(nil, "container.DockerRuntime.Start")()

--- a/pkg/container/docker_test.go
+++ b/pkg/container/docker_test.go
@@ -667,3 +667,69 @@ func TestDockerRuntime_Exec_Integration(t *testing.T) {
 	err = runtime.Exec(ctx, containerID, []string{"echo", "test"}, execOpts)
 	require.NoError(t, err, "Exec should succeed")
 }
+
+// TestDockerRuntime_SharedNetworkAliasReachable_Integration proves the
+// networking primitive every fix in this package's AttachSharedNetwork /
+// CurrentContainerNetwork machinery ultimately depends on: two sibling
+// containers on the same real, user-defined Docker network can resolve each
+// other by their registered alias and actually connect over TCP. Nothing in
+// the rest of the suite asserted this directly against a real daemon --
+// everything else mocks the runtime, which can't catch a Docker/host
+// networking assumption that turns out to be wrong (as the 172.17.0.1
+// bridge-gateway assumption was).
+func TestDockerRuntime_SharedNetworkAliasReachable_Integration(t *testing.T) {
+	runtime := NewDockerRuntime()
+	ctx := context.Background()
+
+	if err := runtime.Pull(ctx, "alpine:latest"); err != nil {
+		t.Skipf("Docker not available, skipping network alias test: %v", err)
+		return
+	}
+
+	const networkName = "atmos-test-alias-net"
+	require.NoError(t, runtime.EnsureNetwork(ctx, networkName))
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "network", "rm", networkName).Run() // Best-effort test cleanup.
+	})
+
+	// The "server" side: a container that just listens on a TCP port,
+	// registered under the alias its sibling will dial.
+	serverID, err := runtime.Create(ctx, &CreateConfig{
+		Name:    "atmos-test-alias-server",
+		Image:   "alpine:latest",
+		Command: []string{"nc", "-l", "-p", "8080"},
+		Networks: []NetworkAttachment{
+			{Name: networkName, Aliases: []string{"probe-server"}},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = runtime.Remove(ctx, serverID, true) })
+	require.NoError(t, runtime.Start(ctx, serverID))
+
+	// The "client" side: a plain sibling container on the same network, with
+	// no special knowledge of the server beyond its alias -- exactly the
+	// relationship between a job container and an emulator container.
+	clientID, err := runtime.Create(ctx, &CreateConfig{
+		Name:            "atmos-test-alias-client",
+		Image:           "alpine:latest",
+		OverrideCommand: true, // sleep infinity.
+		Networks: []NetworkAttachment{
+			{Name: networkName, Aliases: []string{"probe-client"}},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = runtime.Remove(ctx, clientID, true) })
+	require.NoError(t, runtime.Start(ctx, clientID))
+
+	// Retry briefly: the server's nc listener may not be bound the instant
+	// its container reports "started".
+	var lastErr error
+	for range 10 {
+		lastErr = runtime.Exec(ctx, clientID, []string{"nc", "-z", "-w", "2", "probe-server", "8080"}, &ExecOptions{})
+		if lastErr == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	assert.NoError(t, lastErr, "client container must reach the server container by its network alias")
+}

--- a/pkg/container/network.go
+++ b/pkg/container/network.go
@@ -59,7 +59,7 @@ func networkConnectResult(runErr error, output string) error {
 		return nil
 	}
 	lower := strings.ToLower(output)
-	if strings.Contains(lower, "already exists") || strings.Contains(lower, "already connected") || strings.Contains(lower, "already in") {
+	if strings.Contains(lower, "already exists") || strings.Contains(lower, "already connected") {
 		return nil
 	}
 	return fmt.Errorf("%w: connect network: %w: %s", errUtils.ErrContainerRuntimeOperation, runErr, strings.TrimSpace(output))

--- a/pkg/container/network.go
+++ b/pkg/container/network.go
@@ -22,6 +22,22 @@ type NetworkEnsurer interface {
 	EnsureNetwork(ctx context.Context, name string) error
 }
 
+// NetworkConnector is an optional Runtime capability: it attaches an already
+// running container to a named network. Used to join Atmos's own current
+// container to a stack's dedicated network when CurrentContainerNetwork can't
+// reuse its existing network for DNS-alias resolution (e.g. it's only on
+// Docker's default "bridge", which doesn't support aliases) — without this,
+// Atmos would only be able to guess a reachable address for containers it
+// starts, rather than actually being on the same network as them. Runtimes
+// that don't implement it simply skip the join; callers then fall back to a
+// published-port-based address guess.
+type NetworkConnector interface {
+	// ConnectNetwork attaches containerID to the named network, registering
+	// aliases (if any) as its DNS names on that network. Treats a container
+	// already connected to the network as success.
+	ConnectNetwork(ctx context.Context, network, containerID string, aliases []string) error
+}
+
 // networkCreateResult maps a `network create` invocation to an idempotent result:
 // an "already exists" failure is success, so repeated `up`s are no-ops.
 func networkCreateResult(runErr error, output string) error {
@@ -32,4 +48,19 @@ func networkCreateResult(runErr error, output string) error {
 		return nil
 	}
 	return fmt.Errorf("%w: create network: %w: %s", errUtils.ErrContainerRuntimeOperation, runErr, strings.TrimSpace(output))
+}
+
+// networkConnectResult maps a `network connect` invocation to an idempotent
+// result: a container already attached to the network is success, so a repeat
+// join (e.g. across separate Atmos processes in the same job container) is a
+// no-op rather than an error.
+func networkConnectResult(runErr error, output string) error {
+	if runErr == nil {
+		return nil
+	}
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "already exists") || strings.Contains(lower, "already connected") || strings.Contains(lower, "already in") {
+		return nil
+	}
+	return fmt.Errorf("%w: connect network: %w: %s", errUtils.ErrContainerRuntimeOperation, runErr, strings.TrimSpace(output))
 }

--- a/pkg/container/network_test.go
+++ b/pkg/container/network_test.go
@@ -26,3 +26,28 @@ func TestNetworkCreateResult(t *testing.T) {
 		assert.Contains(t, got.Error(), "permission denied")
 	})
 }
+
+func TestNetworkConnectResult(t *testing.T) {
+	t.Run("nil error is success", func(t *testing.T) {
+		require.NoError(t, networkConnectResult(nil, ""))
+	})
+
+	t.Run("docker already-exists output is idempotent success", func(t *testing.T) {
+		err := errors.New("exit status 1")
+		// Docker: "Error response from daemon: endpoint with name X already exists in network Y".
+		require.NoError(t, networkConnectResult(err, "Error response from daemon: endpoint with name atmos-job already exists in network atmos-fixtures"))
+	})
+
+	t.Run("podman already-connected output is idempotent success", func(t *testing.T) {
+		err := errors.New("exit status 125")
+		// Podman: "Error: <container> is already connected to network <network>: network is already connected".
+		require.NoError(t, networkConnectResult(err, "Error: abc123 is already connected to network atmos-fixtures: network is already connected"))
+	})
+
+	t.Run("genuine failure propagates", func(t *testing.T) {
+		err := errors.New("exit status 1")
+		got := networkConnectResult(err, "no such container")
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "no such container")
+	})
+}

--- a/pkg/container/network_test.go
+++ b/pkg/container/network_test.go
@@ -50,4 +50,14 @@ func TestNetworkConnectResult(t *testing.T) {
 		require.Error(t, got)
 		assert.Contains(t, got.Error(), "no such container")
 	})
+
+	t.Run("already-in-use output is a genuine failure, not idempotent success", func(t *testing.T) {
+		// A too-broad "already in" substring match would misreport this as
+		// success -- it must only match the specific "already exists"/"already
+		// connected" idempotent cases above, not any "already in ..." message.
+		err := errors.New("exit status 125")
+		got := networkConnectResult(err, "Error: port 8080 is already in use")
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "already in use")
+	})
 }

--- a/pkg/container/podman.go
+++ b/pkg/container/podman.go
@@ -91,6 +91,18 @@ func (p *PodmanRuntime) EnsureNetwork(ctx context.Context, name string) error {
 	return networkCreateResult(err, string(output))
 }
 
+// ConnectNetwork attaches an already running container to a user-defined podman
+// network, registering aliases as its DNS names on that network. It implements
+// NetworkConnector so Atmos's own container can join a dedicated stack network
+// it didn't start on.
+func (p *PodmanRuntime) ConnectNetwork(ctx context.Context, network, containerID string, aliases []string) error {
+	defer perf.Track(nil, "container.PodmanRuntime.ConnectNetwork")()
+
+	cmd := p.command(ctx, buildNetworkConnectArgs(network, containerID, aliases)...)
+	output, err := cmd.CombinedOutput()
+	return networkConnectResult(err, cleanPodmanOutput(output))
+}
+
 // Create creates a new container.
 func (p *PodmanRuntime) Create(ctx context.Context, config *CreateConfig) (string, error) {
 	defer perf.Track(nil, "container.PodmanRuntime.Create")()

--- a/pkg/container/sibling_network_docker_test.go
+++ b/pkg/container/sibling_network_docker_test.go
@@ -28,6 +28,18 @@ import (
 // and builds inside a nested container and is comparatively slow. Run it at
 // minimum before merging any change to pkg/container's networking machinery,
 // and ideally in a dedicated CI job.
+//
+// The nested `docker run`/`sh`/`apk`/`go test` shell-out (and the raw `docker
+// network rm` cleanup in docker_test.go's network-alias integration test) are
+// a deliberate, approved exception, not an oversight: this package has no
+// Docker Go SDK dependency anywhere (production code shells out to the
+// docker/podman CLIs throughout, see DockerRuntime/PodmanRuntime), and
+// testcontainers-go's network.New() cannot create a fixed-name network at all
+// -- it always generates a random UUID name -- so it can't stand in for
+// EnsureNetwork/ConnectNetwork here without testing a different code path
+// than production actually uses. Do not replace this topology test with
+// mocks: the entire point is that ProcessRunsInContainer/currentHostname/
+// Inspect run for real, unstubbed, against a real nested container.
 func TestSiblingContainerNetworking_Docker(t *testing.T) {
 	if os.Getenv("ATMOS_TEST_SIBLING_CONTAINER") != "1" {
 		t.Skip("set ATMOS_TEST_SIBLING_CONTAINER=1 to run the nested job-container networking regression test")

--- a/pkg/container/sibling_network_docker_test.go
+++ b/pkg/container/sibling_network_docker_test.go
@@ -1,0 +1,83 @@
+package container
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/tests/testhelpers"
+)
+
+// TestSiblingContainerNetworking_Docker drives
+// TestSiblingContainerNetworking_Real (sibling_network_test.go) from outside:
+// it runs the entire `go test` invocation itself inside a container started
+// with no --network (Docker's default bridge) and the host Docker socket
+// mounted in -- the precise shape of the field reproduction this feature
+// fixes (a CI job container that talks to Docker only through a mounted
+// socket, sitting on the default bridge because nothing told it to join a
+// custom network). Because the nested test process is genuinely
+// containerized, its ProcessRunsInContainer()/currentHostname()/Inspect calls
+// are all real, not stubbed -- this is what actually proves the fix works,
+// rather than a mocked runtime asserting the code path taken.
+//
+// Deliberately opt-in via ATMOS_TEST_SIBLING_CONTAINER=1 (mirroring the
+// existing ATMOS_TEST_REGISTRY_CACHE gate in docker_test.go): it downloads
+// and builds inside a nested container and is comparatively slow. Run it at
+// minimum before merging any change to pkg/container's networking machinery,
+// and ideally in a dedicated CI job.
+func TestSiblingContainerNetworking_Docker(t *testing.T) {
+	if os.Getenv("ATMOS_TEST_SIBLING_CONTAINER") != "1" {
+		t.Skip("set ATMOS_TEST_SIBLING_CONTAINER=1 to run the nested job-container networking regression test")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("docker CLI not available: %v", err)
+	}
+
+	repoRoot, err := testhelpers.FindRepoRoot()
+	require.NoError(t, err)
+
+	goModCache, err := goEnv(t, "GOMODCACHE")
+	require.NoError(t, err)
+	goBuildCache, err := goEnv(t, "GOCACHE")
+	require.NoError(t, err)
+
+	// No --network flag: this must land on Docker's default bridge, exactly
+	// like a plain `docker run` job container with no custom network -- the
+	// scenario AttachSharedNetwork's current-container join exists to fix.
+	args := []string{
+		"run", "--rm",
+		"-v", repoRoot + ":/workspace",
+		"-v", goModCache + ":/go/pkg/mod",
+		"-v", goBuildCache + ":/root/.cache/go-build",
+		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		"-w", "/workspace",
+		"-e", "GOMODCACHE=/go/pkg/mod",
+		"-e", "GOCACHE=/root/.cache/go-build",
+		"golang:1.26-alpine",
+		"sh", "-c",
+		"apk add --no-cache docker-cli >/dev/null && " +
+			"go test ./pkg/container/... -run TestSiblingContainerNetworking_Real -v -timeout 180s",
+	}
+
+	cmd := exec.Command("docker", args...)
+	output, runErr := cmd.CombinedOutput()
+	t.Logf("nested job-container test output:\n%s", output)
+	require.NoError(t, runErr, "nested job-container run of TestSiblingContainerNetworking_Real must succeed")
+	require.Contains(t, string(output), "PASS", "nested test run must report PASS, not just exit 0")
+}
+
+// goEnv returns the trimmed output of `go env <key>` on the host, used to
+// mount the host's module/build caches into the nested container so it
+// doesn't re-download the entire module graph on every run.
+func goEnv(t *testing.T, key string) (string, error) {
+	t.Helper()
+
+	out, err := exec.Command("go", "env", key).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/pkg/container/sibling_network_test.go
+++ b/pkg/container/sibling_network_test.go
@@ -1,0 +1,80 @@
+package container
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSiblingContainerNetworking_Real is the regression test for the
+// job-container-on-default-bridge bug (an emulator container started through
+// a mounted Docker socket reported an endpoint -- a guessed bridge-gateway IP
+// -- that the job container that started it couldn't actually reach).
+//
+// Unlike every other test in this package touching AttachSharedNetwork /
+// CurrentContainerNetwork, this one does NOT stub ProcessRunsInContainer,
+// currentHostname, or Inspect: it exercises the real self-detection and
+// network-join mechanism against whatever container this test process is
+// actually running in, talking to the daemon however it actually reaches it
+// (typically a mounted socket). On a normal, non-containerized dev/CI
+// machine, ProcessRunsInContainer() is false and this is a no-op skip -- it
+// only exercises the mechanism it's meant to test when actually run nested
+// inside a container. See sibling_network_docker_test.go, which drives
+// exactly that by running `go test -run TestSiblingContainerNetworking_Real`
+// inside a container started with no `--network` (Docker's default bridge)
+// and the host socket mounted in -- the precise shape of the field
+// reproduction.
+func TestSiblingContainerNetworking_Real(t *testing.T) {
+	if !ProcessRunsInContainer() {
+		t.Skip("only meaningful when this test process is itself running inside a container -- see sibling_network_docker_test.go, which drives that")
+	}
+
+	ctx := context.Background()
+	runtime, err := DetectRuntimeWithPreference(ctx, "docker")
+	if err != nil {
+		t.Skipf("no Docker CLI reachable through a mounted socket, skipping: %v", err)
+		return
+	}
+	if err := runtime.Pull(ctx, "alpine:latest"); err != nil {
+		t.Skipf("Docker not available, skipping: %v", err)
+		return
+	}
+
+	stack, name := "siblingtest", "probe"
+	var networks []NetworkAttachment
+	AttachSharedNetwork(ctx, runtime, &networks, stack, name)
+	require.NotEmpty(t, networks, "AttachSharedNetwork must produce at least one network attachment for the sibling container")
+
+	containerID, err := runtime.Create(ctx, &CreateConfig{
+		Name:     "atmos-sibling-probe",
+		Image:    "alpine:latest",
+		Command:  []string{"nc", "-l", "-p", "8080"},
+		Networks: networks,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = runtime.Remove(ctx, containerID, true) })
+	require.NoError(t, runtime.Start(ctx, containerID))
+
+	alias := StackNetworkAlias(stack, name)
+
+	// This is the exact operation the AWS provider performs against the
+	// emulator's reported endpoint -- a plain TCP dial by hostname, from the
+	// current process, no docker exec involved. Retried briefly: the
+	// sibling's nc listener may not be bound the instant its container
+	// reports "started".
+	var dialErr error
+	for range 20 {
+		var conn net.Conn
+		conn, dialErr = net.DialTimeout("tcp", net.JoinHostPort(alias, "8080"), 2*time.Second)
+		if dialErr == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, dialErr, "current (self) container must reach the sibling container by its network alias -- "+
+		"this is exactly what fails when Atmos's own container can't be joined to the sibling's network")
+}

--- a/pkg/container/stack_network.go
+++ b/pkg/container/stack_network.go
@@ -101,10 +101,15 @@ func HasExplicitNetworkOverride(runArgs []string) bool {
 // emulators in the same stack) can resolve it by name. Prefers Atmos's own
 // current container network when detected (see CurrentContainerNetwork), so a
 // job container that starts a sibling container can still reach it; otherwise
-// idempotently ensures the dedicated per-stack network. It is a no-op when the
-// runtime doesn't implement NetworkEnsurer (e.g. a test mock) or network
-// creation fails -- single-container use still works over the default bridge,
-// only cross-container name resolution is lost.
+// idempotently ensures the dedicated per-stack network and, when Atmos is
+// itself containerized, also joins Atmos's own current container to that same
+// dedicated network (see joinCurrentContainerToNetwork) -- so a job container
+// that couldn't reuse its own network (e.g. it's only on Docker's default
+// "bridge") still ends up able to reach the container it's starting by DNS
+// alias, rather than only the new container being reachable. It is a no-op
+// when the runtime doesn't implement NetworkEnsurer (e.g. a test mock) or
+// network creation fails -- single-container use still works over the default
+// bridge, only cross-container name resolution is lost.
 func AttachSharedNetwork(ctx context.Context, runtime Runtime, networks *[]NetworkAttachment, stack, name string) {
 	defer perf.Track(nil, "container.AttachSharedNetwork")()
 
@@ -131,4 +136,35 @@ func AttachSharedNetwork(ctx context.Context, runtime Runtime, networks *[]Netwo
 		Name:    network,
 		Aliases: []string{alias},
 	})
+	joinCurrentContainerToNetwork(ctx, runtime, network)
+}
+
+// joinCurrentContainerToNetwork best-effort attaches Atmos's own running
+// container to network, so a containerized Atmos whose current network isn't
+// reusable for DNS-alias resolution (e.g. it's only on Docker's default
+// "bridge") can still reach containers it starts on the dedicated per-stack
+// network -- once attached, this container's own future CurrentContainerNetwork
+// calls (from this or any later Atmos process in the same container) will find
+// this network too and take the reuse path directly. No-op when Atmos isn't
+// (and hasn't opted into acting as if it were) containerized, the current
+// container can't be identified, or the runtime doesn't support connecting an
+// existing container to a network.
+func joinCurrentContainerToNetwork(ctx context.Context, runtime Runtime, network string) {
+	defer perf.Track(nil, "container.joinCurrentContainerToNetwork")()
+
+	if !PreferCurrentContainerNetwork() {
+		return
+	}
+	connector, ok := runtime.(NetworkConnector)
+	if !ok {
+		return
+	}
+	hostname, err := currentHostname()
+	if err != nil || hostname == "" {
+		return
+	}
+	if err := connector.ConnectNetwork(ctx, network, hostname, nil); err != nil {
+		log.Debug("could not join current container to shared stack network; falling back to published-port reachability",
+			"network", network, "error", err)
+	}
 }

--- a/pkg/container/stack_network_test.go
+++ b/pkg/container/stack_network_test.go
@@ -170,3 +170,135 @@ func TestAttachSharedNetwork_SharesNetworkAcrossKinds(t *testing.T) {
 	assert.Equal(t, containerNetworks[0].Name, emulatorNetworks[0].Name)
 	assert.NotEqual(t, containerNetworks[0].Aliases, emulatorNetworks[0].Aliases)
 }
+
+// connectCall records one ConnectNetwork invocation on fakeConnectRuntime.
+type connectCall struct {
+	network     string
+	containerID string
+	aliases     []string
+}
+
+// fakeConnectRuntime extends fakeNetworkRuntime with NetworkConnector, recording
+// ConnectNetwork calls so tests can verify AttachSharedNetwork's
+// join-current-container-when-reuse-fails behavior (see
+// joinCurrentContainerToNetwork) without a real container runtime.
+type fakeConnectRuntime struct {
+	*fakeNetworkRuntime
+	connected  []connectCall
+	connectErr error
+}
+
+func (f *fakeConnectRuntime) ConnectNetwork(_ context.Context, network, containerID string, aliases []string) error {
+	f.connected = append(f.connected, connectCall{network: network, containerID: containerID, aliases: aliases})
+	return f.connectErr
+}
+
+// stubCurrentHostname overrides currentHostname for the duration of a test,
+// restoring the original on cleanup.
+func stubCurrentHostname(t *testing.T, hostname string, err error) {
+	t.Helper()
+	orig := currentHostname
+	currentHostname = func() (string, error) { return hostname, err }
+	t.Cleanup(func() { currentHostname = orig })
+}
+
+// TestAttachSharedNetwork_JoinsCurrentContainerWhenReuseFails proves the fix for
+// the job-container-on-default-bridge case: when Atmos is containerized but its
+// own current network can't be reused (bridge-only here), AttachSharedNetwork
+// must both ensure the dedicated per-stack network for the new container *and*
+// connect Atmos's own current container to that same network -- otherwise the
+// new container is reachable by alias only from other peers on that network,
+// never from Atmos's own (job) container.
+func TestAttachSharedNetwork_JoinsCurrentContainerWhenReuseFails(t *testing.T) {
+	t.Setenv(envUseCurrentContainerNetwork, "true")
+	stubCurrentHostname(t, "job-container-abc", nil)
+
+	base := &fakeNetworkRuntime{inspectInfo: &Info{Networks: []string{"bridge"}}}
+	rt := &fakeConnectRuntime{fakeNetworkRuntime: base}
+
+	var networks []NetworkAttachment
+	AttachSharedNetwork(context.Background(), rt, &networks, "fixtures", "aws")
+
+	assert.Equal(t, []string{"atmos-fixtures"}, rt.ensured)
+	assert.Equal(t, []NetworkAttachment{
+		{Name: "atmos-fixtures", Aliases: []string{"fixtures-aws"}},
+	}, networks)
+	if assert.Len(t, rt.connected, 1) {
+		assert.Equal(t, "atmos-fixtures", rt.connected[0].network)
+		assert.Equal(t, "job-container-abc", rt.connected[0].containerID)
+	}
+}
+
+// TestAttachSharedNetwork_NotContainerized_DoesNotJoinCurrentContainer proves
+// normal host-based (non-containerized) behavior is unchanged: even with a
+// runtime that supports NetworkConnector, the current-container join must not
+// be attempted when Atmos isn't (and hasn't opted into acting as if it were)
+// containerized.
+func TestAttachSharedNetwork_NotContainerized_DoesNotJoinCurrentContainer(t *testing.T) {
+	t.Setenv(envUseCurrentContainerNetwork, "")
+	restore := stubCurrentNetworkDetection(t, false)
+	defer restore()
+
+	rt := &fakeConnectRuntime{fakeNetworkRuntime: &fakeNetworkRuntime{}}
+	var networks []NetworkAttachment
+	AttachSharedNetwork(context.Background(), rt, &networks, "dev", "gitserver")
+
+	assert.Equal(t, []string{"atmos-dev"}, rt.ensured)
+	assert.Empty(t, rt.connected, "current container must not be joined when Atmos isn't containerized")
+}
+
+// TestAttachSharedNetwork_JoinIsNoOpWithoutNetworkConnector proves a runtime
+// that only implements NetworkEnsurer (not NetworkConnector) behaves exactly
+// as before this change: the dedicated network is still created, and no panic
+// or error results from the missing capability.
+func TestAttachSharedNetwork_JoinIsNoOpWithoutNetworkConnector(t *testing.T) {
+	t.Setenv(envUseCurrentContainerNetwork, "true")
+	stubCurrentHostname(t, "job-container-abc", nil)
+
+	rt := &fakeNetworkRuntime{inspectInfo: &Info{Networks: []string{"bridge"}}}
+	var networks []NetworkAttachment
+	assert.NotPanics(t, func() {
+		AttachSharedNetwork(context.Background(), rt, &networks, "dev", "gitserver")
+	})
+	assert.Equal(t, []string{"atmos-dev"}, rt.ensured)
+	assert.Equal(t, []NetworkAttachment{
+		{Name: "atmos-dev", Aliases: []string{"dev-gitserver"}},
+	}, networks)
+}
+
+// TestAttachSharedNetwork_JoinFailureIsBestEffort proves a failed
+// ConnectNetwork call never propagates as an error or blocks the new
+// container's own network attachment -- it only means the current container
+// stays unreachable-by-alias, same as if NetworkConnector weren't implemented.
+func TestAttachSharedNetwork_JoinFailureIsBestEffort(t *testing.T) {
+	t.Setenv(envUseCurrentContainerNetwork, "true")
+	stubCurrentHostname(t, "job-container-abc", nil)
+
+	base := &fakeNetworkRuntime{inspectInfo: &Info{Networks: []string{"bridge"}}}
+	rt := &fakeConnectRuntime{fakeNetworkRuntime: base, connectErr: errors.New("connect failed")}
+
+	var networks []NetworkAttachment
+	assert.NotPanics(t, func() {
+		AttachSharedNetwork(context.Background(), rt, &networks, "dev", "gitserver")
+	})
+	assert.Equal(t, []NetworkAttachment{
+		{Name: "atmos-dev", Aliases: []string{"dev-gitserver"}},
+	}, networks)
+}
+
+// TestAttachSharedNetwork_JoinSkippedWhenHostnameUnknown proves the join is
+// skipped (not attempted with an empty container ID) when the current
+// container's own hostname can't be determined, mirroring
+// CurrentContainerNetwork's own hostname short-circuit.
+func TestAttachSharedNetwork_JoinSkippedWhenHostnameUnknown(t *testing.T) {
+	t.Setenv(envUseCurrentContainerNetwork, "true")
+	stubCurrentHostname(t, "", assert.AnError)
+
+	base := &fakeNetworkRuntime{inspectInfo: &Info{Networks: []string{"bridge"}}}
+	rt := &fakeConnectRuntime{fakeNetworkRuntime: base}
+
+	var networks []NetworkAttachment
+	AttachSharedNetwork(context.Background(), rt, &networks, "dev", "gitserver")
+
+	assert.Empty(t, rt.connected)
+}

--- a/pkg/emulator/endpoint_host.go
+++ b/pkg/emulator/endpoint_host.go
@@ -1,10 +1,12 @@
 package emulator
 
 import (
+	"context"
 	"encoding/hex"
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -23,6 +25,11 @@ const (
 	// control after the fact for its own (already running) container -- hence
 	// resolving it defensively via lookupHost before trusting it.
 	hostDockerInternal = "host.docker.internal"
+	// Bounds hostDockerInternalResolves' DNS lookup so a slow or unreachable
+	// resolver can't delay emulator endpoint construction (Manager.Up/
+	// Manager.Resolve) -- this is a best-effort probe on the way to the
+	// gateway/localhost fallback, not a call worth blocking startup on.
+	hostDockerInternalLookupTimeout = 2 * time.Second
 )
 
 var (
@@ -30,7 +37,9 @@ var (
 	// Resolves a hostname; overridable in tests so hostDockerInternal's
 	// resolvable-vs-unresolvable branches are exercisable without depending on
 	// the test host's actual DNS/hosts-file setup.
-	lookupHost = net.LookupHost
+	lookupHost = func(ctx context.Context, host string) ([]string, error) {
+		return net.DefaultResolver.LookupHost(ctx, host)
+	}
 )
 
 // reachableHostForPublishedPorts returns the host an emulator's published ports
@@ -68,7 +77,9 @@ func reachableHostForPublishedPorts() string {
 func hostDockerInternalResolves() bool {
 	defer perf.Track(nil, "emulator.hostDockerInternalResolves")()
 
-	addrs, err := lookupHost(hostDockerInternal)
+	ctx, cancel := context.WithTimeout(context.Background(), hostDockerInternalLookupTimeout)
+	defer cancel()
+	addrs, err := lookupHost(ctx, hostDockerInternal)
 	return err == nil && len(addrs) > 0
 }
 

--- a/pkg/emulator/endpoint_host.go
+++ b/pkg/emulator/endpoint_host.go
@@ -15,15 +15,35 @@ import (
 const (
 	envEmulatorEndpointHost = "ATMOS_EMULATOR_ENDPOINT_HOST"
 	linuxRouteGatewayBytes  = 4
+	// Docker's documented hostname for reaching the host (and, from a sibling
+	// container's perspective, host-published ports) from inside a container.
+	// Docker Desktop (macOS/Windows) resolves it automatically; Linux Docker
+	// Engine only resolves it when the container was started with
+	// `--add-host=host.docker.internal:host-gateway`, which Atmos doesn't
+	// control after the fact for its own (already running) container -- hence
+	// resolving it defensively via lookupHost before trusting it.
+	hostDockerInternal = "host.docker.internal"
 )
 
-var readProcFile = os.ReadFile
+var (
+	readProcFile = os.ReadFile
+	// Resolves a hostname; overridable in tests so hostDockerInternal's
+	// resolvable-vs-unresolvable branches are exercisable without depending on
+	// the test host's actual DNS/hosts-file setup.
+	lookupHost = net.LookupHost
+)
 
 // reachableHostForPublishedPorts returns the host an emulator's published ports
 // are reachable at from outside its container -- unrelated to network
 // *attachment* (see container.AttachSharedNetwork/CurrentContainerNetwork for
-// that), this is purely about guessing a reachable address for reading a
-// published port from the caller's side.
+// that; when reuse or a join succeeds there, Manager.endpoint uses a DNS alias
+// and never reaches this function at all), this is purely a last-resort guess
+// at a reachable address for reading a published port from the caller's side,
+// tried in order: an explicit operator override, host.docker.internal (only if
+// it actually resolves -- see hostDockerInternal), the container's own default
+// gateway (Docker's classic bridge-gateway IP, correct on a native Linux Docker
+// host but not necessarily under Docker Desktop's VM-backed daemon), and
+// finally localhost.
 func reachableHostForPublishedPorts() string {
 	defer perf.Track(nil, "emulator.reachableHostForPublishedPorts")()
 
@@ -33,10 +53,23 @@ func reachableHostForPublishedPorts() string {
 	if !container.ProcessRunsInContainer() {
 		return "localhost"
 	}
+	if hostDockerInternalResolves() {
+		return hostDockerInternal
+	}
 	if gateway := linuxDefaultGateway(); gateway != "" {
 		return gateway
 	}
 	return "localhost"
+}
+
+// hostDockerInternalResolves reports whether hostDockerInternal resolves to at
+// least one address from inside the current container -- the signal that it's
+// actually usable here, rather than assuming it based on platform alone.
+func hostDockerInternalResolves() bool {
+	defer perf.Track(nil, "emulator.hostDockerInternalResolves")()
+
+	addrs, err := lookupHost(hostDockerInternal)
+	return err == nil && len(addrs) > 0
 }
 
 func envString(name string) string {

--- a/pkg/emulator/endpoint_host_test.go
+++ b/pkg/emulator/endpoint_host_test.go
@@ -1,9 +1,11 @@
 package emulator
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -89,12 +91,33 @@ func TestHostDockerInternalResolves(t *testing.T) {
 	})
 }
 
+// TestHostDockerInternalResolves_BoundedByTimeout proves a slow or
+// unresponsive resolver can't delay endpoint construction indefinitely: the
+// lookup's context must actually be cancelled once hostDockerInternalLookupTimeout
+// elapses, not merely passed through unused.
+func TestHostDockerInternalResolves_BoundedByTimeout(t *testing.T) {
+	orig := lookupHost
+	defer func() { lookupHost = orig }()
+
+	lookupHost = func(ctx context.Context, _ string) ([]string, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	start := time.Now()
+	got := hostDockerInternalResolves()
+	elapsed := time.Since(start)
+
+	assert.False(t, got)
+	assert.Less(t, elapsed, 5*time.Second, "a slow/unresponsive resolver must not block past hostDockerInternalLookupTimeout")
+}
+
 // stubLookupHost overrides lookupHost for the duration of a test.
 func stubLookupHost(t *testing.T, addrs []string, err error) func() {
 	t.Helper()
 
 	orig := lookupHost
-	lookupHost = func(string) ([]string, error) { return addrs, err }
+	lookupHost = func(context.Context, string) ([]string, error) { return addrs, err }
 	return func() { lookupHost = orig }
 }
 

--- a/pkg/emulator/endpoint_host_test.go
+++ b/pkg/emulator/endpoint_host_test.go
@@ -99,9 +99,19 @@ func TestHostDockerInternalResolves_BoundedByTimeout(t *testing.T) {
 	orig := lookupHost
 	defer func() { lookupHost = orig }()
 
+	// stubSafetyNet is a finite failure path independent of ctx cancellation --
+	// well above hostDockerInternalLookupTimeout, but still bounded -- so a
+	// regression that stops the production code from ever cancelling the
+	// context fails this test with a clear timing mismatch instead of hanging
+	// the suite indefinitely.
+	const stubSafetyNet = hostDockerInternalLookupTimeout * 10
 	lookupHost = func(ctx context.Context, _ string) ([]string, error) {
-		<-ctx.Done()
-		return nil, ctx.Err()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(stubSafetyNet):
+			return nil, context.DeadlineExceeded
+		}
 	}
 
 	start := time.Now()
@@ -109,7 +119,11 @@ func TestHostDockerInternalResolves_BoundedByTimeout(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.False(t, got)
-	assert.Less(t, elapsed, 5*time.Second, "a slow/unresponsive resolver must not block past hostDockerInternalLookupTimeout")
+	// Tight bound against the actual configured constant (not the safety net
+	// above) -- this fails if the timeout stops being applied at all, since
+	// elapsed would then jump to stubSafetyNet instead.
+	assert.Less(t, elapsed, hostDockerInternalLookupTimeout+time.Second,
+		"resolver context must actually be bounded by hostDockerInternalLookupTimeout")
 }
 
 // stubLookupHost overrides lookupHost for the duration of a test.

--- a/pkg/emulator/endpoint_host_test.go
+++ b/pkg/emulator/endpoint_host_test.go
@@ -1,6 +1,7 @@
 package emulator
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -22,11 +23,16 @@ func TestReachableHostForPublishedPorts_HostNativeUsesLocalhost(t *testing.T) {
 func TestReachableHostForPublishedPorts_ContainerUsesDefaultGateway(t *testing.T) {
 	t.Setenv(envEmulatorEndpointHost, "")
 	restore := stubEndpointHostDetection(t, true, "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\neth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0\n")
+	defer restore()
+	// Deterministic: this test asserts the gateway-guess tier specifically, so
+	// host.docker.internal must not resolve, regardless of the real test host's
+	// own DNS/hosts-file setup.
+	restoreLookup := stubLookupHost(t, nil, errors.New("no such host"))
+	defer restoreLookup()
 
 	got := reachableHostForPublishedPorts()
 
 	assert.Equal(t, "172.17.0.1", got)
-	restore()
 }
 
 func TestReachableHostForPublishedPorts_OverrideWins(t *testing.T) {
@@ -37,6 +43,59 @@ func TestReachableHostForPublishedPorts_OverrideWins(t *testing.T) {
 
 	assert.Equal(t, "host.docker.internal", got)
 	restore()
+}
+
+func TestReachableHostForPublishedPorts_ContainerPrefersResolvableHostDockerInternal(t *testing.T) {
+	t.Setenv(envEmulatorEndpointHost, "")
+	restore := stubEndpointHostDetection(t, true, "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\neth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0\n")
+	defer restore()
+	restoreLookup := stubLookupHost(t, []string{"192.168.65.2"}, nil)
+	defer restoreLookup()
+
+	got := reachableHostForPublishedPorts()
+
+	assert.Equal(t, hostDockerInternal, got)
+}
+
+func TestReachableHostForPublishedPorts_ContainerFallsBackToGatewayWhenHostDockerInternalUnresolvable(t *testing.T) {
+	t.Setenv(envEmulatorEndpointHost, "")
+	restore := stubEndpointHostDetection(t, true, "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\neth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0\n")
+	defer restore()
+	restoreLookup := stubLookupHost(t, nil, errors.New("no such host"))
+	defer restoreLookup()
+
+	got := reachableHostForPublishedPorts()
+
+	assert.Equal(t, "172.17.0.1", got, "must fall back to the gateway guess -- unchanged behavior on native Linux Docker hosts -- when host.docker.internal doesn't resolve")
+}
+
+func TestHostDockerInternalResolves(t *testing.T) {
+	t.Run("resolves", func(t *testing.T) {
+		restore := stubLookupHost(t, []string{"192.168.65.2"}, nil)
+		defer restore()
+		assert.True(t, hostDockerInternalResolves())
+	})
+
+	t.Run("lookup error", func(t *testing.T) {
+		restore := stubLookupHost(t, nil, errors.New("no such host"))
+		defer restore()
+		assert.False(t, hostDockerInternalResolves())
+	})
+
+	t.Run("no addresses", func(t *testing.T) {
+		restore := stubLookupHost(t, nil, nil)
+		defer restore()
+		assert.False(t, hostDockerInternalResolves())
+	})
+}
+
+// stubLookupHost overrides lookupHost for the duration of a test.
+func stubLookupHost(t *testing.T, addrs []string, err error) func() {
+	t.Helper()
+
+	orig := lookupHost
+	lookupHost = func(string) ([]string, error) { return addrs, err }
+	return func() { lookupHost = orig }
 }
 
 func TestParseLinuxDefaultGateway(t *testing.T) {


### PR DESCRIPTION
## what

- Atmos's own container now joins the dedicated per-stack Docker/Podman network when it can't reuse its existing one, via a new `NetworkConnector` runtime capability (`docker`/`podman network connect`).
- Hardens the last-resort emulator endpoint guess to prefer `host.docker.internal` (only when it actually resolves) before falling back to the default-gateway IP guess.
- Adds a real, unmocked regression test that runs entirely inside a nested container (no `--network`, host socket mounted) to prove the self-detection/join mechanism works against a real daemon, not just a mocked runtime.

## why

- `atmos terraform test --ci` run inside a CI job container (talking to Docker only through a mounted socket) started the AWS emulator successfully but reported an endpoint (`http://172.17.0.1:<port>`) unreachable from that same job container -- `connection refused` against the AWS provider's `GetCallerIdentity` call.
- Root cause: a job container started with a plain `docker run` (no `--network`) sits on Docker's default bridge, which `CurrentContainerNetwork` correctly excludes from reuse (no embedded DNS/aliases). Reuse failing meant the endpoint fell back to a guessed default-gateway IP, which isn't where Docker Desktop's port-forwarding actually listens for sibling containers.
- Instead of only checking whether the *existing* network happens to be reusable, `AttachSharedNetwork` now actively makes it reusable by connecting Atmos's own container to the dedicated network too -- so the existing DNS-alias endpoint logic just works, for every built-in emulator driver, not just AWS.
- Verified live against the reported reproduction (disposable copy of the affected application repo, `docker:cli` job container, no `--network`, mounted host socket): the emulator now reports a DNS alias instead of an IP, and `atmos terraform test app -s fixtures --ci` completes fully (`Success! 1 passed, 0 failed, 0 skipped.`) where it previously failed with `connection refused`.
- New `pkg/container/sibling_network_test.go` + `sibling_network_docker_test.go` (opt-in via `ATMOS_TEST_SIBLING_CONTAINER=1`) reproduces the bug end-to-end inside a real nested container -- confirmed it fails with `no such host` when the join logic is reverted, and passes with it in place.

## references

- Closes the job-container endpoint-reachability gap left open by #2942 ("Shared per-stack networking for containers, emulators & run steps").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Running containers can join dedicated Docker or Podman networks with optional DNS aliases.
  * Stack containers automatically connect to shared networks when supported.
  * Improved access to published services through `host.docker.internal`.
* **Bug Fixes**
  * Network connections safely handle already-connected containers.
  * Network attachment failures no longer block container creation.
  * Host gateway detection avoids hanging during unavailable DNS resolution.
* **Tests**
  * Added coverage for aliases, network connectivity, runtime behavior, and container communication.
* **Documentation**
  * Documented emulator endpoint and container networking improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->