### PR TITLE
fix: type: store step misrouted to container decoder in custom commands and hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,13 @@ jobs:
           - { os: "ubuntu-latest", target: linux }
           - { os: "windows-latest", target: windows }
           - { os: "macos-15", target: macos }
-    timeout-minutes: 20
+    # windows-latest is the slowest target here too: the actual test finishes
+    # within its own 15m sub-step timeout, but the post-job Go module/build
+    # cache save (tar + zstd) runs after that and is much slower on Windows,
+    # so a flat 20m job budget can expire mid-save even though the test
+    # itself already passed (see the Acceptance tests step's timeout comment
+    # below for the same Windows-is-slower pattern).
+    timeout-minutes: ${{ matrix.flavor.target == 'windows' && 30 || 20 }}
     runs-on: ${{ matrix.flavor.os }}
     steps:
       - name: Check out code into the Go module directory

--- a/docs/fixes/2026-08-19-terraform-registry-cache-windows-job-timeout.md
+++ b/docs/fixes/2026-08-19-terraform-registry-cache-windows-job-timeout.md
@@ -33,14 +33,14 @@ documenting the same Windows-is-slower-at-caching behavior).
 
 | File                            | Change                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------|
-| `.github/workflows/test.yml`     | `terraform-registry-cache` job `timeout-minutes` changed from a flat `20` to `${{ matrix.flavor.target == 'windows' && 30 || 20 }}`, matching the existing per-target timeout pattern used by the `Acceptance tests` step in the same file |
+| `.github/workflows/test.yml`     | `terraform-registry-cache` job's `timeout-minutes` changed from a flat 20 minutes to 30 minutes on Windows and 20 minutes on other targets, matching the existing per-target timeout pattern used by the `Acceptance tests` step in the same file |
 
 ## Validation
 
 - YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`).
-- Pushed to PR #2961; a new CI run was triggered and the `Terraform registry cache test (windows)`
-  check was being watched for a pass at the time this record was written — see the PR's check
-  history for the final outcome.
+- Pushed to PR #2961. The `Terraform registry cache test (windows)` check for this change is
+  **pending** at the time this record was written; this section has not yet been updated with a
+  pass/fail outcome.
 
 ## Follow-ups
 

--- a/docs/fixes/2026-08-19-terraform-registry-cache-windows-job-timeout.md
+++ b/docs/fixes/2026-08-19-terraform-registry-cache-windows-job-timeout.md
@@ -1,0 +1,47 @@
+# Fix: `Terraform registry cache test (windows)` CI job timed out during cache save, not the test
+
+**Date:** 2026-08-19
+
+## Summary
+
+The `Terraform registry cache test (windows)` CI check failed with `The operation was canceled.`,
+but the actual `TestTerraformRegistryCache` Go test had already passed. The job's own
+`timeout-minutes: 20` expired while the post-job Go module/build cache save step (`tar` + `zstd`)
+was still running — a step that runs notably slower on Windows runners than on macOS/Linux.
+
+## Context
+
+User attached a failing-CI log for job `Terraform registry cache test (windows)` (GitHub job ID
+96243114852) on PR #2961 and asked to fix the failing CI actions.
+
+Reading the log: `--- PASS: TestTerraformRegistryCache (58.69s)` / `ok
+github.com/cloudposse/atmos/tests 59.000s` at 22:24:00, well inside the test step's own 15-minute
+sub-step timeout. The job then moved into `Post job cleanup` and started `tar.exe ... zstd -T0`
+to build the `actions/cache` save archive at 22:24:12. That step was still running when
+`##[error]The operation was canceled.` was logged at 22:29:01 — exactly matching the job's
+20-minute deadline from its 22:08:57 start (22:08:57 + 20m = 22:28:57, plus a few seconds of
+reporting lag). No `concurrency:` block cancels in-progress runs in `.github/workflows/test.yml`,
+so this was conclusively the job's own timeout, not an external cancellation. The corresponding
+Linux (6m39s) and macOS (11m15s) legs of the same job both finished comfortably inside the 20m
+budget — Windows cache-save is the outlier, a pattern this same workflow file already accounts for
+elsewhere (the `Acceptance tests` step grants Windows 40m vs 30m for macOS/Linux, with a comment
+documenting the same Windows-is-slower-at-caching behavior).
+
+## Changes
+
+### Code
+
+| File                            | Change                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------|
+| `.github/workflows/test.yml`     | `terraform-registry-cache` job `timeout-minutes` changed from a flat `20` to `${{ matrix.flavor.target == 'windows' && 30 || 20 }}`, matching the existing per-target timeout pattern used by the `Acceptance tests` step in the same file |
+
+## Validation
+
+- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`).
+- Pushed to PR #2961; a new CI run was triggered and the `Terraform registry cache test (windows)`
+  check was being watched for a pass at the time this record was written — see the PR's check
+  history for the final outcome.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-08-19-type-store-step-with-block-decoding.md
+++ b/docs/fixes/2026-08-19-type-store-step-with-block-decoding.md
@@ -1,0 +1,109 @@
+# Fix: `type: store` step `with:` blocks were silently misrouted or dropped
+
+**Date:** 2026-08-19
+
+## Summary
+
+A documented `type: store, action: write` step failed before ever reaching execution — in
+workflows, custom commands, and via the `kind: step` component-hook bridge — because its `with:`
+configuration never reached the store handler. Two independent decode paths shared the same class
+of bug: one misrouted the step into the container decoder and errored outright, the other silently
+dropped the configuration and produced a confusing generic error.
+
+## Context
+
+Reported bug: a custom-command step shaped like
+
+```yaml
+- type: store
+  action: write
+  with:
+    store: image-metadata
+    key: image-dev
+    value: "some-value"
+    stack: dev
+    component: app
+```
+
+failed immediately with:
+
+```
+invalid workflow control step: container `action: write` does not accept a `with:` block
+```
+
+Investigating the root cause (`decodeStepWith` in `pkg/schema/workflow.go`) surfaced that the same
+shared decode path is used by workflow files, custom commands, *and* archive-style steps, and that
+a second, independent bug existed in the `kind: step` component-hook bridge
+(`pkg/hooks/step_engine.go`) for any step type whose configuration lives only in the generic
+`With` map (`store`, `tflint`) rather than flat `WorkflowStep` fields.
+
+## Changes
+
+### Root cause 1 — `decodeStepWith` container misroute
+
+`decodeStepWith` routed *any* step with a non-empty `action:` into the container `with:` decoder,
+regardless of `type:`:
+
+```go
+if strings.TrimSpace(stepType) == "container" || strings.TrimSpace(action) != "" {
+    return decodeContainerWith(node, action, t.container)
+}
+```
+
+`Action` is a shared field reused by container (`build`/`push`/`run`/`inspect`), store (`write`),
+and archive (`create`/`extract`/`update`/`replace`) steps, so any non-container type that also set
+`action:` fell into `decodeContainerWith`'s `default` case and errored. Fixed by requiring
+`stepType == containerStepType` before routing to the container decoder
+(`pkg/schema/workflow.go`). This is the single shared decode path for both the workflow-file path
+(`WorkflowStep.UnmarshalYAML`) and the custom-command/Viper path (`TasksDecodeHook` →
+`decodeTaskFromMap`), so both were broken and both are now fixed.
+
+### Root cause 2 — `kind: step` hook bridge drops generic `With`
+
+`StepFromHook` and `workflowStepFromHookPayload` (`pkg/hooks/step_engine.go`) round-trip the
+hook's `with:` payload directly into `WorkflowStep`'s top-level fields — correct for step types
+with flat fields (`archive`, `say`), but step types like `store`/`tflint` have no flat fields to
+receive `store`/`key`/`value`, so that config was silently dropped and `StoreHandler.Validate`
+failed with a generic "store is required" error that never named the store the user configured.
+Fixed with a new `preserveGenericWith` helper that backfills `ws.With` from the hook payload
+whenever the normal decode leaves it `nil`, applied at both the static (`StepFromHook`, used by
+preflight) and runtime (`workflowStepFromHookPayload`, used by `stepEngine.Run` and
+`stepsEngine.Run`) decode points.
+
+### Code
+
+| File                          | Change                                                                 |
+|--------------------------------|-------------------------------------------------------------------------|
+| `pkg/schema/workflow.go`       | `decodeStepWith` only routes to the container decoder when `type: container` |
+| `pkg/hooks/step_engine.go`     | New `preserveGenericWith` helper, called from `StepFromHook` and `workflowStepFromHookPayload` |
+
+### Test Coverage Added
+
+- `pkg/schema/task_test.go`: `TestStoreStepWithBlock_WorkflowAndCustomCommandDecodeIdentically`
+  (both decode paths preserve the generic `With` map for `type: store, action: write`); corrected
+  `TestDecodeTaskFromMap_InvalidWithBlock`, which had unknowingly been asserting the *buggy*
+  behavior (`type: shell` + arbitrary `action:` + `with:` only errored because of this bug) —
+  retargeted to `type: container` with a genuinely unsupported action so it tests what its
+  docstring claims.
+- `pkg/hooks/step_engine_test.go`: `TestStepFromHookPreservesGenericWithForStoreType` and
+  `TestStepFromHookWithVariablesPreservesGenericWithForStoreType` cover the static and runtime
+  hook decode paths respectively.
+
+## Validation
+
+- `go build ./...`
+- `go test ./pkg/schema/... ./pkg/runner/step/... ./pkg/hooks/... ./pkg/config/...` — all pass.
+- Live end-to-end verification with a built `atmos` binary: a real custom command and a real
+  workflow file, each with a `type: store, action: write` step, both now decode successfully and
+  fail only on the expected downstream error (`store not configured: <name>`) instead of the
+  reported container-decode error.
+- Regression-checked live: `type: container, action: build` still builds correctly (real Docker
+  build, no leaked images); `type: container` with a genuinely unsupported action still produces
+  the container-specific error.
+- Local `atmos test` (full short-suite) hit an unrelated, pre-existing environment issue (a
+  Podman/vfkit VM auto-boot hang in the sanitized test HOME on this machine, already documented in
+  a separate memory record) — confirmed independent of this change and not a new regression.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-08-19-type-store-step-with-block-decoding.md
+++ b/docs/fixes/2026-08-19-type-store-step-with-block-decoding.md
@@ -27,7 +27,7 @@ Reported bug: a custom-command step shaped like
 
 failed immediately with:
 
-```
+```text
 invalid workflow control step: container `action: write` does not accept a `with:` block
 ```
 

--- a/pkg/hooks/step_engine.go
+++ b/pkg/hooks/step_engine.go
@@ -153,6 +153,7 @@ func StepFromHook(hook *Hook) (*schema.WorkflowStep, error) {
 				Err()
 		}
 	}
+	preserveGenericWith(ws, hook.With)
 	// The envelope owns type and retry; they always win over anything in `with:`.
 	ws.Type = hook.Type
 	ws.Retry = hook.Retry
@@ -160,6 +161,25 @@ func StepFromHook(hook *Hook) (*schema.WorkflowStep, error) {
 		ws.Name = "hook:" + hook.Type
 	}
 	return ws, nil
+}
+
+// preserveGenericWith backfills ws.With from the hook's `with:` payload when
+// the step's own YAML decode left it nil. StepFromHook and
+// workflowStepFromHookPayload treat the hook's `with:` block as the step's
+// own top-level YAML document rather than a nested `with:` key, so step
+// types with flat WorkflowStep fields (archive, container, emulator, and
+// others) decode correctly, but step types whose config lives entirely in
+// the generic With map (store, tflint) have no flat fields to receive it and
+// silently lose their whole configuration. Only backfills when the normal
+// decode left With empty, so a step type that does define a real nested
+// `with:` key of its own is left untouched.
+func preserveGenericWith(ws *schema.WorkflowStep, payload any) {
+	if ws.With != nil {
+		return
+	}
+	if m, ok := payload.(map[string]any); ok {
+		ws.With = m
+	}
 }
 
 // stepsEngine runs an ordered list of registered step types as a single hook.
@@ -261,6 +281,7 @@ func workflowStepFromHookPayload(ctx *ExecContext, vars *runnerstep.Variables, p
 			WithExplanation("Failed to decode a rendered step hook payload into a step").
 			Err()
 	}
+	preserveGenericWith(ws, processed)
 	return ws, nil
 }
 

--- a/pkg/hooks/step_engine_test.go
+++ b/pkg/hooks/step_engine_test.go
@@ -362,6 +362,32 @@ func TestStepFromHookWithVariablesPreservesGenericWithForStoreType(t *testing.T)
 	assert.Equal(t, "sha-test", ws.With["value"])
 }
 
+// TestPreserveGenericWith unit-tests the helper directly, covering both the
+// backfill path (StepFromHook/workflowStepFromHookPayload's normal decode
+// left With nil) and the leave-alone path (a step type -- e.g. a step with a
+// genuinely nested `with:` key of its own -- whose With the normal decode
+// already populated must not be clobbered by the hook payload).
+func TestPreserveGenericWith(t *testing.T) {
+	t.Run("backfills when With is nil and payload is a map", func(t *testing.T) {
+		ws := &schema.WorkflowStep{}
+		preserveGenericWith(ws, map[string]any{"key": "value"})
+		assert.Equal(t, map[string]any{"key": "value"}, ws.With)
+	})
+
+	t.Run("leaves an already-decoded With untouched", func(t *testing.T) {
+		existing := map[string]any{"already": "decoded"}
+		ws := &schema.WorkflowStep{With: existing}
+		preserveGenericWith(ws, map[string]any{"should": "not apply"})
+		assert.Equal(t, existing, ws.With)
+	})
+
+	t.Run("no-op when payload is not a map", func(t *testing.T) {
+		ws := &schema.WorkflowStep{}
+		preserveGenericWith(ws, "not-a-map")
+		assert.Nil(t, ws.With)
+	})
+}
+
 func TestVerifyStepHookType(t *testing.T) {
 	require.NoError(t, verifyStepHookType("announce", "log"))
 

--- a/pkg/hooks/step_engine_test.go
+++ b/pkg/hooks/step_engine_test.go
@@ -299,6 +299,69 @@ func TestStepFromHookDecodesNestedConfig(t *testing.T) {
 	assert.Equal(t, 80, ws.Viewport.Width)
 }
 
+// TestStepFromHookPreservesGenericWithForStoreType confirms a `kind: step` /
+// `type: store` hook (documented at /workflows/steps/type/store) actually
+// carries its `store`/`key`/`value` config through to the decoded step. Those
+// fields have no flat WorkflowStep field to land in -- store.go decodes them
+// from the generic With map -- and StepFromHook's marshal/unmarshal round
+// trip treats the hook's `with:` block as the step's own top-level YAML, so
+// without preserveGenericWith backfilling With, they were silently dropped
+// and StoreHandler.Validate failed with a generic "store is required" error
+// that never mentioned the store name the user actually configured.
+func TestStepFromHookPreservesGenericWithForStoreType(t *testing.T) {
+	hook := &Hook{
+		Kind: stepKindName,
+		Type: "store",
+		With: map[string]any{
+			"action":    "write",
+			"store":     "image-metadata",
+			"key":       "image-dev",
+			"value":     "sha-test",
+			"stack":     "dev",
+			"component": "app",
+		},
+	}
+
+	ws, err := StepFromHook(hook)
+	require.NoError(t, err)
+
+	// action/stack/component have flat WorkflowStep fields and already survived.
+	assert.Equal(t, "write", ws.Action)
+	assert.Equal(t, "dev", ws.Stack)
+	assert.Equal(t, "app", ws.Component)
+
+	// store/key/value only exist in the generic With map.
+	require.NotNil(t, ws.With)
+	assert.Equal(t, "image-metadata", ws.With["store"])
+	assert.Equal(t, "image-dev", ws.With["key"])
+	assert.Equal(t, "sha-test", ws.With["value"])
+}
+
+// TestStepFromHookWithVariablesPreservesGenericWithForStoreType is the
+// runtime counterpart: stepFromHookWithVariables (used by stepEngine.Run, and
+// via workflowStepFromHookPayload by stepsEngine.Run for each `kind: steps`
+// item) must backfill With the same way the static StepFromHook decoder does.
+func TestStepFromHookWithVariablesPreservesGenericWithForStoreType(t *testing.T) {
+	hook := &Hook{
+		Kind: stepKindName,
+		Type: "store",
+		With: map[string]any{
+			"store": "image-metadata",
+			"key":   "image-dev",
+			"value": "sha-test",
+		},
+	}
+	ctx := stepExecContext(hook)
+
+	ws, err := stepFromHookWithVariables(ctx, stepVariables(ctx))
+	require.NoError(t, err)
+
+	require.NotNil(t, ws.With)
+	assert.Equal(t, "image-metadata", ws.With["store"])
+	assert.Equal(t, "image-dev", ws.With["key"])
+	assert.Equal(t, "sha-test", ws.With["value"])
+}
+
 func TestVerifyStepHookType(t *testing.T) {
 	require.NoError(t, verifyStepHookType("announce", "log"))
 

--- a/pkg/schema/task_test.go
+++ b/pkg/schema/task_test.go
@@ -1162,7 +1162,7 @@ func TestDecodeTaskFromMap_InvalidStepsMap(t *testing.T) {
 // and the ErrWorkflowControlStepInvalid sentinel.
 func TestDecodeTaskFromMap_InvalidWithBlock(t *testing.T) {
 	m := map[string]any{
-		"type":   TaskTypeShell,
+		"type":   containerStepType,
 		"action": "not-a-real-action",
 		"with": map[string]any{
 			"context": "app",
@@ -1367,6 +1367,77 @@ func TestContainerStepWithBlock_WorkflowAndCustomCommandDecodeIdentically(t *tes
 		"a type: container step's with: block must decode identically for workflow files and custom commands")
 	assert.Nil(t, workflowStep.With, "with: must not also leak into the generic With map for a container step")
 	assert.Nil(t, commandStep.With, "with: must not also leak into the generic With map for a container step")
+}
+
+// storeStepWithBlockYAML is a single `type: store, action: write` step with
+// a full `with:` block, in the exact shape documented for custom commands
+// (see https://github.com/cloudposse/atmos/issues -- store step misdecoded
+// as a container step).
+const storeStepWithBlockYAML = `
+- name: write-image-metadata
+  type: store
+  action: write
+  with:
+    store: image-metadata
+    key: image-dev
+    value: "some-value"
+    stack: dev
+    component: app
+`
+
+// TestStoreStepWithBlock_WorkflowAndCustomCommandDecodeIdentically confirms a
+// `type: store` step's `with:` block decodes into the generic With map --
+// not the container action decoder -- for both the workflow-file path
+// (yaml.Unmarshal -> Task.UnmarshalYAML) and the custom-command/Viper path
+// (mapstructure -> TasksDecodeHook -> decodeTaskFromMap). Before the fix,
+// decodeStepWith routed any step with a non-empty `action:` (regardless of
+// `type:`) into decodeContainerWith, which rejected `action: write` with
+// "container `action: write` does not accept a `with:` block".
+func TestStoreStepWithBlock_WorkflowAndCustomCommandDecodeIdentically(t *testing.T) {
+	// Workflow-file path: direct YAML decode, invoking Task.UnmarshalYAML.
+	var fromYAML Tasks
+	require.NoError(t, yaml.Unmarshal([]byte(storeStepWithBlockYAML), &fromYAML))
+	require.Len(t, fromYAML, 1)
+
+	// Custom-command / Viper path: decode into a generic tree first (as Viper
+	// does when it reads the YAML file), then mapstructure-decode that tree
+	// into Tasks via the real TasksDecodeHook, mirroring atmosDecodeHook.
+	var generic []any
+	require.NoError(t, yaml.Unmarshal([]byte(storeStepWithBlockYAML), &generic))
+
+	var fromMapstructure Tasks
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &fromMapstructure,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			ConditionDecodeHook(),
+			WorkflowStepDecodeHook(),
+			TasksDecodeHook(),
+		),
+	})
+	require.NoError(t, err)
+	require.NoError(t, decoder.Decode(generic))
+	require.Len(t, fromMapstructure, 1)
+
+	workflowStep := fromYAML[0]
+	commandStep := fromMapstructure[0]
+
+	require.NotNil(t, workflowStep.With, "workflow-file path must decode with: into the generic With map")
+	require.NotNil(t, commandStep.With, "custom-command path must decode with: into the generic With map")
+
+	expected := map[string]any{
+		"store":     "image-metadata",
+		"key":       "image-dev",
+		"value":     "some-value",
+		"stack":     "dev",
+		"component": "app",
+	}
+	assert.Equal(t, expected, workflowStep.With)
+	assert.Equal(t, expected, commandStep.With)
+	assert.Nil(t, workflowStep.Build)
+	assert.Nil(t, commandStep.Build)
 }
 
 // containerStepWithUnknownFieldYAML is the same shape as

--- a/pkg/schema/workflow.go
+++ b/pkg/schema/workflow.go
@@ -637,7 +637,7 @@ func decodeStepWith(node *yaml.Node, stepType, action string, t *stepPolyTargets
 	if node == nil {
 		return nil
 	}
-	if strings.TrimSpace(stepType) == "container" || strings.TrimSpace(action) != "" {
+	if strings.TrimSpace(stepType) == containerStepType {
 		return decodeContainerWith(node, action, t.container)
 	}
 	if t.generic == nil {


### PR DESCRIPTION
## what

- Fix `decodeStepWith` (`pkg/schema/workflow.go`) so a step is only routed to the container `with:` decoder when `type: container`, instead of whenever `action:` is non-empty.
- Fix the `kind: step` hook bridge (`pkg/hooks/step_engine.go`) to backfill `WorkflowStep.With` from the hook's `with:` payload when the normal decode leaves it nil.
- Add regression tests covering both the workflow-file and custom-command/Viper decode paths for `type: store`, and both the static and runtime hook decode paths.

## why

- A documented custom-command/workflow step shaped like:
  ```yaml
  - type: store
    action: write
    with:
      store: image-metadata
      key: image-dev
      value: "..."
      stack: dev
      component: app
  ```
  failed before ever reaching execution with `container `action: write` does not accept a `with:` block`. `decodeStepWith` treated any step with a non-empty `action:` as a container step regardless of `type:`, so `type: store` (and any other non-container type that sets `action:`) was misrouted into the container decoder.
- Investigating the same class of bug surfaced a second, independent issue: the documented `kind: step` / `type: store` component-hook pattern (see `/workflows/steps/type/store`) also silently dropped its `store`/`key`/`value` config, because the hook bridge round-trips the hook's `with:` payload directly into `WorkflowStep`'s top-level fields — which works for step types with flat fields (`archive`, `say`) but not for step types like `store`/`tflint` whose config lives only in the generic `With` map. `StoreHandler.Validate` then failed with a generic "store is required" error that never showed the store the user actually configured.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved `with` values for store hooks when decoding workflow steps.
  - Kept step parameters consistent across workflow, runtime, YAML, and map-based decoding.
  - Limited container-specific processing to container steps.
  - Prevented valid parameters on non-container steps from being lost or misinterpreted.
  - Kept store step parameters available without populating container-only fields.
  - Increased the Terraform registry cache timeout for Windows jobs to improve reliability.

- **Documentation**
  - Documented the step-parameter decoding and Windows timeout fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->