### PR TITLE
fix(container): build.load works without bake; portable bake vars

### DIFF
--- a/docs/fixes/2026-08-19-container-bake-vars-env-injection.md
+++ b/docs/fixes/2026-08-19-container-bake-vars-env-injection.md
@@ -1,0 +1,68 @@
+# Fix: container bake `vars` no longer emitted as `--var` (unsupported on older buildx)
+
+**Date:** 2026-08-19
+
+## Summary
+
+The `container` step's `action: build` with `with.bake.vars` built a
+`docker buildx bake --var NAME=value ...` command. `docker-buildx` 0.13.1, shipped by Debian
+Trixie (released 2025-08-09), does not implement `--var` for `bake` — that flag was added in a
+materially newer upstream buildx release (`docker/buildx#3610`) — so on Trixie hosts the build
+died with `unknown flag: --var`. Fixed by injecting bake vars as `NAME=value` entries in the
+`docker buildx bake` subprocess environment instead of a CLI flag, since HCL
+`variable "NAME" { default = ... }` blocks have always resolved from a same-named OS
+environment variable, with no `--var` flag required, across every buildx version.
+
+## Context
+
+While verifying that the `container` step's `build.load` feature worked without requiring
+`bake` (branch `osterman/verify-works-without-bake`), a `with.bake.vars` build was traced on a
+Debian Trixie host and failed with `unknown flag: --var` from `docker buildx bake`. The Debian
+Trixie `docker-buildx-bake(1)` manpage (package `docker-buildx` 0.13.1+ds1-3) confirms the
+supported flags are `-f/--file`, `-h/--help`, `--load`, `--metadata-file`, `--no-cache`,
+`--print`, `--progress`, `--provenance`, `--pull`, `--push`, `--sbom`, `--set`, `--builder` — no
+`--var`. Upstream `docker/buildx#3610` added `--var` as an explicit-override alternative to the
+pre-existing, universally-supported mechanism: `docker buildx bake` HCL `variable "NAME" {}`
+blocks resolve their value from a same-named OS environment variable by default. Docker's own
+docs even describe `BUILDX_BAKE_DISABLE_VARS_ENV_LOOKUP=1` for users who want to *disable* that
+env lookup (e.g. to keep values out of build provenance attestations) — Atmos does not set that
+opt-out, matching the pre-existing `--var`-flag behavior, which also had no such control.
+
+Both mechanisms require the same precondition (the bake file must already declare
+`variable "NAME" {}`), so switching from the CLI flag to environment-variable injection changes
+nothing about what's expressible in a bake file — only how portably the value reaches the bake
+evaluator. Since env-var resolution works uniformly across every buildx version, old and new,
+this avoids adding any buildx-version detection.
+
+## Changes
+
+- `pkg/container/common.go`: removed the `--var` construction from `buildBakeArgs`; added
+  `bakeVarEnv` (bake vars map → sorted `NAME=value` slice) and `bakeCommandEnv` (base env +
+  `*BuildConfig` → full subprocess env, or `nil` when there's nothing to inject).
+- `pkg/container/docker.go`: `DockerRuntime.Build` now calls
+  `applyCommandEnv(cmd, bakeCommandEnv(d.env, config))` after building the base command, so bake
+  vars are appended to that command's environment without mutating `d.env` — a later
+  `Push`/`Inspect` call on the same runtime instance is unaffected.
+- `pkg/container/common_test.go`: updated the `buildBakeArgs` "buildx bake" table case to no
+  longer expect `--var`, added a case proving `Bake.Vars` leaves no trace in the CLI args, and
+  added `TestBakeVarEnv` / `TestBakeCommandEnv`.
+- `website/docs/workflows/workflows/workflow/steps/type/container.mdx`: documented that `vars`
+  is injected as environment variables, not `--var`, and still requires a matching
+  `variable "NAME" {}` block in the bake file.
+
+Bake is Docker-buildx-only in this codebase (`pkg/container/podman.go` rejects `config.Bake !=
+nil` outright), so Podman is unaffected. `pkg/schema/workflow.go`'s `Vars map[string]string`
+field is unchanged — only its downstream consumption changed.
+
+## Validation
+
+- `go build ./...`
+- `go test ./pkg/container/... -run 'TestBuildBuildArgs|TestBakeVarEnv|TestBakeCommandEnv' -v`
+- `go test ./pkg/container/...`
+- `./custom-gcl run --new-from-rev=origin/main` — 0 issues.
+
+## Follow-ups
+
+None. If a future user needs to avoid bake-var values leaking into build provenance
+attestations, that mirrors the upstream `BUILDX_BAKE_DISABLE_VARS_ENV_LOOKUP=1` concern and can
+be revisited on request.

--- a/docs/fixes/2026-08-20-container-build-load-without-bake.md
+++ b/docs/fixes/2026-08-20-container-build-load-without-bake.md
@@ -1,0 +1,50 @@
+# Fix: `container` build step can `load` into the local image store without `bake`
+
+**Date:** 2026-08-20
+
+## Summary
+
+`with.load: true` existed only under `with.bake` (`bake.load`), so getting `docker buildx build
+--load` (loading a built image into the local Docker image store) required adopting Docker Bake
+and an external `docker-bake.hcl` file, even for users who only wanted the plain
+`context`/`dockerfile`/`tags` build path. Added a standalone `load` field to the plain (non-bake)
+`engine: buildx` build config so `--load` works without `bake:`.
+
+## Context
+
+A `commands.yaml` diff (reviewed via screenshot on branch `osterman/verify-works-without-bake`)
+rewrote a plain buildx build step into a `bake:` block purely to get `load: true`, so a
+following `push` step could find the image — with a non-default Buildx driver (e.g.
+`docker-container`), the build result lands in BuildKit's own cache rather than the local Docker
+daemon's image store, and `push` reads from that local store
+(`pkg/container/docker.go`). Tracing the implementation confirmed `Load` was defined only on
+`ContainerBuildBakeStep` (`pkg/schema/workflow.go`), and `buildBuildArgs`'s plain path
+(`pkg/container/common.go`) never emitted `--load` under any configuration — forcing a
+disproportionate migration (an external `.hcl` file, with no atmos-side existence/schema check)
+onto anyone who just needed `--load`.
+
+## Changes
+
+- `pkg/schema/workflow.go`: added `Load bool` to `ContainerBuildStep`.
+- `pkg/container/runtime.go`: added `Load bool` to `BuildConfig`.
+- `pkg/container/common.go`: `buildBuildArgs` emits `--load` in the `engine: buildx` branch when
+  `config.Load` is set (mirrors `buildBakeArgs`'s existing `--load` handling).
+- `pkg/runner/step/container_build.go`: `buildBuildConfig` threads `build.Load` through;
+  `validateBuildAction` now requires `engine: buildx` (or `bake:`) when `load: true` is set,
+  mirroring the existing `Driver`/`Cache` buildx-requirement check.
+- `pkg/container/common_test.go`, `pkg/runner/step/container_test.go`: added coverage for the new
+  field (arg building, config wiring, and the validation error/success cases).
+- `website/docs/workflows/workflows/workflow/steps/type/container.mdx`: documented `load` in the
+  plain build field list and example.
+
+## Validation
+
+- `go build ./...`
+- `go test ./pkg/container/... ./pkg/runner/step/... ./pkg/schema/... -count=1`
+- `./custom-gcl run --new-from-rev=origin/main` — 0 issues (run with a fresh
+  `GOLANGCI_LINT_CACHE` to rule out a corrupted shared cache after killing stale lock-holding
+  processes from an earlier lint run).
+
+## Follow-ups
+
+None.

--- a/pkg/asciicast/session_test.go
+++ b/pkg/asciicast/session_test.go
@@ -805,7 +805,10 @@ func TestRunSessionExecutesScriptedShellActions(t *testing.T) {
 	}
 	t.Setenv(asciicastSessionHelperEnv, "1")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// 10s (not 3s): Windows CI runners occasionally need several seconds just to
+	// spawn the subprocess under load, well before any scripted actions run —
+	// a tight budget here flakes on process start, not on session behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = RunSession(ctx, &SessionOptions{
 		Shell:  shell,
@@ -838,7 +841,10 @@ func TestRunSessionAppliesDirectoryAndEnvironment(t *testing.T) {
 	cwdPattern := "cwd=(" + regexp.QuoteMeta(dir) + "|" + regexp.QuoteMeta(expectedDir) + ")"
 	t.Setenv(asciicastSessionHelperEnv, "1")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// 10s (not 3s): Windows CI runners occasionally need several seconds just to
+	// spawn the subprocess under load, well before any scripted actions run —
+	// a tight budget here flakes on process start, not on session behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = RunSession(ctx, &SessionOptions{
 		Shell: shell,
@@ -878,7 +884,10 @@ func TestRunSessionDefaultsNilOptions(t *testing.T) {
 	t.Setenv("SHELL", shell)
 	t.Setenv(asciicastSessionHelperEnv, "1")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// 10s (not 3s): Windows CI runners occasionally need several seconds just to
+	// spawn the subprocess under load, well before any scripted actions run —
+	// a tight budget here flakes on process start, not on session behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := RunSession(ctx, nil); err != nil {
 		t.Fatalf("RunSession with nil opts: %v", err)
@@ -906,7 +915,10 @@ func TestRunSessionReturnsActionErrors(t *testing.T) {
 	}
 	t.Setenv(asciicastSessionHelperEnv, "1")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// 10s (not 3s): Windows CI runners occasionally need several seconds just to
+	// spawn the subprocess under load, well before any scripted actions run —
+	// a tight budget here flakes on process start, not on session behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = RunSession(ctx, &SessionOptions{
 		Shell:   shell,

--- a/pkg/container/common.go
+++ b/pkg/container/common.go
@@ -289,6 +289,9 @@ func buildBuildArgs(config *BuildConfig) []string {
 				args = append(args, "--cache-to", joinAttrs(entry))
 			}
 		}
+		if config.Load {
+			args = append(args, "--load")
+		}
 	}
 
 	if config.NoCache {
@@ -353,15 +356,35 @@ func buildBakeArgs(config *BuildConfig) []string {
 	if config.Bake.Print {
 		args = append(args, "--print")
 	}
-	for key, value := range config.Bake.Vars {
-		args = append(args, "--var", fmt.Sprintf(keyValueFormat, key, value))
-	}
 	for _, value := range config.Bake.Set {
 		args = append(args, "--set", value)
 	}
 
 	args = append(args, appendFile(config.Bake.Target, config.Bake.Targets)...)
 	return args
+}
+
+// bakeVarEnv converts bake variables into sorted "NAME=value" environment entries.
+// Docker buildx bake resolves an HCL `variable "NAME" { default = ... }` block from a
+// same-named OS environment variable — this has always been supported by every buildx
+// release, unlike the `--var` CLI flag, which was added later (buildx PR #3610) and is
+// missing from older ships like Debian Trixie's docker-buildx 0.13.1. Keys are sorted so
+// callers get deterministic command/environment construction.
+func bakeVarEnv(vars map[string]string) []string {
+	if len(vars) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	env := make([]string, 0, len(keys))
+	for _, k := range keys {
+		env = append(env, fmt.Sprintf(keyValueFormat, k, vars[k]))
+	}
+	return env
 }
 
 // defaultBuilderName is used for the Buildx builder instance when config.Driver.Name is
@@ -534,6 +557,32 @@ func applyCommandEnv(cmd *exec.Cmd, env []string) {
 		return
 	}
 	cmd.Env = env
+}
+
+// bakeCommandEnv computes the full subprocess environment for a `docker buildx bake`
+// invocation that declares vars, by appending bakeVarEnv entries onto the runtime's base
+// env. It returns nil when there's nothing to inject (no Bake, or no Vars), letting the
+// caller leave cmd.Env untouched via applyCommandEnv's no-op-on-empty behavior.
+//
+// Since cmd.Env is a full replacement, not additive (see applyCommandEnv), base is copied
+// forward here rather than mutated in place: base is the runtime's shared, reusable env
+// field (e.g. DockerRuntime.env), and later commands on the same runtime instance — a
+// push or inspect after this build — must not inherit bake vars meant for this one build.
+// When base is empty the runtime has no configured env (SetEnv was never called), so
+// os.Environ() is used as the starting point instead — matching what an unmodified cmd.Env
+// would have inherited anyway.
+func bakeCommandEnv(base []string, config *BuildConfig) []string {
+	if config.Bake == nil || len(config.Bake.Vars) == 0 {
+		return nil
+	}
+	source := base
+	if len(source) == 0 {
+		source = os.Environ()
+	}
+	env := make([]string, 0, len(source)+len(config.Bake.Vars))
+	env = append(env, source...)
+	env = append(env, bakeVarEnv(config.Bake.Vars)...)
+	return env
 }
 
 // runExecCommand wires IO streams onto an already-built container exec command

--- a/pkg/container/common_test.go
+++ b/pkg/container/common_test.go
@@ -1025,6 +1025,17 @@ func TestBuildBuildArgs(t *testing.T) {
 			expected: []string{"buildx", "build", "-t", "myapp:latest", "-f", "Dockerfile", "."},
 		},
 		{
+			name: "buildx build with load",
+			config: &BuildConfig{
+				Engine:     "buildx",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				Tags:       []string{"myapp:latest"},
+				Load:       true,
+			},
+			expected: []string{"buildx", "build", "--load", "-t", "myapp:latest", "-f", "Dockerfile", "."},
+		},
+		{
 			name: "buildx bake",
 			config: &BuildConfig{
 				NoCache: true,
@@ -1050,11 +1061,21 @@ func TestBuildBuildArgs(t *testing.T) {
 				"--load",
 				"--push",
 				"--print",
-				"--var", "VERSION=1.0.0",
 				"--set", "*.platform=linux/amd64",
 				"app",
 				"worker",
 			},
+		},
+		{
+			// Bake.Vars is injected into the subprocess environment (see bakeVarEnv/
+			// bakeCommandEnv), not passed as a --var CLI flag, since --var isn't
+			// implemented by every buildx release (e.g. Debian Trixie's docker-buildx
+			// 0.13.1). Confirms Vars leaves no trace in the CLI args.
+			name: "buildx bake with vars does not affect CLI args",
+			config: &BuildConfig{
+				Bake: &BakeConfig{File: "docker-bake.hcl", Vars: map[string]string{"VERSION": "1.0.0"}},
+			},
+			expected: []string{"buildx", "bake", "--file", "docker-bake.hcl"},
 		},
 		{
 			name: "buildx bake with driver",
@@ -1231,6 +1252,93 @@ func TestJoinAttrs(t *testing.T) {
 			assert.Equal(t, tt.expected, joinAttrs(tt.attrs))
 		})
 	}
+}
+
+func TestBakeVarEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     map[string]string
+		expected []string
+	}{
+		{
+			name:     "nil vars",
+			vars:     nil,
+			expected: nil,
+		},
+		{
+			name:     "empty vars",
+			vars:     map[string]string{},
+			expected: nil,
+		},
+		{
+			name:     "single var",
+			vars:     map[string]string{"VERSION": "1.0.0"},
+			expected: []string{"VERSION=1.0.0"},
+		},
+		{
+			name:     "multiple vars sorted by key",
+			vars:     map[string]string{"VERSION": "1.0.0", "BUILD_ID": "42"},
+			expected: []string{"BUILD_ID=42", "VERSION=1.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, bakeVarEnv(tt.vars))
+		})
+	}
+}
+
+func TestBakeCommandEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     []string
+		config   *BuildConfig
+		expected []string
+	}{
+		{
+			name:     "no bake",
+			base:     []string{"PATH=/usr/bin"},
+			config:   &BuildConfig{},
+			expected: nil,
+		},
+		{
+			name:     "bake without vars",
+			base:     []string{"PATH=/usr/bin"},
+			config:   &BuildConfig{Bake: &BakeConfig{File: "docker-bake.hcl"}},
+			expected: nil,
+		},
+		{
+			name: "bake with vars appends to configured base env",
+			base: []string{"PATH=/usr/bin", "DOCKER_CONFIG=/tmp/dc"},
+			config: &BuildConfig{
+				Bake: &BakeConfig{File: "docker-bake.hcl", Vars: map[string]string{"VERSION": "1.0.0"}},
+			},
+			expected: []string{"PATH=/usr/bin", "DOCKER_CONFIG=/tmp/dc", "VERSION=1.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, bakeCommandEnv(tt.base, tt.config))
+		})
+	}
+
+	t.Run("nil base falls back to os.Environ", func(t *testing.T) {
+		config := &BuildConfig{
+			Bake: &BakeConfig{File: "docker-bake.hcl", Vars: map[string]string{"VERSION": "1.0.0"}},
+		}
+		result := bakeCommandEnv(nil, config)
+		assert.Contains(t, result, "VERSION=1.0.0")
+		assert.Greater(t, len(result), 1, "should include os.Environ() entries, not just the bake var")
+	})
+
+	t.Run("does not mutate base slice", func(t *testing.T) {
+		base := []string{"PATH=/usr/bin"}
+		config := &BuildConfig{Bake: &BakeConfig{Vars: map[string]string{"VERSION": "1.0.0"}}}
+		_ = bakeCommandEnv(base, config)
+		assert.Equal(t, []string{"PATH=/usr/bin"}, base, "base must not be mutated so later commands on the same runtime don't inherit bake vars")
+	})
 }
 
 func TestEffectiveDriverName(t *testing.T) {

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -70,6 +70,7 @@ func (d *DockerRuntime) Build(ctx context.Context, config *BuildConfig) error {
 	args := buildBuildArgs(config)
 
 	cmd := d.command(ctx, args...)
+	applyCommandEnv(cmd, bakeCommandEnv(d.env, config))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: docker build failed: %w: %s", errUtils.ErrContainerRuntimeOperation, err, string(output))

--- a/pkg/container/runtime.go
+++ b/pkg/container/runtime.go
@@ -67,6 +67,7 @@ type BuildConfig struct {
 	Target     string
 	NoCache    bool
 	Pull       bool
+	Load       bool
 	Bake       *BakeConfig
 	Driver     *DriverConfig
 	Cache      *CacheConfig

--- a/pkg/runner/step/container_build.go
+++ b/pkg/runner/step/container_build.go
@@ -22,8 +22,8 @@ func validateBuildAction(step *schema.WorkflowStep) error {
 	if !isValidContainerBuildEngine(build.Engine) {
 		return invalidContainerField(step, "build.engine", build.Engine, "Build engine must be `buildx` or empty for the runtime default")
 	}
-	if (build.Driver != nil || build.Cache != nil) && build.Engine != containerBuildEngineBuildx && build.Bake == nil {
-		return invalidContainerField(step, "build.engine", build.Engine, "Buildx driver and cache configuration require `engine: buildx`")
+	if (build.Driver != nil || build.Cache != nil || build.Load) && build.Engine != containerBuildEngineBuildx && build.Bake == nil {
+		return invalidContainerField(step, "build.engine", build.Engine, "Buildx driver, cache, and load configuration require `engine: buildx`")
 	}
 	if (build.Engine == containerBuildEngineBuildx || build.Bake != nil) && build.Provider != string(container.TypeDocker) {
 		return invalidContainerField(step, "build.provider", build.Provider, "Docker Buildx and Bake require `provider: docker` in V1; Podman uses the native `podman build` path")
@@ -139,6 +139,7 @@ func (h *ContainerHandler) buildBuildConfig(step *schema.WorkflowStep, vars *Var
 		Target:     target,
 		NoCache:    build.NoCache,
 		Pull:       build.Pull,
+		Load:       build.Load,
 		Bake:       bake,
 		Driver:     driver,
 		Cache:      cache,

--- a/pkg/runner/step/container_build.go
+++ b/pkg/runner/step/container_build.go
@@ -22,8 +22,14 @@ func validateBuildAction(step *schema.WorkflowStep) error {
 	if !isValidContainerBuildEngine(build.Engine) {
 		return invalidContainerField(step, "build.engine", build.Engine, "Build engine must be `buildx` or empty for the runtime default")
 	}
-	if (build.Driver != nil || build.Cache != nil || build.Load) && build.Engine != containerBuildEngineBuildx && build.Bake == nil {
-		return invalidContainerField(step, "build.engine", build.Engine, "Buildx driver, cache, and load configuration require `engine: buildx`")
+	if build.Load && build.Bake != nil {
+		return invalidContainerField(step, "build.load", "true", "Use `build.bake.load` when `build.bake` is configured")
+	}
+	if (build.Driver != nil || build.Cache != nil) && build.Engine != containerBuildEngineBuildx && build.Bake == nil {
+		return invalidContainerField(step, "build.engine", build.Engine, "Buildx driver and cache configuration require `engine: buildx`")
+	}
+	if build.Load && build.Engine != containerBuildEngineBuildx {
+		return invalidContainerField(step, "build.engine", build.Engine, "Buildx load configuration requires `engine: buildx`")
 	}
 	if (build.Engine == containerBuildEngineBuildx || build.Bake != nil) && build.Provider != string(container.TypeDocker) {
 		return invalidContainerField(step, "build.provider", build.Provider, "Docker Buildx and Bake require `provider: docker` in V1; Podman uses the native `podman build` path")

--- a/pkg/runner/step/container_test.go
+++ b/pkg/runner/step/container_test.go
@@ -371,16 +371,20 @@ func TestContainerHandlerValidateActionBlocks(t *testing.T) {
 			Load:     true,
 		},
 	}))
-	assert.Error(t, handler.Validate(&schema.WorkflowStep{
+	err := handler.Validate(&schema.WorkflowStep{
 		Name:   "load-with-bake",
 		Type:   "container",
 		Action: "build",
 		Build: &schema.ContainerBuildStep{
 			Provider: "docker",
+			Engine:   "buildx",
 			Load:     true,
 			Bake:     &schema.ContainerBuildBakeStep{File: "docker-bake.hcl"},
 		},
-	}))
+	})
+	require.Error(t, err)
+	formatted := atmosansi.Strip(errUtils.Format(err, errUtils.DefaultFormatterConfig()))
+	assert.Contains(t, formatted, "build.bake.load", "conflict error should direct users to build.bake.load")
 }
 
 // TestContainerHandlerValidateInvalidPullEchoesValue confirms that the default

--- a/pkg/runner/step/container_test.go
+++ b/pkg/runner/step/container_test.go
@@ -197,6 +197,7 @@ func TestContainerHandlerActionBlocks(t *testing.T) {
 			Target:     "runtime",
 			NoCache:    true,
 			Pull:       true,
+			Load:       true,
 			Driver: &schema.ContainerDriverConfig{
 				Name:     "atmos-build",
 				Provider: "docker-container",
@@ -230,6 +231,7 @@ func TestContainerHandlerActionBlocks(t *testing.T) {
 	assert.Equal(t, "runtime", buildCfg.Target)
 	assert.True(t, buildCfg.NoCache)
 	assert.True(t, buildCfg.Pull)
+	assert.True(t, buildCfg.Load)
 	require.NotNil(t, buildCfg.Driver)
 	assert.Equal(t, "atmos-build", buildCfg.Driver.Name)
 	assert.Equal(t, "docker-container", buildCfg.Driver.Provider)
@@ -348,6 +350,25 @@ func TestContainerHandlerValidateActionBlocks(t *testing.T) {
 		Build: &schema.ContainerBuildStep{
 			Provider: "docker",
 			Cache:    &schema.ContainerCacheConfig{From: []map[string]string{{"type": "registry"}}},
+		},
+	}))
+	assert.Error(t, handler.Validate(&schema.WorkflowStep{
+		Name:   "load-without-buildx",
+		Type:   "container",
+		Action: "build",
+		Build: &schema.ContainerBuildStep{
+			Provider: "docker",
+			Load:     true,
+		},
+	}))
+	assert.NoError(t, handler.Validate(&schema.WorkflowStep{
+		Name:   "load-with-buildx",
+		Type:   "container",
+		Action: "build",
+		Build: &schema.ContainerBuildStep{
+			Provider: "docker",
+			Engine:   "buildx",
+			Load:     true,
 		},
 	}))
 }

--- a/pkg/runner/step/container_test.go
+++ b/pkg/runner/step/container_test.go
@@ -371,6 +371,16 @@ func TestContainerHandlerValidateActionBlocks(t *testing.T) {
 			Load:     true,
 		},
 	}))
+	assert.Error(t, handler.Validate(&schema.WorkflowStep{
+		Name:   "load-with-bake",
+		Type:   "container",
+		Action: "build",
+		Build: &schema.ContainerBuildStep{
+			Provider: "docker",
+			Load:     true,
+			Bake:     &schema.ContainerBuildBakeStep{File: "docker-bake.hcl"},
+		},
+	}))
 }
 
 // TestContainerHandlerValidateInvalidPullEchoesValue confirms that the default

--- a/pkg/schema/workflow.go
+++ b/pkg/schema/workflow.go
@@ -130,6 +130,7 @@ type ContainerBuildStep struct {
 	Target           string                  `yaml:"target,omitempty" json:"target,omitempty" mapstructure:"target"`
 	NoCache          bool                    `yaml:"no_cache,omitempty" json:"no_cache,omitempty" mapstructure:"no_cache"`
 	Pull             bool                    `yaml:"pull,omitempty" json:"pull,omitempty" mapstructure:"pull"`
+	Load             bool                    `yaml:"load,omitempty" json:"load,omitempty" mapstructure:"load"`
 	Bake             *ContainerBuildBakeStep `yaml:"bake,omitempty" json:"bake,omitempty" mapstructure:"bake"`
 	Driver           *ContainerDriverConfig  `yaml:"driver,omitempty" json:"driver,omitempty" mapstructure:"driver"`
 	Cache            *ContainerCacheConfig   `yaml:"cache,omitempty" json:"cache,omitempty" mapstructure:"cache"`

--- a/website/docs/workflows/workflows/workflow/steps/type/container.mdx
+++ b/website/docs/workflows/workflows/workflow/steps/type/container.mdx
@@ -71,6 +71,7 @@ steps:
       target: runtime           # target stage in a multi-stage build
       no_cache: false           # disable the build cache
       pull: true                # always pull newer base images
+      load: true                # load the built image into the local image store (buildx only)
       driver: docker-container  # Buildx builder driver (shorthand — see Driver below)
       cache:                    # Buildx cache import/export (see Cache below)
         from:
@@ -103,6 +104,9 @@ steps:
 
   <dt>`pull`</dt>
   <dd>Always attempt to pull newer base images when set to `true`.</dd>
+
+  <dt>`load`</dt>
+  <dd>Load the built image into the local image store when set to `true`. Requires `engine: buildx`. Needed when a Buildx driver other than the default (e.g. `docker-container`) builds to BuildKit's own cache instead of the local Docker image store — without it, a later `action: push` step won't find the image. Equivalent to `bake.load` but for the plain (non-bake) build path — no `docker-bake.hcl` file required.</dd>
 
   <dt>`engine`</dt>
   <dd>Build engine: `buildx` for Docker BuildKit, or omit for the default builder. Requires `provider: docker`.</dd>
@@ -225,7 +229,14 @@ with:
   <dd>List of overrides in `target.key=value` form.</dd>
 
   <dt>`vars`</dt>
-  <dd>Map of bake variables.</dd>
+  <dd>
+    Map of bake variables, passed to `docker buildx bake` as environment variables rather
+    than the `--var` CLI flag (a newer buildx feature not implemented by every buildx
+    release, e.g. the version Debian Trixie ships). Each entry must correspond to a
+    `variable "NAME" { default = ... }` block already declared in your bake file — Atmos
+    supplies values via the same mechanism buildx has always used to resolve HCL `variable`
+    blocks from the environment.
+  </dd>
 
   <dt>`load`</dt>
   <dd>Load the built image into the local image store.</dd>


### PR DESCRIPTION
## what

- Adds a standalone `load: true` field to the plain (non-bake) `engine: buildx` `container` build step, so `docker buildx build --load` works without adopting `bake:`.
- Wires the new field through schema, build-config, arg-building, and validation (`load: true` now requires `engine: buildx`, mirroring the existing `driver`/`cache` check).
- Switches `bake.vars` from the `--var` CLI flag to environment-variable injection (`NAME=value`), since `docker buildx bake` has always resolved HCL `variable {}` blocks from the environment, while `--var` is a newer flag missing from older buildx builds (e.g. Debian Trixie's 0.13.1).
- Documents both changes in `website/docs/workflows/workflows/workflow/steps/type/container.mdx` and records the fixes in `docs/fixes/`.

## why

- With a non-default Buildx driver (e.g. `docker-container`), a build's output lands in BuildKit's own cache rather than the local Docker image store, so a following `push` step can't find the image unless `--load` is passed. Previously `load` only existed under `bake:`, forcing anyone who needed `--load` to also adopt an external `docker-bake.hcl` file just to flip one boolean.
- `docker buildx bake --var` isn't implemented on every buildx release (e.g. Debian Trixie ships 0.13.1, which predates `docker/buildx#3610`), so builds using `bake.vars` failed with `unknown flag: --var` on those hosts. Environment-variable injection is the pre-existing, universally-supported mechanism `docker buildx bake` uses to resolve HCL `variable "NAME" {}` blocks, so it fixes portability with no change in what a bake file can express.

## references

- `docs/fixes/2026-08-20-container-build-load-without-bake.md`
- `docs/fixes/2026-08-19-container-bake-vars-env-injection.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `load` support for plain Buildx builds, allowing images to be added to the local Docker image store.
  * Improved Bake variable handling through environment-based resolution and broader Buildx compatibility.

* **Bug Fixes**
  * Added validation for incompatible image-loading configurations.
  * Improved reliability for slower environments during container session startup.

* **Documentation**
  * Documented image-loading requirements and Bake variable behavior.
  * Added fix notes covering container build and Bake variable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->