### PR TITLE
fix(commands): rename semantic_type to provides for custom command args/flags

### DIFF
--- a/agent-skills/skills/atmos-modernization/SKILL.md
+++ b/agent-skills/skills/atmos-modernization/SKILL.md
@@ -18,6 +18,7 @@ the umbrella term for replacing legacy patterns with supported, current patterns
 |---|---|
 | `name_pattern` | `name_template` or explicit stack `name` |
 | `settings.depends_on` | `dependencies.components` |
+| Custom command `type: component`/`type: stack` on arguments, or `semantic_type: component`/`semantic_type: stack` on flags | `provides: component`/`provides: stack` on both arguments and flags |
 | `cloudposse/github-action-atmos*` wrapper actions | Native CI with direct `atmos` commands |
 | `cloudposse/github-action-atmos-component-updater` | `atmos vendor update --pull-request` with native GitHub PR publishing |
 | `cloudposse/github-action-setup-atmos` as default | GitHub Actions container `ghcr.io/cloudposse/atmos:<version>` |

--- a/cmd/cmd_semantic_completion.go
+++ b/cmd/cmd_semantic_completion.go
@@ -49,8 +49,8 @@ func customComponentCompletion(componentType string) func(*cobra.Command, []stri
 }
 
 // registerSemanticFlagCompletions registers completion for flags with semantic types.
-// This adds tab completion for flags like --stack (semantic_type: stack) and
-// --component (semantic_type: component) in custom commands.
+// This adds tab completion for flags like --stack (provides: stack) and
+// --component (provides: component) in custom commands.
 func registerSemanticFlagCompletions(cmd *cobra.Command, commandConfig *schema.Command) {
 	defer perf.Track(nil, "cmd.registerSemanticFlagCompletions")()
 
@@ -60,7 +60,7 @@ func registerSemanticFlagCompletions(cmd *cobra.Command, commandConfig *schema.C
 
 	for _, flag := range commandConfig.Flags {
 		var err error
-		switch flag.SemanticType {
+		switch flag.EffectiveProvides() {
 		case semanticTypeStack:
 			err = cmd.RegisterFlagCompletionFunc(flag.Name, StackFlagCompletion)
 		case semanticTypeComponent:
@@ -75,7 +75,7 @@ func registerSemanticFlagCompletions(cmd *cobra.Command, commandConfig *schema.C
 }
 
 // setSemanticArgCompletion sets ValidArgsFunction for the first semantic-typed argument.
-// This enables tab completion for positional arguments with type: component or type: stack.
+// This enables tab completion for positional arguments with provides: component or provides: stack.
 func setSemanticArgCompletion(cmd *cobra.Command, commandConfig *schema.Command) {
 	defer perf.Track(nil, "cmd.setSemanticArgCompletion")()
 
@@ -85,7 +85,7 @@ func setSemanticArgCompletion(cmd *cobra.Command, commandConfig *schema.Command)
 
 	if len(commandConfig.Arguments) > 0 {
 		arg := commandConfig.Arguments[0]
-		switch arg.Type {
+		switch arg.EffectiveProvides() {
 		case semanticTypeComponent:
 			cmd.ValidArgsFunction = customComponentCompletion(commandConfig.Component.Type)
 		case semanticTypeStack:
@@ -168,7 +168,7 @@ func promptSemanticArguments(
 		var selected string
 		var err error
 
-		switch arg.Type {
+		switch arg.EffectiveProvides() {
 		case semanticTypeComponent:
 			selected, err = promptForComponentValue(cmd, arg.Name, commandConfig.Component.Type, stacksMap, promptCfg, true)
 		case semanticTypeStack:
@@ -204,7 +204,7 @@ func promptSemanticFlags(
 		var selected string
 		var err error
 
-		switch flag.SemanticType {
+		switch flag.EffectiveProvides() {
 		case semanticTypeComponent:
 			selected, err = promptForComponentValue(cmd, flag.Name, commandConfig.Component.Type, stacksMap, promptCfg, false)
 		case semanticTypeStack:

--- a/cmd/cmd_semantic_completion_test.go
+++ b/cmd/cmd_semantic_completion_test.go
@@ -26,7 +26,7 @@ func TestRegisterSemanticFlagCompletions(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Flags: []schema.CommandFlag{
-					{Name: "stack", SemanticType: "stack"},
+					{Name: "stack", Provides: "stack"},
 				},
 			},
 			flagsToCreate:       []string{"stack"},
@@ -37,19 +37,30 @@ func TestRegisterSemanticFlagCompletions(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Flags: []schema.CommandFlag{
-					{Name: "component", SemanticType: "component"},
+					{Name: "component", Provides: "component"},
 				},
 			},
 			flagsToCreate:       []string{"component"},
 			expectedCompletions: []string{"component"},
 		},
 		{
+			name: "registers stack completion using deprecated semantic_type (backward compatibility)",
+			commandConfig: &schema.Command{
+				Component: &schema.CommandComponent{Type: "script"},
+				Flags: []schema.CommandFlag{
+					{Name: "stack", SemanticType: "stack"},
+				},
+			},
+			flagsToCreate:       []string{"stack"},
+			expectedCompletions: []string{"stack"},
+		},
+		{
 			name: "skips non-semantic flags",
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Flags: []schema.CommandFlag{
-					{Name: "verbose", SemanticType: ""},
-					{Name: "output", SemanticType: "string"},
+					{Name: "verbose", Provides: ""},
+					{Name: "output", Provides: "string"},
 				},
 			},
 			flagsToCreate:       []string{"verbose", "output"},
@@ -89,7 +100,23 @@ func TestSetSemanticArgCompletion(t *testing.T) {
 		wantSet       bool
 	}{
 		{
-			name: "sets completion for component type",
+			name: "sets completion for component provides",
+			commandConfig: &schema.Command{
+				Component: &schema.CommandComponent{Type: "script"},
+				Arguments: []schema.CommandArgument{{Name: "app", Provides: "component"}},
+			},
+			wantSet: true,
+		},
+		{
+			name: "sets completion for stack provides",
+			commandConfig: &schema.Command{
+				Component: &schema.CommandComponent{Type: "script"},
+				Arguments: []schema.CommandArgument{{Name: "stack", Provides: "stack"}},
+			},
+			wantSet: true,
+		},
+		{
+			name: "sets completion for component using deprecated type field (backward compatibility)",
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{{Name: "app", Type: "component"}},
@@ -97,18 +124,10 @@ func TestSetSemanticArgCompletion(t *testing.T) {
 			wantSet: true,
 		},
 		{
-			name: "sets completion for stack type",
-			commandConfig: &schema.Command{
-				Component: &schema.CommandComponent{Type: "script"},
-				Arguments: []schema.CommandArgument{{Name: "stack", Type: "stack"}},
-			},
-			wantSet: true,
-		},
-		{
 			name: "does not set for string type",
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
-				Arguments: []schema.CommandArgument{{Name: "name", Type: "string"}},
+				Arguments: []schema.CommandArgument{{Name: "name", Provides: "string"}},
 			},
 			wantSet: false,
 		},
@@ -154,38 +173,45 @@ func TestPromptSemanticArguments(t *testing.T) {
 	}{
 		{
 			name:      "skips non-required argument",
-			arg:       schema.CommandArgument{Name: "comp", Type: "component", Required: false},
+			arg:       schema.CommandArgument{Name: "comp", Provides: "component", Required: false},
 			wantValue: "",
 		},
 		{
 			name:           "prompts for component argument",
-			arg:            schema.CommandArgument{Name: "comp", Type: "component", Required: true},
+			arg:            schema.CommandArgument{Name: "comp", Provides: "component", Required: true},
 			mockComponents: []string{"app1", "app2"},
 			promptResult:   "app1",
 			wantValue:      "app1",
 		},
 		{
 			name:         "prompts for stack argument",
-			arg:          schema.CommandArgument{Name: "stack", Type: "stack", Required: true},
+			arg:          schema.CommandArgument{Name: "stack", Provides: "stack", Required: true},
 			mockStacks:   []string{"dev", "prod"},
 			promptResult: "dev",
 			wantValue:    "dev",
 		},
 		{
+			name:           "prompts for component argument using deprecated type field (backward compatibility)",
+			arg:            schema.CommandArgument{Name: "comp", Type: "component", Required: true},
+			mockComponents: []string{"app1", "app2"},
+			promptResult:   "app1",
+			wantValue:      "app1",
+		},
+		{
 			name:          "skips when value already exists",
-			arg:           schema.CommandArgument{Name: "comp", Type: "component", Required: true},
+			arg:           schema.CommandArgument{Name: "comp", Provides: "component", Required: true},
 			existingValue: "existing",
 			wantValue:     "existing",
 		},
 		{
 			name:           "handles empty components list",
-			arg:            schema.CommandArgument{Name: "comp", Type: "component", Required: true},
+			arg:            schema.CommandArgument{Name: "comp", Provides: "component", Required: true},
 			mockComponents: []string{}, // Empty.
 			wantValue:      "",         // No prompt, no value.
 		},
 		{
 			name:      "skips unknown type",
-			arg:       schema.CommandArgument{Name: "name", Type: "string", Required: true},
+			arg:       schema.CommandArgument{Name: "name", Provides: "string", Required: true},
 			wantValue: "",
 		},
 	}
@@ -246,32 +272,39 @@ func TestPromptSemanticFlags(t *testing.T) {
 	}{
 		{
 			name:      "skips non-required flag",
-			flag:      schema.CommandFlag{Name: "comp", SemanticType: "component", Required: false},
+			flag:      schema.CommandFlag{Name: "comp", Provides: "component", Required: false},
 			wantValue: "",
 		},
 		{
 			name:           "prompts for component flag",
-			flag:           schema.CommandFlag{Name: "comp", SemanticType: "component", Required: true},
+			flag:           schema.CommandFlag{Name: "comp", Provides: "component", Required: true},
 			mockComponents: []string{"app1", "app2"},
 			promptResult:   "app1",
 			wantValue:      "app1",
 		},
 		{
 			name:         "prompts for stack flag",
-			flag:         schema.CommandFlag{Name: "stack", SemanticType: "stack", Required: true},
+			flag:         schema.CommandFlag{Name: "stack", Provides: "stack", Required: true},
 			mockStacks:   []string{"dev", "prod"},
 			promptResult: "dev",
 			wantValue:    "dev",
 		},
 		{
+			name:           "prompts for component flag using deprecated semantic_type field (backward compatibility)",
+			flag:           schema.CommandFlag{Name: "comp", SemanticType: "component", Required: true},
+			mockComponents: []string{"app1", "app2"},
+			promptResult:   "app1",
+			wantValue:      "app1",
+		},
+		{
 			name:          "skips when value already exists",
-			flag:          schema.CommandFlag{Name: "comp", SemanticType: "component", Required: true},
+			flag:          schema.CommandFlag{Name: "comp", Provides: "component", Required: true},
 			existingValue: "existing",
 			wantValue:     "existing",
 		},
 		{
 			name:      "skips unknown semantic type",
-			flag:      schema.CommandFlag{Name: "name", SemanticType: "", Required: true},
+			flag:      schema.CommandFlag{Name: "name", Provides: "", Required: true},
 			wantValue: "",
 		},
 	}
@@ -364,8 +397,8 @@ func TestPromptForSemanticValues(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent, Required: true},
-					{Name: "stack", Type: semanticTypeStack, Required: true},
+					{Name: "component", Provides: semanticTypeComponent, Required: true},
+					{Name: "stack", Provides: semanticTypeStack, Required: true},
 				},
 			},
 			argumentsData: map[string]string{},
@@ -378,8 +411,8 @@ func TestPromptForSemanticValues(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Flags: []schema.CommandFlag{
-					{Name: "component", SemanticType: semanticTypeComponent, Required: true},
-					{Name: "stack", SemanticType: semanticTypeStack, Required: true},
+					{Name: "component", Provides: semanticTypeComponent, Required: true},
+					{Name: "stack", Provides: semanticTypeStack, Required: true},
 				},
 			},
 			argumentsData: map[string]string{},
@@ -392,7 +425,7 @@ func TestPromptForSemanticValues(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent, Required: true},
+					{Name: "component", Provides: semanticTypeComponent, Required: true},
 				},
 			},
 			argumentsData: map[string]string{},

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -1636,14 +1636,13 @@ func cloneCommand(orig *schema.Command) (*schema.Command, error) {
 	return &clone, nil
 }
 
-// findTypedValue finds the value of an argument or flag with the specified semantic type.
-// For arguments, it checks the Type field.
-// For flags, it checks the SemanticType field.
-// Returns empty string if no matching typed argument/flag is found.
+// findTypedValue finds the value of an argument or flag whose EffectiveProvides matches
+// the given role ("component" or "stack").
+// Returns empty string if no matching argument/flag is found.
 func findTypedValue(cmd *schema.Command, argumentsData map[string]string, flagsData map[string]any, semanticType string) string {
 	// Check arguments first.
 	for _, arg := range cmd.Arguments {
-		if arg.Type == semanticType {
+		if arg.EffectiveProvides() == semanticType {
 			if val, ok := argumentsData[arg.Name]; ok {
 				return val
 			}
@@ -1652,7 +1651,7 @@ func findTypedValue(cmd *schema.Command, argumentsData map[string]string, flagsD
 
 	// Check flags.
 	for _, flag := range cmd.Flags {
-		if flag.SemanticType == semanticType {
+		if flag.EffectiveProvides() == semanticType {
 			if val, ok := flagsData[flag.Name]; ok {
 				if strVal, ok := val.(string); ok {
 					return strVal
@@ -2553,13 +2552,13 @@ func resolveCustomComponentConfig(
 ) (map[string]any, error) {
 	defer perf.Track(nil, "cmd.resolveCustomComponentConfig")()
 
-	// Find component name from argument/flag with type: component.
+	// Find component name from argument/flag with provides: component.
 	componentName := findTypedValue(commandConfig, argumentsData, flagsData, semanticTypeComponent)
 	if componentName == "" {
 		return nil, errUtils.ErrComponentArgumentNotFound
 	}
 
-	// Find stack name from argument/flag with type: stack (or semantic_type: stack for flags).
+	// Find stack name from argument/flag with provides: stack.
 	stackName := findTypedValue(commandConfig, argumentsData, flagsData, semanticTypeStack)
 	if stackName == "" {
 		return nil, errUtils.ErrStackArgumentNotFound

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -2428,11 +2428,11 @@ func TestFindTypedValue(t *testing.T) {
 		want          string
 	}{
 		{
-			name: "finds value in arguments by type",
+			name: "finds value in arguments by provides",
 			cmd: &schema.Command{
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: "component"},
-					{Name: "stack", Type: "stack"},
+					{Name: "component", Provides: "component"},
+					{Name: "stack", Provides: "stack"},
 				},
 			},
 			argumentsData: map[string]string{
@@ -2444,11 +2444,11 @@ func TestFindTypedValue(t *testing.T) {
 			want:         "vpc",
 		},
 		{
-			name: "finds value in flags by semantic type",
+			name: "finds value in flags by provides",
 			cmd: &schema.Command{
 				Flags: []schema.CommandFlag{
-					{Name: "stack", SemanticType: "stack"},
-					{Name: "component", SemanticType: "component"},
+					{Name: "stack", Provides: "stack"},
+					{Name: "component", Provides: "component"},
 				},
 			},
 			argumentsData: map[string]string{},
@@ -2458,6 +2458,42 @@ func TestFindTypedValue(t *testing.T) {
 			},
 			semanticType: "stack",
 			want:         "prod",
+		},
+		{
+			name: "falls back to deprecated Type when Provides unset on argument",
+			cmd: &schema.Command{
+				Arguments: []schema.CommandArgument{
+					{Name: "component", Type: "component"},
+				},
+			},
+			argumentsData: map[string]string{"component": "vpc"},
+			flagsData:     map[string]any{},
+			semanticType:  "component",
+			want:          "vpc",
+		},
+		{
+			name: "falls back to deprecated SemanticType when Provides unset on flag",
+			cmd: &schema.Command{
+				Flags: []schema.CommandFlag{
+					{Name: "stack", SemanticType: "stack"},
+				},
+			},
+			argumentsData: map[string]string{},
+			flagsData:     map[string]any{"stack": "prod"},
+			semanticType:  "stack",
+			want:          "prod",
+		},
+		{
+			name: "Provides takes precedence over deprecated Type on argument",
+			cmd: &schema.Command{
+				Arguments: []schema.CommandArgument{
+					{Name: "component", Provides: "component", Type: "stack"},
+				},
+			},
+			argumentsData: map[string]string{"component": "vpc"},
+			flagsData:     map[string]any{},
+			semanticType:  "component",
+			want:          "vpc",
 		},
 		{
 			name: "returns empty when not found in arguments",
@@ -2499,10 +2535,10 @@ func TestFindTypedValue(t *testing.T) {
 			name: "arguments take precedence over flags",
 			cmd: &schema.Command{
 				Arguments: []schema.CommandArgument{
-					{Name: "comp", Type: "component"},
+					{Name: "comp", Provides: "component"},
 				},
 				Flags: []schema.CommandFlag{
-					{Name: "component", SemanticType: "component"},
+					{Name: "component", Provides: "component"},
 				},
 			},
 			argumentsData: map[string]string{"comp": "from-arg"},
@@ -2558,7 +2594,7 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			name: "missing component argument returns ErrComponentArgumentNotFound",
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
-				Arguments: []schema.CommandArgument{{Name: "component", Type: semanticTypeComponent}},
+				Arguments: []schema.CommandArgument{{Name: "component", Provides: semanticTypeComponent}},
 			},
 			argumentsData: map[string]string{},
 			flagsData:     map[string]any{},
@@ -2569,8 +2605,8 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent},
-					{Name: "stack", Type: semanticTypeStack},
+					{Name: "component", Provides: semanticTypeComponent},
+					{Name: "stack", Provides: semanticTypeStack},
 				},
 			},
 			argumentsData: map[string]string{"component": "deploy-app"},
@@ -2582,8 +2618,8 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent},
-					{Name: "stack", Type: semanticTypeStack},
+					{Name: "component", Provides: semanticTypeComponent},
+					{Name: "stack", Provides: semanticTypeStack},
 				},
 			},
 			argumentsData: map[string]string{"component": "deploy-app", "stack": "dev"},
@@ -2597,8 +2633,8 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent},
-					{Name: "stack", Type: semanticTypeStack},
+					{Name: "component", Provides: semanticTypeComponent},
+					{Name: "stack", Provides: semanticTypeStack},
 				},
 			},
 			argumentsData: map[string]string{"component": "deploy-app", "stack": "dev"},
@@ -2612,8 +2648,8 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script"},
 				Arguments: []schema.CommandArgument{
-					{Name: "component", Type: semanticTypeComponent},
-					{Name: "stack", Type: semanticTypeStack},
+					{Name: "component", Provides: semanticTypeComponent},
+					{Name: "stack", Provides: semanticTypeStack},
 				},
 			},
 			argumentsData: map[string]string{"component": "deploy-app", "stack": "dev"},
@@ -2627,8 +2663,8 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			commandConfig: &schema.Command{
 				Component: &schema.CommandComponent{Type: "script", BasePath: "custom/path"},
 				Flags: []schema.CommandFlag{
-					{Name: "component", SemanticType: semanticTypeComponent},
-					{Name: "stack", SemanticType: semanticTypeStack},
+					{Name: "component", Provides: semanticTypeComponent},
+					{Name: "stack", Provides: semanticTypeStack},
 				},
 			},
 			argumentsData: map[string]string{},
@@ -2636,6 +2672,23 @@ func TestResolveCustomComponentConfig(t *testing.T) {
 			describeRet:   map[string]any{"component": "deploy-app"},
 			wantConfig:    map[string]any{"component": "deploy-app"},
 			wantBasePath:  "custom/path", // explicit basePath is preserved.
+		},
+		{
+			name: "success using deprecated type/semantic_type fields (backward compatibility)",
+			commandConfig: &schema.Command{
+				Component: &schema.CommandComponent{Type: "script"},
+				Arguments: []schema.CommandArgument{
+					{Name: "component", Type: semanticTypeComponent},
+				},
+				Flags: []schema.CommandFlag{
+					{Name: "stack", SemanticType: semanticTypeStack},
+				},
+			},
+			argumentsData: map[string]string{"component": "deploy-app"},
+			flagsData:     map[string]any{"stack": "dev"},
+			describeRet:   map[string]any{"vars": map[string]any{"foo": "bar"}},
+			wantConfig:    map[string]any{"vars": map[string]any{"foo": "bar"}},
+			wantBasePath:  "components/script",
 		},
 	}
 

--- a/cmd/custom_command_integration_test.go
+++ b/cmd/custom_command_integration_test.go
@@ -1560,10 +1560,10 @@ func TestCustomCommandIntegration_ComponentEnvExported(t *testing.T) {
 		Name:        "test-component-env",
 		Description: "Dump the environment of a custom component step",
 		Arguments: []schema.CommandArgument{
-			{Name: "component", Type: "component", Required: true},
+			{Name: "component", Provides: "component", Required: true},
 		},
 		Flags: []schema.CommandFlag{
-			{Name: "stack", Shorthand: "s", SemanticType: "stack", Required: true},
+			{Name: "stack", Shorthand: "s", Provides: "stack", Required: true},
 		},
 		Component: &schema.CommandComponent{Type: "script"},
 		Env:       []schema.CommandEnv{{Key: "_ATMOS_TEST_DUMP_ENV", Value: envOutputFile}},

--- a/examples/custom-components/README.md
+++ b/examples/custom-components/README.md
@@ -58,7 +58,7 @@ examples/custom-components/
 
 1. **Custom Command Definition** (`atmos.yaml`):
    - The `script` command defines a custom component type
-   - Arguments and flags with `type: component` and `semantic_type: stack` identify which values to use
+   - Arguments and flags with `provides: component` and `provides: stack` identify which values to use
    - The `component:` section specifies the component type name
 
 2. **Stack Configuration** (`stacks/`):

--- a/examples/custom-components/README.md
+++ b/examples/custom-components/README.md
@@ -34,45 +34,45 @@ examples/custom-components/
 ## Usage
 
 1. Inspect the custom component type configuration:
-   ```bash
-   atmos describe config --format=yaml --query .components.script
-   ```
+    ```bash
+    atmos describe config --format=yaml --query .components.script
+    ```
 
 2. Run the custom command:
-   ```bash
-   cd examples/custom-components
-   atmos script deploy-app -s dev
-   ```
+    ```bash
+    cd examples/custom-components
+    atmos script deploy-app -s dev
+    ```
 
 3. Expected output:
-   ```
-   Component: deploy-app
-   Stack: dev
-   App: myapp
-   Version: 1.0.0
-   Replicas: 1
-   Env: deploying v1.0.0 to us-east-1
-   ```
+    ```
+    Component: deploy-app
+    Stack: dev
+    App: myapp
+    Version: 1.0.0
+    Replicas: 1
+    Env: deploying v1.0.0 to us-east-1
+    ```
 
 ## How It Works
 
 1. **Custom Command Definition** (`atmos.yaml`):
-   - The `script` command defines a custom component type
-   - Arguments and flags with `provides: component` and `provides: stack` identify which values to use
-   - The `component:` section specifies the component type name
+    - The `script` command defines a custom component type
+    - Arguments and flags with `provides: component` and `provides: stack` identify which values to use
+    - The `component:` section specifies the component type name
 
 2. **Stack Configuration** (`stacks/`):
-   - Components are defined under `components.script.<name>`
-   - Standard Atmos inheritance and overrides work as expected
+    - Components are defined under `components.script.<name>`
+    - Standard Atmos inheritance and overrides work as expected
 
 3. **Template Access**:
-   - Steps can access component config via `{{ .Component.* }}`
-   - All component sections are available: `vars`, `settings`, `metadata`, etc.
+    - Steps can access component config via `{{ .Component.* }}`
+    - All component sections are available: `vars`, `settings`, `metadata`, etc.
 
 4. **Environment Variables**:
-   - The component `env` section is exported as real environment variables to every step,
-     just like the built-in `terraform`/`helmfile`/`packer`/`ansible` component types.
-   - Steps (and scripts they invoke) read them directly as `$APP_VERSION`, `$DEPLOY_REGION`, etc.
-   - For sensitive values, use `!secret NAME` in the `env` section so the value resolves from a
-     secret backend and is masked in output — never inline a secret into the command string.
-     See [Passing secrets](https://atmos.tools/cli/configuration/secrets).
+    - The component `env` section is exported as real environment variables to every step,
+      just like the built-in `terraform`/`helmfile`/`packer`/`ansible` component types.
+    - Steps (and scripts they invoke) read them directly as `$APP_VERSION`, `$DEPLOY_REGION`, etc.
+    - For sensitive values, use `!secret NAME` in the `env` section so the value resolves from a
+      secret backend and is masked in output — never inline a secret into the command string.
+      See [Passing secrets](https://atmos.tools/cli/configuration/secrets).

--- a/examples/custom-components/README.md
+++ b/examples/custom-components/README.md
@@ -45,7 +45,7 @@ examples/custom-components/
     ```
 
 3. Expected output:
-    ```
+    ```text
     Component: deploy-app
     Stack: dev
     App: myapp

--- a/examples/custom-components/atmos.yaml
+++ b/examples/custom-components/atmos.yaml
@@ -15,13 +15,13 @@ commands:
     arguments:
       - name: component
         description: "Component name"
-        type: component
+        provides: component
         required: true
     flags:
       - name: stack
         shorthand: s
         description: "Stack name"
-        semantic_type: stack
+        provides: stack
         required: true
     component:
       type: script

--- a/pkg/config/schema/generate_test.go
+++ b/pkg/config/schema/generate_test.go
@@ -93,6 +93,8 @@ func TestGenerateMarksDeprecatedConfigurationFields(t *testing.T) {
 		{"Docs", "pagination", "settings.terminal.pagination"},
 		{"Provider", "provider_type", "driver"},
 		{"VersionProvider", "type", "kind"},
+		{"CommandArgument", "type", "provides"},
+		{"CommandFlag", "semantic_type", "provides"},
 	} {
 		t.Run(test.definition+"/"+test.property, func(t *testing.T) {
 			definition := defs[test.definition].(map[string]any)

--- a/pkg/datafetcher/schema/atmos/config/1.0.json
+++ b/pkg/datafetcher/schema/atmos/config/1.0.json
@@ -3502,7 +3502,7 @@
             }
           ]
         },
-        "type": {
+        "provides": {
           "anyOf": [
             {
               "type": "string"
@@ -3511,7 +3511,20 @@
               "type": "null"
             }
           ],
-          "description": "Type specifies the semantic type of this argument: \"component\" or \"stack\".\nWhen set, the argument value is used to resolve component configuration."
+          "description": "Provides specifies what this argument's value provides: \"component\" or \"stack\".\nWhen set, the argument value is used to resolve component configuration."
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string",
+              "deprecated": true,
+              "x-atmos-replacement": "provides"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Deprecated: use Provides."
         },
         "values": {
           "anyOf": [
@@ -3700,7 +3713,7 @@
           ]
         },
         "default": true,
-        "semantic_type": {
+        "provides": {
           "anyOf": [
             {
               "type": "string"
@@ -3709,7 +3722,20 @@
               "type": "null"
             }
           ],
-          "description": "SemanticType specifies the semantic type of this flag: \"component\" or \"stack\".\nWhen set, the flag value is used to resolve component configuration."
+          "description": "Provides specifies what this flag's value provides: \"component\" or \"stack\".\nWhen set, the flag value is used to resolve component configuration."
+        },
+        "semantic_type": {
+          "anyOf": [
+            {
+              "type": "string",
+              "deprecated": true,
+              "x-atmos-replacement": "provides"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Deprecated: use Provides."
         },
         "values": {
           "anyOf": [

--- a/pkg/schema/command.go
+++ b/pkg/schema/command.go
@@ -84,14 +84,24 @@ type CommandArgument struct {
 	Description string `yaml:"description" json:"description" mapstructure:"description"`
 	Required    bool   `yaml:"required" json:"required" mapstructure:"required"`
 	Default     string `yaml:"default" json:"default" mapstructure:"default"`
-	// Type specifies the semantic type of this argument: "component" or "stack".
+	// Provides specifies what this argument's value provides: "component" or "stack".
 	// When set, the argument value is used to resolve component configuration.
-	Type string `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type"`
+	Provides string `yaml:"provides,omitempty" json:"provides,omitempty" mapstructure:"provides"`
+	Type     string `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type" jsonschema_extras:"deprecated=true,x-atmos-replacement=provides"` // Deprecated: use Provides.
 	// Values restricts this argument to a fixed set of allowed strings, validated the same way
 	// pkg/flags' built-in-command `valid_values:` already is (flags.ValidateValue). When
 	// Required and missing in an interactive terminal, the user is prompted to pick one instead
 	// of erroring, reusing pkg/flags/interactive.go's PromptForPositionalArg machinery.
 	Values []string `yaml:"values,omitempty" json:"values,omitempty" mapstructure:"values"`
+}
+
+// EffectiveProvides returns Provides, falling back to the deprecated Type field
+// for configs authored before Provides existed.
+func (a *CommandArgument) EffectiveProvides() string {
+	if a.Provides != "" {
+		return a.Provides
+	}
+	return a.Type
 }
 
 // CommandFlag defines a flag for a custom command.
@@ -103,14 +113,24 @@ type CommandFlag struct {
 	Usage       string `yaml:"usage" json:"usage" mapstructure:"usage"`
 	Required    bool   `yaml:"required" json:"required" mapstructure:"required"`
 	Default     any    `yaml:"default" json:"default" mapstructure:"default"`
-	// SemanticType specifies the semantic type of this flag: "component" or "stack".
+	// Provides specifies what this flag's value provides: "component" or "stack".
 	// When set, the flag value is used to resolve component configuration.
-	SemanticType string `yaml:"semantic_type,omitempty" json:"semantic_type,omitempty" mapstructure:"semantic_type"`
+	Provides     string `yaml:"provides,omitempty" json:"provides,omitempty" mapstructure:"provides"`
+	SemanticType string `yaml:"semantic_type,omitempty" json:"semantic_type,omitempty" mapstructure:"semantic_type" jsonschema_extras:"deprecated=true,x-atmos-replacement=provides"` // Deprecated: use Provides.
 	// Values restricts this flag to a fixed set of allowed strings, validated the same way
 	// pkg/flags' built-in-command `valid_values:` already is (flags.ValidateValue). When
 	// Required and missing in an interactive terminal, the user is prompted to pick one instead
 	// of erroring, reusing pkg/flags/interactive.go's PromptForMissingRequired machinery.
 	Values []string `yaml:"values,omitempty" json:"values,omitempty" mapstructure:"values"`
+}
+
+// EffectiveProvides returns Provides, falling back to the deprecated SemanticType field
+// for configs authored before Provides existed.
+func (f *CommandFlag) EffectiveProvides() string {
+	if f.Provides != "" {
+		return f.Provides
+	}
+	return f.SemanticType
 }
 
 // CommandEnv defines an environment variable for a custom command.

--- a/pkg/schema/command_test.go
+++ b/pkg/schema/command_test.go
@@ -94,3 +94,63 @@ func TestDecodeCommandEnvMapValue_UnexpectedKind(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrTaskUnexpectedNodeKind))
 	assert.Contains(t, err.Error(), "BAD_KEY")
 }
+
+func TestCommandArgument_EffectiveProvides(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  CommandArgument
+		want string
+	}{
+		{
+			name: "Provides set wins",
+			arg:  CommandArgument{Provides: "component", Type: "stack"},
+			want: "component",
+		},
+		{
+			name: "falls back to deprecated Type when Provides unset",
+			arg:  CommandArgument{Type: "stack"},
+			want: "stack",
+		},
+		{
+			name: "empty when neither set",
+			arg:  CommandArgument{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.arg.EffectiveProvides())
+		})
+	}
+}
+
+func TestCommandFlag_EffectiveProvides(t *testing.T) {
+	tests := []struct {
+		name string
+		flag CommandFlag
+		want string
+	}{
+		{
+			name: "Provides set wins",
+			flag: CommandFlag{Provides: "component", SemanticType: "stack"},
+			want: "component",
+		},
+		{
+			name: "falls back to deprecated SemanticType when Provides unset",
+			flag: CommandFlag{SemanticType: "stack"},
+			want: "stack",
+		},
+		{
+			name: "empty when neither set",
+			flag: CommandFlag{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.flag.EffectiveProvides())
+		})
+	}
+}

--- a/website/docs/cli/configuration/commands/command/arguments.mdx
+++ b/website/docs/cli/configuration/commands/command/arguments.mdx
@@ -89,10 +89,10 @@ PLAY [web] *********************************************************************
 
 ## Typed Arguments
 
-Set `type: component` or `type: stack` to tell Atmos that an argument provides the component
-name or stack name. Atmos then resolves the matching component configuration and exposes it as
-`{{ .Component.* }}`. See [`component`](/cli/configuration/commands/component) for the full
-custom component type workflow.
+Set `provides: component` or `provides: stack` to tell Atmos that an argument provides the
+component name or stack name. Atmos then resolves the matching component configuration and
+exposes it as `{{ .Component.* }}`. See [`component`](/cli/configuration/commands/component) for
+the full custom component type workflow.
 
 ```yaml
 commands:
@@ -101,7 +101,7 @@ commands:
     arguments:
       - name: component
         description: "Component name"
-        type: component              # this argument provides the component name
+        provides: component          # this argument provides the component name
         required: true
     component:
       type: script
@@ -109,5 +109,13 @@ commands:
       - 'echo "Running {{ .Component.component }} in {{ .Component.atmos_stack }}"'
 ```
 
-For flags, use [`semantic_type`](/cli/configuration/commands/flags#semantic-types) instead of
-`type` (since `type` on a flag specifies its data type).
+The same `provides:` field works on flags too — see
+[`provides`](/cli/configuration/commands/flags#provides).
+
+<details>
+<summary>Deprecated: `type: component` / `type: stack`</summary>
+
+Older configs may still use `type: component` or `type: stack` on arguments. This still works but
+is deprecated in favor of `provides:`, which uses the same field name on both arguments and flags.
+
+</details>

--- a/website/docs/cli/configuration/commands/command/component.mdx
+++ b/website/docs/cli/configuration/commands/command/component.mdx
@@ -22,12 +22,15 @@ When you define a `component:` section in a custom command with a `type`, Atmos:
 
 ### Typed Arguments and Flags
 
-To tell Atmos which argument or flag provides the component name and stack name, use semantic types:
+To tell Atmos which argument or flag provides the component name and stack name, set `provides:`
+on the argument or flag definition:
 
-- **Arguments**: Set `type: component` or `type: stack` in the argument definition
-- **Flags**: Set `semantic_type: component` or `semantic_type: stack` in the flag definition
+- **Arguments**: Set `provides: component` or `provides: stack`
+- **Flags**: Set `provides: component` or `provides: stack`
 
-Note: For flags, we use `semantic_type` because `type` is already used to specify the data type (`string`, `bool`).
+Older configs may instead use `type: component`/`type: stack` on arguments, or
+`semantic_type: component`/`semantic_type: stack` on flags — both still work but are deprecated in
+favor of `provides:`, which uses the same field name on both.
 
 ### Example: Script Runner
 
@@ -42,13 +45,13 @@ commands:
     arguments:
       - name: component
         description: "Component name"
-        type: component              # This argument provides the component name
+        provides: component          # This argument provides the component name
         required: true
     flags:
       - name: stack
         shorthand: s
         description: "Stack name"
-        semantic_type: stack         # This flag provides the stack name
+        provides: stack               # This flag provides the stack name
         required: true
     component:
       type: script                   # Define the custom component type
@@ -144,12 +147,12 @@ commands:
   - name: deploy
     arguments:
       - name: component
-        type: component
+        provides: component
         required: true
     flags:
       - name: stack
         shorthand: s
-        semantic_type: stack
+        provides: stack
         required: true
     component:
       type: script
@@ -200,12 +203,12 @@ commands:
     description: "Run Ansible playbooks"
     arguments:
       - name: component
-        type: component
+        provides: component
         required: true
     flags:
       - name: stack
         shorthand: s
-        semantic_type: stack
+        provides: stack
         required: true
       - name: check
         description: "Run in check mode (dry-run)"
@@ -230,12 +233,12 @@ commands:
     description: "Apply Kubernetes manifests"
     arguments:
       - name: component
-        type: component
+        provides: component
         required: true
     flags:
       - name: stack
         shorthand: s
-        semantic_type: stack
+        provides: stack
         required: true
       - name: dry-run
         type: bool

--- a/website/docs/cli/configuration/commands/command/flags.mdx
+++ b/website/docs/cli/configuration/commands/command/flags.mdx
@@ -59,8 +59,8 @@ atmos hello -n world
   <dt>`default`</dt>
   <dd>Value used when the flag is omitted. See [Flag Defaults](#flag-defaults).</dd>
 
-  <dt>`semantic_type`</dt>
-  <dd>Optional `component` or `stack`. See [Semantic Types](#semantic-types).</dd>
+  <dt>`provides`</dt>
+  <dd>Optional `component` or `stack`. See [Provides](#provides).</dd>
 
   <dt>`values`</dt>
   <dd>Optional list of allowed string values. See [Restricting Values](#restricting-values).</dd>
@@ -198,12 +198,11 @@ flags:
 
 When a flag has a default value, users can omit it from the command line. The default value will be used unless explicitly overridden.
 
-## Semantic Types
+## Provides
 
-Set `semantic_type: component` or `semantic_type: stack` to tell Atmos that a flag provides the
+Set `provides: component` or `provides: stack` to tell Atmos that a flag provides the
 component name or stack name, so Atmos can resolve the matching component configuration and expose
-it as `{{ .Component.* }}`. We use `semantic_type` for flags because `type` already specifies the
-data type (`string`, `bool`).
+it as `{{ .Component.* }}`. The same `provides:` field is used on [arguments](/cli/configuration/commands/arguments#typed-arguments).
 
 ```yaml
 commands:
@@ -213,7 +212,7 @@ commands:
       - name: stack
         shorthand: s
         description: "Stack name"
-        semantic_type: stack         # this flag provides the stack name
+        provides: stack               # this flag provides the stack name
         required: true
     component:
       type: script
@@ -222,6 +221,14 @@ commands:
 ```
 
 See [`component`](/cli/configuration/commands/component) for the full custom component type workflow.
+
+<details>
+<summary>Deprecated: `semantic_type`</summary>
+
+Older configs may still use `semantic_type: component` or `semantic_type: stack`. This still works
+but is deprecated in favor of `provides:`, which frees `type` to mean only the flag's data type.
+
+</details>
 
 ## Restricting Values
 

--- a/website/docs/components/custom.mdx
+++ b/website/docs/components/custom.mdx
@@ -25,12 +25,12 @@ commands:
     description: "Run script components"
     arguments:
       - name: component
-        type: component          # Provides the component name
+        provides: component      # Provides the component name
         required: true
     flags:
       - name: stack
         shorthand: s
-        semantic_type: stack     # Provides the stack name
+        provides: stack           # Provides the stack name
         required: true
     component:
       type: script               # Your custom component type


### PR DESCRIPTION
## what

- Add a `provides:` field to custom-command `arguments:` and `flags:`, replacing the two inconsistent spellings of the same "this value provides the component/stack name" concept: `type: component`/`type: stack` on arguments, and `semantic_type: component`/`semantic_type: stack` on flags.
- Deprecate `Type` (on `CommandArgument`) and `SemanticType` (on `CommandFlag`) via the existing `jsonschema_extras` deprecation pattern (schema marks them `deprecated` with `x-atmos-replacement: provides`), with a new `EffectiveProvides()` helper so existing configs using the old fields keep working unchanged.
- Regenerate the committed JSON Schema and update docs (`arguments.mdx`, `flags.mdx`, `component.mdx`, `custom.mdx`), the `examples/custom-components/` fixture, and the `atmos-modernization` skill's legacy-pattern checklist.

## why

- `semantic_type` existed only on `CommandFlag` because `Flag.Type` was already used for the flag's data type (`string`/`bool`); `CommandArgument.Type` carried the identical role under a different name purely because arguments don't have a competing data-type field. Same concept, two field names, driven by an implementation detail rather than a naming decision.
- `provides:` uses one consistent field name on both arguments and flags, and matches the wording the docs already used to describe the behavior in prose ("this flag provides the stack name").
- This field shipped in a prior release (custom component types, #1904), so the rename is backward-compatible: old configs keep working, marked deprecated, rather than breaking on upgrade.

## references

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `provides` configuration for identifying component and stack values in command arguments and flags.
  * Updated completion and value resolution to use the new metadata.

* **Bug Fixes**
  * Preserved compatibility with existing `type` and `semantic_type` configurations, with the new `provides` value taking precedence.

* **Documentation**
  * Updated command configuration guides and examples to use `provides`.
  * Marked legacy configuration fields as deprecated while documenting continued support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->