### PR TITLE
fix: name the offending component/stack in backend_type mismatch errors

### DIFF
--- a/internal/exec/stack_processor_backend.go
+++ b/internal/exec/stack_processor_backend.go
@@ -22,6 +22,7 @@ const (
 type terraformBackendConfig struct {
 	atmosConfig                 *schema.AtmosConfiguration
 	component                   string
+	stackName                   string
 	baseComponentName           string
 	componentMetadata           map[string]any
 	globalBackendType           string
@@ -67,6 +68,7 @@ func processTerraformBackend(cfg *terraformBackendConfig) (string, map[string]an
 		}
 	} else if err := checkTerraformBackendTypeMatch(
 		cfg.component,
+		cfg.stackName,
 		finalComponentBackendType,
 		finalComponentBackendSection,
 	); err != nil {
@@ -97,7 +99,14 @@ func processTerraformBackend(cfg *terraformBackendConfig) (string, map[string]an
 // config. An empty backend_type is a separate, already-handled case (the
 // caller skips backend generation and logs a warning), not a mismatch.
 // Mirrors checkRemoteStateBackendTypeMatch.
-func checkTerraformBackendTypeMatch(component, backendType string, backendSection map[string]any) error {
+//
+// Component and stackName are included directly in the hint text (not just as
+// WithContext, which only renders with --verbose) because this check fires
+// during whole-repo stack processing: a single misconfigured component in an
+// unrelated stack blocks `describe stacks`/`terraform plan` etc. for every
+// other stack too, and the resolved type/keys alone give no way to find which
+// component is actually at fault out of a large repo.
+func checkTerraformBackendTypeMatch(component, stackName, backendType string, backendSection map[string]any) error {
 	if backendType == "" || len(backendSection) == 0 {
 		return nil
 	}
@@ -110,10 +119,11 @@ func checkTerraformBackendTypeMatch(component, backendType string, backendSectio
 
 	return errUtils.Build(errUtils.ErrBackendTypeMismatch).
 		WithContext("component", component).
+		WithContext("stack", stackName).
 		WithContext("backend_type", backendType).
 		WithContext("backend_keys", strings.Join(configuredKeys, ", ")).
-		WithHintf("backend_type is %q but backend: only configures %s. Add a %q key under backend:, or change backend_type to match.",
-			backendType, strings.Join(configuredKeys, ", "), backendType).
+		WithHintf("component %q in stack %q: backend_type is %q but backend: only configures %s. Add a %q key under backend:, or change backend_type to match.",
+			component, stackName, backendType, strings.Join(configuredKeys, ", "), backendType).
 		Err()
 }
 
@@ -229,6 +239,7 @@ func shouldPreserveAuthoredKey(finalComponentBackend map[string]any, globalBacke
 type remoteStateBackendConfig struct {
 	atmosConfig                            *schema.AtmosConfiguration
 	component                              string
+	stackName                              string
 	finalComponentBackendType              string
 	finalComponentBackendSection           map[string]any
 	globalRemoteStateBackendType           string
@@ -332,6 +343,13 @@ func extractBackendTypeMap(section map[string]any, backendType, component string
 // {s3: {...}}) that would otherwise silently resolve to an empty remote-state
 // backend config. Mirrors the backend_type/backend check in
 // processTerraformBackend.
+//
+// Component and cfg.stackName are included directly in the hint text (not just as
+// WithContext, which only renders with --verbose) for the same reason as in
+// checkTerraformBackendTypeMatch: this fires during whole-repo stack processing,
+// so a mismatch anywhere blocks unrelated `describe stacks`/`terraform plan`
+// invocations too, and without naming the component/stack there is no way to
+// find which one is at fault.
 func checkRemoteStateBackendTypeMatch(cfg *remoteStateBackendConfig, finalComponentRemoteStateBackendType string) error {
 	configuredKeys := map[string]bool{}
 	for _, section := range []map[string]any{
@@ -355,10 +373,11 @@ func checkRemoteStateBackendTypeMatch(cfg *remoteStateBackendConfig, finalCompon
 
 	return errUtils.Build(errUtils.ErrBackendTypeMismatch).
 		WithContext("component", cfg.component).
+		WithContext("stack", cfg.stackName).
 		WithContext("remote_state_backend_type", finalComponentRemoteStateBackendType).
 		WithContext("remote_state_backend_keys", strings.Join(keys, ", ")).
-		WithHintf("remote_state_backend_type is %q but remote_state_backend: only configures %s. Add a %q key under remote_state_backend:, or change remote_state_backend_type to match.",
-			finalComponentRemoteStateBackendType, strings.Join(keys, ", "), finalComponentRemoteStateBackendType).
+		WithHintf("component %q in stack %q: remote_state_backend_type is %q but remote_state_backend: only configures %s. Add a %q key under remote_state_backend:, or change remote_state_backend_type to match.",
+			cfg.component, cfg.stackName, finalComponentRemoteStateBackendType, strings.Join(keys, ", "), finalComponentRemoteStateBackendType).
 		Err()
 }
 

--- a/internal/exec/stack_processor_backend_test.go
+++ b/internal/exec/stack_processor_backend_test.go
@@ -975,6 +975,31 @@ func TestProcessTerraformBackend_TypeKeyMismatch(t *testing.T) {
 		assert.True(t, errUtils.HasHint(err, "backend_type is"))
 	})
 
+	// This check runs during whole-repo stack processing (mergeComponentConfigurations
+	// processes every stack, not just the one requested via -s/--stack), so a mismatch
+	// in one component blocks describe/plan for every other stack too. Prior to this
+	// test, the component/stack causing the failure were attached only via WithContext,
+	// which the CLI's default (non---verbose) error renderer drops entirely -- the printed
+	// error gave no way to find which of potentially hundreds of components was at fault.
+	t.Run("mismatch names the offending component and stack directly in the hint", func(t *testing.T) {
+		cfg := &terraformBackendConfig{
+			atmosConfig:       &schema.AtmosConfiguration{},
+			component:         "vpc-no-provider",
+			stackName:         "orgs/cplive/plat/sandbox/us-east-2",
+			globalBackendType: "http",
+			globalBackendSection: map[string]any{
+				"s3": map[string]any{"bucket": "wrong-key-for-http"},
+			},
+		}
+		_, _, err := processTerraformBackend(cfg)
+		require.Error(t, err)
+		assert.True(t, errUtils.HasContext(err, "stack", "orgs/cplive/plat/sandbox/us-east-2"))
+		assert.True(t, errUtils.HasHint(err, "vpc-no-provider"),
+			"hint text must name the offending component directly, not just as hidden verbose-only context")
+		assert.True(t, errUtils.HasHint(err, "orgs/cplive/plat/sandbox/us-east-2"),
+			"hint text must name the offending stack directly, not just as hidden verbose-only context")
+	})
+
 	t.Run("no backend section configured at all is not a mismatch", func(t *testing.T) {
 		cfg := &terraformBackendConfig{
 			atmosConfig:       &schema.AtmosConfiguration{},
@@ -1038,6 +1063,82 @@ func TestProcessTerraformRemoteStateBackend_TypeKeyMismatch(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "http", gotType)
 	})
+
+	// Same rationale as TestProcessTerraformBackend_TypeKeyMismatch's equivalent case:
+	// the hint text is the only thing the CLI prints by default, so it must name the
+	// offending component/stack directly rather than relying on hidden verbose-only context.
+	t.Run("mismatch names the offending component and stack directly in the hint", func(t *testing.T) {
+		cfg := &remoteStateBackendConfig{
+			atmosConfig:                  &schema.AtmosConfiguration{},
+			component:                    "vpc-no-provider",
+			stackName:                    "orgs/cplive/plat/sandbox/us-east-2",
+			finalComponentBackendType:    "s3",
+			finalComponentBackendSection: map[string]any{"s3": map[string]any{"bucket": "b"}},
+			globalRemoteStateBackendType: "http",
+			globalRemoteStateBackendSection: map[string]any{
+				"s3": map[string]any{"bucket": "wrong-key-for-http"},
+			},
+		}
+		_, _, err := processTerraformRemoteStateBackend(cfg)
+		require.Error(t, err)
+		assert.True(t, errUtils.HasContext(err, "stack", "orgs/cplive/plat/sandbox/us-east-2"))
+		assert.True(t, errUtils.HasHint(err, "vpc-no-provider"),
+			"hint text must name the offending component directly, not just as hidden verbose-only context")
+		assert.True(t, errUtils.HasHint(err, "orgs/cplive/plat/sandbox/us-east-2"),
+			"hint text must name the offending stack directly, not just as hidden verbose-only context")
+	})
+}
+
+// TestProcessTerraformRemoteStateBackend_InheritedLocalTypeMismatch reproduces the exact
+// real-world shape found in cloudposse/infra-live: an org-level stack manifest sets a global
+// s3 remote_state_backend default, and one unrelated component overrides backend_type: local
+// (with a valid backend.local section, so the backend/backend_type check passes cleanly) but
+// never sets remote_state_backend_type or remote_state_backend to match. The type then
+// legitimately inherits "local" from the component's own backend_type (per
+// processTerraformRemoteStateBackend's documented precedence), but the only configured
+// remote_state_backend key anywhere in scope is the inherited global "s3" -- a genuine
+// mismatch, not a defaulting bug. This is intended behavior (the component's remote-state
+// config silently resolved to nothing under the pre-1.226.0 code, which is the exact silent-
+// misconfiguration class this check was added to catch) -- this test guards it staying an
+// error, and that the error names the component/stack.
+func TestProcessTerraformRemoteStateBackend_InheritedLocalTypeMismatch(t *testing.T) {
+	backendCfg := &terraformBackendConfig{
+		atmosConfig: &schema.AtmosConfiguration{},
+		component:   "vpc-no-provider",
+		stackName:   "orgs/cplive/plat/sandbox/us-east-2",
+		// Global backend_type is s3 (org default); the component overrides it to local.
+		globalBackendType: "s3",
+		globalBackendSection: map[string]any{
+			"s3": map[string]any{"bucket": "org-tfstate"},
+		},
+		componentBackendType: "local",
+		componentBackendSection: map[string]any{
+			"local": map[string]any{"path": "terraform.tfstate"},
+		},
+	}
+	finalBackendType, finalBackend, err := processTerraformBackend(backendCfg)
+	require.NoError(t, err, "backend_type/backend must resolve cleanly -- local is validly configured")
+	assert.Equal(t, "local", finalBackendType)
+
+	remoteCfg := &remoteStateBackendConfig{
+		atmosConfig:                  &schema.AtmosConfiguration{},
+		component:                    "vpc-no-provider",
+		stackName:                    "orgs/cplive/plat/sandbox/us-east-2",
+		finalComponentBackendType:    finalBackendType,
+		finalComponentBackendSection: map[string]any{finalBackendType: finalBackend},
+		// Global remote_state_backend only configures s3 (org default); nothing at any
+		// scope sets remote_state_backend_type or a "local" key under remote_state_backend.
+		globalRemoteStateBackendSection: map[string]any{
+			"s3": map[string]any{"role_arn": "arn:aws:iam::123456789012:role/readonly"},
+		},
+	}
+	_, _, err = processTerraformRemoteStateBackend(remoteCfg)
+	require.Error(t, err, "local backend_type with only an s3 remote_state_backend default is a genuine mismatch")
+	assert.ErrorIs(t, err, errUtils.ErrBackendTypeMismatch)
+	assert.True(t, errUtils.HasHint(err, "vpc-no-provider"))
+	assert.True(t, errUtils.HasHint(err, "orgs/cplive/plat/sandbox/us-east-2"))
+	assert.True(t, errUtils.HasHint(err, `"local"`))
+	assert.True(t, errUtils.HasHint(err, "s3"))
 }
 
 // TestShouldPreserveAuthoredKey covers the three decision paths of the

--- a/internal/exec/stack_processor_merge.go
+++ b/internal/exec/stack_processor_merge.go
@@ -572,6 +572,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 			&terraformBackendConfig{
 				atmosConfig:                 atmosConfig,
 				component:                   opts.Component,
+				stackName:                   opts.StackName,
 				baseComponentName:           result.BaseComponentName,
 				componentMetadata:           finalComponentMetadata,
 				globalBackendType:           opts.GlobalBackendType,
@@ -591,6 +592,7 @@ func mergeComponentConfigurations(atmosConfig *schema.AtmosConfiguration, opts *
 			&remoteStateBackendConfig{
 				atmosConfig:                            atmosConfig,
 				component:                              opts.Component,
+				stackName:                              opts.StackName,
 				finalComponentBackendType:              finalComponentBackendType,
 				finalComponentBackendSection:           map[string]any{finalComponentBackendType: finalComponentBackend},
 				globalRemoteStateBackendType:           opts.GlobalRemoteStateBackendType,

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -1405,7 +1405,14 @@ func TestGitHubAuthenticatedTransport_AllRedirectStatusCodes(t *testing.T) {
 			}))
 			defer origin.Close()
 
+			// Use a dedicated transport instead of falling back to http.DefaultTransport:
+			// httptest.Server.Close() unconditionally calls CloseIdleConnections() on
+			// http.DefaultTransport (net/http/httptest), which races with in-flight
+			// requests from the other parallel subtests here and intermittently fails
+			// with "http: CloseIdleConnections called". An isolated transport per
+			// subtest removes the shared state that makes this racy.
 			client := NewDefaultClient(
+				WithTransport(&http.Transport{}),
 				WithGitHubToken("redir-test-token"),
 			)
 

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/atmos.yaml
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/atmos.yaml
@@ -1,0 +1,19 @@
+base_path: "./"
+
+components:
+  terraform:
+    base_path: "components/terraform"
+    apply_auto_approve: false
+    deploy_run_init: false
+    init_run_reconfigure: false
+    auto_generate_backend_file: false
+
+stacks:
+  base_path: "stacks"
+  included_paths:
+    - "**/*"
+  name_pattern: "{stage}"
+
+logs:
+  file: "/dev/stderr"
+  level: Info

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/components/terraform/bootstrap/main.tf
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/components/terraform/bootstrap/main.tf
@@ -1,0 +1,4 @@
+variable "stage" {
+  type    = string
+  default = ""
+}

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/components/terraform/vpc/main.tf
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/components/terraform/vpc/main.tf
@@ -1,0 +1,4 @@
+variable "stage" {
+  type    = string
+  default = ""
+}

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/_defaults.yaml
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/_defaults.yaml
@@ -1,0 +1,16 @@
+# Org-level defaults, imported by every stack -- mirrors cloudposse/infra-live's
+# stacks/orgs/cplive/{core,plat}/_defaults.yaml shape: an s3 backend_type/backend and a
+# remote_state_backend that only ever configures an "s3" key. No remote_state_backend_type
+# is set anywhere at this scope; it's expected to inherit backend_type.
+terraform:
+  backend_type: s3
+  backend:
+    s3:
+      bucket: test-bucket
+      dynamodb_table: test-lock
+      encrypt: true
+      key: terraform.tfstate
+      region: us-east-1
+  remote_state_backend:
+    s3:
+      role_arn: arn:aws:iam::123456789012:role/readonly

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/dev.yaml
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/dev.yaml
@@ -1,0 +1,10 @@
+import:
+  - _defaults
+
+vars:
+  stage: dev
+
+components:
+  terraform:
+    vpc:
+      vars: {}

--- a/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/sandbox.yaml
+++ b/tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/sandbox.yaml
@@ -1,0 +1,20 @@
+# Deliberately unrelated to `dev`. Mirrors cloudposse/infra-live's
+# stacks/orgs/cplive/plat/sandbox/us-east-2.yaml `vpc-no-provider` component: overrides
+# backend_type: local with a valid backend.local section (so the backend/backend_type check
+# passes cleanly), but never sets remote_state_backend_type or a matching remote_state_backend
+# key. It inherits the org-wide s3 remote_state_backend default from _defaults.yaml, which is a
+# genuine mismatch against the "local" type inherited from its own backend_type override.
+import:
+  - _defaults
+
+vars:
+  stage: sandbox
+
+components:
+  terraform:
+    bootstrap:
+      vars: {}
+      backend_type: local
+      backend:
+        local:
+          path: terraform.tfstate

--- a/tests/test-cases/remote-state-backend-type-mismatch.yaml
+++ b/tests/test-cases/remote-state-backend-type-mismatch.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=schema.json
+# Regression coverage for the checkRemoteStateBackendTypeMatch/checkTerraformBackendTypeMatch
+# error message. Reproduces the exact shape found in cloudposse/infra-live: an org-level
+# manifest sets a global s3 remote_state_backend default (no remote_state_backend_type set
+# anywhere), and one component in a stack UNRELATED to the one being queried overrides
+# backend_type: local with a valid backend.local section but no matching remote-state override.
+# See tests/fixtures/scenarios/remote-state-backend-type-mismatch/stacks/sandbox.yaml.
+#
+# This is intentionally correct-but-surprising behavior, not a bug to remove: Atmos merges the
+# whole stacks map before filtering to the requested stack, so a genuine misconfiguration
+# anywhere blocks `describe stacks`/`terraform plan` for every stack, including totally
+# unrelated ones. The two things this guards are (1) that the mismatch keeps erroring rather
+# than silently resolving to an empty remote-state config (the pre-1.226.0 bug this check was
+# added to catch), and (2) that the error names the actual offending component and stack
+# directly in the printed hint -- previously that only existed as WithContext, which the CLI's
+# default (non---verbose) renderer drops, making the failure effectively unsleuthable in a
+# large repo (see internal/exec/stack_processor_backend_test.go's
+# TestProcessTerraformRemoteStateBackend_InheritedLocalTypeMismatch for the underlying unit).
+tests:
+  - name: "remote-state-backend-type-mismatch: unrelated stack's local backend_type blocks an unrelated describe stacks query"
+    enabled: true
+    tty: false
+    snapshot: false
+    clean: true
+    description: "describe stacks -s dev fails because of the sandbox stack's bootstrap component, and names it in the error"
+    workdir: "fixtures/scenarios/remote-state-backend-type-mismatch/"
+    command: "atmos"
+    args:
+      - "describe"
+      - "stacks"
+      - "-s"
+      - "dev"
+    expect:
+      exit_code: 1
+      stderr:
+        - "component \"bootstrap\""
+        - "stack \"sandbox\""
+        - "remote_state_backend_type is \"local\""


### PR DESCRIPTION
## what

- `checkTerraformBackendTypeMatch` / `checkRemoteStateBackendTypeMatch` now name the offending component and stack directly in the error's hint text, e.g.:
  > component "bootstrap" in stack "sandbox": remote_state_backend_type is "local" but remote_state_backend: only configures s3...
- Added a Go unit test (`TestProcessTerraformRemoteStateBackend_InheritedLocalTypeMismatch`) reproducing the exact real-world shape that surfaced this, plus hint-text assertions on the existing mismatch tests.
- Added a CLI-level fixture/test-case (`tests/fixtures/scenarios/remote-state-backend-type-mismatch/`, `tests/test-cases/remote-state-backend-type-mismatch.yaml`) proving the fix end-to-end through the real binary.

## why

- These two checks (added in #2953) run during whole-repo stack processing, so a mismatch in one component blocks `describe stacks`/`terraform plan` for every *other* stack too, including ones totally unrelated to the misconfigured component.
- The component/stack causing the failure were previously attached only via `WithContext`, which the CLI's default (non `--verbose`) error renderer drops entirely. The printed error gave zero indication of which of potentially hundreds of components across a repo was actually at fault.
- Found live in cloudposse/infra-live: `atmos describe stacks --stack core-gbl-marketplace` failed with only "remote_state_backend_type is local but remote_state_backend: only configures s3" — no component, no stack. It took manually instrumenting the binary with debug prints to discover the real cause was an unrelated `plat/sandbox` component (`vpc-no-provider`) that overrides `backend_type: local` without a matching `remote_state_backend_type`. With this fix, that same failure now reads:
  > component "vpc-no-provider" in stack "orgs/cplive/plat/sandbox/us-east-2": remote_state_backend_type is "local" but remote_state_backend: only configures s3...
  which is immediately actionable.

## references

None — found and reported internally, no existing issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terraform backend and remote-state mismatch errors with clearer component and stack context.
  * Enhanced error hints to identify conflicting backend types, including inherited configuration issues.
* **Tests**
  * Added regression coverage for backend mismatches across regular and remote-state configurations.
  * Added scenario coverage for mismatches involving unrelated stacks.
  * Improved parallel HTTP redirect test isolation to prevent connection cleanup races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->