### PR TITLE
fix(ci): bump docker-build-push to v3.2.1 to fix release job summary crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: "Docker Build"
         id: build
-        uses: cloudposse/github-action-docker-build-push@02993d675b44dcc7082e6de7485c1ff8740bce9d # v3.1.0
+        uses: cloudposse/github-action-docker-build-push@ff59bd5b5c0c953aef60f5eb9b80178fff407597 # v3.2.1
         with:
           registry: ghcr.io
           organization: "${{ github.event.repository.owner.login }}"


### PR DESCRIPTION
## what

- Bump the `Docker Build` step in `.github/workflows/build.yml` from `cloudposse/github-action-docker-build-push` **v3.1.0** (`02993d67`) to **v3.2.1** (`ff59bd5`).

## why

- The `release / Build and push Docker image for Atmos CLI` job has been failing on the post-build **Docker Inspect** summary step with `jq: error (at inspect.json:79): Cannot iterate over null (null)` → exit code 5, even though the image builds and pushes fine.
- Root cause was in the action itself: its summary step fed `docker inspect` fields (`.Config.Entrypoint`, `.Config.Cmd`, `.Config.Env`, `.RootFS.Layers`) straight into jq's `join`/`.[]`/`to_entries`, all of which iterate. Atmos's image is `FROM debian:trixie-slim` with **no `ENTRYPOINT`**, so `.Config.Entrypoint` is `null` and jq aborts; under the default `bash -e` shell that fails the whole step.
- Fixed upstream in cloudposse/github-action-docker-build-push#111 (guards each iterating expression with `// []`), released as v3.2.1. Verified `ff59bd5` contains all four guards. This bump pins Atmos to that release so the release job's summary no longer crashes.

## references

- Failing run: https://github.com/cloudposse/atmos/actions/runs/32415649296/job/96577335200
- Upstream fix: https://github.com/cloudposse/github-action-docker-build-push/pull/111
- Release: https://github.com/cloudposse/github-action-docker-build-push/releases/tag/v3.2.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build workflow to use a newer action version, improving build pipeline maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->