### PR TITLE
Add Validation, Scaffolding, and Emulators cards to landing grid

### DIFF
--- a/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
+++ b/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
@@ -1,0 +1,140 @@
+# Toolchain Verification: Cosign's TUF Trust-Root CDN Fetch Errors Weren't Classified as Retryable
+
+**Date:** 2026-08-21
+**Severity:** Medium — spurious `atmos toolchain install` / CI failures on transient Sigstore TUF CDN blips
+**Reproducer:** `pkg/toolchain/verification/signature_rekor_test.go` —
+`TestClassifySignatureVerificationError/TUF_CDN_root.json_fetch_403_is_retryable`,
+`TestClassifySignatureVerificationError/TUF_CDN_timestamp.json_fetch_403_is_retryable`,
+`TestRunCosignWithRetry_RecoversFromTUFCDNFetch403`
+
+---
+
+## Symptom
+
+CI job `[mock-linux] examples/demo-context` on PR #2974 failed installing `opentofu/opentofu`:
+
+```text
+✗ Install failed opentofu/opentofu@1.12.2: failed to verify downloaded asset: signature verification failed:
+  .../cosign [verify-blob --certificate ... --signature ... SHA256SUMS]: exit status 1
+  WARNING: Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets.
+  Error from TUF: error getting live trusted root: failed to create TUF client failed to load metadata:
+  tuf refresh failed: failed to download https://tuf-repo-cdn.sigstore.dev/16.root.json, http status code: 403
+  Error: getting Rekor public keys: updating local metadata and targets: error updating to TUF remote
+  mirror: tuf: failed to download timestamp.json: GET "https://tuf-repo-cdn.sigstore.dev/timestamp.json":
+  unexpected HTTP status 403
+```
+
+Same as the `2026-07-07` cosign-direct-fetch-5xx fix, the install failed on the first attempt —
+no retry occurred — even though `runCosignWithRetry` exists specifically to survive transient
+upstream flakes.
+
+---
+
+## Root Cause
+
+Before every `verify-blob` invocation, cosign refreshes its Sigstore TUF trust-root/timestamp
+metadata by fetching `16.root.json` and `timestamp.json` from `tuf-repo-cdn.sigstore.dev`. This
+is a third distinct network call, separate from both:
+
+- the Rekor transparency-log `/api/v1/log/entries/retrieve` endpoint (`rekorTlogEndpointMarker`,
+  already retried), and
+- a direct `--certificate`/`--signature` asset fetch (`cosignHTTPFetchMarker`, added in the
+  2026-07-07 fix).
+
+`isRetryableSignatureError` had no marker at all for this TUF-CDN fetch shape, so a transient
+`403` from the CDN — an upstream blip unrelated to the actual signature being verified — was left
+unclassified, `isRetryableCosignError` returned `false`, and the retry loop gave up after one
+attempt.
+
+---
+
+## Fix
+
+Added a fourth classification rule to `pkg/toolchain/verification/signature_rekor.go`, scoped
+tightly to the TUF CDN host rather than a bare `"403"` match anywhere in cosign output — 403 is a
+terminal authorization failure on most endpoints (see `pkg/toolchain/registry/githubratelimit.go`,
+which only treats 403 as retryable when GitHub's rate-limit headers are present), so an unscoped
+match would risk silently retrying away a real permissions problem on an unrelated request:
+
+```go
+const tufCDNHostMarker = "tuf-repo-cdn.sigstore.dev"
+
+var tufCDNRetryableStatusMarkers = []string{"http status code: 403", "unexpected HTTP status 403"}
+
+func hasTUFCDNRetryableStatus(msg string) bool {
+    if !strings.Contains(msg, tufCDNHostMarker) {
+        return false
+    }
+    return matchesAnyMarker(msg, tufCDNRetryableStatusMarkers)
+}
+```
+
+Both message phrasings observed in the CI log are matched (cosign's TUF client reports a non-2xx
+CDN response two different ways depending on which metadata file it was fetching). This is safe
+to broaden because:
+
+- The error occurs while cosign is still refreshing trust metadata — before any signature verdict
+  is rendered. It can never mask a real verification failure (tampering, expired cert, identity
+  mismatch).
+- The match requires both the TUF CDN hostname *and* one of the two observed status phrasings, so
+  a 403 anywhere else in cosign's output (e.g. a genuine auth failure fetching a private asset)
+  stays unclassified and surfaces immediately — covered by the
+  `403_outside_the_TUF_CDN_host_is_NOT_retryable` test case.
+
+No changes were needed to `runCosignWithRetry`, `cosignRetryConfig`, or `isRetryableCosignError` —
+the only gap was the classifier not wrapping this particular error shape.
+
+---
+
+## Tests
+
+`pkg/toolchain/verification/signature_rekor_test.go`:
+
+- `TestClassifySignatureVerificationError` — added cases for a `16.root.json` fetch 403, a
+  `timestamp.json` fetch 403, and a 403 outside the TUF CDN host (must NOT be retried), using the
+  verbatim error text observed in CI.
+- `TestRunCosignWithRetry_RecoversFromTUFCDNFetch403` — end-to-end: a flaky runner that fails
+  twice with the CI's exact `16.root.json ... http status code: 403` error, then succeeds; asserts
+  `runCosignWithRetry` retries and ultimately succeeds after 3 calls.
+
+---
+
+## Verification
+
+1. `go test ./pkg/toolchain/verification/... -run 'TestClassifySignatureVerificationError|TestRunCosignWithRetry'`
+   — new cases pass; all existing Rekor/transport-flake/cosign-HTTP-fetch and non-retryable cases
+   (tampering, identity mismatch, unscoped 403) remain correctly classified.
+2. `go test ./pkg/toolchain/verification/...` — full package suite passes, no regressions.
+3. `go build ./...` — clean.
+
+---
+
+## Related
+
+- `pkg/toolchain/verification/signature.go`: `runCosignWithRetry`, cosign invocation.
+- `pkg/toolchain/verification/signature_rekor.go`: `classifySignatureVerificationError`,
+  `isRetryableSignatureError`, `hasTUFCDNRetryableStatus`.
+- `docs/fixes/2026-07-07-cosign-direct-fetch-http-5xx-not-retried.md` — the prior fix for cosign's
+  *direct* asset-fetch errors; this fix covers a distinct network call (TUF trust-root refresh)
+  that neither that fix nor the Rekor-tlog handling covered.
+- PR #2974 CI run: `[mock-linux] examples/demo-context`, job ID `96885492588`.
+
+---
+
+## Known unrelated flake in the same CI run (not fixed here)
+
+The same PR's `Acceptance Tests (windows, shard 7/10)` job failed independently with:
+
+```text
+Head "https://github.com/helmfile/helmfile/releases/latest": context deadline exceeded
+--- FAIL: TestExecuteHelmfile_Version (26.47s)
+```
+
+This is the real `helmfile` binary's own internal update-check HTTP call (made by the
+toolchain-installed `helmfile` CLI itself when running `helmfile version`), not a call atmos makes
+— `internal/exec/helmfile.go`'s `version` handler shells out to `helmfile version` with no extra
+flags or env vars. No suppression flag/env var for helmfile's own update check is currently wired
+into atmos's invocation, and no other `_Version` test in the package (`TestExecuteTerraform_Version`,
+`TestExecutePacker_Version`) guards against this class of external check either, so there's no
+existing convention to extend. This is upstream/network flakiness outside atmos's code; re-run the
+job rather than patch code for it.

--- a/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
+++ b/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
@@ -93,9 +93,10 @@ the only gap was the classifier not wrapping this particular error shape.
 - `TestClassifySignatureVerificationError` — added cases for a `16.root.json` fetch 403, a
   `timestamp.json` fetch 403, and a 403 outside the TUF CDN host (must NOT be retried), using the
   verbatim error text observed in CI.
-- `TestRunCosignWithRetry_RecoversFromTUFCDNFetch403` — end-to-end: a flaky runner that fails
-  twice with the CI's exact `16.root.json ... http status code: 403` error, then succeeds; asserts
-  `runCosignWithRetry` retries and ultimately succeeds after 3 calls.
+- `TestRunCosignWithRetry_RecoversFromTUFCDNFetch403` — retry-path recovery test: an in-process
+  `flakyRunner` (not a real `cosign` binary or the external TUF service) fails twice with the CI's
+  exact `16.root.json ... http status code: 403` error, then succeeds; asserts `runCosignWithRetry`
+  retries and ultimately succeeds after 3 calls.
 
 ---
 

--- a/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
+++ b/docs/fixes/2026-08-21-cosign-tuf-cdn-403-not-retried.md
@@ -102,8 +102,8 @@ the only gap was the classifier not wrapping this particular error shape.
 ## Verification
 
 1. `go test ./pkg/toolchain/verification/... -run 'TestClassifySignatureVerificationError|TestRunCosignWithRetry'`
-   — new cases pass; all existing Rekor/transport-flake/cosign-HTTP-fetch and non-retryable cases
-   (tampering, identity mismatch, unscoped 403) remain correctly classified.
+    — new cases pass; all existing Rekor/transport-flake/cosign-HTTP-fetch and non-retryable cases
+    (tampering, identity mismatch, unscoped 403) remain correctly classified.
 2. `go test ./pkg/toolchain/verification/...` — full package suite passes, no regressions.
 3. `go build ./...` — clean.
 

--- a/pkg/toolchain/verification/signature.go
+++ b/pkg/toolchain/verification/signature.go
@@ -81,12 +81,14 @@ func (v *Verifier) verifyCosign(ctx context.Context, req *Request, cfg *registry
 }
 
 // runCosignWithRetry invokes cosign with bounded exponential backoff,
-// retrying only on transient Sigstore Rekor failures. All other cosign
-// failures (tampering, expired cert, identity mismatch, missing signature)
-// surface immediately on the first attempt.
+// retrying only on transient upstream failures (Sigstore Rekor, cosign's own
+// direct asset fetches, its TUF trust-root CDN refresh, or the network
+// transport itself). All other cosign failures (tampering, expired cert,
+// identity mismatch, missing signature) surface immediately on the first
+// attempt.
 func runCosignWithRetry(ctx context.Context, req *Request, args []string) error {
 	return runVerificationCommandWithRetry(ctx, req, "cosign", args,
-		"cosign verification hit transient Sigstore Rekor error; retrying")
+		"cosign verification hit a transient error; retrying")
 }
 
 // runVerificationCommandWithRetry invokes a verification command (cosign,

--- a/pkg/toolchain/verification/signature_rekor.go
+++ b/pkg/toolchain/verification/signature_rekor.go
@@ -91,12 +91,35 @@ const cosignHTTPFetchMarker = "server returned HTTP "
 
 var cosignHTTPFetchRetryableStatuses = []string{"429", "500", "502", "503", "504"}
 
+// tufCDNHostMarker is the Sigstore TUF trust-root CDN hostname. Before every
+// verification, cosign refreshes its TUF trust-root/timestamp metadata from
+// this host (distinct from both the Rekor tlog endpoint and a direct
+// --certificate/--signature asset fetch); a transient CDN blip here has
+// nothing to do with the signature actually being verified.
+const tufCDNHostMarker = "tuf-repo-cdn.sigstore.dev"
+
+// tufCDNRetryableStatusMarkers are the two distinct phrasings cosign's TUF
+// client uses to report a non-2xx response from the CDN, observed in CI
+// (cloudposse/atmos#2974) as a transient 403 fetching both 16.root.json and
+// timestamp.json:
+//
+//	failed to download https://tuf-repo-cdn.sigstore.dev/16.root.json, http status code: 403
+//	failed to download timestamp.json: GET "https://tuf-repo-cdn.sigstore.dev/timestamp.json": unexpected HTTP status 403
+//
+// Kept as literal message substrings, scoped to tufCDNHostMarker, rather than
+// matching a bare "403" anywhere in cosign output: 403 is a terminal
+// authorization failure elsewhere in this codebase (see
+// pkg/toolchain/registry/githubratelimit.go), so an unscoped match would risk
+// silently retrying away a real permissions problem on an unrelated request.
+var tufCDNRetryableStatusMarkers = []string{"http status code: 403", "unexpected HTTP status 403"}
+
 // classifySignatureVerificationError joins ErrSignatureRetryable into err when
-// signature-verifier output contains a known transient failure marker. Three classes qualify:
+// signature-verifier output contains a known transient failure marker. Four classes qualify:
 // Sigstore Rekor API flakes (rekorFlakeMarkers, tlog 5xx), transport-level
-// network errors (transportFlakeMarkers), and generic upstream HTTP 5xx/429
+// network errors (transportFlakeMarkers), generic upstream HTTP 5xx/429
 // responses cosign surfaces when it directly fetches a URL
-// (cosignHTTPFetchMarker). Otherwise returns err unchanged.
+// (cosignHTTPFetchMarker), and Sigstore TUF trust-root CDN fetch failures
+// (tufCDNHostMarker). Otherwise returns err unchanged.
 //
 // Never broaden what counts as retryable beyond known upstream-service
 // flakes and transport failures — real signature failures (tampering,
@@ -118,16 +141,17 @@ func classifySignatureVerificationError(err error) error {
 // isRetryableSignatureError reports whether msg matches one of the known
 // transient-failure marker categories: Sigstore Rekor API flakes
 // (rekorFlakeMarkers), transport-level network errors (transportFlakeMarkers),
-// Rekor tlog 5xx responses, Rekor stream internal errors, or generic upstream
-// HTTP 5xx/429 responses cosign surfaces when it directly fetches a URL. Kept
-// as a single predicate so classifySignatureVerificationError stays a flat
-// check-then-wrap pipeline.
+// Rekor tlog 5xx responses, Rekor stream internal errors, generic upstream
+// HTTP 5xx/429 responses cosign surfaces when it directly fetches a URL, or a
+// Sigstore TUF trust-root CDN fetch failure. Kept as a single predicate so
+// classifySignatureVerificationError stays a flat check-then-wrap pipeline.
 func isRetryableSignatureError(msg string) bool {
 	return matchesAnyMarker(msg, rekorFlakeMarkers) ||
 		matchesAnyMarker(msg, transportFlakeMarkers) ||
 		hasRekorTlog5xxStatus(msg) ||
 		isRekorStreamInternalError(msg) ||
-		hasCosignHTTPFetchRetryableStatus(msg)
+		hasCosignHTTPFetchRetryableStatus(msg) ||
+		hasTUFCDNRetryableStatus(msg)
 }
 
 // matchesAnyMarker reports whether msg contains any of the given substrings.
@@ -166,6 +190,15 @@ func hasCosignHTTPFetchRetryableStatus(msg string) bool {
 		}
 	}
 	return false
+}
+
+// hasTUFCDNRetryableStatus reports whether msg is a Sigstore TUF trust-root
+// CDN fetch failure carrying one of tufCDNRetryableStatusMarkers.
+func hasTUFCDNRetryableStatus(msg string) bool {
+	if !strings.Contains(msg, tufCDNHostMarker) {
+		return false
+	}
+	return matchesAnyMarker(msg, tufCDNRetryableStatusMarkers)
 }
 
 func isRekorStreamInternalError(msg string) bool {

--- a/pkg/toolchain/verification/signature_rekor_test.go
+++ b/pkg/toolchain/verification/signature_rekor_test.go
@@ -74,6 +74,28 @@ func TestClassifySignatureVerificationError(t *testing.T) {
 		"Error: loading verifier from key opts: loading cert: loading URL " +
 		"https://example.com/missing.pem: server returned HTTP 404"
 
+	// Verbatim (trimmed) cosign output captured from cloudposse/atmos#2974 CI:
+	// cosign's TUF trust-root refresh (distinct from both the Rekor tlog
+	// endpoint and a direct --certificate/--signature fetch) got a transient
+	// 403 from Sigstore's TUF CDN while fetching the root manifest.
+	tufRootFetch403 := "cosign [verify-blob ...]: exit status 1\n" +
+		"WARNING: Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. " +
+		"Error from TUF: error getting live trusted root: failed to create TUF client failed to load metadata: " +
+		"tuf refresh failed: failed to download https://tuf-repo-cdn.sigstore.dev/16.root.json, http status code: 403"
+
+	// Same outage, surfaced instead while fetching timestamp.json (the other
+	// phrasing cosign's TUF client uses for a non-2xx CDN response).
+	tufTimestampFetch403 := "cosign [verify-blob ...]: exit status 1\n" +
+		"Error: getting Rekor public keys: updating local metadata and targets: error updating to TUF remote mirror: " +
+		"tuf: failed to download timestamp.json: GET \"https://tuf-repo-cdn.sigstore.dev/timestamp.json\": unexpected HTTP status 403"
+
+	// A 403 anywhere else in cosign output (i.e. not scoped to the TUF CDN
+	// host) must NOT be retried — 403 is a terminal authorization failure on
+	// most endpoints, and only the TUF-CDN-scoped phrasings above qualify.
+	unscoped403 := "cosign [verify-blob --certificate https://example.com/tool.pem ...]: exit status 1\n" +
+		"Error: loading verifier from key opts: loading cert: loading URL " +
+		"https://example.com/tool.pem: server returned HTTP 403"
+
 	cases := []struct {
 		name        string
 		err         error
@@ -92,6 +114,9 @@ func TestClassifySignatureVerificationError(t *testing.T) {
 		{name: "macOS certificate-sidecar TLS failure is retryable", err: errors.New(macOSCertificateFetchTLSFailure), wantWrapped: true},
 		{name: "macOS terminated cosign process is retryable", err: errors.New("cosign [verify-blob ...]: signal: killed"), wantWrapped: true},
 		{name: "cosign --certificate fetch 404 is NOT retryable", err: errors.New(certFetch404), wantWrapped: false},
+		{name: "TUF CDN root.json fetch 403 is retryable", err: errors.New(tufRootFetch403), wantWrapped: true},
+		{name: "TUF CDN timestamp.json fetch 403 is retryable", err: errors.New(tufTimestampFetch403), wantWrapped: true},
+		{name: "403 outside the TUF CDN host is NOT retryable", err: errors.New(unscoped403), wantWrapped: false},
 		{name: "connection reset is retryable", err: transportErr("read tcp 10.0.0.1:443: connection reset by peer"), wantWrapped: true},
 		{name: "TLS handshake timeout is retryable", err: transportErr("net/http: TLS handshake timeout"), wantWrapped: true},
 		{name: "i/o timeout is retryable", err: transportErr("dial tcp 10.0.0.1:443: i/o timeout"), wantWrapped: true},
@@ -194,6 +219,26 @@ func TestRunCosignWithRetry_RecoversFromCertificateFetch504(t *testing.T) {
 		ErrSignatureFailed)
 
 	runner := &flakyRunner{retryableErr: certFetchErr, failAttempts: 2}
+	req := &Request{Runner: runner}
+
+	err := runCosignWithRetry(context.Background(), req, []string{"verify-blob", "asset.tar.gz"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, runner.calls, "expected 2 retried failures + 1 success")
+	assert.Equal(t, []string{"verify-blob", "asset.tar.gz"}, runner.finalCallArgs)
+}
+
+// TestRunCosignWithRetry_RecoversFromTUFCDNFetch403 reproduces the CI failure
+// in cloudposse/atmos#2974: cosign's TUF trust-root refresh got a transient
+// 403 from Sigstore's TUF CDN before it reached any verification verdict.
+func TestRunCosignWithRetry_RecoversFromTUFCDNFetch403(t *testing.T) {
+	t.Parallel()
+
+	tufFetchErr := fmt.Errorf("%w: cosign [verify-blob ...]: exit status 1\n"+
+		"Error from TUF: error getting live trusted root: failed to create TUF client failed to load metadata: "+
+		"tuf refresh failed: failed to download https://tuf-repo-cdn.sigstore.dev/16.root.json, http status code: 403",
+		ErrSignatureFailed)
+
+	runner := &flakyRunner{retryableErr: tufFetchErr, failAttempts: 2}
 	req := &Request{Runner: runner}
 
 	err := runCosignWithRetry(context.Background(), req, []string{"verify-blob", "asset.tar.gz"})

--- a/website/docs/cli/configuration/commands/index.mdx
+++ b/website/docs/cli/configuration/commands/index.mdx
@@ -18,6 +18,8 @@ Atmos can be extended to support any number of custom CLI commands. Custom comma
 
 One great way to use custom commands is to tie all your miscellaneous scripts into one consistent CLI interface. Then you can kiss those ugly, inconsistent arguments to bash scripts goodbye — just wire up the commands in `atmos` to call the script. Developers can then run `atmos help` and discover every available command.
 
+Paired with [workflows](/workflows), custom commands turn Atmos into a full task runner — the same tool that plans your infrastructure can replace Make, Just, or Taskfile for everything else your team runs.
+
 ## Simple Example
 
 Adding the following to `atmos.yaml` introduces a new `hello` command:

--- a/website/docs/quick-start/advanced/add-custom-commands.mdx
+++ b/website/docs/quick-start/advanced/add-custom-commands.mdx
@@ -7,20 +7,18 @@ import File from '@site/src/components/File'
 import Terminal from '@site/src/components/Terminal'
 
 :::note Optional chapter
-This is an advanced extension point, not a required step — most people add custom commands only after running Atmos for a while and noticing a command they wish existed.
+This chapter is optional. Most people add a custom command only after they use Atmos for a while and find a task they repeat.
 :::
 
-Atmos can be extended with any number of **custom CLI commands** — your own `atmos <verb>` subcommands, defined in YAML, that wrap whatever your team repeats.
+You can extend Atmos with custom CLI commands. Each command is your own `atmos <verb>` subcommand. Define it in YAML to wrap a task your team repeats.
 
 :::tip
 See [Atmos Custom Commands](/cli/configuration/commands) for the full reference.
 :::
 
-Custom commands are defined in the `commands` section of your `atmos.yaml`.
+You define custom commands in the `commands` section of `atmos.yaml`.
 
-Atmos already has built-in commands for discovery, including `atmos list stacks`, `atmos list components`, and `atmos list instances`.
-Instead of reimplementing those, the quick-start example adds an `operator` command group that combines the built-ins into the views operators
-usually need.
+This example adds an `operator` command group. It wraps `atmos list stacks`, `atmos list components`, and `atmos list instances` in the views operators use most.
 
 <File title="atmos.yaml">
 ```yaml
@@ -90,7 +88,7 @@ commands:
 ```
 </File>
 
-Run the status command to see stack inheritance, component instances, the component catalog, and the next operator commands:
+Run the status command. It shows stack inheritance, component instances, the component catalog, and the next operator commands:
 
 <Terminal title="atmos operator status -s plat-ue2-dev">
 ```console
@@ -101,7 +99,7 @@ Next operator commands
 ```
 </Terminal>
 
-Run the inspect command when you need to answer where a value came from:
+Run the inspect command to find where a value came from:
 
 ```shell
 atmos operator inspect app-config -s plat-ue2-dev
@@ -114,7 +112,7 @@ atmos describe component app-config -s plat-ue2-dev --provenance
 ```
 
 :::tip Let Atmos prompt you
-Prompting is built into single-component Terraform commands. If you forget the component or stack, omit it and Atmos will ask:
+Atmos prompts you in single-component Terraform commands. If you omit the component or stack, Atmos asks for it:
 
 ```shell
 # Explicit

--- a/website/src/components/landing/Batteries/index.js
+++ b/website/src/components/landing/Batteries/index.js
@@ -84,7 +84,7 @@ const BATTERIES = [
   {
     icon: RiCloudLine,
     title: 'Emulators',
-    desc: 'Run AWS, GCP, Azure, and Kubernetes emulators locally — plan and apply against real APIs with no cloud account and no bill.',
+    desc: 'Run AWS, GCP, Azure, and Kubernetes emulators locally — plan and apply against them with no cloud account and no bill.',
     tag: 'AWS · GCP · AZURE · K8S',
     to: '/cli/commands/emulator/usage',
   },

--- a/website/src/components/landing/Batteries/index.js
+++ b/website/src/components/landing/Batteries/index.js
@@ -5,10 +5,13 @@ import {
   RiShieldKeyholeLine,
   RiKey2Line,
   RiBox3Line,
+  RiCheckboxCircleLine,
   RiDatabase2Line,
   RiToolsLine,
+  RiLayoutGridLine,
   RiPriceTag3Line,
   RiTerminalBoxLine,
+  RiCloudLine,
   RiGitMergeLine,
   RiRobot2Line,
 } from 'react-icons/ri';
@@ -37,6 +40,13 @@ const BATTERIES = [
     to: '/cli/configuration/vendor',
   },
   {
+    icon: RiCheckboxCircleLine,
+    title: 'Validation',
+    desc: 'Catch misconfigurations before they ship — JSON Schema and OPA policies validate stacks, EditorConfig and actionlint check formatting and CI workflows.',
+    tag: 'JSON SCHEMA · OPA · EDITORCONFIG · ACTIONLINT',
+    to: '/validation/validating',
+  },
+  {
     icon: RiDatabase2Line,
     title: 'Caching & Mirroring',
     desc: 'A native build cache plus a transparent Terraform provider and module registry mirror — warm in CI, instant on your laptop.',
@@ -51,6 +61,13 @@ const BATTERIES = [
     to: '/cli/configuration/toolchain',
   },
   {
+    icon: RiLayoutGridLine,
+    title: 'Scaffolding',
+    desc: 'Generate components, stacks, and entire projects from versioned templates, then re-apply them later with three-way merges when the template changes.',
+    tag: 'INIT · GENERATE · THREE-WAY MERGE',
+    to: '/cli/commands/scaffold/usage',
+  },
+  {
     icon: RiPriceTag3Line,
     title: 'Version Management',
     desc: 'Tracks software versions whether Atmos installs the tool locally or only renders the version into workflows, images, and config files.',
@@ -63,6 +80,13 @@ const BATTERIES = [
     desc: 'Run, automate, and chain anything — 25+ step types and custom commands orchestrate tasks across every component.',
     tag: '25+ STEP TYPES · CUSTOM COMMANDS',
     to: '/workflows',
+  },
+  {
+    icon: RiCloudLine,
+    title: 'Emulators',
+    desc: 'Run AWS, GCP, Azure, and Kubernetes emulators locally — plan and apply against real APIs with no cloud account and no bill.',
+    tag: 'AWS · GCP · AZURE · K8S',
+    to: '/cli/commands/emulator/usage',
   },
   {
     icon: RiGitMergeLine,

--- a/website/src/components/landing/Batteries/index.js
+++ b/website/src/components/landing/Batteries/index.js
@@ -77,8 +77,8 @@ const BATTERIES = [
   {
     icon: RiTerminalBoxLine,
     title: 'Workflows & Automation',
-    desc: 'Run, automate, and chain anything — 25+ step types and custom commands orchestrate tasks across every component.',
-    tag: '25+ STEP TYPES · CUSTOM COMMANDS',
+    desc: 'Run, automate, and chain anything — 35+ step types and custom commands orchestrate tasks across every component.',
+    tag: '35+ STEP TYPES · CUSTOM COMMANDS',
     to: '/workflows',
   },
   {

--- a/website/src/components/landing/Extensibility/index.js
+++ b/website/src/components/landing/Extensibility/index.js
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import DemoVideo from '@site/src/components/landing/DemoVideo';
 
 const EXTENSIONS = [
-  { title: 'Custom commands', desc: 'Wrap any script as a first-class atmos command, with flags, args, and identity.', to: '/quick-start/advanced/add-custom-commands' },
+  { title: 'Custom commands', desc: 'Your task runner, built in — wrap any script as a first-class atmos command, with flags, args, and identity.', to: '/quick-start/advanced/add-custom-commands' },
   { title: 'Component types', desc: 'Register your own component kinds via the same registry the built-ins use.', to: '/components' },
   { title: 'YAML functions', desc: 'Resolve state, outputs, secrets, and Git metadata right inside your config.', to: '/functions/yaml' },
   { title: 'Hooks & stores', desc: 'Run infracost, checkov, trivy, or any command on lifecycle events, and plug in SSM, Secrets Manager, Key Vault, Vault, Redis, and more for cross-component data.', to: '/stacks/hooks' },

--- a/website/src/components/landing/Extensibility/index.js
+++ b/website/src/components/landing/Extensibility/index.js
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import DemoVideo from '@site/src/components/landing/DemoVideo';
 
 const EXTENSIONS = [
-  { title: 'Custom commands', desc: 'Your task runner, built in — wrap any script as a first-class atmos command, with flags, args, and identity.', to: '/quick-start/advanced/add-custom-commands' },
+  { title: 'Custom commands', desc: 'Your task runner, built in — wrap any script as a first-class atmos command, with flags, args, and identity.', to: '/cli/configuration/commands' },
   { title: 'Component types', desc: 'Register your own component kinds via the same registry the built-ins use.', to: '/components' },
   { title: 'YAML functions', desc: 'Resolve state, outputs, secrets, and Git metadata right inside your config.', to: '/functions/yaml' },
   { title: 'Hooks & stores', desc: 'Run infracost, checkov, trivy, or any command on lifecycle events, and plug in SSM, Secrets Manager, Key Vault, Vault, Redis, and more for cross-component data.', to: '/stacks/hooks' },


### PR DESCRIPTION
## what

- Add three feature cards to the homepage "Batteries included" grid: **Validation**, **Scaffolding**, and **Emulators**.
- Each card follows the existing schema (icon, title, description, tag line, doc link) and slots next to its closest existing sibling card (Validation next to Vendoring, Scaffolding next to Toolchain, Emulators next to Workflows & Automation) so the grid still fills to full rows of 4.
- Link targets (`/validation/validating`, `/cli/commands/scaffold/usage`, `/cli/commands/emulator/usage`) were verified against how other docs pages already link to these same destinations internally, not guessed.

## why

- These three capabilities already ship in Atmos and have full docs, but weren't represented anywhere on the landing page, understating what the runtime includes out of the box.
- Kept to three additions (not four) so the grid still lands on a clean multiple of 4 cards per row instead of leaving a new single orphaned card in the last row.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Validation, Scaffolding, and Emulators to the landing page’s battery features.
  * Updated workflow messaging to highlight 35+ step types and revised emulator wording.
* **Bug Fixes**
  * Improved retries for transient Sigstore trust-root CDN errors while excluding unrelated certificate-fetch failures.
* **Documentation**
  * Explained how custom commands and workflows can work together as a task runner replacement.
  * Clarified custom command configuration, optional usage, wrapped commands, and examples.
  * Updated the custom commands link to point to the expanded documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->