### PR TITLE
fix(devcontainer): disable moby so docker feature installs on Debian trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,14 @@
     "postCreateCommand": "/workspace/.devcontainer/post-create.sh",
     "service": "localstack",
     "features": {
-        "ghcr.io/devcontainers/features/docker-outside-of-docker": {},
+        // Debian 13 (trixie) does not package moby-cli, so the default
+        // "moby": true makes this feature fail to install. Disable moby so it
+        // installs Docker CE instead (Docker's repo is already configured by
+        // the Dockerfile). Without this, the Codespaces prebuild fails on
+        // every push to main.
+        "ghcr.io/devcontainers/features/docker-outside-of-docker": {
+            "moby": false
+        },
         /*"ghcr.io/devcontainers/features/go:1": {
             "version": "1.22"
         },*/


### PR DESCRIPTION
## what

- Set `"moby": false` on the `docker-outside-of-docker` devcontainer feature in `.devcontainer/devcontainer.json`.

## why

The **Codespaces Prebuilds** workflow (`prebuild`) fails on every push to `main`. Example failed run: https://github.com/cloudposse/atmos/actions/runs/32431458655/job/96623702606

The base image `mcr.microsoft.com/vscode/devcontainers/base:debian` now resolves to **Debian 13 (trixie)**, which does not package `moby-cli`. The `docker-outside-of-docker` feature defaults to `moby: true` and errors out during the prebuild image build:

```
(!) The 'moby' option is not supported on debian 'trixie' because 'moby-cli'
    and related system packages are not available in that distribution.
(!) To continue, either set the feature option '"moby": false' or use a
    different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
ERROR: Feature "Docker (docker-outside-of-docker)" failed to install!
```

Setting `moby: false` makes the feature install Docker CE instead. This is safe and non-redundant: the devcontainer `Dockerfile` already configures Docker's official apt repo and installs `docker-ce`/`docker-ce-cli`, so no moby packages were ever needed — the feature only wires up the forwarded host Docker socket.

## references

- Failed run: https://github.com/cloudposse/atmos/actions/runs/32431458655/job/96623702606
- Feature docs: https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development container configuration to install Docker CE instead of Moby on Debian 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->