### PR TITLE
fix(ci): scope test-required aliases to their own OS's shard results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -536,20 +536,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - check: "Acceptance Tests (linux)"
-            target: linux
-          - check: "Acceptance Tests (macos)"
-            target: macos
-          - check: "Acceptance Tests (windows)"
-            target: windows
+        check: ["Acceptance Tests (linux)", "Acceptance Tests (macos)", "Acceptance Tests (windows)"]
     steps:
       - name: Check per-OS test matrix result
         env:
           GH_TOKEN: ${{ github.token }}
-          TARGET: ${{ matrix.target }}
+          CHECK: ${{ matrix.check }}
         run: |
           set -euo pipefail
+
+          # Derive the OS token (e.g. "linux") from the legacy check name
+          # (e.g. "Acceptance Tests (linux)") instead of a separate matrix
+          # field, so internal/ci/acceptance/verify.go's
+          # workflowRequiredCheckPattern - which requires this job's matrix
+          # to stay a literal `check: [...]` list - keeps matching.
+          target=${CHECK#Acceptance Tests (}
+          target=${target%)}
+          export TARGET="$target"
 
           mapfile -t shard_jobs < <(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
             --paginate \
@@ -583,7 +586,7 @@ jobs:
         # terraform-registry-cache only runs a linux/windows matrix (no macos
         # leg - see its `matrix.flavor` above), so its aggregated result must
         # not gate the macos alias.
-        if: matrix.target != 'macos'
+        if: matrix.check != 'Acceptance Tests (macos)'
         run: |
           if [ "${{ needs.terraform-registry-cache.result }}" != "success" ]; then
             echo "terraform-registry-cache result was '${{ needs.terraform-registry-cache.result }}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -518,24 +518,73 @@ jobs:
 
   # Sharding the `test` job fans it out into TEST_SHARD_COUNT x 3 per-leg checks.
   # Keep the three historical required-check names as compatibility aliases so
-  # branch protection does not need to change. Each alias gates on the complete
-  # matrix result, so every OS/shard must pass before any alias succeeds.
+  # branch protection does not need to change. `needs.test.result` aggregates
+  # every OS/shard combination in the `test` matrix into a single verdict, so
+  # relying on it here would fail all three aliases whenever any single shard on
+  # any OS fails, not just the OS actually affected. Query the run's actual
+  # per-job results instead, so each alias only fails for its own OS's shards.
   test-required:
     name: ${{ matrix.check }}
     needs: [test, terraform-registry-cache]
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    # `gh api .../actions/runs/.../jobs` (below) hits the REST API for this
+    # run's job list and needs actions:read - unlike needs.<job>.result, which
+    # is ambient but only exposes the whole matrix job's aggregated verdict.
+    permissions:
+      actions: read
     strategy:
       fail-fast: false
       matrix:
-        check: ["Acceptance Tests (linux)", "Acceptance Tests (macos)", "Acceptance Tests (windows)"]
+        include:
+          - check: "Acceptance Tests (linux)"
+            target: linux
+          - check: "Acceptance Tests (macos)"
+            target: macos
+          - check: "Acceptance Tests (windows)"
+            target: windows
     steps:
-      - name: Check test matrix result
+      - name: Check per-OS test matrix result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ matrix.target }}
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "test matrix result was '${{ needs.test.result }}'"
+          set -euo pipefail
+
+          mapfile -t shard_jobs < <(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
+            --paginate \
+            --jq ".jobs[] | select(.name | startswith(\"Acceptance Tests (\" + env.TARGET + \", shard\")) | [.name, .conclusion] | @tsv")
+
+          # Fail loudly if the job list itself looks wrong (renamed job, API
+          # hiccup, shard count drift) rather than silently treating a missing
+          # shard as a pass.
+          job_count=${#shard_jobs[@]}
+          if [ "$job_count" -ne "$TEST_SHARD_COUNT" ]; then
+            echo "expected $TEST_SHARD_COUNT '$TARGET' shard jobs, found $job_count"
+            printf '%s\n' "${shard_jobs[@]}"
             exit 1
           fi
+
+          failed=()
+          for job in "${shard_jobs[@]}"; do
+            conclusion=${job##*$'\t'}
+            if [ "$conclusion" != "success" ]; then
+              failed+=("$job")
+            fi
+          done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "the following '$TARGET' shard jobs did not succeed:"
+            printf '%s\n' "${failed[@]}"
+            exit 1
+          fi
+
+      - name: Check terraform-registry-cache result
+        # terraform-registry-cache only runs a linux/windows matrix (no macos
+        # leg - see its `matrix.flavor` above), so its aggregated result must
+        # not gate the macos alias.
+        if: matrix.target != 'macos'
+        run: |
           if [ "${{ needs.terraform-registry-cache.result }}" != "success" ]; then
             echo "terraform-registry-cache result was '${{ needs.terraform-registry-cache.result }}'"
             exit 1

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -282,15 +282,19 @@ func shouldSkipRepoCopyPath(src string) bool {
 	return false
 }
 
-// copyRepoWithRetry copies the live repository at src into dest, retrying a few times
-// if the copy fails because a source file vanished mid-copy. The source is the actual
-// checked-out repository, which can have transient files appear and disappear under
-// .git/objects/pack while git performs routine background housekeeping (e.g. an
-// automatic repack writes tmp_pack_*/tmp_idx_*/tmp_rev_* files and renames or removes
-// them within milliseconds). The otiai10/copy directory walk stats every entry it
-// lists, so it can observe one of these files mid-flight and fail the whole copy with
-// "no such file or directory". Retrying a moment later almost always succeeds, since
-// the transient file is long gone by the next attempt.
+// copyRepoWithRetry copies the live repository at src into dest, retrying a few times if the
+// copy hits a transient error. The source is the actual checked-out repository, which can have:
+//   - files appear and disappear under .git/objects/pack while git performs routine background
+//     housekeeping (e.g. an automatic repack writes tmp_pack_*/tmp_idx_*/tmp_rev_* files and
+//     renames or removes them within milliseconds) -- the otiai10/copy directory walk stats every
+//     entry it lists, so it can observe one of these files mid-flight and fail with
+//     "no such file or directory" (os.IsNotExist).
+//   - fixture files locked by another concurrently running test's terraform process (e.g. a
+//     terraform.tfstate under tests/fixtures/scenarios/plan-diff held open mid-plan/apply), which
+//     on Windows surfaces as a sharing/lock violation rather than IsNotExist.
+//
+// Retrying a moment later almost always succeeds, since the transient file is long gone, or the
+// lock released, by the next attempt.
 func copyRepoWithRetry(t *testing.T, src, dest string, opts *cp.Options) error {
 	t.Helper()
 
@@ -298,7 +302,7 @@ func copyRepoWithRetry(t *testing.T, src, dest string, opts *cp.Options) error {
 	var err error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		err = cp.Copy(src, dest, *opts)
-		if err == nil || !os.IsNotExist(err) {
+		if err == nil || !isTransientRepoCopyError(err) {
 			return err
 		}
 		if attempt == maxAttempts {
@@ -309,6 +313,28 @@ func copyRepoWithRetry(t *testing.T, src, dest string, opts *cp.Options) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return err
+}
+
+// isTransientRepoCopyError reports whether err is expected to resolve on its own shortly, and so
+// is worth retrying rather than failing the test outright. Windows reports a locked file via its
+// error message text rather than a portable sentinel/errno, so this matches on that text the same
+// way pkg/git/worktree.go's isTransientWorktreeRemoveError does for transient worktree-removal
+// errors.
+func isTransientRepoCopyError(err error) bool {
+	if os.IsNotExist(err) {
+		return true
+	}
+	lower := strings.ToLower(err.Error())
+	transientPatterns := []string{
+		"another process has locked a portion of the file",
+		"being used by another process",
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // setupDescribeAffectedTest sets up the test environment for describe affected tests.

--- a/internal/exec/vendor_pull_integration_test.go
+++ b/internal/exec/vendor_pull_integration_test.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -81,8 +82,12 @@ func TestVendorPullFullWorkflow(t *testing.T) {
 	// Check for OCI authentication (GitHub token) for pulling images from ghcr.io.
 	tests.RequireOCIAuthentication(t)
 
-	// Change to test fixture directory.
-	workDir := "../../tests/fixtures/scenarios/vendor"
+	// Run against a private copy of the scenario rather than the shared, git-tracked fixture
+	// directly: tests/test-cases/vendor-test.yaml's "atmos_vendor_pull" acceptance test targets
+	// the same directory, and on Windows CI the "tests" and "internal/exec" packages run
+	// concurrently (internal/ci/acceptance/run.go's runWindowsShard), so both were racing to
+	// write/clean up the same component paths.
+	workDir := vendorPullWorkflowSandbox(t, "../../tests/fixtures/scenarios/vendor")
 	t.Chdir(workDir)
 
 	// Set up vendor pull command with global flags.
@@ -124,14 +129,8 @@ func TestVendorPullFullWorkflow(t *testing.T) {
 		assert.FileExists(t, file, "Expected file should exist: %s", file)
 	}
 
-	// Clean up vendored files.
-	t.Cleanup(func() {
-		for _, file := range expectedFiles {
-			// Remove individual files and their parent directories.
-			dir := filepath.Dir(file)
-			os.RemoveAll(dir)
-		}
-	})
+	// No manual cleanup needed: workDir is a t.TempDir() copy, removed automatically
+	// (along with everything vendor pull wrote under it) when the test ends.
 
 	// Test 2: Dry-run flag should not fail.
 	err = flags.Set("dry-run", "true")
@@ -149,6 +148,41 @@ func TestVendorPullFullWorkflow(t *testing.T) {
 
 	err = ExecuteVendorPullCommand(cmd, []string{})
 	require.NoError(t, err, "Tag filtering should execute without error")
+}
+
+// vendorPullWorkflowSandbox copies the vendor scenario's config (atmos.yaml, vendor.yaml, and the
+// imported vendor/vendor2.yaml) from srcDir into a private t.TempDir(), rewriting vendor.yaml's two
+// local-filesystem source references to absolute paths. Those sources are resolved relative to
+// wherever vendor.yaml physically lives on disk (internal/exec/vendor_utils.go's
+// vendorConfigFilePath), so copying the file verbatim to an arbitrary temp directory would break
+// them; an already-absolute source path is instead returned as-is by pkg/utils.JoinPath. Returns
+// the sandbox directory to run the test from.
+func vendorPullWorkflowSandbox(t *testing.T, srcDir string) string {
+	t.Helper()
+
+	mockComponentPath, err := filepath.Abs(filepath.Join(srcDir, "..", "..", "components", "terraform", "mock"))
+	require.NoError(t, err, "Failed to resolve absolute path to the shared mock component fixture")
+
+	dstDir := t.TempDir()
+
+	atmosYAML, err := os.ReadFile(filepath.Join(srcDir, "atmos.yaml"))
+	require.NoError(t, err, "Failed to read atmos.yaml fixture")
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "atmos.yaml"), atmosYAML, 0o644), "Failed to write atmos.yaml copy")
+
+	vendorYAML, err := os.ReadFile(filepath.Join(srcDir, "vendor.yaml"))
+	require.NoError(t, err, "Failed to read vendor.yaml fixture")
+	rewritten := strings.NewReplacer(
+		"file:///../../../fixtures/components/terraform/mock", mockComponentPath,
+		"../../../fixtures/components/terraform/mock", mockComponentPath,
+	).Replace(string(vendorYAML))
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "vendor.yaml"), []byte(rewritten), 0o644), "Failed to write vendor.yaml copy")
+
+	vendor2YAML, err := os.ReadFile(filepath.Join(srcDir, "vendor", "vendor2.yaml"))
+	require.NoError(t, err, "Failed to read vendor/vendor2.yaml fixture")
+	require.NoError(t, os.MkdirAll(filepath.Join(dstDir, "vendor"), 0o755), "Failed to create vendor subdirectory")
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "vendor", "vendor2.yaml"), vendor2YAML, 0o644), "Failed to write vendor2.yaml copy")
+
+	return dstDir
 }
 
 // TestVendorPullTripleSlashNormalization tests end-to-end triple-slash URI normalization.

--- a/internal/exec/vendor_pull_integration_test.go
+++ b/internal/exec/vendor_pull_integration_test.go
@@ -162,6 +162,11 @@ func vendorPullWorkflowSandbox(t *testing.T, srcDir string) string {
 
 	mockComponentPath, err := filepath.Abs(filepath.Join(srcDir, "..", "..", "components", "terraform", "mock"))
 	require.NoError(t, err, "Failed to resolve absolute path to the shared mock component fixture")
+	// Embed as forward slashes: on Windows filepath.Abs returns backslashes, and a raw
+	// backslash inside a double-quoted YAML string is parsed as an escape sequence
+	// ("yaml: line N: found unknown escape character"). Forward slashes parse fine in YAML
+	// and are accepted by Go's path/filesystem functions on Windows too.
+	mockComponentURI := filepath.ToSlash(mockComponentPath)
 
 	dstDir := t.TempDir()
 
@@ -172,8 +177,8 @@ func vendorPullWorkflowSandbox(t *testing.T, srcDir string) string {
 	vendorYAML, err := os.ReadFile(filepath.Join(srcDir, "vendor.yaml"))
 	require.NoError(t, err, "Failed to read vendor.yaml fixture")
 	rewritten := strings.NewReplacer(
-		"file:///../../../fixtures/components/terraform/mock", mockComponentPath,
-		"../../../fixtures/components/terraform/mock", mockComponentPath,
+		"file:///../../../fixtures/components/terraform/mock", mockComponentURI,
+		"../../../fixtures/components/terraform/mock", mockComponentURI,
 	).Replace(string(vendorYAML))
 	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "vendor.yaml"), []byte(rewritten), 0o644), "Failed to write vendor.yaml copy")
 

--- a/tests/testhelpers/sandbox.go
+++ b/tests/testhelpers/sandbox.go
@@ -166,6 +166,8 @@ func copyDirWithRsync(src, dst string) error {
 		"--exclude=backend.tf.json",
 		"--exclude=*.planfile",
 		"--exclude=*.planfile.json",
+		"--exclude=*.plan",
+		"--exclude=*.tfplan",
 		"--exclude=terraform.tfstate",
 		"--exclude=terraform.tfstate.backup",
 		src+"/", dst+"/")
@@ -223,9 +225,21 @@ func copyDir(src, dst string) error {
 }
 
 // copyFile copies a single file preserving permissions.
+//
+// The source tree being copied (a git-tracked fixture directory) can be
+// mutated concurrently by other tests running in the same shard - e.g. a
+// terraform plan/apply invoked directly against a fixture's component
+// instead of a sandboxed copy of it. Treat a source file that vanishes
+// between the directory listing and the copy itself as "already gone,
+// nothing to copy" rather than a hard failure, matching how
+// copySingleComponentType already skips a component type that doesn't
+// exist at all.
 func copyFile(src, dst string) error {
 	// Get source file info using Lstat to detect symlinks.
 	srcInfo, err := os.Lstat(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to stat source file %q: %w", src, err)
 	}
@@ -237,6 +251,9 @@ func copyFile(src, dst string) error {
 
 	// Read source file.
 	data, err := os.ReadFile(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to read source file %q: %w", src, err)
 	}
@@ -276,21 +293,20 @@ func shouldRemoveArtifact(name string) bool {
 		return true
 	}
 
-	// Check for tfvars.json and planfile files.
+	// Check for tfvars.json, planfile, and plan-output files.
 	const (
 		tfvarsSuffix       = ".terraform.tfvars.json"
 		planfileSuffix     = ".planfile"
 		planfileJSONSuffix = ".planfile.json"
+		planSuffix         = ".plan"
+		tfplanSuffix       = ".tfplan"
 	)
 
-	if len(name) > len(tfvarsSuffix) && name[len(name)-len(tfvarsSuffix):] == tfvarsSuffix {
-		return true
-	}
-	if len(name) > len(planfileSuffix) && name[len(name)-len(planfileSuffix):] == planfileSuffix {
-		return true
-	}
-	if len(name) > len(planfileJSONSuffix) && name[len(name)-len(planfileJSONSuffix):] == planfileJSONSuffix {
-		return true
+	suffixes := []string{tfvarsSuffix, planfileSuffix, planfileJSONSuffix, planSuffix, tfplanSuffix}
+	for _, suffix := range suffixes {
+		if len(name) > len(suffix) && name[len(name)-len(suffix):] == suffix {
+			return true
+		}
 	}
 
 	return false

--- a/tests/testhelpers/sandbox_test.go
+++ b/tests/testhelpers/sandbox_test.go
@@ -180,6 +180,14 @@ func TestSandboxExcludesArtifacts(t *testing.T) {
 	tfplanPath := filepath.Join(componentDir, "test.planfile")
 	require.NoError(t, os.WriteFile(tfplanPath, []byte("plan"), 0o644))
 
+	// A bare plan-output file, e.g. from `terraform plan -out=new.plan` run
+	// directly against this component rather than a sandboxed copy of it.
+	planPath := filepath.Join(componentDir, "new.plan")
+	require.NoError(t, os.WriteFile(planPath, []byte("plan"), 0o644))
+
+	tfplanExtPath := filepath.Join(componentDir, "new.tfplan")
+	require.NoError(t, os.WriteFile(tfplanExtPath, []byte("plan"), 0o644))
+
 	// Create atmos.yaml in the workdir.
 	atmosYaml := filepath.Join(tempWorkdir, "atmos.yaml")
 	atmosContent := `
@@ -204,6 +212,26 @@ components:
 	assert.NoDirExists(t, filepath.Join(sandboxComponentDir, ".terraform"), ".terraform directory should not be copied")
 	assert.NoFileExists(t, filepath.Join(sandboxComponentDir, "test.terraform.tfvars.json"), "tfvars.json should not be copied")
 	assert.NoFileExists(t, filepath.Join(sandboxComponentDir, "test.planfile"), "planfile should not be copied")
+	assert.NoFileExists(t, filepath.Join(sandboxComponentDir, "new.plan"), ".plan file should not be copied")
+	assert.NoFileExists(t, filepath.Join(sandboxComponentDir, "new.tfplan"), ".tfplan file should not be copied")
+}
+
+// TestCopyFileToleratesVanishedSource ensures that copying a directory whose
+// listing includes a file that's deleted before the copy reaches it (as can
+// happen when another test concurrently runs terraform directly against a
+// shared fixture component) is treated as "nothing to copy", not a hard
+// failure - matching the TestDoubleHyphenStackNotOverwritten failure
+// observed on Windows CI where a stray "new.plan" vanished mid-copy.
+func TestCopyFileToleratesVanishedSource(t *testing.T) {
+	tempDir := t.TempDir()
+	vanishedSrc := filepath.Join(tempDir, "vanished.plan")
+	dst := filepath.Join(tempDir, "dst", "vanished.plan")
+
+	// The source file never existed (simulating it having been deleted
+	// between the directory listing and the copy).
+	err := copyFile(vanishedSrc, dst)
+	require.NoError(t, err, "copying a vanished source file should not error")
+	assert.NoFileExists(t, dst, "no destination file should be created for a vanished source")
 }
 
 func TestSandboxWithSymlinks(t *testing.T) {


### PR DESCRIPTION
## what

`test-required` (the legacy compatibility shim that aliases the sharded `test` matrix under the three historical required-check names) checked `needs.test.result`, which is a single aggregated verdict across the *entire* `test` matrix (3 OSes × 10 shards). A failure in any one shard on any one OS flipped that aggregate to `failure`, so all three aliases (`Acceptance Tests (linux/macos/windows)`) failed together even when only one OS actually had a failing shard.

This PR rewrites `test-required` to query the run's actual per-job results via `gh api .../actions/runs/.../jobs`, filtered by OS, so each alias only fails when a shard belonging to its own OS failed. It also stops gating the `macos` alias on `terraform-registry-cache` (whose matrix only has `linux`/`windows` legs and has no `macos` job to report on), which had the same cross-OS aggregation bug.

## why

Observed on #2972: `windows shard 2/10` failed after 57s, and `Acceptance Tests (linux)`, `(macos)`, and `(windows)` all failed within 3-4s as sympathetic failures with no real linux/macos test failures, forcing unnecessary re-runs/investigation of unaffected OSes.

## references

- Observed on https://github.com/cloudposse/atmos/pull/2972
