### PR TITLE
fix: ECR/ACR ambient-credential errors and broken --identity selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,14 @@ tests/fixtures/scenarios/vendor-simple-excludes/vendor.lock.yaml
 # the output would make `clean: true` a no-op and let stale files from one test leak into the other's
 # file_not_exists assertions.
 tests/fixtures/scenarios/complete/components/terraform/infra/account-map/context.tf
+
+# scaffold-matrix-computed/generated/ and scaffold-matrix-freetext/generated/ are the `atmos scaffold
+# generate` output for the sibling test cases in tests/test-cases/scaffold.yaml (each fixture is
+# shared by multiple cases with `clean: true` set). Same reasoning as vendor-stack-labels above:
+# intentionally NOT gitignored, and never committed, so `clean: true` keeps resetting these
+# untracked-and-not-ignored paths between runs -- gitignoring or committing either one would make
+# `clean: true` a no-op and let a stale file from one case leak into another's file_not_exists
+# assertion.
 internal/exec/output.*
 
 # Coverage files

--- a/cmd/aws/ecr/login.go
+++ b/cmd/aws/ecr/login.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/auth/types"
 	"github.com/cloudposse/atmos/pkg/auth/validation"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	pkgFlags "github.com/cloudposse/atmos/pkg/flags"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui"
@@ -281,11 +282,7 @@ func executeExplicitRegistries(ctx context.Context, registries []string) error {
 func resolveSelectedIdentity(authManager auth.AuthManager, identityName string) (string, error) {
 	defer perf.Track(nil, "aws.ecr.resolveSelectedIdentity")()
 
-	if identityName != cfg.IdentityFlagSelectValue {
-		return identityName, nil
-	}
-
-	selected, err := authManager.GetDefaultIdentity(true)
+	selected, err := auth.ResolveSelectedIdentity(authManager, identityName, cfg.IdentityFlagSelectValue)
 	if err != nil {
 		// User explicitly aborted (Ctrl+C/ESC) — surface a clean SIGINT exit.
 		if errors.Is(err, errUtils.ErrUserAborted) {
@@ -309,15 +306,10 @@ var createAuthManager = func(authConfig *schema.AuthConfig, cliConfigPath string
 }
 
 func init() {
-	// Add --identity flag locally since this command is outside the auth command tree.
-	loginCmd.Flags().StringP("identity", "i", "", "Specify the target identity to use for linked integrations.")
-
-	// Set NoOptDefVal to enable optional flag value.
-	// When --identity is used without a value, it will receive IdentityFlagSelectValue.
-	identityFlag := loginCmd.Flags().Lookup("identity")
-	if identityFlag != nil {
-		identityFlag.NoOptDefVal = cfg.IdentityFlagSelectValue
-	}
+	// Add --identity flag locally since this command is outside the auth command tree. Uses the
+	// shared flags.WithIdentityFlag() builder (rather than a hand-rolled Flags().StringP() +
+	// manual NoOptDefVal patch) so it stays in sync with the one canonical --identity definition.
+	pkgFlags.NewStandardParser(pkgFlags.WithIdentityFlag()).RegisterFlags(loginCmd)
 
 	// Add --registry as a local flag specific to login.
 	loginCmd.Flags().StringArrayP("registry", "r", nil, "ECR registry URL(s) - explicit mode")

--- a/cmd/aws/eks/token.go
+++ b/cmd/aws/eks/token.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/auth/validation"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/data"
+	pkgFlags "github.com/cloudposse/atmos/pkg/flags"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -35,6 +36,9 @@ var authenticateForTokenFn = authenticateForToken
 
 // getEKSTokenFn generates an EKS bearer token. Overridable in tests.
 var getEKSTokenFn = awsCloud.GetToken
+
+// newAuthManagerFn constructs the AuthManager used to authenticate for a token. Overridable in tests.
+var newAuthManagerFn = auth.NewAuthManager
 
 // tokenCmd generates a short-lived EKS bearer token for kubectl.
 var tokenCmd = &cobra.Command{
@@ -169,9 +173,16 @@ func authenticateForToken(ctx context.Context, authConfig *schema.AuthConfig, cl
 	credStore := credentials.NewCredentialStoreWithConfig(authConfig)
 	validator := validation.NewValidator()
 
-	mgr, err := auth.NewAuthManager(authConfig, credStore, validator, authStackInfo, cliConfigPath)
+	mgr, err := newAuthManagerFn(authConfig, credStore, validator, authStackInfo, cliConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrFailedToInitializeAuthManager, err)
+	}
+
+	// Resolve the interactive-selection sentinel (produced when --identity is passed without a
+	// value) to a concrete identity before falling back to the empty-identity default lookup.
+	identityName, err = auth.ResolveSelectedIdentity(mgr, identityName, cfg.IdentityFlagSelectValue)
+	if err != nil {
+		return nil, fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrDefaultIdentity, err)
 	}
 
 	// If no identity specified, try to resolve default.
@@ -252,6 +263,11 @@ func exportAWSCredsToEnv(creds types.ICredentials) error {
 func init() {
 	tokenCmd.Flags().String("cluster-name", "", "EKS cluster name (required)")
 	tokenCmd.Flags().String("region", "", "AWS region (required)")
-	tokenCmd.Flags().StringP("identity", "i", "", "Atmos identity to authenticate with")
+
+	// Uses the shared flags.WithIdentityFlag() builder (rather than a hand-rolled
+	// Flags().StringP()) so bare --identity triggers the interactive selector like every
+	// other Atmos command.
+	pkgFlags.NewStandardParser(pkgFlags.WithIdentityFlag()).RegisterFlags(tokenCmd)
+
 	EksCmd.AddCommand(tokenCmd)
 }

--- a/cmd/aws/eks/token_test.go
+++ b/cmd/aws/eks/token_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth/types"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/data"
 	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -514,4 +516,44 @@ func TestAuthenticateForToken_NilAuthConfig(t *testing.T) {
 	require.Error(t, err)
 	// NewAuthManager should fail with nil config.
 	assert.ErrorIs(t, err, errUtils.ErrFailedToInitializeAuthManager)
+}
+
+func TestAuthenticateForToken_SelectValueResolvesViaGetDefaultIdentity(t *testing.T) {
+	// A bare --identity (carrying the select sentinel) must resolve to a concrete identity via
+	// GetDefaultIdentity(forceSelect=true) -- which is what triggers the interactive picker --
+	// instead of being passed straight to Authenticate (which would fail to find an identity
+	// literally named "__SELECT__").
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("dev-admin", nil)
+	mgr.EXPECT().Authenticate(gomock.Any(), "dev-admin").
+		Return(&types.WhoamiInfo{Credentials: &types.AWSCredentials{AccessKeyID: "test"}}, nil)
+
+	orig := newAuthManagerFn
+	newAuthManagerFn = func(*schema.AuthConfig, types.CredentialStore, types.Validator, *schema.ConfigAndStacksInfo, string) (types.AuthManager, error) {
+		return mgr, nil
+	}
+	t.Cleanup(func() { newAuthManagerFn = orig })
+
+	creds, err := authenticateForToken(context.Background(), &schema.AuthConfig{}, "", cfg.IdentityFlagSelectValue)
+	require.NoError(t, err)
+	assert.NotNil(t, creds)
+}
+
+func TestAuthenticateForToken_SelectValuePropagatesSelectionError(t *testing.T) {
+	// If GetDefaultIdentity fails (e.g. no TTY for interactive selection), the error must
+	// propagate rather than falling through to the empty-identity default lookup.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("", errUtils.ErrIdentitySelectionRequiresTTY)
+
+	orig := newAuthManagerFn
+	newAuthManagerFn = func(*schema.AuthConfig, types.CredentialStore, types.Validator, *schema.ConfigAndStacksInfo, string) (types.AuthManager, error) {
+		return mgr, nil
+	}
+	t.Cleanup(func() { newAuthManagerFn = orig })
+
+	_, err := authenticateForToken(context.Background(), &schema.AuthConfig{}, "", cfg.IdentityFlagSelectValue)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrIdentitySelectionRequiresTTY)
 }

--- a/cmd/azure/aks/token.go
+++ b/cmd/azure/aks/token.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudposse/atmos/pkg/auth/validation"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/data"
+	pkgFlags "github.com/cloudposse/atmos/pkg/flags"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -33,6 +34,9 @@ var authenticateForTokenFn = authenticateForToken
 
 // getAKSTokenFn returns the AKS-scoped bearer token. Overridable in tests.
 var getAKSTokenFn = azureCloud.GetToken
+
+// newAuthManagerFn constructs the AuthManager used to authenticate for a token. Overridable in tests.
+var newAuthManagerFn = auth.NewAuthManager
 
 // tokenCmd generates a short-lived AKS bearer token for kubectl.
 var tokenCmd = &cobra.Command{
@@ -197,9 +201,16 @@ func authenticateForToken(ctx context.Context, authConfig *schema.AuthConfig, cl
 	credStore := credentials.NewCredentialStoreWithConfig(authConfig)
 	validator := validation.NewValidator()
 
-	mgr, err := auth.NewAuthManager(authConfig, credStore, validator, authStackInfo, cliConfigPath)
+	mgr, err := newAuthManagerFn(authConfig, credStore, validator, authStackInfo, cliConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrFailedToInitializeAuthManager, err)
+	}
+
+	// Resolve the interactive-selection sentinel (produced when --identity is passed without a
+	// value) to a concrete identity before falling back to the empty-identity default lookup.
+	identityName, err = auth.ResolveSelectedIdentity(mgr, identityName, cfg.IdentityFlagSelectValue)
+	if err != nil {
+		return nil, fmt.Errorf(errUtils.ErrWrapFormat, errUtils.ErrDefaultIdentity, err)
 	}
 
 	// If no identity specified, try to resolve default.
@@ -243,6 +254,11 @@ func init() {
 	tokenCmd.Flags().String("resource-group", "", "Azure resource group (required)")
 	tokenCmd.Flags().String("subscription-id", "", "Azure subscription ID (optional, falls back to identity's subscription)")
 	tokenCmd.Flags().String("server-id", "", "AKS AAD server application ID (internal kubeconfig exec setting)")
-	tokenCmd.Flags().StringP("identity", "i", "", "Atmos identity to authenticate with")
+
+	// Uses the shared flags.WithIdentityFlag() builder (rather than a hand-rolled
+	// Flags().StringP()) so bare --identity triggers the interactive selector like every
+	// other Atmos command.
+	pkgFlags.NewStandardParser(pkgFlags.WithIdentityFlag()).RegisterFlags(tokenCmd)
+
 	AksCmd.AddCommand(tokenCmd)
 }

--- a/cmd/azure/aks/token_test.go
+++ b/cmd/azure/aks/token_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	azureCloud "github.com/cloudposse/atmos/pkg/auth/cloud/azure"
 	"github.com/cloudposse/atmos/pkg/auth/types"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/data"
 	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -479,4 +481,44 @@ func TestAuthenticateForToken_NilAuthConfig(t *testing.T) {
 	_, err := authenticateForToken(ctx, nil, "", "test-identity")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrFailedToInitializeAuthManager)
+}
+
+func TestAuthenticateForToken_SelectValueResolvesViaGetDefaultIdentity(t *testing.T) {
+	// A bare --identity (carrying the select sentinel) must resolve to a concrete identity via
+	// GetDefaultIdentity(forceSelect=true) -- which is what triggers the interactive picker --
+	// instead of being passed straight to Authenticate (which would fail to find an identity
+	// literally named "__SELECT__").
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("dev-admin", nil)
+	mgr.EXPECT().Authenticate(gomock.Any(), "dev-admin").
+		Return(&types.WhoamiInfo{Credentials: &types.AzureCredentials{}}, nil)
+
+	orig := newAuthManagerFn
+	newAuthManagerFn = func(*schema.AuthConfig, types.CredentialStore, types.Validator, *schema.ConfigAndStacksInfo, string) (types.AuthManager, error) {
+		return mgr, nil
+	}
+	t.Cleanup(func() { newAuthManagerFn = orig })
+
+	creds, err := authenticateForToken(context.Background(), &schema.AuthConfig{}, "", cfg.IdentityFlagSelectValue)
+	require.NoError(t, err)
+	assert.NotNil(t, creds)
+}
+
+func TestAuthenticateForToken_SelectValuePropagatesSelectionError(t *testing.T) {
+	// If GetDefaultIdentity fails (e.g. no TTY for interactive selection), the error must
+	// propagate rather than falling through to the empty-identity default lookup.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("", errUtils.ErrIdentitySelectionRequiresTTY)
+
+	orig := newAuthManagerFn
+	newAuthManagerFn = func(*schema.AuthConfig, types.CredentialStore, types.Validator, *schema.ConfigAndStacksInfo, string) (types.AuthManager, error) {
+		return mgr, nil
+	}
+	t.Cleanup(func() { newAuthManagerFn = orig })
+
+	_, err := authenticateForToken(context.Background(), &schema.AuthConfig{}, "", cfg.IdentityFlagSelectValue)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrIdentitySelectionRequiresTTY)
 }

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -889,7 +889,7 @@ func executeCustomCommand(
 		commandIdentity = strings.TrimSpace(commandConfig.Identity)
 	}
 
-	authManager := prepareCustomCommandAuth(&atmosConfig, commandIdentity, commandConfig.Name, hasRunnableStep)
+	authManager, commandIdentity := prepareCustomCommandAuth(&atmosConfig, commandIdentity, commandConfig.Name, hasRunnableStep)
 
 	// Determine working directory for command execution.
 	workDir, err := resolveWorkingDirectory(commandConfig.WorkingDirectory, atmosConfig.BasePath, currentDirPath)
@@ -1594,9 +1594,14 @@ func customCommandConditionContext(commandName string, step *schema.Task, index 
 // command's --identity. Overridable in tests.
 var newCustomCommandAuthManagerFn = auth.NewAuthManager
 
-func prepareCustomCommandAuth(atmosConfig *schema.AtmosConfiguration, commandIdentity, commandName string, hasRunnableStep bool) auth.AuthManager {
+// prepareCustomCommandAuth authenticates commandIdentity for a custom command, resolving the
+// interactive-selection sentinel to a concrete identity name first. It returns that resolved
+// identity alongside the AuthManager so callers use it (not the original sentinel) for any
+// identity-dependent operation that runs after authentication, e.g. PrepareShellEnvironment or
+// ExecuteCustomCommandControlStep.
+func prepareCustomCommandAuth(atmosConfig *schema.AtmosConfiguration, commandIdentity, commandName string, hasRunnableStep bool) (auth.AuthManager, string) {
 	if commandIdentity == "" || !hasRunnableStep {
-		return nil
+		return nil, commandIdentity
 	}
 
 	authStackInfo := &schema.ConfigAndStacksInfo{
@@ -1623,20 +1628,20 @@ func prepareCustomCommandAuth(atmosConfig *schema.AtmosConfiguration, commandIde
 	ctx := context.Background()
 	if _, err = authManager.GetCachedCredentials(ctx, commandIdentity); err == nil {
 		log.Debug("Authenticated with cached identity for custom command", customCommandKeyIdentity, commandIdentity, customCommandKeyCommand, commandName)
-		return authManager
+		return authManager, commandIdentity
 	}
 
 	log.Debug("No valid cached credentials found, authenticating", customCommandKeyIdentity, commandIdentity, "error", err)
 	if _, err = authManager.Authenticate(ctx, commandIdentity); err == nil {
 		log.Debug("Authenticated with identity for custom command", customCommandKeyIdentity, commandIdentity, customCommandKeyCommand, commandName)
-		return authManager
+		return authManager, commandIdentity
 	}
 	if errors.Is(err, errUtils.ErrUserAborted) {
 		errUtils.CheckErrorPrintAndExit(errUtils.ErrUserAborted, "", "")
 	}
 	errUtils.CheckErrorPrintAndExit(fmt.Errorf("%w for identity %q in custom command %q: %w",
 		errUtils.ErrAuthenticationFailed, commandIdentity, commandName, err), "", "")
-	return authManager
+	return authManager, commandIdentity
 }
 
 // cloneCommand clones a custom command config into a new struct.

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -510,8 +510,11 @@ func createCustomCommand(
 	}
 	customCommand.PersistentFlags().Bool("", false, doubleDashHint)
 
-	// Add --identity flag to all custom commands to allow runtime override.
-	customCommand.PersistentFlags().String(customCommandKeyIdentity, "", "Identity to use for authentication (overrides identity in command config)")
+	// Add --identity flag to all custom commands to allow runtime override. Uses the shared
+	// flags.WithIdentityFlag() builder (rather than a hand-rolled PersistentFlags().String())
+	// so custom commands get the same NoOptDefVal-driven interactive-selector behavior
+	// (bare --identity) as every other Atmos command.
+	pkgFlags.NewStandardParser(pkgFlags.WithIdentityFlag()).RegisterPersistentFlags(customCommand)
 	AddIdentityCompletion(customCommand)
 
 	if err := validateCustomCommandFlags(commandConfig, parentCommand); err != nil {
@@ -1587,6 +1590,10 @@ func customCommandConditionContext(commandName string, step *schema.Task, index 
 	}
 }
 
+// newCustomCommandAuthManagerFn constructs the AuthManager used to authenticate a custom
+// command's --identity. Overridable in tests.
+var newCustomCommandAuthManagerFn = auth.NewAuthManager
+
 func prepareCustomCommandAuth(atmosConfig *schema.AtmosConfiguration, commandIdentity, commandName string, hasRunnableStep bool) auth.AuthManager {
 	if commandIdentity == "" || !hasRunnableStep {
 		return nil
@@ -1597,9 +1604,20 @@ func prepareCustomCommandAuth(atmosConfig *schema.AtmosConfiguration, commandIde
 	}
 	credStore := credentials.NewCredentialStoreWithConfig(&atmosConfig.Auth)
 	validator := validation.NewValidator()
-	authManager, err := auth.NewAuthManager(&atmosConfig.Auth, credStore, validator, authStackInfo, atmosConfig.CliConfigPath)
+	authManager, err := newCustomCommandAuthManagerFn(&atmosConfig.Auth, credStore, validator, authStackInfo, atmosConfig.CliConfigPath)
 	if err != nil {
 		errUtils.CheckErrorPrintAndExit(fmt.Errorf("%w: %w", errUtils.ErrFailedToInitializeAuthManager, err), "", "")
+	}
+
+	// Resolve the interactive-selection sentinel (produced when --identity is passed without a
+	// value) to a concrete identity before checking the credential cache or authenticating.
+	commandIdentity, err = auth.ResolveSelectedIdentity(authManager, commandIdentity, cfg.IdentityFlagSelectValue)
+	if err != nil {
+		if errors.Is(err, errUtils.ErrUserAborted) {
+			errUtils.CheckErrorPrintAndExit(errUtils.ErrUserAborted, "", "")
+		}
+		errUtils.CheckErrorPrintAndExit(fmt.Errorf("%w for custom command %q: %w",
+			errUtils.ErrDefaultIdentity, commandName, err), "", "")
 	}
 
 	ctx := context.Background()

--- a/cmd/custom_command_identity_test.go
+++ b/cmd/custom_command_identity_test.go
@@ -3,120 +3,74 @@ package cmd
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/cloudposse/atmos/pkg/auth/types"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
-func TestCustomCommandWithIdentity(t *testing.T) {
-	if testing.Short() {
-		t.Skipf("Skipping integration test in short mode: spawns actual shell process")
-	}
-
-	// Set up test fixture with auth configuration.
+// TestCustomCommand_IdentityFlagNoOptDefVal verifies custom commands register --identity via
+// the shared flags.WithIdentityFlag() builder, so a bare --identity (no value) is legal and
+// carries the interactive-selection sentinel instead of failing with "flag needs an argument".
+func TestCustomCommand_IdentityFlagNoOptDefVal(t *testing.T) {
 	testDir := "../tests/fixtures/scenarios/atmos-auth-mock"
 	t.Setenv("ATMOS_CLI_CONFIG_PATH", testDir)
 	t.Setenv("ATMOS_BASE_PATH", testDir)
 
-	// Load atmos configuration.
-	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, false)
-	require.NoError(t, err)
-
-	// Verify that custom commands with identity were loaded.
-	assert.NotEmpty(t, atmosConfig.Commands)
-
-	foundTestIdentityCmd := false
-	foundTestIdentityMultiCmd := false
-
-	for _, cmd := range atmosConfig.Commands {
-		if cmd.Name == "test-identity" {
-			foundTestIdentityCmd = true
-			assert.Equal(t, "mock-identity", cmd.Identity)
-			assert.NotEmpty(t, cmd.Steps)
-		}
-		if cmd.Name == "test-identity-multi" {
-			foundTestIdentityMultiCmd = true
-			assert.Equal(t, "mock-identity-2", cmd.Identity)
-			assert.Len(t, cmd.Steps, 2)
-		}
-	}
-
-	assert.True(t, foundTestIdentityCmd, "test-identity command should be loaded")
-	assert.True(t, foundTestIdentityMultiCmd, "test-identity-multi command should be loaded")
-}
-
-func TestCustomCommandIdentityAuthentication(t *testing.T) {
-	if testing.Short() {
-		t.Skipf("Skipping integration test in short mode: requires auth system")
-	}
-
-	// Set up test fixture with auth configuration.
-	testDir := "../tests/fixtures/scenarios/atmos-auth-mock"
-	t.Setenv("ATMOS_CLI_CONFIG_PATH", testDir)
-	t.Setenv("ATMOS_BASE_PATH", testDir)
-
-	// Create a test kit to ensure clean RootCmd state.
 	_ = NewTestKit(t)
 
-	// Load atmos configuration to register custom commands.
 	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, false)
 	require.NoError(t, err)
 
-	// Process custom commands to register them with RootCmd.
+	atmosConfig.Commands = []schema.Command{
+		{
+			Name:  "ci-build",
+			Steps: schema.Tasks{{Type: "shell", Command: "true"}},
+		},
+	}
+
 	err = processCustomCommands(atmosConfig, atmosConfig.Commands, RootCmd)
 	require.NoError(t, err)
 
-	// Find the registered test-identity command.
-	var testIdentityCmd *schema.Command
-	for _, cmd := range atmosConfig.Commands {
-		if cmd.Name == "test-identity" {
-			testIdentityCmd = &cmd
-			break
-		}
-	}
-	require.NotNil(t, testIdentityCmd, "test-identity command should be registered")
+	buildCmd := findSubcommand(RootCmd, "ci-build")
+	require.NotNil(t, buildCmd, "ci-build command should be registered")
 
-	// Verify that identity field is correctly set.
-	assert.Equal(t, "mock-identity", testIdentityCmd.Identity)
+	identityFlag := buildCmd.PersistentFlags().Lookup(customCommandKeyIdentity)
+	require.NotNil(t, identityFlag, "identity flag should be registered on custom command")
+	assert.Equal(t, cfg.IdentityFlagSelectValue, identityFlag.NoOptDefVal,
+		"bare --identity must carry the select sentinel, matching every other Atmos command")
+	assert.Equal(t, "i", identityFlag.Shorthand, "identity flag should support the -i shorthand like other commands")
 }
 
-func TestCustomCommandIdentityFlagOverride(t *testing.T) {
-	if testing.Short() {
-		t.Skipf("Skipping integration test in short mode: requires auth system")
+// TestPrepareCustomCommandAuth_SelectValue verifies that passing the interactive-selection
+// sentinel (produced by a bare --identity) resolves to a concrete identity via
+// GetDefaultIdentity(forceSelect=true) before the cache check and Authenticate call, instead of
+// being passed through literally (which would fail with ErrIdentityNotFound).
+func TestPrepareCustomCommandAuth_SelectValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+
+	mgr.EXPECT().GetDefaultIdentity(true).Return("resolved-identity", nil)
+	mgr.EXPECT().GetCachedCredentials(gomock.Any(), "resolved-identity").
+		Return(nil, assert.AnError)
+	mgr.EXPECT().Authenticate(gomock.Any(), "resolved-identity").
+		Return(&types.WhoamiInfo{Credentials: &types.AWSCredentials{}}, nil)
+
+	orig := newCustomCommandAuthManagerFn
+	newCustomCommandAuthManagerFn = func(*schema.AuthConfig, types.CredentialStore, types.Validator, *schema.ConfigAndStacksInfo, string) (types.AuthManager, error) {
+		return mgr, nil
+	}
+	t.Cleanup(func() { newCustomCommandAuthManagerFn = orig })
+
+	atmosConfig := &schema.AtmosConfiguration{
+		Auth: schema.AuthConfig{Identities: map[string]schema.Identity{"resolved-identity": {Kind: "aws/user"}}},
 	}
 
-	// Set up test fixture with auth configuration.
-	testDir := "../tests/fixtures/scenarios/atmos-auth-mock"
-	t.Setenv("ATMOS_CLI_CONFIG_PATH", testDir)
-	t.Setenv("ATMOS_BASE_PATH", testDir)
+	result := prepareCustomCommandAuth(atmosConfig, cfg.IdentityFlagSelectValue, "ci-build", true)
 
-	// Create a test kit to ensure clean RootCmd state.
-	_ = NewTestKit(t)
-
-	// Load atmos configuration to register custom commands.
-	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, false)
-	require.NoError(t, err)
-
-	// Process custom commands to register them with RootCmd.
-	err = processCustomCommands(atmosConfig, atmosConfig.Commands, RootCmd)
-	require.NoError(t, err)
-
-	// Find the registered test-identity command.
-	var cobraCmd *cobra.Command
-	for _, cmd := range RootCmd.Commands() {
-		if cmd.Name() == "test-identity" {
-			cobraCmd = cmd
-			break
-		}
-	}
-	require.NotNil(t, cobraCmd, "test-identity command should be registered as a Cobra command")
-
-	// Verify that --identity flag is automatically added.
-	identityFlag := cobraCmd.PersistentFlags().Lookup("identity")
-	require.NotNil(t, identityFlag, "--identity flag should be automatically added to custom commands")
-	assert.Equal(t, "string", identityFlag.Value.Type())
-	assert.Contains(t, identityFlag.Usage, "overrides identity in command config")
+	require.NotNil(t, result)
+	assert.Same(t, mgr, result)
 }

--- a/cmd/custom_command_identity_test.go
+++ b/cmd/custom_command_identity_test.go
@@ -69,8 +69,11 @@ func TestPrepareCustomCommandAuth_SelectValue(t *testing.T) {
 		Auth: schema.AuthConfig{Identities: map[string]schema.Identity{"resolved-identity": {Kind: "aws/user"}}},
 	}
 
-	result := prepareCustomCommandAuth(atmosConfig, cfg.IdentityFlagSelectValue, "ci-build", true)
+	result, resolvedIdentity := prepareCustomCommandAuth(atmosConfig, cfg.IdentityFlagSelectValue, "ci-build", true)
 
 	require.NotNil(t, result)
 	assert.Same(t, mgr, result)
+	assert.Equal(t, "resolved-identity", resolvedIdentity,
+		"caller must receive the resolved identity, not the select sentinel, for use in "+
+			"PrepareShellEnvironment/ExecuteCustomCommandControlStep")
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	pkgFlags "github.com/cloudposse/atmos/pkg/flags"
 )
 
 // describeCmd describes configuration for stacks and components.
@@ -21,11 +23,13 @@ func init() {
 	// By default, all describe commands execute YAML functions and Go templates unless
 	// disabled with --process-functions=false or --process-templates=false flags.
 	//
-	// NOTE: NoOptDefVal is NOT used here to avoid Cobra parsing issues with commands
-	// that have positional arguments. When NoOptDefVal is set and a space-separated value
-	// is used (--identity value), Cobra misinterprets the value as a subcommand/positional arg.
-	// Users should use --identity=select or similar for interactive selection.
-	describeCmd.PersistentFlags().StringP("identity", "i", "", "Specify the identity to authenticate with before describing")
+	// Uses the shared flags.WithIdentityFlag() builder (rather than a hand-rolled
+	// PersistentFlags().StringP()) so bare --identity triggers the interactive selector like
+	// every other Atmos command. Space-separated values on subcommands with positional args
+	// (e.g. `describe component vpc --identity foo`) are normalized to `--identity=foo` by the
+	// generic NoOptDefVal preprocessor in cmd/root.go before Cobra parses, and identity
+	// retrieval already goes through GetIdentityFromFlags for extra safety.
+	pkgFlags.NewStandardParser(pkgFlags.WithIdentityFlag()).RegisterPersistentFlags(describeCmd)
 
 	// Register shell completion for identity flag.
 	AddIdentityCompletion(describeCmd)

--- a/cmd/describe_identity_test.go
+++ b/cmd/describe_identity_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/cloudposse/atmos/pkg/config"
+)
+
+// TestDescribeCmd_IdentityFlagNoOptDefVal verifies describeCmd registers --identity via the
+// shared flags.WithIdentityFlag() builder, so a bare --identity (no value) carries the
+// interactive-selection sentinel instead of failing with "flag needs an argument".
+func TestDescribeCmd_IdentityFlagNoOptDefVal(t *testing.T) {
+	identityFlag := describeCmd.PersistentFlags().Lookup("identity")
+	require.NotNil(t, identityFlag, "identity flag should be registered on the describe command")
+	assert.Equal(t, cfg.IdentityFlagSelectValue, identityFlag.NoOptDefVal,
+		"bare --identity must carry the select sentinel, matching every other Atmos command")
+	assert.Equal(t, "i", identityFlag.Shorthand)
+}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -20,15 +20,16 @@ var listCmd = &cobra.Command{
 func init() {
 	// Add --identity flag to all list commands to enable authentication
 	// when processing YAML template functions (!terraform.state, !terraform.output).
-	// This follows the same pattern as the describe commands.
 	//
-	// NOTE: NoOptDefVal is NOT used here to avoid Cobra parsing issues with commands
-	// that have positional arguments. When NoOptDefVal is set and a space-separated value
-	// is used (--identity value), Cobra misinterprets the value as a subcommand/positional arg.
+	// Uses the shared flags.WithIdentityFlag() builder (rather than a hand-rolled
+	// PersistentFlags().StringP()) so bare --identity triggers the interactive selector like
+	// every other Atmos command. Space-separated values on subcommands with positional args
+	// are normalized to `--identity=value` by the generic NoOptDefVal preprocessor in
+	// cmd/root.go before Cobra parses.
 	//
 	// The ATMOS_IDENTITY environment variable binding is handled centrally by the global
 	// flag registry in pkg/flags/global_builder.go, so no explicit viper.BindEnv is needed here.
-	listCmd.PersistentFlags().StringP("identity", "i", "", "Specify the identity to authenticate with")
+	flags.NewStandardParser(flags.WithIdentityFlag()).RegisterPersistentFlags(listCmd)
 
 	// Attach all subcommands
 	listCmd.AddCommand(affectedCmd)

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	l "github.com/cloudposse/atmos/pkg/list"
 	"github.com/cloudposse/atmos/pkg/list/errors"
 )
@@ -24,6 +25,17 @@ func setupTestCommand(use string) *cobra.Command {
 	cmd.PersistentFlags().Bool("process-templates", true, "Enable/disable Go template processing")
 	cmd.PersistentFlags().Bool("process-functions", true, "Enable/disable YAML functions processing")
 	return cmd
+}
+
+// TestListCmd_IdentityFlagNoOptDefVal verifies listCmd registers --identity via the shared
+// flags.WithIdentityFlag() builder, so a bare --identity (no value) carries the interactive-
+// selection sentinel instead of failing with "flag needs an argument".
+func TestListCmd_IdentityFlagNoOptDefVal(t *testing.T) {
+	identityFlag := listCmd.PersistentFlags().Lookup("identity")
+	require.NotNil(t, identityFlag, "identity flag should be registered on the list command")
+	assert.Equal(t, cfg.IdentityFlagSelectValue, identityFlag.NoOptDefVal,
+		"bare --identity must carry the select sentinel, matching every other Atmos command")
+	assert.Equal(t, "i", identityFlag.Shorthand)
 }
 
 // TestComponentDefinitionNotFoundError tests that the ComponentDefinitionNotFoundError.

--- a/docs/fixes/2026-08-20-ecr-acr-ambient-credential-identity-hint.md
+++ b/docs/fixes/2026-08-20-ecr-acr-ambient-credential-identity-hint.md
@@ -1,0 +1,64 @@
+# Fix: AWS ECR / Azure ACR ambient-credential login failures now hint at configuring an Atmos identity
+
+**Date:** 2026-08-20
+
+## Summary
+
+`atmos aws ecr login --registry`/`--public` and `atmos azure acr login --registry` use an
+ambient-credential fallback (the plain AWS/Azure SDK default credential chain) instead of Atmos's
+identity system. When no Atmos identity was configured and the ambient chain also had nothing to
+offer, the chain's last resort (EC2 IMDS for AWS, managed identity for Azure) would time out off
+those clouds, and the user only saw the raw SDK error — e.g. `no EC2 IMDS role found ... context
+deadline exceeded` — with no indication that configuring an Atmos identity was the fix.
+
+## Context
+
+A user ran `atmos app build` and hit:
+
+```
+ECR authentication failed: failed to retrieve AWS credentials: failed to refresh cached credentials, no EC2
+IMDS role found, operation error ec2imds: GetMetadata, request canceled, context deadline exceeded
+```
+
+Diagnosis traced this to `pkg/auth/cloud/aws/ecr.go`'s `LoadDefaultAWSCredentials`, which is only
+invoked on the ambient-credential ECR login paths (`cmd/aws/ecr/login.go`'s
+`executeExplicitRegistries` and `executePublicLoginAmbient`) — it never touches Atmos's own
+`pkg/auth` identity system. A follow-up check found the identical pattern in
+`pkg/auth/cloud/azure/acr.go`'s `LoadDefaultAzureCredentials` (used by `cmd/azure/acr/login.go`'s
+`executeExplicitRegistries`), whose `azidentity.NewDefaultAzureCredential` default chain includes a
+Managed Identity Credential that probes Azure IMDS. GCP has no container-registry (Artifact
+Registry/GCR) integration at all yet, so there was nothing to fix on that cloud.
+
+The ambient-credential escape hatch itself is intentional (for callers already authenticated
+outside Atmos, e.g. a CI job running under an IAM role) and was kept as-is. The actual defect was
+the failure mode: a bare SDK error with no pointer to the fix, which reads as an Atmos bug rather
+than a config gap.
+
+## Changes
+
+- `pkg/auth/cloud/aws/ecr.go`: `LoadDefaultAWSCredentials`'s `awsCfg.Credentials.Retrieve(ctx)`
+  failure branch now uses `errUtils.Build(errUtils.ErrECRAuthFailed).WithCause(err).WithExplanation(...).WithHint(...)`
+  instead of a plain `fmt.Errorf`. The hint points at `atmos aws ecr login --identity <name>` or
+  configuring `via.identity` under `auth.integrations`.
+- `pkg/auth/cloud/azure/acr.go`: `LoadDefaultAzureCredentials`'s `cred.GetToken(...)` failure branch
+  gets the same treatment, hinting at `atmos azure acr login --identity <name>`.
+- Both changes preserve the original sentinel errors (`ErrECRAuthFailed`, `ErrACRAuthFailed`) via
+  `errUtils.Build(...)`'s auto-sentinel marking, and preserve the underlying SDK error text via
+  `WithCause`, so `errors.Is()` checks against either the sentinel or the original error still hold.
+- The other early-return branches in each function (`config.LoadDefaultConfig` /
+  `azidentity.NewDefaultAzureCredential` construction failures) were left as plain wraps — those
+  indicate malformed SDK config, not "no identity configured," so a hint there would mislead.
+
+## Validation
+
+- Added `TestLoadDefaultAWSCredentials_RetrieveFailureHasIdentityHint`
+  (`pkg/auth/cloud/aws/ecr_test.go`) and `TestLoadDefaultAzureCredentials_RetrieveFailureHasIdentityHint`
+  (`pkg/auth/cloud/azure/acr_test.go`), each using a pre-canceled `context.Context` to force the
+  failure branch deterministically without a real network/IMDS call. Both assert `errors.Is` against
+  the sentinel still holds and that `cockroachdb/errors.GetAllHints` contains the new hint text.
+- `go test ./pkg/auth/...` — all packages pass.
+- `atmos lint --changed` — 0 issues.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-08-20-ecr-acr-ambient-credential-identity-hint.md
+++ b/docs/fixes/2026-08-20-ecr-acr-ambient-credential-identity-hint.md
@@ -15,7 +15,7 @@ deadline exceeded` — with no indication that configuring an Atmos identity was
 
 A user ran `atmos app build` and hit:
 
-```
+```text
 ECR authentication failed: failed to retrieve AWS credentials: failed to refresh cached credentials, no EC2
 IMDS role found, operation error ec2imds: GetMetadata, request canceled, context deadline exceeded
 ```

--- a/docs/fixes/2026-08-21-identity-flag-noOptDefVal-consolidation.md
+++ b/docs/fixes/2026-08-21-identity-flag-noOptDefVal-consolidation.md
@@ -1,0 +1,67 @@
+# Fix: bare `--identity` failed instead of showing the interactive selector on 6 commands
+
+**Date:** 2026-08-21
+
+## Summary
+
+`atmos <custom-command> --identity` (bare, no value) failed with `Error: --identity flag needs an
+argument` instead of popping up the interactive identity picker that other Atmos commands show.
+The same defect existed, independently, on five other commands.
+
+## Context
+
+A user hit this running a downstream custom command (`atmos app build --identity`). `--identity`
+is meant to be a single, centrally-defined flag: `flags.WithIdentityFlag()` (`pkg/flags/options.go`)
+pulls the one canonical definition — including `NoOptDefVal: cfg.IdentityFlagSelectValue` (the
+`"__SELECT__"` sentinel), which is what makes a bare `--identity` legal and triggers the
+interactive `huh` selector (`pkg/auth/manager.go`'s `promptForIdentity`) — out of
+`GlobalFlagsRegistry()`. ~150 command files already wire this correctly via
+`flags.NewStandardParser(flags.WithIdentityFlag())`.
+
+Six command files never got migrated onto that shared parser and instead hand-rolled their own
+`cmd.Flags().StringP("identity", "i", ...)` registration, silently bypassing the single
+implementation:
+
+| File                         | Flag registration missing `NoOptDefVal` | Sentinel (`__SELECT__`) never resolved to a real identity |
+| ----------------------------- | :--------------------------------------: | :---------------------------------------------------------: |
+| `cmd/cmd_utils.go` (custom commands) | yes | yes — `Authenticate(ctx, "__SELECT__")` called directly, failed with `ErrIdentityNotFound` |
+| `cmd/describe.go`            | yes (deliberately, per a stale comment)  | no — already correct downstream |
+| `cmd/list/list.go`           | yes (same stale comment)                 | no — already correct downstream |
+| `cmd/aws/ecr/login.go`       | no — already hand-patched                | no — already correct, but via a locally duplicated helper |
+| `cmd/aws/eks/token.go`       | yes                                       | yes |
+| `cmd/azure/aks/token.go`     | yes                                       | yes |
+
+## Changes
+
+- `pkg/auth/manager_helpers.go`: added exported `ResolveSelectedIdentity(authManager, identityName,
+  selectValue)`, extracted from the existing local `resolveSelectedIdentity` in
+  `cmd/aws/ecr/login.go`, so the sentinel → `GetDefaultIdentity(forceSelect=true)` resolution
+  exists in exactly one place. `authenticateWithIdentity` now delegates to it internally.
+- `cmd/cmd_utils.go` (`createCustomCommand`): replaced the hand-rolled `PersistentFlags().String()`
+  identity registration with `flags.NewStandardParser(flags.WithIdentityFlag()).RegisterPersistentFlags(...)`.
+  `prepareCustomCommandAuth` now resolves the sentinel via `auth.ResolveSelectedIdentity` before the
+  credential-cache check and `Authenticate` call. Added a `newCustomCommandAuthManagerFn` seam for
+  testing.
+- `cmd/describe.go`, `cmd/list/list.go`: same flag-registration migration (their downstream sentinel
+  resolution was already correct, via `GetIdentityFromFlags` / `CreateAndAuthenticateManagerWithStackScan`).
+- `cmd/aws/ecr/login.go`: flag registration migrated to the shared builder; the local
+  `resolveSelectedIdentity` now delegates its body to `auth.ResolveSelectedIdentity`.
+- `cmd/aws/eks/token.go`, `cmd/azure/aks/token.go`: same flag-registration migration, plus
+  `authenticateForToken` now resolves the sentinel via `auth.ResolveSelectedIdentity` before the
+  existing empty-identity default-lookup fallback. Added a `newAuthManagerFn` seam for testing.
+
+## Validation
+
+- Added `TestResolveSelectedIdentity_*` (`pkg/auth/manager_helpers_test.go`),
+  `TestCustomCommand_IdentityFlagNoOptDefVal` / `TestPrepareCustomCommandAuth_SelectValue`
+  (`cmd/custom_command_identity_test.go`), `TestDescribeCmd_IdentityFlagNoOptDefVal`
+  (`cmd/describe_identity_test.go`), `TestListCmd_IdentityFlagNoOptDefVal` (`cmd/list/list_test.go`),
+  and `TestAuthenticateForToken_SelectValue*` in both `cmd/aws/eks/token_test.go` and
+  `cmd/azure/aks/token_test.go`.
+- `go build ./...` and `go test ./cmd/... ./pkg/auth/... ./cmd/aws/eks/... ./cmd/azure/aks/...
+  ./cmd/aws/ecr/...` — all pass, no regressions.
+- `./custom-gcl run --new-from-rev=origin/main ./...` — 0 issues.
+
+## Follow-ups
+
+None.

--- a/pkg/auth/cloud/aws/ecr.go
+++ b/pkg/auth/cloud/aws/ecr.go
@@ -143,7 +143,11 @@ func LoadDefaultAWSCredentials(ctx context.Context) (*types.AWSCredentials, erro
 	// Retrieve credentials.
 	awsCreds, err := awsCfg.Credentials.Retrieve(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to retrieve AWS credentials: %w", errUtils.ErrECRAuthFailed, err)
+		return nil, errUtils.Build(errUtils.ErrECRAuthFailed).
+			WithCause(err).
+			WithExplanation("Failed to retrieve AWS credentials from the ambient environment (env vars, shared config, SSO, or EC2 instance metadata).").
+			WithHint("No Atmos identity is configured for this registry — run `atmos aws ecr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
+			Err()
 	}
 
 	return &types.AWSCredentials{

--- a/pkg/auth/cloud/aws/ecr.go
+++ b/pkg/auth/cloud/aws/ecr.go
@@ -146,7 +146,7 @@ func LoadDefaultAWSCredentials(ctx context.Context) (*types.AWSCredentials, erro
 		return nil, errUtils.Build(errUtils.ErrECRAuthFailed).
 			WithCause(err).
 			WithExplanation("Failed to retrieve AWS credentials from the ambient environment (env vars, shared config, SSO, or EC2 instance metadata).").
-			WithHint("No Atmos identity is configured for this registry — run `atmos aws ecr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
+			WithHint("If ambient credentials aren't available in this environment, configure an Atmos identity instead — run `atmos aws ecr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
 			Err()
 	}
 

--- a/pkg/auth/cloud/aws/ecr_test.go
+++ b/pkg/auth/cloud/aws/ecr_test.go
@@ -1,9 +1,13 @@
 package aws
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 )
@@ -121,6 +125,21 @@ func TestParseRegistryURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadDefaultAWSCredentials_RetrieveFailureHasIdentityHint(t *testing.T) {
+	// A pre-canceled context makes credential retrieval fail immediately
+	// (no real network/IMDS calls), exercising the same failure branch
+	// hit when no Atmos identity is configured for ambient ECR login.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := LoadDefaultAWSCredentials(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrECRAuthFailed)
+
+	hints := strings.Join(errors.GetAllHints(err), "\n")
+	assert.Contains(t, hints, "atmos aws ecr login --identity")
 }
 
 func TestIsECRRegistry(t *testing.T) {

--- a/pkg/auth/cloud/aws/ecr_test.go
+++ b/pkg/auth/cloud/aws/ecr_test.go
@@ -137,6 +137,7 @@ func TestLoadDefaultAWSCredentials_RetrieveFailureHasIdentityHint(t *testing.T) 
 	_, err := LoadDefaultAWSCredentials(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrECRAuthFailed)
+	assert.ErrorIs(t, err, context.Canceled, "WithCause must preserve the original cancellation error in the chain")
 
 	hints := strings.Join(errors.GetAllHints(err), "\n")
 	assert.Contains(t, hints, "atmos aws ecr login --identity")

--- a/pkg/auth/cloud/azure/acr.go
+++ b/pkg/auth/cloud/azure/acr.go
@@ -169,7 +169,11 @@ func LoadDefaultAzureCredentials(ctx context.Context) (*types.AzureCredentials, 
 
 	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{PublicCloud.ManagementScope}})
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to retrieve ambient Azure credentials: %w", errUtils.ErrACRAuthFailed, err)
+		return nil, errUtils.Build(errUtils.ErrACRAuthFailed).
+			WithCause(err).
+			WithExplanation("Failed to retrieve Azure credentials from the ambient environment (env vars, managed identity, workload identity, or Azure CLI).").
+			WithHint("No Atmos identity is configured for this registry — run `atmos azure acr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
+			Err()
 	}
 
 	tenantID := ""

--- a/pkg/auth/cloud/azure/acr.go
+++ b/pkg/auth/cloud/azure/acr.go
@@ -172,7 +172,7 @@ func LoadDefaultAzureCredentials(ctx context.Context) (*types.AzureCredentials, 
 		return nil, errUtils.Build(errUtils.ErrACRAuthFailed).
 			WithCause(err).
 			WithExplanation("Failed to retrieve Azure credentials from the ambient environment (env vars, managed identity, workload identity, or Azure CLI).").
-			WithHint("No Atmos identity is configured for this registry — run `atmos azure acr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
+			WithHint("If ambient credentials aren't available in this environment, configure an Atmos identity instead — run `atmos azure acr login --identity <name>`, or add `via.identity` under `auth.integrations` in atmos.yaml.").
 			Err()
 	}
 

--- a/pkg/auth/cloud/azure/acr_test.go
+++ b/pkg/auth/cloud/azure/acr_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -107,6 +109,21 @@ func TestGetAuthorizationToken_EmptyRefreshToken(t *testing.T) {
 	_, err := GetAuthorizationToken(t.Context(), creds, "myregistry.azurecr.io")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrACRAuthFailed)
+}
+
+func TestLoadDefaultAzureCredentials_RetrieveFailureHasIdentityHint(t *testing.T) {
+	// A pre-canceled context makes token retrieval fail immediately (no real
+	// network/managed-identity calls), exercising the same failure branch hit
+	// when no Atmos identity is configured for ambient ACR login.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := LoadDefaultAzureCredentials(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrACRAuthFailed)
+
+	hints := strings.Join(errors.GetAllHints(err), "\n")
+	assert.Contains(t, hints, "atmos azure acr login --identity")
 }
 
 func TestBuildRegistryURL(t *testing.T) {

--- a/pkg/auth/cloud/azure/acr_test.go
+++ b/pkg/auth/cloud/azure/acr_test.go
@@ -121,6 +121,11 @@ func TestLoadDefaultAzureCredentials_RetrieveFailureHasIdentityHint(t *testing.T
 	_, err := LoadDefaultAzureCredentials(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrACRAuthFailed)
+	// azidentity's DefaultAzureCredential returns an aggregate error over each attempted
+	// credential's failure text rather than chaining context.Canceled via Unwrap(), so
+	// errors.Is(err, context.Canceled) does not hold here (unlike the AWS SDK case in
+	// ecr_test.go). Assert on the preserved cancellation message instead.
+	assert.Contains(t, err.Error(), "context canceled", "WithCause must preserve the original cancellation cause")
 
 	hints := strings.Join(errors.GetAllHints(err), "\n")
 	assert.Contains(t, hints, "atmos azure acr login --identity")

--- a/pkg/auth/manager_helpers.go
+++ b/pkg/auth/manager_helpers.go
@@ -125,21 +125,31 @@ func createAuthManagerInstance(authConfig *schema.AuthConfig, cliConfigPath stri
 	return authManager, nil
 }
 
+// ResolveSelectedIdentity resolves the interactive-selection sentinel (identityName == selectValue,
+// produced when --identity is passed without a value) to a concrete identity by prompting the
+// user via GetDefaultIdentity(forceSelect=true). Any other identityName passes through unchanged.
+//
+// Callers that need the resolved identity before authenticating (e.g. to check a credential cache
+// first) should call this directly instead of authenticateWithIdentity.
+func ResolveSelectedIdentity(authManager AuthManager, identityName, selectValue string) (string, error) {
+	defer perf.Track(nil, "auth.ResolveSelectedIdentity")()
+
+	if identityName != selectValue {
+		return identityName, nil
+	}
+	return authManager.GetDefaultIdentity(true)
+}
+
 // authenticateWithIdentity authenticates using the provided identity name.
 // Handles interactive selection if identity matches selectValue.
 func authenticateWithIdentity(authManager AuthManager, identityName string, selectValue string) error {
-	// Handle interactive selection if identity matches the select value.
-	forceSelect := identityName == selectValue
-	if forceSelect {
-		selectedIdentity, err := authManager.GetDefaultIdentity(forceSelect)
-		if err != nil {
-			return err
-		}
-		identityName = selectedIdentity
+	resolvedIdentity, err := ResolveSelectedIdentity(authManager, identityName, selectValue)
+	if err != nil {
+		return err
 	}
 
 	// Authenticate to populate AuthContext with credentials.
-	_, err := authManager.Authenticate(context.Background(), identityName)
+	_, err = authManager.Authenticate(context.Background(), resolvedIdentity)
 	return err
 }
 

--- a/pkg/auth/manager_helpers_test.go
+++ b/pkg/auth/manager_helpers_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/auth/credentials"
+	"github.com/cloudposse/atmos/pkg/auth/types"
 	"github.com/cloudposse/atmos/pkg/auth/validation"
 	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
@@ -1519,4 +1521,55 @@ func TestCreateAndAuthenticateManagerWithStackScan_ConflictingDefaultsDiscarded(
 	scannedCopy := scanStackFilesForDefaults(authConfig, atmosConfig)
 	assert.Nil(t, scannedCopy, "scan must return nil when stacks disagree on default identity (Issue #2072 allAgree preserved)")
 	assert.True(t, authConfig.Identities["atmos-yaml-default"].Default, "atmos.yaml-level default must remain intact")
+}
+
+func TestResolveSelectedIdentity_PassthroughForConcreteName(t *testing.T) {
+	// A concrete identity name (not the sentinel) must pass through unchanged, without
+	// ever calling GetDefaultIdentity.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+
+	resolved, err := ResolveSelectedIdentity(mgr, "dev-admin", cfg.IdentityFlagSelectValue)
+
+	require.NoError(t, err)
+	assert.Equal(t, "dev-admin", resolved)
+}
+
+func TestResolveSelectedIdentity_PassthroughForEmptyName(t *testing.T) {
+	// Empty identity name (flag omitted entirely) is a distinct case from the select
+	// sentinel and must also pass through unchanged.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+
+	resolved, err := ResolveSelectedIdentity(mgr, "", cfg.IdentityFlagSelectValue)
+
+	require.NoError(t, err)
+	assert.Empty(t, resolved)
+}
+
+func TestResolveSelectedIdentity_PromptsForSentinel(t *testing.T) {
+	// The select sentinel (bare --identity) must resolve via GetDefaultIdentity(forceSelect=true),
+	// which is what triggers the interactive huh picker.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("selected-identity", nil)
+
+	resolved, err := ResolveSelectedIdentity(mgr, cfg.IdentityFlagSelectValue, cfg.IdentityFlagSelectValue)
+
+	require.NoError(t, err)
+	assert.Equal(t, "selected-identity", resolved)
+}
+
+func TestResolveSelectedIdentity_PropagatesSelectionError(t *testing.T) {
+	// Errors from GetDefaultIdentity (e.g. ErrUserAborted, ErrIdentitySelectionRequiresTTY)
+	// must propagate unwrapped so callers can branch on errors.Is.
+	ctrl := gomock.NewController(t)
+	mgr := types.NewMockAuthManager(ctrl)
+	mgr.EXPECT().GetDefaultIdentity(true).Return("", errUtils.ErrUserAborted)
+
+	resolved, err := ResolveSelectedIdentity(mgr, cfg.IdentityFlagSelectValue, cfg.IdentityFlagSelectValue)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrUserAborted)
+	assert.Empty(t, resolved)
 }

--- a/tests/snapshots/TestCLICommands_deploy_component_help_shows_stack_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_deploy_component_help_shows_stack_flag.stdout.golden
@@ -16,7 +16,7 @@ FLAGS
 
   -h, --help             help for component
 
-      --identity string  Identity to use for authentication (overrides identity in command config)
+  -i, --identity string  Identity to use for authentication (use without value to select interactively)
 
   -s, --stack string     Name of the stack
 
@@ -97,5 +97,3 @@ GLOBAL FLAGS
 
   -v, --verbose                              Enable verbose error output with full context, stack traces, and detailed
                                              information
-
-

--- a/tests/snapshots/TestCLICommands_describe_component_help_shows_stack_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_describe_component_help_shows_stack_flag.stdout.golden
@@ -103,7 +103,8 @@ GLOBAL FLAGS
       --heatmap-mode string                  Heatmap visualization mode: bar, sparkline, table (press 1-3 to switch in
                                              TUI) (default bar)
 
-  -i, --identity string                      Specify the identity to authenticate with before describing
+  -i, --identity string                      Identity to use for authentication (use without value to select
+                                             interactively)
 
       --interactive                          Enable interactive prompts for missing required flags, optional value
                                              flags using the sentinel pattern, and missing positional arguments
@@ -153,4 +154,3 @@ GLOBAL FLAGS
 
   -v, --verbose                              Enable verbose error output with full context, stack traces, and detailed
                                              information
-

--- a/tests/snapshots/TestCLICommands_echo_info_help_shows_verbose_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_echo_info_help_shows_verbose_flag.stdout.golden
@@ -16,7 +16,7 @@ FLAGS
 
   -h, --help             help for info
 
-      --identity string  Identity to use for authentication (overrides identity in command config)
+  -i, --identity string  Identity to use for authentication (use without value to select interactively)
 
 
 GLOBAL FLAGS
@@ -95,5 +95,3 @@ GLOBAL FLAGS
 
   -v, --verbose                              Enable verbose error output with full context, stack traces, and detailed
                                              information
-
-

--- a/tests/snapshots/TestCLICommands_show_component_help_shows_inherited_stack_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_show_component_help_shows_inherited_stack_flag.stdout.golden
@@ -16,7 +16,7 @@ FLAGS
 
   -h, --help             help for component
 
-      --identity string  Identity to use for authentication (overrides identity in command config)
+  -i, --identity string  Identity to use for authentication (use without value to select interactively)
 
   -s, --stack string     Name of the stack
 
@@ -97,5 +97,3 @@ GLOBAL FLAGS
 
   -v, --verbose                              Enable verbose error output with full context, stack traces, and detailed
                                              information
-
-

--- a/tests/snapshots/TestCLICommands_terraform_provision_help_shows_inherited_stack_flag.stdout.golden
+++ b/tests/snapshots/TestCLICommands_terraform_provision_help_shows_inherited_stack_flag.stdout.golden
@@ -16,7 +16,7 @@ FLAGS
 
   -h, --help             help for provision
 
-      --identity string  Identity to use for authentication (overrides identity in command config)
+  -i, --identity string  Identity to use for authentication (use without value to select interactively)
 
 
 GLOBAL FLAGS


### PR DESCRIPTION
## what

- `atmos aws ecr login` / `atmos azure acr login` ambient-credential fallback (no Atmos identity
  configured) now returns a rich, actionable error when the underlying cloud SDK fails to retrieve
  credentials (e.g. EC2 IMDS timeout, Azure managed identity failure), with an explanation and a
  hint to run `login --identity <name>` or configure `via.identity`.
- Fixed bare `--identity` (no value) failing with `flag needs an argument` instead of showing the
  interactive identity selector, on 6 commands: custom commands (`atmos.yaml` `commands:`),
  `describe`, `list`, `aws ecr login`, `aws eks token`, and `azure aks token`. Each had hand-rolled
  its own `--identity` flag registration instead of using the shared `flags.WithIdentityFlag()`
  builder that ~150 other commands already use, so each silently lost the `NoOptDefVal` wiring that
  makes bare `--identity` legal and triggers the picker.
- Exported `auth.ResolveSelectedIdentity` (`pkg/auth/manager_helpers.go`) so the
  sentinel-to-interactive-picker resolution logic lives in one place instead of being duplicated
  (`aws ecr login`) or missing entirely (the other five commands).

## why

- A user hit both issues running a downstream custom command (`atmos app build`): first
  `--identity` (bare) rejected as a usage error instead of prompting, and separately — once
  ambient AWS credentials were tried as a fallback — a bare EC2 IMDS timeout with no indication
  that configuring an Atmos identity was the fix.
- The `--identity` flag exists as a single, centrally-defined flag specifically so this class of
  bug can't happen; these 6 commands were the stragglers that never got migrated onto that shared
  definition, so the bug had to be independently rediscovered and patched (see the ad-hoc
  `NoOptDefVal` fix already present on `aws ecr login`) instead of being fixed once.

## references

- `docs/fixes/2026-08-20-ecr-acr-ambient-credential-identity-hint.md`
- `docs/fixes/2026-08-21-identity-flag-noOptDefVal-consolidation.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare `--identity` now opens interactive identity selection across supported AWS, Azure, EKS, listing, description, and custom commands.
  * Selected identities are consistently applied to subsequent authentication and operations.

* **Bug Fixes**
  * Improved ECR and ACR authentication errors with actionable identity configuration guidance.
  * Preserved underlying authentication and selection errors for easier troubleshooting.

* **Documentation**
  * Added guidance covering interactive identity selection and ambient credential troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->