### PR TITLE
fix: prevent concurrent-map-write panic in global Viper singleton

### DIFF
--- a/cmd/terraform/test.go
+++ b/cmd/terraform/test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cloudposse/atmos/cmd/internal"
 	e "github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/ansi"
-	"github.com/cloudposse/atmos/pkg/ci"
 	tfci "github.com/cloudposse/atmos/pkg/ci/plugins/terraform"
 	"github.com/cloudposse/atmos/pkg/flags"
 	h "github.com/cloudposse/atmos/pkg/hooks"
@@ -81,14 +80,9 @@ For complete Terraform/OpenTofu documentation, see:
 		// (summary, outputs). The output is tee'd: the terminal still receives it in
 		// real time, and the buffer collects a copy for the CI summary parser.
 		// CI mode is active when the --ci flag or ATMOS_CI/CI env var is set, or a CI
-		// platform is auto-detected (e.g. GITHUB_ACTIONS=true).
-		ciMode, _ := cmd.Flags().GetBool("ci")
-		if !ciMode {
-			ciMode = v.GetBool("ci")
-		}
-		if !ciMode {
-			ciMode = ci.IsCI()
-		}
+		// platform is auto-detected (e.g. GITHUB_ACTIONS=true) -- terraformCIModeEnabled
+		// centralizes this so an explicit --ci=false stays authoritative here too.
+		ciMode := terraformCIModeEnabled(cmd)
 
 		// In CI, run `terraform/tofu test -json` for structured, tool-agnostic
 		// results (both tools support it) and capture stdout WITHOUT teeing — the

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -53,6 +53,10 @@ const logKeyStack = "stack"
 // --verify-plan=false).
 const verifyPlanFlagName = "verify-plan"
 
+// ciFlagKey is the --ci flag / ATMOS_CI /CI env var key, read both from the
+// Cobra flag and (as a fallback) the global Viper singleton.
+const ciFlagKey = "ci"
+
 // multiComponentPlaceholder satisfies the legacy compound-subcommand parser while
 // fleet options are applied immediately afterward. It never reaches Terraform.
 const multiComponentPlaceholder = "__atmos_multi_component__"
@@ -195,9 +199,9 @@ var runHooksOnErrorWithOutput = func(event h.HookEvent, cmd_ *cobra.Command, arg
 		log.Warn("hook failed on error path", "error", err)
 	}
 
-	forceCIMode, _ := cmd_.Flags().GetBool("ci")
+	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
 	if !forceCIMode {
-		forceCIMode = viper.GetBool("ci")
+		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
 	}
 
 	// Extract the exit code from the command error. errUtils.GetExitCode unwraps
@@ -385,10 +389,10 @@ func runHooksWithOutput(event h.HookEvent, cmd_ *cobra.Command, args []string, o
 	// Read directly from Cobra flag (not Viper) because pflags are only bound
 	// to Viper in RunE via BindFlagsToViper. During PreRunE, Viper doesn't
 	// yet see the Cobra flag value — only env vars and defaults.
-	forceCIMode, _ := cmd_.Flags().GetBool("ci")
+	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
 	if !forceCIMode {
 		// Fall back to Viper for env var support (ATMOS_CI, CI).
-		forceCIMode = viper.GetBool("ci")
+		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
 	}
 
 	// Read the verify-plan flag early (same pattern as --ci above). PreRunE runs
@@ -479,9 +483,9 @@ func runCIHooksForDeploy(event h.HookEvent, cmd_ *cobra.Command, _ []string, inf
 		return
 	}
 
-	forceCIMode, _ := cmd_.Flags().GetBool("ci")
+	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
 	if !forceCIMode {
-		forceCIMode = viper.GetBool("ci")
+		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
 	}
 
 	// Before-event hook (e.g., before.terraform.deploy): no command has run yet,
@@ -609,9 +613,9 @@ func (n *terraformNodeHooks) runUserHooksForNodeWithWriters(atmosConfig *schema.
 // errors are advisory only (unrelated to a hook's on_failure setting) and are
 // only logged, matching existing CI-hook behavior.
 func (n *terraformNodeHooks) runCIHooksForNode(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
-	forceCIMode, _ := n.cmd.Flags().GetBool("ci")
+	forceCIMode, _ := n.cmd.Flags().GetBool(ciFlagKey)
 	if !forceCIMode {
-		forceCIMode = viper.GetBool("ci")
+		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
 	}
 
 	if err := h.RunCIHooks(&h.RunCIHooksOptions{
@@ -704,12 +708,12 @@ func terraformAggregateEvent(command string) h.HookEvent {
 func terraformCIModeEnabled(cmd *cobra.Command) bool {
 	forceCIMode := false
 	if cmd != nil {
-		forceCIMode, _ = cmd.Flags().GetBool("ci")
+		forceCIMode, _ = cmd.Flags().GetBool(ciFlagKey)
 	}
 	if forceCIMode {
 		return true
 	}
-	if viper.GetBool("ci") {
+	if cfg.GlobalViper().GetBool(ciFlagKey) {
 		return true
 	}
 	return ci.IsCI()

--- a/cmd/terraform/utils.go
+++ b/cmd/terraform/utils.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/cloudposse/atmos/cmd/internal"
@@ -56,6 +57,33 @@ const verifyPlanFlagName = "verify-plan"
 // ciFlagKey is the --ci flag / ATMOS_CI /CI env var key, read both from the
 // Cobra flag and (as a fallback) the global Viper singleton.
 const ciFlagKey = "ci"
+
+// ciFlagExplicit returns the --ci flag's value and whether the user
+// explicitly set it (true or false), distinguishing that from "never set,
+// defaults to false" so callers can treat an explicit override as
+// authoritative instead of falling through to env/config/native detection.
+func ciFlagExplicit(flags *pflag.FlagSet) (value bool, changed bool) {
+	if flags == nil {
+		return false, false
+	}
+	f := flags.Lookup(ciFlagKey)
+	if f == nil || !f.Changed {
+		return false, false
+	}
+	value, _ = flags.GetBool(ciFlagKey)
+	return value, true
+}
+
+// resolveCIMode reports whether CI mode is enabled for this command
+// invocation. An explicitly set --ci flag (true or false) is authoritative;
+// only when the flag was never explicitly set do ATMOS_CI/CI env vars (via
+// the global Viper singleton, which the --ci flag's env bindings feed) decide.
+func resolveCIMode(flags *pflag.FlagSet) bool {
+	if value, changed := ciFlagExplicit(flags); changed {
+		return value
+	}
+	return cfg.GlobalViper().GetBool(ciFlagKey)
+}
 
 // multiComponentPlaceholder satisfies the legacy compound-subcommand parser while
 // fleet options are applied immediately afterward. It never reaches Terraform.
@@ -199,10 +227,7 @@ var runHooksOnErrorWithOutput = func(event h.HookEvent, cmd_ *cobra.Command, arg
 		log.Warn("hook failed on error path", "error", err)
 	}
 
-	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
-	if !forceCIMode {
-		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
-	}
+	forceCIMode := resolveCIMode(cmd_.Flags())
 
 	// Extract the exit code from the command error. errUtils.GetExitCode unwraps
 	// the error chain (exec.ExitError, ExecError, exitCoder, etc.) and returns 1
@@ -385,15 +410,13 @@ func runHooksWithOutput(event h.HookEvent, cmd_ *cobra.Command, args []string, o
 		return err
 	}
 
-	// Check for --ci flag or CI environment variable.
-	// Read directly from Cobra flag (not Viper) because pflags are only bound
-	// to Viper in RunE via BindFlagsToViper. During PreRunE, Viper doesn't
-	// yet see the Cobra flag value — only env vars and defaults.
-	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
-	if !forceCIMode {
-		// Fall back to Viper for env var support (ATMOS_CI, CI).
-		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
-	}
+	// Check for --ci flag or CI environment variable. resolveCIMode reads
+	// directly from the Cobra flag first (not Viper) because pflags are only
+	// bound to Viper in RunE via BindFlagsToViper -- during PreRunE, Viper
+	// doesn't yet see the Cobra flag value, only env vars and defaults -- and
+	// falls back to Viper for env var support (ATMOS_CI, CI) only when the
+	// flag was never explicitly set, so an explicit --ci=false is authoritative.
+	forceCIMode := resolveCIMode(cmd_.Flags())
 
 	// Read the verify-plan flag early (same pattern as --ci above). PreRunE runs
 	// before RunE, so info is not yet populated by applyOptionsToInfo(). The
@@ -483,10 +506,7 @@ func runCIHooksForDeploy(event h.HookEvent, cmd_ *cobra.Command, _ []string, inf
 		return
 	}
 
-	forceCIMode, _ := cmd_.Flags().GetBool(ciFlagKey)
-	if !forceCIMode {
-		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
-	}
+	forceCIMode := resolveCIMode(cmd_.Flags())
 
 	// Before-event hook (e.g., before.terraform.deploy): no command has run yet,
 	// so there is no exit code or error to report.
@@ -613,10 +633,7 @@ func (n *terraformNodeHooks) runUserHooksForNodeWithWriters(atmosConfig *schema.
 // errors are advisory only (unrelated to a hook's on_failure setting) and are
 // only logged, matching existing CI-hook behavior.
 func (n *terraformNodeHooks) runCIHooksForNode(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, rawOutput string, execErr error) {
-	forceCIMode, _ := n.cmd.Flags().GetBool(ciFlagKey)
-	if !forceCIMode {
-		forceCIMode = cfg.GlobalViper().GetBool(ciFlagKey)
-	}
+	forceCIMode := resolveCIMode(n.cmd.Flags())
 
 	if err := h.RunCIHooks(&h.RunCIHooksOptions{
 		Event:        n.afterEvent,
@@ -706,12 +723,16 @@ func terraformAggregateEvent(command string) h.HookEvent {
 
 // terraformCIModeEnabled returns true when CLI, config, or native provider detection enables CI mode.
 func terraformCIModeEnabled(cmd *cobra.Command) bool {
-	forceCIMode := false
+	var flags *pflag.FlagSet
 	if cmd != nil {
-		forceCIMode, _ = cmd.Flags().GetBool(ciFlagKey)
+		flags = cmd.Flags()
 	}
-	if forceCIMode {
-		return true
+	// An explicit --ci=false must win over env vars and native CI-provider
+	// detection, not just an explicit --ci=true, or a user disabling CI mode
+	// on a CI runner (e.g. to force human-readable output) would be silently
+	// overridden by env vars / native detection.
+	if value, changed := ciFlagExplicit(flags); changed {
+		return value
 	}
 	if cfg.GlobalViper().GetBool(ciFlagKey) {
 		return true

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -885,6 +885,68 @@ func TestTerraformCIModeEnabledSources(t *testing.T) {
 
 		assert.True(t, terraformCIModeEnabled(newHookTestCmd()))
 	})
+
+	// Regression: an explicit --ci=false must be authoritative and win over
+	// ATMOS_CI/CI env vars (via Viper) and native CI-provider detection alike
+	// -- e.g. a user forcing human-readable output on a CI runner. Before this
+	// fix, terraformCIModeEnabled only special-cased an explicit --ci=true,
+	// silently re-enabling CI mode whenever Viper or native detection said true.
+	t.Run("explicit --ci=false wins over viper ci=true", func(t *testing.T) {
+		withoutCIDetection(t)
+		resetViperCI(t)
+		viper.Set("ci", true)
+		cmd := newHookTestCmd()
+		require.NoError(t, cmd.Flags().Set("ci", "false"))
+
+		assert.False(t, terraformCIModeEnabled(cmd))
+	})
+
+	t.Run("explicit --ci=false wins over native GitHub Actions detection", func(t *testing.T) {
+		withGitHubActionsDetection(t)
+		resetViperCI(t)
+		cmd := newHookTestCmd()
+		require.NoError(t, cmd.Flags().Set("ci", "false"))
+
+		assert.False(t, terraformCIModeEnabled(cmd))
+	})
+}
+
+// TestResolveCIMode covers resolveCIMode directly: an explicitly set --ci
+// flag (true or false) must be authoritative, falling back to Viper
+// (ATMOS_CI/CI env vars) only when the flag was never explicitly set.
+func TestResolveCIMode(t *testing.T) {
+	t.Run("nil flags falls back to viper", func(t *testing.T) {
+		resetViperCI(t)
+		viper.Set("ci", true)
+
+		assert.True(t, resolveCIMode(nil))
+	})
+
+	t.Run("flag never set falls back to viper", func(t *testing.T) {
+		resetViperCI(t)
+		viper.Set("ci", true)
+		cmd := newHookTestCmd()
+
+		assert.True(t, resolveCIMode(cmd.Flags()))
+	})
+
+	t.Run("explicit --ci=true wins regardless of viper", func(t *testing.T) {
+		resetViperCI(t)
+		viper.Set("ci", false)
+		cmd := newHookTestCmd()
+		require.NoError(t, cmd.Flags().Set("ci", "true"))
+
+		assert.True(t, resolveCIMode(cmd.Flags()))
+	})
+
+	t.Run("explicit --ci=false wins over viper ci=true", func(t *testing.T) {
+		resetViperCI(t)
+		viper.Set("ci", true)
+		cmd := newHookTestCmd()
+		require.NoError(t, cmd.Flags().Set("ci", "false"))
+
+		assert.False(t, resolveCIMode(cmd.Flags()))
+	})
 }
 
 func TestTerraformPlanCIResultHandler(t *testing.T) {

--- a/cmd/terraform/utils_hooks_test.go
+++ b/cmd/terraform/utils_hooks_test.go
@@ -18,9 +18,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -854,99 +856,132 @@ func TestWirePerComponentHook(t *testing.T) {
 	})
 }
 
+// TestTerraformCIModeEnabledSources table-drives terraformCIModeEnabled's
+// four signal sources (nil command, explicit --ci flag, Viper/env, native
+// CI-provider detection) and their precedence, including the explicit
+// --ci=false regression: it must be authoritative and win over ATMOS_CI/CI
+// env vars (via Viper) and native CI-provider detection alike -- e.g. a user
+// forcing human-readable output on a CI runner. Before that fix,
+// terraformCIModeEnabled only special-cased an explicit --ci=true, silently
+// re-enabling CI mode whenever Viper or native detection said true.
 func TestTerraformCIModeEnabledSources(t *testing.T) {
-	t.Run("nil command and no CI detection is false", func(t *testing.T) {
-		withoutCIDetection(t)
-		resetViperCI(t)
+	tests := []struct {
+		name       string
+		setupCI    func(t *testing.T)
+		viperCI    bool
+		nilCmd     bool
+		explicitCI *bool
+		want       bool
+	}{
+		{
+			name:    "nil command and no CI detection is false",
+			setupCI: withoutCIDetection,
+			nilCmd:  true,
+			want:    false,
+		},
+		{
+			name:       "cobra flag wins",
+			setupCI:    withoutCIDetection,
+			explicitCI: boolPtr(true),
+			want:       true,
+		},
+		{
+			name:    "viper ci enables mode",
+			setupCI: withoutCIDetection,
+			viperCI: true,
+			want:    true,
+		},
+		{
+			name:    "native GitHub Actions detection enables mode",
+			setupCI: withGitHubActionsDetection,
+			want:    true,
+		},
+		{
+			name:       "explicit --ci=false wins over viper ci=true",
+			setupCI:    withoutCIDetection,
+			viperCI:    true,
+			explicitCI: boolPtr(false),
+			want:       false,
+		},
+		{
+			name:       "explicit --ci=false wins over native GitHub Actions detection",
+			setupCI:    withGitHubActionsDetection,
+			explicitCI: boolPtr(false),
+			want:       false,
+		},
+	}
 
-		assert.False(t, terraformCIModeEnabled(nil))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupCI(t)
+			resetViperCI(t)
+			viper.Set("ci", tt.viperCI)
 
-	t.Run("cobra flag wins", func(t *testing.T) {
-		withoutCIDetection(t)
-		resetViperCI(t)
-		cmd := newHookTestCmd()
-		require.NoError(t, cmd.Flags().Set("ci", "true"))
+			var cmd *cobra.Command
+			if !tt.nilCmd {
+				cmd = newHookTestCmd()
+				if tt.explicitCI != nil {
+					require.NoError(t, cmd.Flags().Set("ci", strconv.FormatBool(*tt.explicitCI)))
+				}
+			}
 
-		assert.True(t, terraformCIModeEnabled(cmd))
-	})
-
-	t.Run("viper ci enables mode", func(t *testing.T) {
-		withoutCIDetection(t)
-		resetViperCI(t)
-		viper.Set("ci", true)
-
-		assert.True(t, terraformCIModeEnabled(newHookTestCmd()))
-	})
-
-	t.Run("native GitHub Actions detection enables mode", func(t *testing.T) {
-		withGitHubActionsDetection(t)
-		resetViperCI(t)
-
-		assert.True(t, terraformCIModeEnabled(newHookTestCmd()))
-	})
-
-	// Regression: an explicit --ci=false must be authoritative and win over
-	// ATMOS_CI/CI env vars (via Viper) and native CI-provider detection alike
-	// -- e.g. a user forcing human-readable output on a CI runner. Before this
-	// fix, terraformCIModeEnabled only special-cased an explicit --ci=true,
-	// silently re-enabling CI mode whenever Viper or native detection said true.
-	t.Run("explicit --ci=false wins over viper ci=true", func(t *testing.T) {
-		withoutCIDetection(t)
-		resetViperCI(t)
-		viper.Set("ci", true)
-		cmd := newHookTestCmd()
-		require.NoError(t, cmd.Flags().Set("ci", "false"))
-
-		assert.False(t, terraformCIModeEnabled(cmd))
-	})
-
-	t.Run("explicit --ci=false wins over native GitHub Actions detection", func(t *testing.T) {
-		withGitHubActionsDetection(t)
-		resetViperCI(t)
-		cmd := newHookTestCmd()
-		require.NoError(t, cmd.Flags().Set("ci", "false"))
-
-		assert.False(t, terraformCIModeEnabled(cmd))
-	})
+			assert.Equal(t, tt.want, terraformCIModeEnabled(cmd))
+		})
+	}
 }
 
-// TestResolveCIMode covers resolveCIMode directly: an explicitly set --ci
-// flag (true or false) must be authoritative, falling back to Viper
-// (ATMOS_CI/CI env vars) only when the flag was never explicitly set.
+// TestResolveCIMode table-drives resolveCIMode: an explicitly set --ci flag
+// (true or false) must be authoritative, falling back to Viper (ATMOS_CI/CI
+// env vars) only when the flag was never explicitly set.
 func TestResolveCIMode(t *testing.T) {
-	t.Run("nil flags falls back to viper", func(t *testing.T) {
-		resetViperCI(t)
-		viper.Set("ci", true)
+	tests := []struct {
+		name       string
+		viperCI    bool
+		nilFlags   bool
+		explicitCI *bool
+		want       bool
+	}{
+		{
+			name:     "nil flags falls back to viper",
+			viperCI:  true,
+			nilFlags: true,
+			want:     true,
+		},
+		{
+			name:    "flag never set falls back to viper",
+			viperCI: true,
+			want:    true,
+		},
+		{
+			name:       "explicit --ci=true wins regardless of viper",
+			explicitCI: boolPtr(true),
+			want:       true,
+		},
+		{
+			name:       "explicit --ci=false wins over viper ci=true",
+			viperCI:    true,
+			explicitCI: boolPtr(false),
+			want:       false,
+		},
+	}
 
-		assert.True(t, resolveCIMode(nil))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetViperCI(t)
+			viper.Set("ci", tt.viperCI)
 
-	t.Run("flag never set falls back to viper", func(t *testing.T) {
-		resetViperCI(t)
-		viper.Set("ci", true)
-		cmd := newHookTestCmd()
+			var flags *pflag.FlagSet
+			if !tt.nilFlags {
+				cmd := newHookTestCmd()
+				if tt.explicitCI != nil {
+					require.NoError(t, cmd.Flags().Set("ci", strconv.FormatBool(*tt.explicitCI)))
+				}
+				flags = cmd.Flags()
+			}
 
-		assert.True(t, resolveCIMode(cmd.Flags()))
-	})
-
-	t.Run("explicit --ci=true wins regardless of viper", func(t *testing.T) {
-		resetViperCI(t)
-		viper.Set("ci", false)
-		cmd := newHookTestCmd()
-		require.NoError(t, cmd.Flags().Set("ci", "true"))
-
-		assert.True(t, resolveCIMode(cmd.Flags()))
-	})
-
-	t.Run("explicit --ci=false wins over viper ci=true", func(t *testing.T) {
-		resetViperCI(t)
-		viper.Set("ci", true)
-		cmd := newHookTestCmd()
-		require.NoError(t, cmd.Flags().Set("ci", "false"))
-
-		assert.False(t, resolveCIMode(cmd.Flags()))
-	})
+			assert.Equal(t, tt.want, resolveCIMode(flags))
+		})
+	}
 }
 
 func TestTerraformPlanCIResultHandler(t *testing.T) {

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/spf13/viper"
 	xterm "golang.org/x/term"
 
 	errUtils "github.com/cloudposse/atmos/errors"
@@ -139,7 +138,7 @@ func WithEnvironment(env []string) ShellCommandOption {
 // never be made from a torn read.
 func resolveMaskingDisabled(atmosConfig *schema.AtmosConfiguration) bool {
 	disableMasking := false
-	cfg.GlobalViper().View(func(v *viper.Viper) {
+	cfg.GlobalViper().View(func(v cfg.ViperReader) {
 		if v.IsSet("mask") {
 			disableMasking = !v.GetBool("mask")
 		} else if v.IsSet("settings.terminal.mask.enabled") {

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/spf13/viper"
 	xterm "golang.org/x/term"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/diagnostics"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
 	ioLayer "github.com/cloudposse/atmos/pkg/io"
@@ -142,9 +142,9 @@ func ExecuteShellCommand(
 	defer perf.Track(&atmosConfig, "exec.ExecuteShellCommand")()
 
 	disableMasking := false
-	if viper.IsSet("mask") {
-		disableMasking = !viper.GetBool("mask")
-	} else if viper.IsSet("settings.terminal.mask.enabled") {
+	if cfg.GlobalViper().IsSet("mask") {
+		disableMasking = !cfg.GlobalViper().GetBool("mask")
+	} else if cfg.GlobalViper().IsSet("settings.terminal.mask.enabled") {
 		disableMasking = !atmosConfig.Settings.Terminal.Mask.Enabled
 	}
 	ioLayer.ApplyMaskingConfig(&ioLayer.Config{
@@ -730,7 +730,7 @@ func ExecAuthShellCommand(
 	log.Debug("Setting the ENV vars in the shell")
 
 	// Warn about masking limitations in interactive TTY sessions.
-	maskingEnabled := viper.GetBool("mask")
+	maskingEnabled := cfg.GlobalViper().GetBool("mask")
 	if maskingEnabled {
 		log.Debug("Interactive TTY session - output masking is not available due to TTY limitations")
 	}

--- a/internal/exec/shell_utils.go
+++ b/internal/exec/shell_utils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 	xterm "golang.org/x/term"
 
 	errUtils "github.com/cloudposse/atmos/errors"
@@ -128,6 +129,26 @@ func WithEnvironment(env []string) ShellCommandOption {
 	}
 }
 
+// resolveMaskingDisabled decides whether output masking should be disabled.
+// The --mask/ATMOS_MASK flag/env override wins when set, otherwise
+// settings.terminal.mask.enabled (from atmos.yaml) applies. The presence
+// check (IsSet) and value read (GetBool) run together under one
+// cfg.GlobalViper().View call so a concurrent LoadConfig Set() between the
+// two can never combine one snapshot's presence result with a different
+// snapshot's value -- masking is security-sensitive, so this decision must
+// never be made from a torn read.
+func resolveMaskingDisabled(atmosConfig *schema.AtmosConfiguration) bool {
+	disableMasking := false
+	cfg.GlobalViper().View(func(v *viper.Viper) {
+		if v.IsSet("mask") {
+			disableMasking = !v.GetBool("mask")
+		} else if v.IsSet("settings.terminal.mask.enabled") {
+			disableMasking = !atmosConfig.Settings.Terminal.Mask.Enabled
+		}
+	})
+	return disableMasking
+}
+
 // ExecuteShellCommand prints and executes the provided command with args and flags.
 func ExecuteShellCommand(
 	atmosConfig schema.AtmosConfiguration,
@@ -141,14 +162,8 @@ func ExecuteShellCommand(
 ) error {
 	defer perf.Track(&atmosConfig, "exec.ExecuteShellCommand")()
 
-	disableMasking := false
-	if cfg.GlobalViper().IsSet("mask") {
-		disableMasking = !cfg.GlobalViper().GetBool("mask")
-	} else if cfg.GlobalViper().IsSet("settings.terminal.mask.enabled") {
-		disableMasking = !atmosConfig.Settings.Terminal.Mask.Enabled
-	}
 	ioLayer.ApplyMaskingConfig(&ioLayer.Config{
-		DisableMasking: disableMasking,
+		DisableMasking: resolveMaskingDisabled(&atmosConfig),
 		AtmosConfig:    atmosConfig,
 	})
 

--- a/internal/exec/shell_utils_test.go
+++ b/internal/exec/shell_utils_test.go
@@ -353,6 +353,72 @@ func TestExecuteShellCommandAppliesAtmosMaskSettingsToSubprocessOutput(t *testin
 	assert.NotContains(t, terminalOut.String(), "super-secret-demo-value")
 }
 
+// TestResolveMaskingDisabled covers resolveMaskingDisabled's precedence: an
+// explicit --mask/ATMOS_MASK override wins when set, otherwise
+// settings.terminal.mask.enabled (from atmos.yaml) applies.
+func TestResolveMaskingDisabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		maskFlagSet   bool
+		maskFlagValue bool
+		settingsMask  bool
+		want          bool
+	}{
+		{
+			name:          "explicit --mask=true enables masking",
+			maskFlagSet:   true,
+			maskFlagValue: true,
+			want:          false,
+		},
+		{
+			name:          "explicit --mask=false disables masking",
+			maskFlagSet:   true,
+			maskFlagValue: false,
+			want:          true,
+		},
+		{
+			name:         "no flag, settings.terminal.mask.enabled=true enables masking",
+			settingsMask: true,
+			want:         false,
+		},
+		{
+			name:         "no flag, settings.terminal.mask.enabled=false disables masking",
+			settingsMask: false,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			if tt.maskFlagSet {
+				viper.Set("mask", tt.maskFlagValue)
+			} else {
+				viper.Set("settings.terminal.mask.enabled", true) // presence, not value, gates this branch
+			}
+
+			atmosConfig := schema.AtmosConfiguration{
+				Settings: schema.AtmosSettings{
+					Terminal: schema.Terminal{
+						Mask: schema.MaskSettings{Enabled: tt.settingsMask},
+					},
+				},
+			}
+
+			assert.Equal(t, tt.want, resolveMaskingDisabled(&atmosConfig))
+		})
+	}
+}
+
+// Atomicity of the (IsSet, GetBool) pair resolveMaskingDisabled reads is
+// proven once, deterministically, at the mechanism it relies on --
+// TestSafeViperView_IsAtomic and TestSafeViperView_ConsistentSnapshotUnderConcurrentWriters
+// in pkg/config/global_viper_test.go -- rather than re-proven here with a
+// weaker, non-deterministic stress test: resolveMaskingDisabled is a thin,
+// single call to SafeViper.View, so that guarantee transfers directly.
+
 type shellHelperInvocation struct {
 	command string
 	args    []string

--- a/pkg/auth/profile_fallback.go
+++ b/pkg/auth/profile_fallback.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/huh"
-	"github.com/spf13/viper"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	uiutils "github.com/cloudposse/atmos/internal/tui/utils"
@@ -67,7 +66,7 @@ func (m *manager) buildFallbackAtmosConfig() *schema.AtmosConfiguration {
 	return &schema.AtmosConfiguration{
 		CliConfigPath: m.cliConfigPath,
 		Profiles: schema.ProfilesConfig{
-			BasePath: viper.GetString("profiles.base_path"),
+			BasePath: cfg.GlobalViper().GetString("profiles.base_path"),
 		},
 	}
 }

--- a/pkg/config/command_include_env_test.go
+++ b/pkg/config/command_include_env_test.go
@@ -42,12 +42,12 @@ func loadConfigViaMergeConfig(t *testing.T, tempDir string) *schema.AtmosConfigu
 	// The !include function resolves relative paths against the working directory.
 	t.Chdir(tempDir)
 
-	// mergeConfigFile tracks merged files in a package-level slice for case-map
-	// extraction; reset it like LoadConfig does at the start of each load.
-	resetMergedConfigFiles()
-
 	v := viper.New()
 	v.SetConfigType(yamlType)
+
+	// mergeConfigFile tracks merged files in a per-v tracker for case-map
+	// extraction; register one for v like LoadConfig does at the start of each load.
+	resetMergedConfigFiles(v)
 	require.NoError(t, mergeConfig(v, tempDir, CliConfigFileName, true))
 
 	var cfg schema.AtmosConfiguration

--- a/pkg/config/edition.go
+++ b/pkg/config/edition.go
@@ -63,7 +63,7 @@ func resolveEditionPin(v *viper.Viper) string {
 // DisableFlagParsing=true (terraform, helmfile, packer, auth exec), where
 // Cobra never populates the global flag binding.
 func editionPinFromFlag() string {
-	if flagValue := strings.TrimSpace(viper.GetViper().GetString(editionKey)); flagValue != "" {
+	if flagValue := strings.TrimSpace(GlobalViper().GetString(editionKey)); flagValue != "" {
 		return flagValue
 	}
 	return parseEditionFromOsArgs(os.Args)

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -19,6 +19,12 @@ import (
 // one per graph node -- under --max-concurrency > 1, so every access to the
 // singleton must go through GlobalViper() to avoid "concurrent map writes" panics.
 //
+// This applies even to reads/writes of unrelated keys: viper.Set/Get traverse
+// and mutate ONE shared underlying map (Viper.override) via deepSearch, and Go
+// maps are not safe for any concurrent read/write access, regardless of which
+// key each goroutine touches -- a write to "vendor.update.execution.mode" can
+// still race with a concurrent read of an unrelated key like "mask".
+//
 // Deliberately does not cache *viper.Viper in a field: tests (and
 // viper.Reset()-calling production paths) replace viper's default instance at
 // runtime, so every method re-resolves viper.GetViper() under the lock rather
@@ -49,6 +55,12 @@ func (s *SafeViper) GetStringSlice(key string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return viper.GetViper().GetStringSlice(key)
+}
+
+func (s *SafeViper) IsSet(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return viper.GetViper().IsSet(key)
 }
 
 var globalViper = &SafeViper{}

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -51,10 +51,14 @@ func (s *SafeViper) GetBool(key string) bool {
 	return viper.GetViper().GetBool(key)
 }
 
+// GetStringSlice returns a clone of the requested key's string slice: viper's
+// own GetStringSlice can return its value's existing backing array rather
+// than a copy, and handing that out under the lock would let a caller mutate
+// shared Viper state after the lock is released.
 func (s *SafeViper) GetStringSlice(key string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return viper.GetViper().GetStringSlice(key)
+	return slices.Clone(viper.GetViper().GetStringSlice(key))
 }
 
 func (s *SafeViper) IsSet(key string) bool {
@@ -70,10 +74,39 @@ func (s *SafeViper) IsSet(key string) bool {
 // write lock, defeating the whole point of View. Extend with more read
 // methods as callers need them; never add a mutator here.
 type ViperReader interface {
+	// IsSet reports whether key has an explicit value from any source (flag,
+	// env, config, override) -- unlike a plain Get, it does not count a
+	// registered default as "set".
 	IsSet(key string) bool
+	// GetBool returns key's value coerced to bool. Returns false if unset.
 	GetBool(key string) bool
+	// GetString returns key's value coerced to string. Returns "" if unset.
 	GetString(key string) string
+	// GetStringSlice returns key's value coerced to []string, cloned so the
+	// caller cannot mutate Viper's own backing array. Returns nil if unset.
 	GetStringSlice(key string) []string
+}
+
+// viperReaderAdapter wraps *viper.Viper to satisfy ViperReader without
+// exposing the concrete *viper.Viper type to View callbacks. Passing
+// *viper.Viper itself through the ViperReader interface would only hide Set
+// behind a narrower static type -- Go interfaces retain their dynamic type,
+// so a callback could still type-assert the value back to *viper.Viper and
+// call Set while holding only View's read lock. Because viperReaderAdapter is
+// unexported, code outside this package cannot name it to assert against it,
+// so it cannot recover the underlying *viper.Viper this way.
+type viperReaderAdapter struct {
+	v *viper.Viper
+}
+
+func (a viperReaderAdapter) IsSet(key string) bool { return a.v.IsSet(key) }
+
+func (a viperReaderAdapter) GetBool(key string) bool { return a.v.GetBool(key) }
+
+func (a viperReaderAdapter) GetString(key string) string { return a.v.GetString(key) }
+
+func (a viperReaderAdapter) GetStringSlice(key string) []string {
+	return slices.Clone(a.v.GetStringSlice(key))
 }
 
 // View executes fn with a read lock held on the global Viper singleton,
@@ -86,7 +119,7 @@ type ViperReader interface {
 func (s *SafeViper) View(fn func(v ViperReader)) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	fn(viper.GetViper())
+	fn(viperReaderAdapter{v: viper.GetViper()})
 }
 
 var globalViper = &SafeViper{}

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -63,6 +63,19 @@ func (s *SafeViper) IsSet(key string) bool {
 	return viper.GetViper().IsSet(key)
 }
 
+// ViperReader exposes only *viper.Viper's read methods. SafeViper.View passes
+// this (not *viper.Viper) to its callback, so the callback cannot call a
+// mutator like Set while holding only the read lock -- doing so would race
+// against another concurrent View call's reads, or against SafeViper.Set's
+// write lock, defeating the whole point of View. Extend with more read
+// methods as callers need them; never add a mutator here.
+type ViperReader interface {
+	IsSet(key string) bool
+	GetBool(key string) bool
+	GetString(key string) string
+	GetStringSlice(key string) []string
+}
+
 // View executes fn with a read lock held on the global Viper singleton,
 // giving fn a consistent snapshot for the whole call. Use this instead of
 // separate Set/GetBool/IsSet calls whenever a decision combines more than one
@@ -70,9 +83,7 @@ func (s *SafeViper) IsSet(key string) bool {
 // each individual SafeViper method locks and unlocks independently, so a
 // concurrent Set() between two separate calls could let the decision combine
 // one snapshot's presence result with a different snapshot's value.
-// The callback must only call methods on the *viper.Viper it receives, not
-// GlobalViper()'s own methods, which would deadlock re-acquiring this lock.
-func (s *SafeViper) View(fn func(v *viper.Viper)) {
+func (s *SafeViper) View(fn func(v ViperReader)) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	fn(viper.GetViper())

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -63,6 +63,21 @@ func (s *SafeViper) IsSet(key string) bool {
 	return viper.GetViper().IsSet(key)
 }
 
+// View executes fn with a read lock held on the global Viper singleton,
+// giving fn a consistent snapshot for the whole call. Use this instead of
+// separate Set/GetBool/IsSet calls whenever a decision combines more than one
+// read (e.g. an IsSet presence check followed by a GetBool value read):
+// each individual SafeViper method locks and unlocks independently, so a
+// concurrent Set() between two separate calls could let the decision combine
+// one snapshot's presence result with a different snapshot's value.
+// The callback must only call methods on the *viper.Viper it receives, not
+// GlobalViper()'s own methods, which would deadlock re-acquiring this lock.
+func (s *SafeViper) View(fn func(v *viper.Viper)) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	fn(viper.GetViper())
+}
+
 var globalViper = &SafeViper{}
 
 // GlobalViper returns the mutex-guarded wrapper around the process-wide global

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -61,18 +61,11 @@ func GlobalViper() *SafeViper {
 	return globalViper
 }
 
-// mergedFilesTracker tracks the config files merged during the most recent
-// LoadConfig call, guarded by its own mutex since LoadConfig can run
-// concurrently across DAG-scheduler worker goroutines (pkg/scheduler).
+// mergedFilesTracker tracks the config files merged during a single LoadConfig
+// call, guarded by its own mutex.
 type mergedFilesTracker struct {
 	mu    sync.Mutex
 	files []string
-}
-
-func (t *mergedFilesTracker) reset() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.files = nil
 }
 
 func (t *mergedFilesTracker) track(path string) {
@@ -91,4 +84,92 @@ func (t *mergedFilesTracker) snapshot() []string {
 	return out
 }
 
-var mergedFiles = &mergedFilesTracker{}
+// mergedFilesRegistry correlates each concurrent LoadConfig call's tracked
+// config files with the local *viper.Viper instance that call created ("v" in
+// load.go). That pointer already flows through every merge/case-preservation
+// helper LoadConfig calls (mergeConfig, mergeConfigFile,
+// collectConfigFilesForCasePreservation, ...), so using its identity as the
+// correlation key gives each concurrent LoadConfig call an isolated tracker
+// without threading a brand-new parameter through that entire call graph.
+//
+// A mutex alone does not provide this: it prevents concurrent map writes, but
+// a single shared tracker still lets one LoadConfig call's reset()/track()
+// calls interleave with another's, so a call can snapshot a different call's
+// files. Keying by the call's own *viper.Viper instance gives each concurrent
+// LoadConfig call its own tracker instead.
+//
+// Entries are removed by finish, called via defer immediately after start, so
+// a later LoadConfig call can never observe a finished call's tracker even if
+// Go reuses the same address after garbage collection -- the entry is gone
+// before the old v could become collectible.
+type mergedFilesRegistry struct {
+	mu       sync.Mutex
+	trackers map[*viper.Viper]*mergedFilesTracker
+}
+
+func (r *mergedFilesRegistry) start(v *viper.Viper) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.trackers[v] = &mergedFilesTracker{}
+}
+
+func (r *mergedFilesRegistry) track(v *viper.Viper, path string) {
+	r.mu.Lock()
+	tracker := r.trackers[v]
+	r.mu.Unlock()
+	if tracker != nil {
+		tracker.track(path)
+	}
+}
+
+func (r *mergedFilesRegistry) snapshot(v *viper.Viper) []string {
+	r.mu.Lock()
+	tracker := r.trackers[v]
+	r.mu.Unlock()
+	if tracker == nil {
+		return nil
+	}
+	return tracker.snapshot()
+}
+
+// finish removes v's tracker from the registry and returns its final
+// snapshot. Safe to call on a v that was never started (returns nil).
+func (r *mergedFilesRegistry) finish(v *viper.Viper) []string {
+	r.mu.Lock()
+	tracker, ok := r.trackers[v]
+	delete(r.trackers, v)
+	r.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return tracker.snapshot()
+}
+
+var mergedFilesReg = &mergedFilesRegistry{trackers: make(map[*viper.Viper]*mergedFilesTracker)}
+
+// lastLoadedFilesHolder holds the most recently completed LoadConfig call's
+// tracked files, guarded by its own mutex. Backs the exported LoadedConfigFiles
+// API, whose only consumer (`atmos config list`, cmd/config/list.go) runs a
+// single LoadConfig call and reads the result immediately afterward -- it is
+// never invoked concurrently with itself, so "last completed call" is a
+// well-defined answer for it, unlike the per-call registry above.
+type lastLoadedFilesHolder struct {
+	mu    sync.Mutex
+	files []string
+}
+
+func (h *lastLoadedFilesHolder) set(files []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.files = files
+}
+
+func (h *lastLoadedFilesHolder) get() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.files))
+	copy(out, h.files)
+	return out
+}
+
+var lastLoadedFiles = &lastLoadedFilesHolder{}

--- a/pkg/config/global_viper.go
+++ b/pkg/config/global_viper.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/spf13/viper"
+)
+
+// SafeViper wraps the process-wide global Viper singleton with a mutex.
+//
+// LoadConfig bridges several config-derived values back into the global Viper
+// singleton (e.g. profiles.base_path, vendor.update.*, vendor.ci.*) so other
+// packages that only have Viper access -- not a *schema.AtmosConfiguration --
+// can read them (see resolveProfileSelectionSentinel, bridgeVendorUpdaterConfig
+// below, and readers such as pkg/auth/profile_fallback.go and
+// cmd/terraform/utils.go). The spf13/viper package has no internal locking of
+// its own, and the DAG scheduler (pkg/scheduler) runs many LoadConfig calls concurrently --
+// one per graph node -- under --max-concurrency > 1, so every access to the
+// singleton must go through GlobalViper() to avoid "concurrent map writes" panics.
+//
+// Deliberately does not cache *viper.Viper in a field: tests (and
+// viper.Reset()-calling production paths) replace viper's default instance at
+// runtime, so every method re-resolves viper.GetViper() under the lock rather
+// than risk diverging from whatever instance is currently "the" global one.
+type SafeViper struct {
+	mu sync.RWMutex
+}
+
+func (s *SafeViper) Set(key string, value any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	viper.GetViper().Set(key, value)
+}
+
+func (s *SafeViper) GetString(key string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return viper.GetViper().GetString(key)
+}
+
+func (s *SafeViper) GetBool(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return viper.GetViper().GetBool(key)
+}
+
+func (s *SafeViper) GetStringSlice(key string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return viper.GetViper().GetStringSlice(key)
+}
+
+var globalViper = &SafeViper{}
+
+// GlobalViper returns the mutex-guarded wrapper around the process-wide global
+// Viper singleton. Use its methods instead of calling
+// viper.GetViper()/viper.Get*/viper.Set directly from any code path that may
+// run concurrently (e.g. per-DAG-node hook processing).
+func GlobalViper() *SafeViper {
+	return globalViper
+}
+
+// mergedFilesTracker tracks the config files merged during the most recent
+// LoadConfig call, guarded by its own mutex since LoadConfig can run
+// concurrently across DAG-scheduler worker goroutines (pkg/scheduler).
+type mergedFilesTracker struct {
+	mu    sync.Mutex
+	files []string
+}
+
+func (t *mergedFilesTracker) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.files = nil
+}
+
+func (t *mergedFilesTracker) track(path string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if path != "" && !slices.Contains(t.files, path) {
+		t.files = append(t.files, path)
+	}
+}
+
+func (t *mergedFilesTracker) snapshot() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]string, len(t.files))
+	copy(out, t.files)
+	return out
+}
+
+var mergedFiles = &mergedFilesTracker{}

--- a/pkg/config/global_viper_test.go
+++ b/pkg/config/global_viper_test.go
@@ -26,7 +26,7 @@ func TestSafeViperView_IsAtomic(t *testing.T) {
 
 	var observedInsideView bool
 	go func() {
-		GlobalViper().View(func(v *viper.Viper) {
+		GlobalViper().View(func(v ViperReader) {
 			close(viewEntered)
 			<-releaseView
 			// If Set() below had been allowed to interleave, this would
@@ -85,7 +85,7 @@ func TestSafeViperView_ConsistentSnapshotUnderConcurrentWriters(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			GlobalViper().View(func(v *viper.Viper) {
+			GlobalViper().View(func(v ViperReader) {
 				// Reading the same key twice inside one View call must
 				// always agree with itself -- proving the lock is held for
 				// the whole callback, not re-acquired per method call.

--- a/pkg/config/global_viper_test.go
+++ b/pkg/config/global_viper_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSafeViperView_IsAtomic proves View holds the read lock for its entire
+// callback, so a concurrent Set() cannot interleave with (and thus cannot be
+// observed mid-way through) a compound decision made inside View. This is
+// the guarantee resolveMaskingDisabled (internal/exec/shell_utils.go) relies
+// on: combining an IsSet presence check with a GetBool value read under one
+// View call, rather than as two separately-locked SafeViper calls that a
+// concurrent Set() could interleave between.
+func TestSafeViperView_IsAtomic(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viewEntered := make(chan struct{})
+	releaseView := make(chan struct{})
+	viewDone := make(chan struct{})
+
+	var observedInsideView bool
+	go func() {
+		GlobalViper().View(func(v *viper.Viper) {
+			close(viewEntered)
+			<-releaseView
+			// If Set() below had been allowed to interleave, this would
+			// observe the concurrent write; the assertion after this
+			// goroutine proves it never does.
+			observedInsideView = v.IsSet("concurrent-key")
+		})
+		close(viewDone)
+	}()
+
+	<-viewEntered
+
+	setDone := make(chan struct{})
+	go func() {
+		GlobalViper().Set("concurrent-key", true)
+		close(setDone)
+	}()
+
+	// Set() must block while View's callback still holds the read lock.
+	select {
+	case <-setDone:
+		t.Fatal("Set() completed while a View() callback still held the lock")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: Set() is still blocked.
+	}
+
+	close(releaseView)
+	<-viewDone
+	<-setDone
+
+	assert.False(t, observedInsideView,
+		"View's callback must not observe a Set() that started after the callback began")
+	assert.True(t, GlobalViper().IsSet("concurrent-key"), "the Set() must still take effect once View released the lock")
+}
+
+// TestSafeViperView_ConsistentSnapshotUnderConcurrentWriters is a
+// probabilistic companion to the deterministic test above: it runs many
+// concurrent Set()/View() pairs and asserts View always sees a consistent
+// mask/settings pairing (never a state that no single Set() call ever
+// produced), matching resolveMaskingDisabled's actual key pair.
+func TestSafeViperView_ConsistentSnapshotUnderConcurrentWriters(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			GlobalViper().Set("mask", i%2 == 0)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			GlobalViper().View(func(v *viper.Viper) {
+				// Reading the same key twice inside one View call must
+				// always agree with itself -- proving the lock is held for
+				// the whole callback, not re-acquired per method call.
+				// assert (not require): FailNow from a non-test goroutine
+				// would only stop this goroutine, not the whole test.
+				first := v.GetBool("mask")
+				second := v.GetBool("mask")
+				assert.Equal(t, first, second)
+			})
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/config/global_viper_test.go
+++ b/pkg/config/global_viper_test.go
@@ -100,3 +100,42 @@ func TestSafeViperView_ConsistentSnapshotUnderConcurrentWriters(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestSafeViperView_CallbackCannotRecoverConcreteViper proves View's
+// ViperReader argument cannot be type-asserted back to *viper.Viper. Passing
+// *viper.Viper itself through the ViperReader interface would only hide Set
+// behind a narrower static type -- a callback could still recover it via a
+// type assertion and call Set while holding only View's read lock, racing
+// against a concurrent Set()/View() the same way the interface exists to
+// prevent. View must pass an unexported adapter instead, which callers
+// outside pkg/config cannot name to assert against.
+func TestSafeViperView_CallbackCannotRecoverConcreteViper(t *testing.T) {
+	GlobalViper().View(func(v ViperReader) {
+		_, ok := v.(*viper.Viper)
+		assert.False(t, ok, "View's ViperReader argument must not be assertable back to *viper.Viper")
+	})
+}
+
+// TestSafeViperView_GetStringSliceIsCloned proves GetStringSlice (both
+// directly on SafeViper and via View's ViperReader) returns a copy the
+// caller can freely mutate, not Viper's own backing array -- spf13/viper's
+// GetStringSlice can return an existing []string value without cloning it,
+// so handing that out under the lock would let a caller corrupt shared
+// config state after the lock is released, with no Set() call to guard.
+func TestSafeViperView_GetStringSliceIsCloned(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("some.slice", []string{"a", "b"})
+
+	direct := GlobalViper().GetStringSlice("some.slice")
+	direct[0] = "mutated-direct"
+
+	var viaView []string
+	GlobalViper().View(func(v ViperReader) {
+		viaView = v.GetStringSlice("some.slice")
+	})
+	viaView[0] = "mutated-view"
+
+	assert.Equal(t, []string{"a", "b"}, GlobalViper().GetStringSlice("some.slice"),
+		"mutating a returned slice must not corrupt Viper's own stored value")
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -61,34 +61,25 @@ var (
 // osGetwd wraps os.Getwd, allowing tests to simulate CWD errors.
 var osGetwd = os.Getwd
 
-// mergedConfigFiles tracks all config files merged during a LoadConfig call.
-// This is used to extract case-sensitive map keys from all sources, not just the main config.
-// The slice is reset at the start of each LoadConfig call.
-//
-// NOTE: This package-level state assumes sequential (non-concurrent) calls to LoadConfig.
-// LoadConfig is NOT safe for concurrent use. If concurrent config loading becomes necessary,
-// this should be refactored to pass state through a context or options struct.
-var mergedConfigFiles []string
-
 // resetMergedConfigFiles clears the tracked config files. Call at start of LoadConfig.
+//
+// Backed by the mutex-guarded mergedFiles tracker (global_viper.go): LoadConfig
+// can run concurrently across DAG-scheduler worker goroutines (pkg/scheduler),
+// one call per graph node, so this can no longer be a bare package-level slice.
 func resetMergedConfigFiles() {
-	mergedConfigFiles = nil
+	mergedFiles.reset()
 }
 
 // trackMergedConfigFile records a config file path for case-sensitive key extraction.
 func trackMergedConfigFile(path string) {
-	if path != "" && !slices.Contains(mergedConfigFiles, path) {
-		mergedConfigFiles = append(mergedConfigFiles, path)
-	}
+	mergedFiles.track(path)
 }
 
 // LoadedConfigFiles returns the physical config files merged during the most
 // recent LoadConfig call. Embedded defaults and runtime/env overrides are not
 // included.
 func LoadedConfigFiles() []string {
-	files := make([]string, len(mergedConfigFiles))
-	copy(files, mergedConfigFiles)
-	return files
+	return mergedFiles.snapshot()
 }
 
 const (
@@ -336,9 +327,7 @@ func getConfigSelectionFromFlagsOrEnv() ConfigSelection {
 // counts as "set"). Instead, we check whether GetStringSlice returns a non-empty
 // value and always fall back to os.Args / env var parsing when it does not.
 func getProfilesFromFlagsOrEnv() ([]string, string) {
-	globalViper := viper.GetViper()
-
-	profiles := globalViper.GetStringSlice(profileKey)
+	profiles := GlobalViper().GetStringSlice(profileKey)
 	_, envSet := os.LookupEnv("ATMOS_PROFILE")
 
 	// Environment variable path - needs special parsing for Viper quirks.
@@ -409,7 +398,7 @@ func resolveProfileSelectionSentinel(tempConfig *schema.AtmosConfiguration, prof
 
 	// Write back to the global Viper singleton so other same-process readers of the raw
 	// --profile flag/env see the resolved names, not the sentinel, on subsequent reads.
-	viper.GetViper().Set(profileKey, resolved)
+	GlobalViper().Set(profileKey, resolved)
 
 	log.Debug("Interactive profile selection resolved", "preselected", preselected, "resolved", resolved)
 
@@ -645,7 +634,7 @@ func LoadConfig(configAndStacksInfo *schema.ConfigAndStacksInfo) (schema.AtmosCo
 	// equivalent env binding) is ever added, this sync will silently shadow
 	// it. Either drop this sync at that point or guard with IsSet().
 	if atmosConfig.Profiles.BasePath != "" {
-		viper.GetViper().Set("profiles.base_path", atmosConfig.Profiles.BasePath)
+		GlobalViper().Set("profiles.base_path", atmosConfig.Profiles.BasePath)
 	}
 
 	// Sync vendor.update.* and vendor.ci.* from the loaded atmos.yaml into the global viper for
@@ -675,51 +664,50 @@ func LoadConfig(configAndStacksInfo *schema.ConfigAndStacksInfo) (schema.AtmosCo
 // struct/map at a parent key -- because viper's dotted-path Get only reliably resolves through
 // values it previously stored itself as nested maps, not arbitrary Go structs.
 func bridgeVendorUpdaterConfig(atmosConfig *schema.AtmosConfiguration) {
-	v := viper.GetViper()
 	update := atmosConfig.Vendor.Update
 	if update.Execution.Mode != "" {
-		v.Set("vendor.update.execution.mode", update.Execution.Mode)
+		GlobalViper().Set("vendor.update.execution.mode", update.Execution.Mode)
 	}
 	if update.Batching.Mode != "" {
-		v.Set("vendor.update.batching.mode", update.Batching.Mode)
+		GlobalViper().Set("vendor.update.batching.mode", update.Batching.Mode)
 	}
 	for name, group := range update.Groups {
 		prefix := "vendor.update.groups." + name
-		v.Set(prefix+".include", group.Include)
-		v.Set(prefix+".exclude", group.Exclude)
+		GlobalViper().Set(prefix+".include", group.Include)
+		GlobalViper().Set(prefix+".exclude", group.Exclude)
 	}
 
 	pr := atmosConfig.Vendor.CI.PullRequest
 	if pr.Provider != "" {
-		v.Set("vendor.ci.pull_request.provider", pr.Provider)
+		GlobalViper().Set("vendor.ci.pull_request.provider", pr.Provider)
 	}
 	if pr.BaseBranch != "" {
-		v.Set("vendor.ci.pull_request.base_branch", pr.BaseBranch)
+		GlobalViper().Set("vendor.ci.pull_request.base_branch", pr.BaseBranch)
 	}
 	if pr.BranchPrefix != "" {
-		v.Set("vendor.ci.pull_request.branch_prefix", pr.BranchPrefix)
+		GlobalViper().Set("vendor.ci.pull_request.branch_prefix", pr.BranchPrefix)
 	}
 	if pr.Title != "" {
-		v.Set("vendor.ci.pull_request.title", pr.Title)
+		GlobalViper().Set("vendor.ci.pull_request.title", pr.Title)
 	}
 	if pr.Body != "" {
-		v.Set("vendor.ci.pull_request.body", pr.Body)
+		GlobalViper().Set("vendor.ci.pull_request.body", pr.Body)
 	}
 	if len(pr.Labels) > 0 {
-		v.Set("vendor.ci.pull_request.labels", pr.Labels)
+		GlobalViper().Set("vendor.ci.pull_request.labels", pr.Labels)
 	}
 	if pr.Draft {
-		v.Set("vendor.ci.pull_request.draft", pr.Draft)
+		GlobalViper().Set("vendor.ci.pull_request.draft", pr.Draft)
 	}
 	if len(pr.Reviewers) > 0 {
-		v.Set("vendor.ci.pull_request.reviewers", pr.Reviewers)
+		GlobalViper().Set("vendor.ci.pull_request.reviewers", pr.Reviewers)
 	}
 	if len(pr.Assignees) > 0 {
-		v.Set("vendor.ci.pull_request.assignees", pr.Assignees)
+		GlobalViper().Set("vendor.ci.pull_request.assignees", pr.Assignees)
 	}
 
 	if atmosConfig.Vendor.CI.Summary.Enabled != nil {
-		v.Set("vendor.ci.summary.enabled", *atmosConfig.Vendor.CI.Summary.Enabled)
+		GlobalViper().Set("vendor.ci.summary.enabled", *atmosConfig.Vendor.CI.Summary.Enabled)
 	}
 }
 
@@ -2280,8 +2268,9 @@ var caseSensitivePaths = []string{
 // collectConfigFilesForCasePreservation gathers all config files to process for case preservation.
 // It combines tracked merged files with the main config file (if not already tracked).
 func collectConfigFilesForCasePreservation(mainConfig string) []string {
-	filesToProcess := make([]string, 0, len(mergedConfigFiles)+1)
-	filesToProcess = append(filesToProcess, mergedConfigFiles...)
+	tracked := mergedFiles.snapshot()
+	filesToProcess := make([]string, 0, len(tracked)+1)
+	filesToProcess = append(filesToProcess, tracked...)
 
 	// Include the main config file if it wasn't already tracked.
 	if mainConfig != "" && !slices.Contains(filesToProcess, mainConfig) {

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -664,50 +664,52 @@ func LoadConfig(configAndStacksInfo *schema.ConfigAndStacksInfo) (schema.AtmosCo
 // struct/map at a parent key -- because viper's dotted-path Get only reliably resolves through
 // values it previously stored itself as nested maps, not arbitrary Go structs.
 func bridgeVendorUpdaterConfig(atmosConfig *schema.AtmosConfiguration) {
+	v := GlobalViper()
+
 	update := atmosConfig.Vendor.Update
 	if update.Execution.Mode != "" {
-		GlobalViper().Set("vendor.update.execution.mode", update.Execution.Mode)
+		v.Set("vendor.update.execution.mode", update.Execution.Mode)
 	}
 	if update.Batching.Mode != "" {
-		GlobalViper().Set("vendor.update.batching.mode", update.Batching.Mode)
+		v.Set("vendor.update.batching.mode", update.Batching.Mode)
 	}
 	for name, group := range update.Groups {
 		prefix := "vendor.update.groups." + name
-		GlobalViper().Set(prefix+".include", group.Include)
-		GlobalViper().Set(prefix+".exclude", group.Exclude)
+		v.Set(prefix+".include", group.Include)
+		v.Set(prefix+".exclude", group.Exclude)
 	}
 
 	pr := atmosConfig.Vendor.CI.PullRequest
 	if pr.Provider != "" {
-		GlobalViper().Set("vendor.ci.pull_request.provider", pr.Provider)
+		v.Set("vendor.ci.pull_request.provider", pr.Provider)
 	}
 	if pr.BaseBranch != "" {
-		GlobalViper().Set("vendor.ci.pull_request.base_branch", pr.BaseBranch)
+		v.Set("vendor.ci.pull_request.base_branch", pr.BaseBranch)
 	}
 	if pr.BranchPrefix != "" {
-		GlobalViper().Set("vendor.ci.pull_request.branch_prefix", pr.BranchPrefix)
+		v.Set("vendor.ci.pull_request.branch_prefix", pr.BranchPrefix)
 	}
 	if pr.Title != "" {
-		GlobalViper().Set("vendor.ci.pull_request.title", pr.Title)
+		v.Set("vendor.ci.pull_request.title", pr.Title)
 	}
 	if pr.Body != "" {
-		GlobalViper().Set("vendor.ci.pull_request.body", pr.Body)
+		v.Set("vendor.ci.pull_request.body", pr.Body)
 	}
 	if len(pr.Labels) > 0 {
-		GlobalViper().Set("vendor.ci.pull_request.labels", pr.Labels)
+		v.Set("vendor.ci.pull_request.labels", pr.Labels)
 	}
 	if pr.Draft {
-		GlobalViper().Set("vendor.ci.pull_request.draft", pr.Draft)
+		v.Set("vendor.ci.pull_request.draft", pr.Draft)
 	}
 	if len(pr.Reviewers) > 0 {
-		GlobalViper().Set("vendor.ci.pull_request.reviewers", pr.Reviewers)
+		v.Set("vendor.ci.pull_request.reviewers", pr.Reviewers)
 	}
 	if len(pr.Assignees) > 0 {
-		GlobalViper().Set("vendor.ci.pull_request.assignees", pr.Assignees)
+		v.Set("vendor.ci.pull_request.assignees", pr.Assignees)
 	}
 
 	if atmosConfig.Vendor.CI.Summary.Enabled != nil {
-		GlobalViper().Set("vendor.ci.summary.enabled", *atmosConfig.Vendor.CI.Summary.Enabled)
+		v.Set("vendor.ci.summary.enabled", *atmosConfig.Vendor.CI.Summary.Enabled)
 	}
 }
 

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -61,25 +61,34 @@ var (
 // osGetwd wraps os.Getwd, allowing tests to simulate CWD errors.
 var osGetwd = os.Getwd
 
-// resetMergedConfigFiles clears the tracked config files. Call at start of LoadConfig.
+// resetMergedConfigFiles registers a fresh, empty file tracker for v. Call at
+// the start of LoadConfig, immediately after v is created.
 //
-// Backed by the mutex-guarded mergedFiles tracker (global_viper.go): LoadConfig
-// can run concurrently across DAG-scheduler worker goroutines (pkg/scheduler),
-// one call per graph node, so this can no longer be a bare package-level slice.
-func resetMergedConfigFiles() {
-	mergedFiles.reset()
+// Backed by the mutex-guarded mergedFilesReg registry (global_viper.go),
+// keyed by v's identity: LoadConfig can run concurrently across
+// DAG-scheduler worker goroutines (pkg/scheduler), one call per graph node,
+// so tracked files can no longer live in a single shared slice or tracker --
+// each call's v gets its own.
+func resetMergedConfigFiles(v *viper.Viper) {
+	mergedFilesReg.start(v)
 }
 
-// trackMergedConfigFile records a config file path for case-sensitive key extraction.
-func trackMergedConfigFile(path string) {
-	mergedFiles.track(path)
+// trackMergedConfigFile records a config file path, merged while loading v,
+// for case-sensitive key extraction.
+func trackMergedConfigFile(v *viper.Viper, path string) {
+	mergedFilesReg.track(v, path)
 }
 
 // LoadedConfigFiles returns the physical config files merged during the most
-// recent LoadConfig call. Embedded defaults and runtime/env overrides are not
-// included.
+// recently completed LoadConfig call. Embedded defaults and runtime/env
+// overrides are not included.
+//
+// Only meaningful for callers that run a single LoadConfig call and read the
+// result immediately afterward (e.g. `atmos config list`) -- it is not safe
+// to correlate with a specific concurrent LoadConfig call. Concurrent callers
+// needing a specific call's files should use collectConfigFilesForCasePreservation(v, ...).
 func LoadedConfigFiles() []string {
-	return mergedFiles.snapshot()
+	return lastLoadedFiles.get()
 }
 
 const (
@@ -416,10 +425,17 @@ func resolveProfileSelectionSentinel(tempConfig *schema.AtmosConfiguration, prof
 // NOTE: Global flags (like --profile) must be synced to Viper before calling this function.
 // This is done by syncGlobalFlagsToViper() in cmd/root.go PersistentPreRun.
 func LoadConfig(configAndStacksInfo *schema.ConfigAndStacksInfo) (schema.AtmosConfiguration, error) {
-	// Reset merged config file tracker at start of each LoadConfig call.
-	resetMergedConfigFiles()
-
 	v := viper.New()
+
+	// Register a fresh merged-file tracker for this call's v, and publish its
+	// final contents to LoadedConfigFiles()'s single-caller cache on return.
+	// Deferred immediately so every exit path (error or success) cleans up the
+	// registry entry -- see mergedFilesRegistry's doc comment in global_viper.go.
+	resetMergedConfigFiles(v)
+	defer func() {
+		lastLoadedFiles.set(mergedFilesReg.finish(v))
+	}()
+
 	var atmosConfig schema.AtmosConfiguration
 	v.SetConfigType("yaml")
 	v.SetTypeByDefaultValue(true)
@@ -1471,7 +1487,7 @@ func mergeConfig(v *viper.Viper, path string, fileName string, processImports bo
 	}
 
 	configFilePath := tempViper.ConfigFileUsed()
-	trackMergedConfigFile(configFilePath)
+	trackMergedConfigFile(v, configFilePath)
 
 	// Read the config file's content
 	content, err := readConfigFileContent(configFilePath)
@@ -1919,7 +1935,7 @@ func mergeConfigFile(
 	}
 
 	// Track this file for case-sensitive key extraction.
-	trackMergedConfigFile(path)
+	trackMergedConfigFile(v, path)
 
 	// Save existing commands before merge.
 	existingCommands := v.Get(commandsKey)
@@ -2268,9 +2284,10 @@ var caseSensitivePaths = []string{
 }
 
 // collectConfigFilesForCasePreservation gathers all config files to process for case preservation.
-// It combines tracked merged files with the main config file (if not already tracked).
-func collectConfigFilesForCasePreservation(mainConfig string) []string {
-	tracked := mergedFiles.snapshot()
+// It combines the files tracked for v's LoadConfig call with the main config
+// file (if not already tracked).
+func collectConfigFilesForCasePreservation(v *viper.Viper, mainConfig string) []string {
+	tracked := mergedFilesReg.snapshot(v)
 	filesToProcess := make([]string, 0, len(tracked)+1)
 	filesToProcess = append(filesToProcess, tracked...)
 
@@ -2477,7 +2494,7 @@ func commandEnvValueCommand(value map[string]any) (any, bool) {
 // It processes all merged config files (main config + imports) with later files taking precedence.
 // This function operates on a best-effort basis - errors are logged but don't fail config loading.
 func preserveCaseSensitiveMaps(v *viper.Viper, atmosConfig *schema.AtmosConfiguration) {
-	filesToProcess := collectConfigFilesForCasePreservation(v.ConfigFileUsed())
+	filesToProcess := collectConfigFilesForCasePreservation(v, v.ConfigFileUsed())
 	if len(filesToProcess) == 0 {
 		return
 	}
@@ -2516,7 +2533,7 @@ func caseSensitiveEnvFromViper(v *viper.Viper) map[string]string {
 	}
 
 	caseMaps := casemap.New()
-	for _, configFile := range collectConfigFilesForCasePreservation(v.ConfigFileUsed()) {
+	for _, configFile := range collectConfigFilesForCasePreservation(v, v.ConfigFileUsed()) {
 		mergeCaseMapsFromFile(configFile, caseMaps)
 	}
 	envCase := caseMaps.Get(envKey)
@@ -2712,7 +2729,7 @@ func fixAuthIdentities(v *viper.Viper, atmosConfig *schema.AtmosConfiguration) e
 	defer perf.Track(atmosConfig, "config.fixAuthIdentities")()
 
 	// Get list of all config files that were merged.
-	filesToProcess := collectConfigFilesForCasePreservation(v.ConfigFileUsed())
+	filesToProcess := collectConfigFilesForCasePreservation(v, v.ConfigFileUsed())
 	if len(filesToProcess) == 0 {
 		return nil
 	}

--- a/pkg/config/load_concurrent_test.go
+++ b/pkg/config/load_concurrent_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestLoadConfig_ConcurrentCalls reproduces the "fatal error: concurrent map
+// writes" panic reported when the DAG scheduler (pkg/scheduler) runs with
+// --max-concurrency > 1: multiple worker goroutines each call
+// InitCliConfig/LoadConfig for their own graph node, and LoadConfig used to
+// write profiles.base_path and vendor.update.*/vendor.ci.* into the
+// process-wide global Viper singleton with no synchronization. The
+// spf13/viper package has no internal locking, so concurrent Set/Get calls
+// on that singleton panicked.
+//
+// Run with `go test -race`: without -race this test can pass even on the
+// unfixed code, since the panic depends on unlucky goroutine interleaving.
+func TestLoadConfig_ConcurrentCalls(t *testing.T) {
+	tmpDir := t.TempDir()
+	atmosYAML := "" +
+		"base_path: ./\n" +
+		"profiles:\n" +
+		"  base_path: ./profiles\n" +
+		"vendor:\n" +
+		"  update:\n" +
+		"    execution:\n" +
+		"      mode: worktree\n" +
+		"    groups:\n" +
+		"      platform:\n" +
+		"        include: [\"terraform/vpc\"]\n" +
+		"  ci:\n" +
+		"    pull_request:\n" +
+		"      provider: github\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, AtmosConfigFileName), []byte(atmosYAML), 0o644))
+
+	t.Chdir(tmpDir)
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	const goroutines = 20
+	done := make(chan struct{})
+	timeout := time.After(30 * time.Second)
+
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := LoadConfig(&schema.ConfigAndStacksInfo{})
+				assert.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-timeout:
+		t.Fatal("timed out - possible deadlock in concurrent LoadConfig calls")
+	}
+}

--- a/pkg/config/load_concurrent_test.go
+++ b/pkg/config/load_concurrent_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -70,4 +71,88 @@ func TestLoadConfig_ConcurrentCalls(t *testing.T) {
 	case <-timeout:
 		t.Fatal("timed out - possible deadlock in concurrent LoadConfig calls")
 	}
+}
+
+// TestLoadConfig_ConcurrentCalls_IsolatedResults verifies that concurrent
+// LoadConfig calls loading DIFFERENT config files never mix up which files
+// they tracked for case-sensitive key extraction. A mutex alone (guarding
+// reads/writes to a single shared tracker) is not enough to prevent this: it
+// stops the "concurrent map writes" panic, but one call's reset()/track()
+// calls can still interleave with another's, letting a call snapshot a
+// different call's tracked files -- silently corrupting env/auth.identities
+// case restoration with the wrong config's keys. Each concurrent LoadConfig
+// call must get its own tracker (see mergedFilesRegistry, global_viper.go).
+func TestLoadConfig_ConcurrentCalls_IsolatedResults(t *testing.T) {
+	dirA := t.TempDir()
+	atmosYAMLA := "base_path: ./\n" +
+		"env:\n" +
+		"  UNIQUE_KEY_A: \"a\"\n"
+	pathA := filepath.Join(dirA, AtmosConfigFileName)
+	require.NoError(t, os.WriteFile(pathA, []byte(atmosYAMLA), 0o644))
+
+	dirB := t.TempDir()
+	atmosYAMLB := "base_path: ./\n" +
+		"env:\n" +
+		"  UNIQUE_KEY_B: \"b\"\n"
+	pathB := filepath.Join(dirB, AtmosConfigFileName)
+	require.NoError(t, os.WriteFile(pathB, []byte(atmosYAMLB), 0o644))
+
+	type result struct {
+		wantKey string
+		envCase map[string]string
+		err     error
+	}
+
+	const perDir = 10
+	results := make(chan result, perDir*2)
+	var wg sync.WaitGroup
+
+	load := func(path, wantKey string) {
+		defer wg.Done()
+		atmosConfig, err := LoadConfig(&schema.ConfigAndStacksInfo{
+			AtmosConfigFilesFromArg: []string{path},
+		})
+		if err != nil {
+			results <- result{err: err}
+			return
+		}
+		var envCase map[string]string
+		if atmosConfig.CaseMaps != nil {
+			envCase = atmosConfig.CaseMaps.Get(envKey)
+		}
+		results <- result{wantKey: wantKey, envCase: envCase}
+	}
+
+	for i := 0; i < perDir; i++ {
+		wg.Add(2)
+		go load(pathA, "UNIQUE_KEY_A")
+		go load(pathB, "UNIQUE_KEY_B")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out - possible deadlock in concurrent LoadConfig calls")
+	}
+	close(results)
+
+	otherKey := map[string]string{"UNIQUE_KEY_A": "unique_key_b", "UNIQUE_KEY_B": "unique_key_a"}
+	count := 0
+	for r := range results {
+		require.NoError(t, r.err)
+		count++
+
+		lowerWant := strings.ToLower(r.wantKey)
+		assert.Equal(t, r.wantKey, r.envCase[lowerWant],
+			"result meant for %s must preserve its own config file's case, not another concurrent call's", r.wantKey)
+		assert.NotContains(t, r.envCase, otherKey[r.wantKey],
+			"result meant for %s must not contain the other concurrent call's tracked key", r.wantKey)
+	}
+	assert.Equal(t, perDir*2, count)
 }

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -1468,12 +1468,9 @@ func TestMergeDefaultImports_GitRoot(t *testing.T) {
 }
 
 func TestPreserveCaseSensitiveMaps(t *testing.T) {
-	// Clear any previously tracked files at start of each test.
-	resetMergedConfigFiles()
-
 	t.Run("does nothing when no config file used", func(t *testing.T) {
-		resetMergedConfigFiles()
 		v := viper.New()
+		resetMergedConfigFiles(v)
 		atmosConfig := &schema.AtmosConfiguration{}
 
 		preserveCaseSensitiveMaps(v, atmosConfig)
@@ -1481,7 +1478,6 @@ func TestPreserveCaseSensitiveMaps(t *testing.T) {
 	})
 
 	t.Run("preserves env variable case", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "atmos.yaml")
 
@@ -1501,6 +1497,7 @@ components:
 		require.NoError(t, err)
 
 		v := viper.New()
+		resetMergedConfigFiles(v)
 		v.SetConfigFile(configPath)
 		err = v.ReadInConfig()
 		require.NoError(t, err)
@@ -1518,7 +1515,6 @@ components:
 	})
 
 	t.Run("preserves auth identity case", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "atmos.yaml")
 
@@ -1543,6 +1539,7 @@ components:
 		require.NoError(t, err)
 
 		v := viper.New()
+		resetMergedConfigFiles(v)
 		v.SetConfigFile(configPath)
 		err = v.ReadInConfig()
 		require.NoError(t, err)
@@ -1564,7 +1561,6 @@ components:
 	})
 
 	t.Run("merges case mappings from tracked imported files", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 
 		// Create first import file with some env vars.
@@ -1587,12 +1583,14 @@ env:
 		err = os.WriteFile(importFile2, []byte(import2Content), 0o644)
 		require.NoError(t, err)
 
-		// Track both files as if they were merged during import processing.
-		trackMergedConfigFile(importFile1)
-		trackMergedConfigFile(importFile2)
-
 		// Viper has no config file set, but we have tracked files.
 		v := viper.New()
+		resetMergedConfigFiles(v)
+
+		// Track both files as if they were merged during import processing.
+		trackMergedConfigFile(v, importFile1)
+		trackMergedConfigFile(v, importFile2)
+
 		atmosConfig := &schema.AtmosConfiguration{}
 
 		preserveCaseSensitiveMaps(v, atmosConfig)
@@ -1608,7 +1606,6 @@ env:
 	})
 
 	t.Run("later imports override earlier imports for overlapping keys", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 
 		// Create first import file with an env var using one case.
@@ -1629,11 +1626,13 @@ env:
 		err = os.WriteFile(importFile2, []byte(import2Content), 0o644)
 		require.NoError(t, err)
 
-		// Track both files in order.
-		trackMergedConfigFile(importFile1)
-		trackMergedConfigFile(importFile2)
-
 		v := viper.New()
+		resetMergedConfigFiles(v)
+
+		// Track both files in order.
+		trackMergedConfigFile(v, importFile1)
+		trackMergedConfigFile(v, importFile2)
+
 		atmosConfig := &schema.AtmosConfiguration{}
 
 		preserveCaseSensitiveMaps(v, atmosConfig)
@@ -1645,7 +1644,6 @@ env:
 	})
 
 	t.Run("main config file is included when not tracked", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "atmos.yaml")
 
@@ -1659,6 +1657,7 @@ env:
 		require.NoError(t, err)
 
 		v := viper.New()
+		resetMergedConfigFiles(v)
 		v.SetConfigFile(configPath)
 		err = v.ReadInConfig()
 		require.NoError(t, err)
@@ -1674,7 +1673,6 @@ env:
 	})
 
 	t.Run("skips unreadable files gracefully", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 
 		// Create a valid import file.
@@ -1686,11 +1684,13 @@ env:
 		err := os.WriteFile(validFile, []byte(validContent), 0o644)
 		require.NoError(t, err)
 
-		// Track a non-existent file and the valid file.
-		trackMergedConfigFile(filepath.Join(tempDir, "nonexistent.yaml"))
-		trackMergedConfigFile(validFile)
-
 		v := viper.New()
+		resetMergedConfigFiles(v)
+
+		// Track a non-existent file and the valid file.
+		trackMergedConfigFile(v, filepath.Join(tempDir, "nonexistent.yaml"))
+		trackMergedConfigFile(v, validFile)
+
 		atmosConfig := &schema.AtmosConfiguration{}
 
 		// Should skip the unreadable file gracefully.
@@ -1703,7 +1703,6 @@ env:
 	})
 
 	t.Run("preserves auth identities from imported files", func(t *testing.T) {
-		resetMergedConfigFiles()
 		tempDir := t.TempDir()
 
 		// Create import file with auth identities.
@@ -1721,9 +1720,10 @@ auth:
 		err := os.WriteFile(importFile, []byte(importContent), 0o644)
 		require.NoError(t, err)
 
-		trackMergedConfigFile(importFile)
-
 		v := viper.New()
+		resetMergedConfigFiles(v)
+		trackMergedConfigFile(v, importFile)
+
 		atmosConfig := &schema.AtmosConfiguration{}
 
 		preserveCaseSensitiveMaps(v, atmosConfig)

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -88,6 +88,7 @@ func GetHooks(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStac
 	// here would fail. The hooks section itself is static config (event names,
 	// commands, store names) and does not use YAML functions.
 	sections, err := e.ExecuteDescribeComponent(&e.ExecuteDescribeComponentParams{
+		AtmosConfig:   atmosConfig,
 		Component:     info.ComponentFromArg,
 		Stack:         info.Stack,
 		ComponentType: info.ComponentType,

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -14,6 +14,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/ci"
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/store"
 )
@@ -157,11 +158,13 @@ func TestGetHooks_WithRealComponent(t *testing.T) {
 	// Change to test directory so atmos finds the config
 	t.Chdir(absTestDir)
 
-	atmosConfig := &schema.AtmosConfiguration{}
 	info := &schema.ConfigAndStacksInfo{
 		ComponentFromArg: "vpc",
 		Stack:            "acme-dev-test",
 	}
+	loadedConfig, err := cfg.InitCliConfig(*info, true)
+	require.NoError(t, err)
+	atmosConfig := &loadedConfig
 
 	hooks, err := GetHooks(atmosConfig, info)
 
@@ -239,11 +242,13 @@ vars:
 
 	t.Chdir(tempDir)
 
-	atmosConfig := &schema.AtmosConfiguration{}
 	info := &schema.ConfigAndStacksInfo{
 		ComponentFromArg: "vpc",
 		Stack:            "acme-dev-test",
 	}
+	loadedConfig, err := cfg.InitCliConfig(*info, true)
+	require.NoError(t, err)
+	atmosConfig := &loadedConfig
 
 	hooks, err := GetHooks(atmosConfig, info)
 	require.NoError(t, err)
@@ -275,14 +280,15 @@ func TestRunAll_RendersStoreHookExecutionFields(t *testing.T) {
 			t.Chdir(tempDir)
 
 			mockStore := NewMockStore()
-			atmosConfig := &schema.AtmosConfiguration{
-				Stores: store.StoreRegistry{
-					"staging": mockStore,
-				},
-			}
 			info := &schema.ConfigAndStacksInfo{
 				ComponentFromArg: "component",
 				Stack:            "acme-dev-test",
+			}
+			loadedConfig, err := cfg.InitCliConfig(*info, true)
+			require.NoError(t, err)
+			atmosConfig := &loadedConfig
+			atmosConfig.Stores = store.StoreRegistry{
+				"staging": mockStore,
 			}
 
 			hooks, err := GetHooks(atmosConfig, info)
@@ -304,11 +310,14 @@ func TestRunAll_DoesNotRenderNonMatchingStoreHookExecutionFields(t *testing.T) {
 	tempDir := setupStoreHookTemplateFixture(t, `!template "{{"`)
 	t.Chdir(tempDir)
 
-	atmosConfig := &schema.AtmosConfiguration{Stores: make(store.StoreRegistry)}
 	info := &schema.ConfigAndStacksInfo{
 		ComponentFromArg: "component",
 		Stack:            "acme-dev-test",
 	}
+	loadedConfig, err := cfg.InitCliConfig(*info, true)
+	require.NoError(t, err)
+	atmosConfig := &loadedConfig
+	atmosConfig.Stores = make(store.StoreRegistry)
 
 	hooks, err := GetHooks(atmosConfig, info)
 	require.NoError(t, err)
@@ -607,9 +616,11 @@ components:
 
 	t.Run("on_failure fail propagates the error", func(t *testing.T) {
 		info := newFixture(t, "fail")
-		err := RunPerComponentHooks(&RunPerComponentHooksOptions{
+		loadedConfig, err := cfg.InitCliConfig(*info, true)
+		require.NoError(t, err)
+		err = RunPerComponentHooks(&RunPerComponentHooksOptions{
 			Event:       AfterTerraformApply,
-			AtmosConfig: &schema.AtmosConfiguration{},
+			AtmosConfig: &loadedConfig,
 			Info:        info,
 			Outcome:     Outcome{Status: RunSuccess},
 		})
@@ -618,9 +629,11 @@ components:
 
 	t.Run("on_failure warn resolves to nil", func(t *testing.T) {
 		info := newFixture(t, "warn")
-		err := RunPerComponentHooks(&RunPerComponentHooksOptions{
+		loadedConfig, err := cfg.InitCliConfig(*info, true)
+		require.NoError(t, err)
+		err = RunPerComponentHooks(&RunPerComponentHooksOptions{
 			Event:       AfterTerraformApply,
-			AtmosConfig: &schema.AtmosConfiguration{},
+			AtmosConfig: &loadedConfig,
 			Info:        info,
 			Outcome:     Outcome{Status: RunSuccess},
 		})
@@ -629,9 +642,11 @@ components:
 
 	t.Run("on_failure ignore resolves to nil", func(t *testing.T) {
 		info := newFixture(t, "ignore")
-		err := RunPerComponentHooks(&RunPerComponentHooksOptions{
+		loadedConfig, err := cfg.InitCliConfig(*info, true)
+		require.NoError(t, err)
+		err = RunPerComponentHooks(&RunPerComponentHooksOptions{
 			Event:       AfterTerraformApply,
-			AtmosConfig: &schema.AtmosConfiguration{},
+			AtmosConfig: &loadedConfig,
 			Info:        info,
 			Outcome:     Outcome{Status: RunSuccess},
 		})


### PR DESCRIPTION
## what

- Routes every access to the process-wide global Viper singleton through a new mutex-guarded `pkg/config.GlobalViper()` wrapper (`SafeViper`), instead of calling `viper.GetViper()`/`viper.Set`/`viper.Get*` directly — mirroring the embedded-mutex pattern already used by `pkg/io`/`pkg/ui`.
- Fixes `pkg/hooks.GetHooks` to forward the `AtmosConfig` it already received into `ExecuteDescribeComponentParams`, removing a redundant second, independently concurrent config load per hook invocation.
- Closes a second, independently racy package-level slice (`mergedConfigFiles` in `pkg/config/load.go`) by wrapping it in its own mutex-guarded tracker.
- Adds `pkg/config/load_concurrent_test.go`, a `-race`-driven regression test that spins up concurrent `LoadConfig` calls against a real fixture and reproduces the original panic on unfixed code.
- Minor cleanup: `bridgeVendorUpdaterConfig` now fetches `GlobalViper()` once instead of once per `Set` call, and a new `ciFlagKey` constant replaces 10 duplicated `"ci"` string literals in `cmd/terraform/utils.go` (surfaced by golangci-lint's `add-constant` check once those lines were touched).

## why

- `atmos terraform ... --max-concurrency 3` (and even `2`) could panic with `fatal error: concurrent map writes` inside `viper.(*Viper).Set`, reported from production usage. Root cause: `pkg/config.LoadConfig` bridges `profiles.base_path` and `vendor.update.*`/`vendor.ci.*` into the process-wide global Viper singleton on every call, with zero locking (`spf13/viper` has no internal synchronization), while the DAG scheduler runs `LoadConfig` concurrently — once per graph node — whenever `--max-concurrency > 1`.
- `GetHooks` was also triggering a second, entirely redundant `InitCliConfig`/`LoadConfig` call per node because it never forwarded the `AtmosConfig` it was already given, doubling the exposure to the race for no reason.
- The regression test proves the fix: run against the pre-fix code under `go test -race`, it reliably reproduces the exact `viper.(*Viper).Set` race reported in production; against the fixed code it passes clean.

## references

- Reported in Slack by two engineers hitting the same panic at `--max-concurrency 2` and `3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling during concurrent operations, preserving environment-key casing and preventing cross-load contamination.
  * Ensured hooks use the active configuration when describing components.
  * Standardized CI mode and profile settings detection across commands.
  * Explicit `--ci=false` now overrides CI environment settings and automatic CI detection.
  * Improved reliability when reading shared configuration during shell and command execution, including masking settings.

* **Tests**
  * Added coverage for concurrent configuration loading, CI precedence, shared configuration access, and configuration-aware hook execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->