### PR TITLE
fix(packer): inject Atmos Auth credentials into the packer subprocess

### DIFF
--- a/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
+++ b/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
@@ -22,11 +22,10 @@ Fixed by wiring the same component-auth setup and credential-injection path that
 
 ## Context
 
-Reported against a real workload (`atmos packer build fatvm -s safire-use2-platform`) that
-relies on Atmos Auth identities rather than pre-assumed ambient credentials.
+Reported against a real workload (`atmos packer build <component> -s <stack>`) that relies on
+Atmos Auth identities rather than pre-assumed ambient credentials.
 
-The DriveWealth reference pipeline
-(`packer-aws-al2023/.github/workflows/ami.yml`) sidesteps the bug entirely: it runs
+A common GitHub Actions packer pipeline sidesteps the bug entirely: it runs
 `aws-actions/configure-aws-credentials` (GitHub OIDC, `role-to-assume`) **before**
 `atmos packer build`, so the AWS SDK inside packer finds credentials in the process
 environment. That masks the defect in CI but leaves local runs — and any flow that

--- a/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
+++ b/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
@@ -1,0 +1,93 @@
+# Fix: `atmos packer` honors Atmos Auth and injects credentials into the subprocess
+
+**Date:** 2026-08-23
+
+## Summary
+
+`atmos packer build` ran completely unauthenticated when relying on Atmos Auth. Unlike
+`atmos terraform` and `atmos helmfile`, the packer executor never created an `AuthManager`,
+never evaluated the merged `auth:` config, and never injected credentials into the packer
+subprocess environment. The packer process therefore inherited only the ambient environment,
+and its AWS datasources failed with:
+
+```
+Error: Datasource.Execute failed: No valid credential sources found
+
+  on main.pkr.hcl line 99:
+  (source code not available)
+```
+
+Fixed by wiring the same component-auth setup and credential-injection path that
+`helmfile` uses into `ExecutePacker`.
+
+## Context
+
+Reported against a real workload (`atmos packer build fatvm -s safire-use2-platform`) that
+relies on Atmos Auth identities rather than pre-assumed ambient credentials.
+
+The DriveWealth reference pipeline
+(`packer-aws-al2023/.github/workflows/ami.yml`) sidesteps the bug entirely: it runs
+`aws-actions/configure-aws-credentials` (GitHub OIDC, `role-to-assume`) **before**
+`atmos packer build`, so the AWS SDK inside packer finds credentials in the process
+environment. That masks the defect in CI but leaves local runs — and any flow that
+depends on the `auth:` block — broken.
+
+Tracing the three executors made the gap concrete:
+
+- **terraform** (`internal/exec/terraform.go`): calls `setupTerraformAuth` (creates and
+  authenticates the `AuthManager`, injects the store auth resolver), passes the manager to
+  `ProcessStacks`, and later runs `auth.TerraformPreHook` which calls
+  `PrepareShellEnvironment` and sets `info.SanitizedEnv`.
+- **helmfile** (`internal/exec/helmfile.go`): calls `SetupComponentAuthForCLI`, passes the
+  manager to `ProcessStacks`, and injects credentials via `prepareHelmfileAuthEnvironment`
+  (→ `AuthManager.PrepareShellEnvironment`) into the subprocess env just before executing.
+- **packer** (`internal/exec/packer.go`): called `ProcessStacks(..., nil)` with a **nil**
+  `AuthManager` and **never** prepared an authenticated environment. Two distinct failures:
+  1. YAML functions/stores (`!terraform.output`, `!store`, …) resolved during packer var
+     processing ran unauthenticated.
+  2. No AWS credentials were ever placed into the packer subprocess environment — the direct
+     cause of "No valid credential sources found".
+
+The `AuthManager` interface docstring (`pkg/auth/types/interfaces.go:303`) explicitly lists
+Packer as a supported subprocess for `PrepareShellEnvironment`, so the interface contract and
+the implementation were out of sync.
+
+## Changes
+
+- `internal/exec/packer.go`:
+  - Call `SetupComponentAuthForCLI` (the shared helper helmfile uses) before stack processing
+    to build and authenticate the component `AuthManager`.
+  - Pass the resolved `authManager` to `ProcessStacks` instead of `nil`, so YAML
+    functions/stores evaluated during packer var processing are authenticated.
+  - Inject the resolved identity's credentials into the subprocess env via
+    `prepareComponentAuthEnvironment` (→ `PrepareShellEnvironment`) just before executing
+    packer — a no-op when auth is disabled or no identity is configured.
+  - Added two test seams (`processStacksForPacker`, `executePackerShellCommand`) mirroring the
+    existing `var x = Func` seam convention used elsewhere in the package.
+- `internal/exec/utils_auth.go`: extracted `resolveDefaultIdentity` and the renamed
+  `prepareComponentAuthEnvironment` (formerly `prepareHelmfileAuthEnvironment`) into the shared
+  exec-layer auth file so helmfile and packer share one credential-injection path (Code Reuse
+  mandate — extend, don't duplicate).
+- `internal/exec/helmfile.go`: removed the now-shared local copies and call the shared
+  `prepareComponentAuthEnvironment`.
+- `internal/exec/helmfile_utils_test.go`: updated references to the renamed shared helper.
+- `internal/exec/packer_auth_test.go` (new):
+  - `TestExecutePacker_PassesAuthManagerToProcessStacks` — primary regression test; intercepts
+    `ProcessStacks` and asserts a non-nil `AuthManager` is passed (fails against the old `nil`
+    behavior). Requires no packer binary.
+  - `TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv` — a fake `AuthManager` injects a
+    sentinel AWS credential via `PrepareShellEnvironment`; the packer shell invocation is
+    intercepted and the env is asserted to contain the sentinel. Guarded by `RequirePacker`.
+
+## Validation
+
+- `go build ./...`
+- `go test ./internal/exec/ -run 'TestExecutePacker_PassesAuthManagerToProcessStacks|TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv|TestPrepareComponentAuthEnvironment' -count=1 -v`
+  — all pass. Confirmed `TestExecutePacker_PassesAuthManagerToProcessStacks` **fails** against
+  the pre-fix code (nil `AuthManager`) and passes after.
+- `go test ./internal/exec/ -run 'Packer|Helmfile' -count=1` — ok.
+- `atmos lint --changed` — 0 issues.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
+++ b/docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md
@@ -10,7 +10,7 @@ never evaluated the merged `auth:` config, and never injected credentials into t
 subprocess environment. The packer process therefore inherited only the ambient environment,
 and its AWS datasources failed with:
 
-```
+```text
 Error: Datasource.Execute failed: No valid credential sources found
 
   on main.pkr.hcl line 99:
@@ -43,10 +43,9 @@ Tracing the three executors made the gap concrete:
   (→ `AuthManager.PrepareShellEnvironment`) into the subprocess env just before executing.
 - **packer** (`internal/exec/packer.go`): called `ProcessStacks(..., nil)` with a **nil**
   `AuthManager` and **never** prepared an authenticated environment. Two distinct failures:
-  1. YAML functions/stores (`!terraform.output`, `!store`, …) resolved during packer var
-     processing ran unauthenticated.
-  2. No AWS credentials were ever placed into the packer subprocess environment — the direct
-     cause of "No valid credential sources found".
+  (1) YAML functions/stores (`!terraform.output`, `!store`, …) resolved during packer var
+  processing ran unauthenticated; (2) no AWS credentials were ever placed into the packer
+  subprocess environment — the direct cause of "No valid credential sources found".
 
 The `AuthManager` interface docstring (`pkg/auth/types/interfaces.go:303`) explicitly lists
 Packer as a supported subprocess for `PrepareShellEnvironment`, so the interface contract and

--- a/internal/exec/helmfile.go
+++ b/internal/exec/helmfile.go
@@ -398,7 +398,7 @@ func ExecuteHelmfile(info schema.ConfigAndStacksInfo) error {
 	}
 	envVars = append(envVars, fmt.Sprintf("ATMOS_BASE_PATH=%s", basePath))
 
-	envVars, err = prepareHelmfileAuthEnvironment(authManager, info.Identity, envVars)
+	envVars, err = prepareComponentAuthEnvironment(authManager, info.Identity, envVars)
 	if err != nil {
 		return err
 	}
@@ -527,38 +527,5 @@ func deliverHelmfileToTarget(
 	})
 }
 
-// resolveDefaultIdentity resolves the default identity. A lookup failure is fatal
-// only when the caller explicitly requested the select-default path; for an
-// implicit empty identity the requested value is returned so execution can
-// continue without identity.
-func resolveDefaultIdentity(authManager auth.AuthManager, requested string) (string, error) {
-	defaultIdentity, err := authManager.GetDefaultIdentity(false)
-	if err == nil {
-		return defaultIdentity, nil
-	}
-	if requested == cfg.IdentityFlagSelectValue {
-		return "", fmt.Errorf("%w: resolve default identity: %w", errUtils.ErrAuthenticationFailed, err)
-	}
-	return requested, nil
-}
-
-func prepareHelmfileAuthEnvironment(authManager auth.AuthManager, identity string, envVars []string) ([]string, error) {
-	if authManager == nil {
-		return envVars, nil
-	}
-	if identity == "" || identity == cfg.IdentityFlagSelectValue {
-		resolved, err := resolveDefaultIdentity(authManager, identity)
-		if err != nil {
-			return nil, err
-		}
-		identity = resolved
-	}
-	if identity == "" || identity == cfg.IdentityFlagDisabledValue {
-		return envVars, nil
-	}
-	preparedEnv, err := authManager.PrepareShellEnvironment(context.Background(), identity, envVars)
-	if err != nil {
-		return nil, fmt.Errorf("%w: prepare helmfile environment for identity %q: %w", errUtils.ErrAuthenticationFailed, identity, err)
-	}
-	return preparedEnv, nil
-}
+// resolveDefaultIdentity and prepareComponentAuthEnvironment now live in utils_auth.go
+// so the helmfile and packer subprocess executors share one credential-injection path.

--- a/internal/exec/helmfile_utils_test.go
+++ b/internal/exec/helmfile_utils_test.go
@@ -193,11 +193,11 @@ func BenchmarkCheckHelmfileConfig(b *testing.B) {
 	}
 }
 
-func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
+func TestPrepareComponentAuthEnvironment(t *testing.T) {
 	baseEnv := []string{"PATH=/bin"}
 
 	t.Run("nil manager returns original env", func(t *testing.T) {
-		got, err := prepareHelmfileAuthEnvironment(nil, "dev", baseEnv)
+		got, err := prepareComponentAuthEnvironment(nil, "dev", baseEnv)
 		require.NoError(t, err)
 		assert.Equal(t, baseEnv, got)
 	})
@@ -206,7 +206,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		manager := mockTypes.NewMockAuthManager(ctrl)
 
-		got, err := prepareHelmfileAuthEnvironment(manager, cfg.IdentityFlagDisabledValue, baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, cfg.IdentityFlagDisabledValue, baseEnv)
 		require.NoError(t, err)
 		assert.Equal(t, baseEnv, got)
 	})
@@ -219,7 +219,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 			PrepareShellEnvironment(gomock.Any(), "dev", baseEnv).
 			Return(prepared, nil)
 
-		got, err := prepareHelmfileAuthEnvironment(manager, "dev", baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, "dev", baseEnv)
 		require.NoError(t, err)
 		assert.Equal(t, prepared, got)
 	})
@@ -233,7 +233,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 			PrepareShellEnvironment(gomock.Any(), "default", baseEnv).
 			Return(prepared, nil)
 
-		got, err := prepareHelmfileAuthEnvironment(manager, "", baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, "", baseEnv)
 		require.NoError(t, err)
 		assert.Equal(t, prepared, got)
 	})
@@ -243,7 +243,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 		manager := mockTypes.NewMockAuthManager(ctrl)
 		manager.EXPECT().GetDefaultIdentity(false).Return("", errors.New("no default"))
 
-		got, err := prepareHelmfileAuthEnvironment(manager, "", baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, "", baseEnv)
 		require.NoError(t, err)
 		assert.Equal(t, baseEnv, got)
 	})
@@ -253,7 +253,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 		manager := mockTypes.NewMockAuthManager(ctrl)
 		manager.EXPECT().GetDefaultIdentity(false).Return("", errors.New("no default"))
 
-		got, err := prepareHelmfileAuthEnvironment(manager, cfg.IdentityFlagSelectValue, baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, cfg.IdentityFlagSelectValue, baseEnv)
 		require.Error(t, err)
 		assert.Nil(t, got)
 		assert.ErrorIs(t, err, errUtils.ErrAuthenticationFailed)
@@ -267,7 +267,7 @@ func TestPrepareHelmfileAuthEnvironment(t *testing.T) {
 			PrepareShellEnvironment(gomock.Any(), "dev", baseEnv).
 			Return(nil, prepareErr)
 
-		got, err := prepareHelmfileAuthEnvironment(manager, "dev", baseEnv)
+		got, err := prepareComponentAuthEnvironment(manager, "dev", baseEnv)
 		require.Error(t, err)
 		assert.Nil(t, got)
 		assert.ErrorIs(t, err, errUtils.ErrAuthenticationFailed)

--- a/internal/exec/packer.go
+++ b/internal/exec/packer.go
@@ -23,6 +23,16 @@ import (
 
 const componentTypePacker = "packer"
 
+// processStacksForPacker is a seam over ProcessStacks so tests can observe the
+// arguments the packer executor passes (notably the auth manager) without running
+// the full stack-processing pipeline.
+var processStacksForPacker = ProcessStacks
+
+// executePackerShellCommand is a seam over ExecuteShellCommand for the main packer
+// subprocess invocation so tests can observe the environment (including Atmos Auth
+// credentials) delivered to the packer process without launching a real binary.
+var executePackerShellCommand = ExecuteShellCommand
+
 // PackerFlags represents Packer command-line flags passed to ExecutePacker and ExecutePackerOutput.
 type PackerFlags struct {
 	// Template specifies the Packer template file or directory path.
@@ -78,7 +88,16 @@ func ExecutePacker(
 		)
 	}
 
-	*info, err = ProcessStacks(&atmosConfig, *info, true, true, true, nil, nil)
+	// Set up authentication (merge global + component auth, create and authenticate the
+	// AuthManager, inject the store auth resolver). Mirrors terraform (setupTerraformAuth)
+	// and helmfile (SetupComponentAuthForCLI). Without this, packer ran unauthenticated and
+	// its datasources failed with "No valid credential sources found".
+	authManager, err := SetupComponentAuthForCLI(&atmosConfig, info)
+	if err != nil {
+		return err
+	}
+
+	*info, err = processStacksForPacker(&atmosConfig, *info, true, true, true, nil, authManager)
 	if err != nil {
 		return err
 	}
@@ -264,6 +283,15 @@ func ExecutePacker(
 		return err
 	}
 	envVars = append(envVars, fmt.Sprintf("ATMOS_BASE_PATH=%s", basePath))
+
+	// Inject Atmos Auth credentials for the resolved identity into the subprocess
+	// environment (file-based creds, region, emulator/static creds). No-op when auth
+	// is disabled or no identity is configured. Mirrors helmfile's credential injection.
+	envVars, err = prepareComponentAuthEnvironment(authManager, info.Identity, envVars)
+	if err != nil {
+		return err
+	}
+
 	log.Debug("Using ENV", "variables", envVars)
 
 	// Resolve info.Command to the toolchain-installed binary (if any), mirroring
@@ -273,7 +301,7 @@ func ExecutePacker(
 	// "executable file not found in $PATH", because exec.Command resolves the
 	// binary via the process's real PATH at call time, not via the PATH=...
 	// entry later added to envVars.
-	return ExecuteShellCommand(
+	return executePackerShellCommand(
 		atmosConfig,
 		tenv.Resolve(info.Command),
 		allArgsAndFlags,

--- a/internal/exec/packer_auth_test.go
+++ b/internal/exec/packer_auth_test.go
@@ -11,7 +11,6 @@ import (
 	auth "github.com/cloudposse/atmos/pkg/auth"
 	mockTypes "github.com/cloudposse/atmos/pkg/auth/types"
 	"github.com/cloudposse/atmos/pkg/schema"
-	"github.com/cloudposse/atmos/tests"
 )
 
 // stubPackerAuthSeams replaces the auth-config and auth-manager creation seams so
@@ -96,8 +95,9 @@ func TestExecutePacker_PassesAuthManagerToProcessStacks(t *testing.T) {
 // A fake AuthManager injects a sentinel AWS credential via PrepareShellEnvironment;
 // the packer shell invocation is intercepted so no real packer binary runs.
 func TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv(t *testing.T) {
-	tests.RequirePacker(t)
-
+	// No RequirePacker guard: executePackerShellCommand is replaced below, so no real
+	// Packer binary is launched, and the fixture declares no packer tool-dependencies,
+	// so the pre-exec pipeline (path resolution, validation, varfile) needs no binary.
 	const sentinel = "AWS_ACCESS_KEY_ID=ATMOS_AUTH_SENTINEL"
 
 	workDir := "../../tests/fixtures/scenarios/packer"

--- a/internal/exec/packer_auth_test.go
+++ b/internal/exec/packer_auth_test.go
@@ -1,0 +1,154 @@
+package exec
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	auth "github.com/cloudposse/atmos/pkg/auth"
+	mockTypes "github.com/cloudposse/atmos/pkg/auth/types"
+	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/cloudposse/atmos/tests"
+)
+
+// stubPackerAuthSeams replaces the auth-config and auth-manager creation seams so
+// ExecutePacker builds a fake, non-nil AuthManager without touching a real cloud.
+// The returned manager only needs GetStackInfo (called by setupTerraformAuth); an
+// explicit info.Identity short-circuits the chain/default-identity lookups.
+func stubPackerAuthSeams(t *testing.T, manager auth.AuthManager) {
+	t.Helper()
+
+	origGetter := defaultMergedAuthConfigGetter
+	origCreator := defaultAuthManagerCreator
+	t.Cleanup(func() {
+		defaultMergedAuthConfigGetter = origGetter
+		defaultAuthManagerCreator = origCreator
+	})
+
+	defaultMergedAuthConfigGetter = func(*schema.AtmosConfiguration, *schema.ConfigAndStacksInfo) (*schema.AuthConfig, error) {
+		return &schema.AuthConfig{}, nil
+	}
+	defaultAuthManagerCreator = func(identity string, authConfig *schema.AuthConfig, selectValue string, atmosConfig *schema.AtmosConfiguration, stack string) (auth.AuthManager, error) {
+		return manager, nil
+	}
+}
+
+// TestExecutePacker_PassesAuthManagerToProcessStacks is the primary regression test
+// for the packer auth bug: `atmos packer` historically called ProcessStacks with a
+// nil AuthManager, so the `auth:` section was never evaluated and no credentials were
+// injected into the packer subprocess ("No valid credential sources found").
+//
+// The test intercepts ProcessStacks via the processStacksForPacker seam and asserts
+// that ExecutePacker passes a non-nil AuthManager, matching terraform and helmfile.
+func TestExecutePacker_PassesAuthManagerToProcessStacks(t *testing.T) {
+	workDir := "../../tests/fixtures/scenarios/packer"
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", workDir)
+
+	ctrl := gomock.NewController(t)
+	fakeManager := mockTypes.NewMockAuthManager(ctrl)
+	// setupTerraformAuth calls GetStackInfo; return nil so it is a no-op.
+	fakeManager.EXPECT().GetStackInfo().Return(nil).AnyTimes()
+	stubPackerAuthSeams(t, fakeManager)
+
+	origProcess := processStacksForPacker
+	t.Cleanup(func() { processStacksForPacker = origProcess })
+
+	var captured auth.AuthManager
+	var called bool
+	processStacksForPacker = func(
+		atmosConfig *schema.AtmosConfiguration,
+		info schema.ConfigAndStacksInfo,
+		checkStack, processTemplates, processFunctions bool,
+		skip []string,
+		authManager auth.AuthManager,
+	) (schema.ConfigAndStacksInfo, error) {
+		captured = authManager
+		called = true
+		// Short-circuit ExecutePacker before component-path resolution: keep the
+		// stack set (so the missing-stack guard passes) but mark it disabled so
+		// ExecutePacker returns early.
+		info.ComponentIsEnabled = false
+		return info, nil
+	}
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentType:    "packer",
+		ComponentFromArg: "aws/bastion",
+		Stack:            "nonprod",
+		SubCommand:       "build",
+		Identity:         "test-identity",
+	}
+
+	err := ExecutePacker(info, &PackerFlags{})
+	require.NoError(t, err)
+	require.True(t, called, "processStacksForPacker should have been invoked")
+	require.NotNil(t, captured,
+		"ExecutePacker must pass a non-nil AuthManager to ProcessStacks so Atmos Auth "+
+			"credentials are evaluated and injected into the packer subprocess "+
+			"(regression: packer passed nil, causing 'No valid credential sources found')")
+}
+
+// TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv confirms that the
+// resolved Atmos Auth credentials actually reach the packer subprocess environment.
+// A fake AuthManager injects a sentinel AWS credential via PrepareShellEnvironment;
+// the packer shell invocation is intercepted so no real packer binary runs.
+func TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv(t *testing.T) {
+	tests.RequirePacker(t)
+
+	const sentinel = "AWS_ACCESS_KEY_ID=ATMOS_AUTH_SENTINEL"
+
+	workDir := "../../tests/fixtures/scenarios/packer"
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", workDir)
+
+	ctrl := gomock.NewController(t)
+	fakeManager := mockTypes.NewMockAuthManager(ctrl)
+	fakeManager.EXPECT().GetStackInfo().Return(nil).AnyTimes()
+	// prepareComponentAuthEnvironment calls PrepareShellEnvironment with the resolved
+	// identity; return the incoming env with the sentinel credential appended.
+	fakeManager.EXPECT().
+		PrepareShellEnvironment(gomock.Any(), "test-identity", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, env []string) ([]string, error) {
+			return append(env, sentinel), nil
+		}).
+		AnyTimes()
+	stubPackerAuthSeams(t, fakeManager)
+
+	origShell := executePackerShellCommand
+	t.Cleanup(func() { executePackerShellCommand = origShell })
+
+	var capturedEnv []string
+	var shellCalled bool
+	executePackerShellCommand = func(
+		atmosConfig schema.AtmosConfiguration,
+		command string,
+		args []string,
+		dir string,
+		env []string,
+		dryRun bool,
+		redirectStdError string,
+		opts ...ShellCommandOption,
+	) error {
+		capturedEnv = env
+		shellCalled = true
+		return nil
+	}
+
+	info := &schema.ConfigAndStacksInfo{
+		ComponentType:    "packer",
+		ComponentFromArg: "aws/bastion",
+		Stack:            "nonprod",
+		SubCommand:       "validate",
+		ProcessTemplates: true,
+		ProcessFunctions: true,
+		Identity:         "test-identity",
+	}
+
+	err := ExecutePacker(info, &PackerFlags{})
+	require.NoError(t, err)
+	require.True(t, shellCalled, "packer shell command should have been invoked")
+	require.Contains(t, strings.Join(capturedEnv, "\n"), sentinel,
+		"Atmos Auth credentials must be injected into the packer subprocess environment")
+}

--- a/internal/exec/utils_auth.go
+++ b/internal/exec/utils_auth.go
@@ -11,6 +11,7 @@
 package exec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -230,4 +231,51 @@ func handleMergeError(componentSection, globalAuthSection, componentAuthSection 
 		return globalAuthSection
 	}
 	return map[string]any{}
+}
+
+// resolveDefaultIdentity resolves the default identity. A lookup failure is fatal
+// only when the caller explicitly requested the select-default path; for an
+// implicit empty identity the requested value is returned so execution can
+// continue without identity.
+//
+// Shared by the helmfile and packer subprocess executors (and any other
+// non-terraform command layer) so credential injection stays consistent.
+func resolveDefaultIdentity(authManager auth.AuthManager, requested string) (string, error) {
+	defaultIdentity, err := authManager.GetDefaultIdentity(false)
+	if err == nil {
+		return defaultIdentity, nil
+	}
+	if requested == cfg.IdentityFlagSelectValue {
+		return "", fmt.Errorf("%w: resolve default identity: %w", errUtils.ErrAuthenticationFailed, err)
+	}
+	return requested, nil
+}
+
+// prepareComponentAuthEnvironment augments envVars with the auth credentials for the
+// resolved identity so a component subprocess (helmfile, packer, etc.) inherits
+// file-based credentials (AWS_PROFILE/AWS_SHARED_CREDENTIALS_FILE), regions, and
+// emulator/static credentials from Atmos Auth.
+//
+// It is a no-op when there is no auth manager or when auth is explicitly disabled,
+// mirroring the terraform pre-hook's disabled-identity short-circuit. An empty or
+// "select" identity falls back to the stack's default identity.
+func prepareComponentAuthEnvironment(authManager auth.AuthManager, identity string, envVars []string) ([]string, error) {
+	if authManager == nil {
+		return envVars, nil
+	}
+	if identity == "" || identity == cfg.IdentityFlagSelectValue {
+		resolved, err := resolveDefaultIdentity(authManager, identity)
+		if err != nil {
+			return nil, err
+		}
+		identity = resolved
+	}
+	if identity == "" || identity == cfg.IdentityFlagDisabledValue {
+		return envVars, nil
+	}
+	preparedEnv, err := authManager.PrepareShellEnvironment(context.Background(), identity, envVars)
+	if err != nil {
+		return nil, fmt.Errorf("%w: prepare component environment for identity %q: %w", errUtils.ErrAuthenticationFailed, identity, err)
+	}
+	return preparedEnv, nil
 }


### PR DESCRIPTION
## what

- `atmos packer` now sets up Atmos Auth the same way `terraform` and `helmfile` do: it creates and authenticates the component `AuthManager`, passes it to `ProcessStacks`, and injects the resolved identity's credentials into the packer subprocess environment before executing.
- Extracted the credential-injection helpers (`resolveDefaultIdentity` and the renamed `prepareComponentAuthEnvironment`, formerly `prepareHelmfileAuthEnvironment`) into `internal/exec/utils_auth.go` so helmfile and packer share one path instead of duplicating it.
- Added regression tests (`internal/exec/packer_auth_test.go`) via two test seams: one asserts a non-nil `AuthManager` is passed to `ProcessStacks`; the other asserts an injected credential reaches the packer subprocess env.
- Added a fix record under `docs/fixes/`.

## why

- `atmos packer build` ran **completely unauthenticated** when relying on Atmos Auth. `internal/exec/packer.go` called `ProcessStacks(..., nil)` (nil `AuthManager`) and never called `PrepareShellEnvironment`, so no AWS credentials ever reached the packer process. Its datasources failed with:

  ```
  Error: Datasource.Execute failed: No valid credential sources found
  ```

- Both other component executors already do this — `terraform` via `setupTerraformAuth` + `auth.TerraformPreHook`, `helmfile` via `SetupComponentAuthForCLI` + credential injection — so packer was the odd one out, even though the `AuthManager` interface docstring explicitly lists Packer as a supported subprocess.
- Verified against a real workload: `atmos packer build <component> -s <stack>` now proceeds into the AMI build (VPC prevalidation, keypair creation, etc.) where the stock binary failed with the credential error.

## references

- Mirrors the existing helmfile auth flow in `internal/exec/helmfile.go`.
- `AuthManager` contract: `pkg/auth/types/interfaces.go` (`PrepareShellEnvironment` — "Use this for all subprocess invocations: Terraform, Helmfile, Packer, ...").
- Fix doc: `docs/fixes/2026-08-23-packer-atmos-auth-credential-injection.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- `atmos packer build` now honors configured authentication settings.
- Credentials for authenticated components are automatically resolved and provided during Packer builds.
- Authentication behavior is now consistent across supported component workflows.
- Added regression coverage to improve reliability and prevent authentication regressions.

## Documentation

- Added guidance for configuring authentication when using Packer builds.
- Updated workload and continuous integration examples with clearer, generic descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->