### PR TITLE
perf(lint): move golangci-lint cache/tmp out of worktrees

### DIFF
--- a/docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md
+++ b/docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md
@@ -1,0 +1,86 @@
+# Fix: Relocate golangci-lint cache/tmp outside worktrees (git fsmonitor saturation)
+
+**Date:** 2026-08-24
+
+## Summary
+
+Commits had grown so slow (tens of seconds to minutes before the signing prompt) that developers
+walked away mid-commit. The dominant cause was `core.fsmonitor = true` in the shared repo config on
+the affected machine, saturated by filesystem churn that repo tooling placed *inside* each worktree —
+chiefly the golangci-lint cache/tmp dirs (156MB / ~37k files, rewritten on every lint run) introduced
+by #2701. The fix relocates those dirs to the OS user-cache directory, keyed by a hash of the worktree
+path, so no filesystem watcher observing a worktree ever sees lint-cache churn again.
+
+## Context
+
+Measured on the affected machine (macOS, ~91 Conductor worktrees nested under the main checkout):
+
+- `git status --porcelain`: 2.9–10.2s with fsmonitor (one run exceeded a 2-minute timeout);
+  0.04–0.15s without. `git diff --name-only`: 6.8s vs 0.02s. `git ls-files -s -z`: up to 8.6s vs
+  0.014s. All wall-clock wait at ~0% CPU — git blocked on fsmonitor daemon IPC, not doing work.
+- 132+ fsmonitor daemons were running for 91 registered worktrees (dozens orphaned from deleted
+  workspaces). Even near-empty worktrees showed 14–68s statuses, i.e. the saturation was
+  FSEvents-system-wide, not per-worktree.
+- A single pre-commit run issues dozens of index-refreshing git commands (pre-commit's own
+  stash/diff/status cycle plus each hook's git calls), each paying that tax. SSH commit signing
+  (1Password) prompts only after all hooks pass — minutes later, when the developer was AFK.
+- New-worktree creation (a full ~10k-file checkout plus a ~100k-file `pnpm install` under the same
+  watched tree) stretched to 30+ minutes under the same saturation.
+
+Why it tipped in July–August 2026, having been fine for a year prior:
+
+- 2026-07-09 `4ee0f7ff4e` (#2701) pointed `GOLANGCI_LINT_CACHE`/`TMPDIR` at `<worktree>/.golangci-cache`
+  and `<worktree>/.golangci-tmp` to isolate golangci-lint's machine-global single-instance lock per
+  worktree (fixing real cross-worktree lint serialization). Correct goal, wrong location: it moved
+  constant high-volume churn under the watchers.
+- 2026-07-16 and 2026-07-30 added two `always_run: true` pre-commit hooks (`tracked-symlinks-check`,
+  `atmos-validate-editorconfig`), each shelling out to git/atmos unconditionally per commit —
+  cheap on a healthy filesystem, expensive under the multiplier.
+- Steady growth to ~91 worktrees, most carrying a 675MB `website/node_modules`.
+
+Cleared as non-causes: the 2026-08-19 Mage migration (`a134752c75`; mage startup measures ~0.4s) and
+the goimports→gci formatter swap (a documented 15–20x speedup). Also corrected a prior assumption:
+Conductor does not use or require git fsmonitor — its change detection is a bundled `watchexec`, and
+its binary contains no fsmonitor references. Nothing in this repo sets `core.fsmonitor`; it had been
+enabled manually on the machine.
+
+## Changes
+
+- `magefiles/mage_lint_golangci_run.go`
+  - `setWorktreeIsolationEnv()` now derives the default cache/tmp location from
+    `os.UserCacheDir()` instead of the worktree root: `<user-cache>/atmos-lint/<hash>/cache` and
+    `<user-cache>/atmos-lint/<hash>/tmp`, where `<hash>` is the first 12 hex chars of the SHA-256 of
+    the absolute worktree path (new helper `worktreeLintCacheRoot()`). Per-worktree lock isolation —
+    #2701's intent — is preserved; the dirs just live outside any watched tree.
+  - The `ATMOS_LINT_SHARED_CACHE=1` opt-out and explicit `GOLANGCI_LINT_CACHE` override behave
+    exactly as before.
+  - `userCacheDirFunc` is a package var so tests can inject a fake user-cache root.
+- `magefiles/mage_lint_golangci_run_test.go` — updated `TestSetWorktreeIsolationEnv` to assert the
+  new location (and that it is *not* under the worktree), added `TestWorktreeLintCacheRoot`
+  (determinism + cross-worktree non-collision), added a user-cache-dir resolution-failure case, and
+  repointed the `runGolangciLintPrecommit` isolation-failure subtest at the new failure path.
+- `.gitignore` keeps the legacy `.golangci-cache/` / `.golangci-tmp/` entries so pre-fix leftovers in
+  existing worktrees stay ignored; delete those directories at leisure to reclaim disk.
+
+Machine-level remediation applied alongside (not a repo change, recorded for operators hitting the
+same wall): `git config core.fsmonitor false` + `git config core.untrackedCache true` in the shared
+repo config, then stopping all `git fsmonitor--daemon` processes. `git status` dropped from
+2.9s–timeout to 0.04–0.2s across every worktree checked.
+
+## Validation
+
+- `go vet -tags mage ./magefiles/...` and `go build ./...` pass.
+- `go test -tags mage ./magefiles/...` passes (full package, including the new/updated cases).
+- End-to-end cold run: staged a scratch `.go` edit, ran `go tool mage lint:precommit` — no
+  `.golangci-cache`/`.golangci-tmp` created in the worktree; cache and tmp appeared under
+  `~/Library/Caches/atmos-lint/<hash>/`; the run correctly flagged the scratch edit's gci violation.
+- Warm-cache rerun on the real staged change: 1.5s wall (vs 9.1s cold) — cache reuse confirmed;
+  `0 issues.` after fixes.
+- No leakage into the real user cache dir from the test suite (fake-injected root verified).
+- `gofumpt -l` clean on changed files.
+- Not validated here: Windows `TMP`/`TEMP` branch behavior (unchanged logic, exercised by the
+  existing platform-conditional test on Windows CI).
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md
+++ b/docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md
@@ -46,6 +46,8 @@ enabled manually on the machine.
 
 ## Changes
 
+Landed in PR #2988.
+
 - `magefiles/mage_lint_golangci_run.go`
   - `setWorktreeIsolationEnv()` now derives the default cache/tmp location from
     `os.UserCacheDir()` instead of the worktree root: `<user-cache>/atmos-lint/<hash>/cache` and
@@ -78,6 +80,8 @@ repo config, then stopping all `git fsmonitor--daemon` processes. `git status` d
   `0 issues.` after fixes.
 - No leakage into the real user cache dir from the test suite (fake-injected root verified).
 - `gofumpt -l` clean on changed files.
+- End-to-end commit: the PR's own commit — every pre-commit hook plus 1Password SSH signing —
+  completed in 4.8s wall, where the pre-fix state exceeded a 2-minute `git status` timeout.
 - Not validated here: Windows `TMP`/`TEMP` branch behavior (unchanged logic, exercised by the
   existing platform-conditional test on Windows CI).
 

--- a/magefiles/mage_lint_golangci_run.go
+++ b/magefiles/mage_lint_golangci_run.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,6 +23,11 @@ const gitCmd = "git"
 // dirPerm is the permission mode used for the isolated cache/tmp directory
 // created below.
 const dirPerm = 0o755
+
+// worktreeHashLen is the number of hex characters of the worktree-root
+// SHA-256 kept in the per-worktree cache directory name — enough to never
+// collide across worktrees while keeping paths short.
+const worktreeHashLen = 12
 
 // stagedPatch bundles the staged-changes patch file path and the affected
 // package list returned by buildStagedPatchAndPackages.
@@ -66,6 +73,10 @@ func runGolangciLintPrecommit(root, binPath string) error {
 	return sh.RunWithV(env, binPath, args...)
 }
 
+// userCacheDirFunc resolves the OS user-cache root; a package var so tests
+// can point it at a temp dir without touching real HOME/XDG_CACHE_HOME.
+var userCacheDirFunc = os.UserCacheDir
+
 // setWorktreeIsolationEnv computes the per-worktree GOLANGCI_LINT_CACHE/temp
 // directory overrides that keep parallel worktree lints from serializing on
 // golangci-lint's machine-global single-instance lock file (a fixed path
@@ -78,19 +89,32 @@ func runGolangciLintPrecommit(root, binPath string) error {
 // Windows and checks TMP/TEMP/USERPROFILE instead, so the bash version's
 // isolation silently didn't apply there. This is a deliberate behavior fix,
 // not just a port.
+//
+// The cache/tmp dirs default to a location under the OS user-cache
+// directory, keyed by a hash of the worktree root, rather than inside the
+// worktree itself. Placing them in-worktree (the original design) put their
+// constant churn under any filesystem watcher (git fsmonitor, Conductor's
+// watchexec) watching the worktree tree, which at scale (dozens of parallel
+// worktrees) saturates the watcher and makes every git command stall for
+// seconds; see docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md.
 func setWorktreeIsolationEnv(root string) (map[string]string, error) {
 	env := map[string]string{}
 	if os.Getenv("ATMOS_LINT_SHARED_CACHE") == "1" {
 		return env, nil
 	}
 
+	lintCacheRoot, err := worktreeLintCacheRoot(root)
+	if err != nil {
+		return nil, err
+	}
+
 	cacheDir := os.Getenv("GOLANGCI_LINT_CACHE")
 	if cacheDir == "" {
-		cacheDir = filepath.Join(root, ".golangci-cache")
+		cacheDir = filepath.Join(lintCacheRoot, "cache")
 	}
 	env["GOLANGCI_LINT_CACHE"] = cacheDir
 
-	tmpDir := filepath.Join(root, ".golangci-tmp")
+	tmpDir := filepath.Join(lintCacheRoot, "tmp")
 	if err := os.MkdirAll(tmpDir, dirPerm); err != nil {
 		return nil, fmt.Errorf("mage: mkdir %s: %w", tmpDir, err)
 	}
@@ -100,6 +124,23 @@ func setWorktreeIsolationEnv(root string) (map[string]string, error) {
 		env["TEMP"] = tmpDir
 	}
 	return env, nil
+}
+
+// worktreeLintCacheRoot returns "<user-cache-dir>/atmos-lint/<hash>", where
+// hash identifies the worktree by its absolute path so concurrent worktrees
+// never collide.
+func worktreeLintCacheRoot(root string) (string, error) {
+	base, err := userCacheDirFunc()
+	if err != nil {
+		return "", fmt.Errorf("mage: resolve user cache dir: %w", err)
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("mage: resolve absolute worktree root %s: %w", root, err)
+	}
+	sum := sha256.Sum256([]byte(absRoot))
+	hash := hex.EncodeToString(sum[:])[:worktreeHashLen]
+	return filepath.Join(base, "atmos-lint", hash), nil
 }
 
 // golangciLintArgs assembles the shared `run` args: config, optional

--- a/magefiles/mage_lint_golangci_run_test.go
+++ b/magefiles/mage_lint_golangci_run_test.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,6 +178,15 @@ func TestBuildStagedPatchAndPackages(t *testing.T) {
 	})
 }
 
+// withFakeUserCacheDir points userCacheDirFunc at dir for the duration of
+// the calling test, restoring the original on cleanup.
+func withFakeUserCacheDir(t *testing.T, dir string) {
+	t.Helper()
+	restore := userCacheDirFunc
+	userCacheDirFunc = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { userCacheDirFunc = restore })
+}
+
 func TestSetWorktreeIsolationEnv(t *testing.T) {
 	t.Run("shared cache opt-out returns empty map", func(t *testing.T) {
 		t.Setenv("ATMOS_LINT_SHARED_CACHE", "1")
@@ -184,16 +195,26 @@ func TestSetWorktreeIsolationEnv(t *testing.T) {
 		assert.Empty(t, env)
 	})
 
-	t.Run("default isolates cache and tmp under root", func(t *testing.T) {
+	t.Run("default isolates cache and tmp under the user cache dir, not root", func(t *testing.T) {
 		t.Setenv("ATMOS_LINT_SHARED_CACHE", "")
 		t.Setenv("GOLANGCI_LINT_CACHE", "")
+		fakeUserCache := t.TempDir()
+		withFakeUserCacheDir(t, fakeUserCache)
+
 		root := t.TempDir()
 		env, err := setWorktreeIsolationEnv(root)
 		require.NoError(t, err)
 
-		assert.Equal(t, filepath.Join(root, ".golangci-cache"), env["GOLANGCI_LINT_CACHE"])
-		tmpDir := filepath.Join(root, ".golangci-tmp")
-		assert.Equal(t, tmpDir, env["TMPDIR"])
+		wantBase := filepath.Join(fakeUserCache, "atmos-lint")
+		cacheDir := env["GOLANGCI_LINT_CACHE"]
+		tmpDir := env["TMPDIR"]
+		assert.True(t, strings.HasPrefix(cacheDir, wantBase+string(filepath.Separator)))
+		assert.Equal(t, "cache", filepath.Base(cacheDir))
+		assert.True(t, strings.HasPrefix(tmpDir, wantBase+string(filepath.Separator)))
+		assert.Equal(t, "tmp", filepath.Base(tmpDir))
+		assert.Equal(t, filepath.Dir(cacheDir), filepath.Dir(tmpDir), "cache and tmp share the same hashed worktree dir")
+		assert.False(t, strings.HasPrefix(cacheDir, root), "cache dir must not live inside the worktree")
+
 		info, statErr := os.Stat(tmpDir)
 		require.NoError(t, statErr)
 		assert.True(t, info.IsDir())
@@ -206,6 +227,7 @@ func TestSetWorktreeIsolationEnv(t *testing.T) {
 
 	t.Run("GOLANGCI_LINT_CACHE override respected", func(t *testing.T) {
 		t.Setenv("ATMOS_LINT_SHARED_CACHE", "")
+		withFakeUserCacheDir(t, t.TempDir())
 		custom := filepath.Join(t.TempDir(), "custom-cache")
 		t.Setenv("GOLANGCI_LINT_CACHE", custom)
 		env, err := setWorktreeIsolationEnv(t.TempDir())
@@ -213,15 +235,48 @@ func TestSetWorktreeIsolationEnv(t *testing.T) {
 		assert.Equal(t, custom, env["GOLANGCI_LINT_CACHE"])
 	})
 
-	t.Run("mkdir failure when root path component is a file", func(t *testing.T) {
+	t.Run("mkdir failure when cache root path component is a file", func(t *testing.T) {
 		t.Setenv("ATMOS_LINT_SHARED_CACHE", "")
 		t.Setenv("GOLANGCI_LINT_CACHE", "")
 		blocker := t.TempDir()
 		filePath := filepath.Join(blocker, "not-a-dir")
 		require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))
-		_, err := setWorktreeIsolationEnv(filePath)
+		withFakeUserCacheDir(t, filePath)
+
+		_, err := setWorktreeIsolationEnv(t.TempDir())
 		require.Error(t, err)
 	})
+
+	t.Run("propagates user cache dir resolution failure", func(t *testing.T) {
+		t.Setenv("ATMOS_LINT_SHARED_CACHE", "")
+		t.Setenv("GOLANGCI_LINT_CACHE", "")
+		restore := userCacheDirFunc
+		userCacheDirFunc = func() (string, error) { return "", errors.New("no cache dir") }
+		t.Cleanup(func() { userCacheDirFunc = restore })
+
+		_, err := setWorktreeIsolationEnv(t.TempDir())
+		require.Error(t, err)
+	})
+}
+
+func TestWorktreeLintCacheRoot(t *testing.T) {
+	fakeUserCache := t.TempDir()
+	withFakeUserCacheDir(t, fakeUserCache)
+
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+
+	dirA, err := worktreeLintCacheRoot(rootA)
+	require.NoError(t, err)
+	dirB, err := worktreeLintCacheRoot(rootB)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, dirA, dirB, "distinct worktrees must not collide on the same cache dir")
+	assert.True(t, strings.HasPrefix(dirA, filepath.Join(fakeUserCache, "atmos-lint")))
+
+	dirAAgain, err := worktreeLintCacheRoot(rootA)
+	require.NoError(t, err)
+	assert.Equal(t, dirA, dirAAgain, "the same worktree root must hash to the same dir")
 }
 
 func TestRunGolangciLintPrecommit(t *testing.T) {
@@ -284,17 +339,19 @@ func TestRunGolangciLintPrecommit(t *testing.T) {
 	})
 
 	// TestRunGolangciLintPrecommit/isolation env error propagates covers the
-	// setWorktreeIsolationEnv failure branch: root has a path component that's
-	// a file, not a directory, so MkdirAll(".golangci-tmp") under it fails
-	// before any subprocess is invoked.
+	// setWorktreeIsolationEnv failure branch: the user-cache-dir root
+	// resolves to a file, not a directory, so MkdirAll(".../tmp") under it
+	// fails before any subprocess is invoked.
 	t.Run("isolation env error propagates", func(t *testing.T) {
 		t.Setenv("ATMOS_LINT_SHARED_CACHE", "")
 		t.Setenv("GOLANGCI_LINT_CACHE", "")
 		blocker := t.TempDir()
 		filePath := filepath.Join(blocker, "not-a-dir")
 		require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))
+		withFakeUserCacheDir(t, filePath)
 
-		err := runGolangciLintPrecommit(filePath, "irrelevant-bin")
+		root := initGitRepoFixture(t)
+		err := runGolangciLintPrecommit(root, "irrelevant-bin")
 		require.Error(t, err)
 	})
 


### PR DESCRIPTION
## what

- Relocate the default golangci-lint cache and tmp directories from inside each worktree (`.golangci-cache/`, `.golangci-tmp/`) to the OS user cache directory: `<user-cache>/atmos-lint/<worktree-hash>/{cache,tmp}` (`~/Library/Caches/atmos-lint/...` on macOS).
- The `<worktree-hash>` (first 12 hex chars of SHA-256 of the absolute worktree path) preserves #2701's per-worktree isolation of golangci-lint's single-instance lock — the dirs just no longer live under the worktree tree.
- `ATMOS_LINT_SHARED_CACHE=1` opt-out and explicit `GOLANGCI_LINT_CACHE` overrides behave exactly as before.
- Tests updated/added: new-location assertions, hash determinism + cross-worktree non-collision, user-cache-dir failure propagation.
- Adds `docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md` with the full measured diagnosis.

## why

#2701 put a 156MB / ~37k-file cache that churns on every lint run *inside* each worktree — directly under any filesystem watcher observing that tree (git fsmonitor, Conductor's watchexec). At multi-worktree scale this saturated macOS FSEvents: `git status` measured 2.9s–timeout (>2min) with fsmonitor vs 0.04–0.15s without, and every pre-commit run pays that tax dozens of times, stretching commits to minutes. Moving the churn outside the watched tree makes this impossible to re-trigger on any machine, regardless of watcher configuration.

Measured after the fix: cold `lint:precommit` 9.1s, warm 1.5s, no cache dirs created in the worktree; a full commit through all pre-commit hooks + signing completes in ~5s.

## references

- #2701 (`perf(lint): isolate golangci-lint cache and lock per worktree`) — introduced the in-worktree location this PR relocates; its lock-isolation intent is preserved
- `docs/fixes/2026-08-24-fsmonitor-worktree-saturation.md` — full diagnosis, timeline, and machine-level remediation notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting in Git worktrees by storing cache and temporary files in isolated user-cache locations.
  * Reduced unnecessary file-monitor activity caused by lint-related file churn.
  * Preserved support for shared caches and explicitly configured cache locations.
  * Improved error handling when cache locations cannot be resolved or created.
  * Added safeguards to keep cache data separated between worktrees.

* **Documentation**
  * Added troubleshooting guidance for worktree file-monitor saturation and remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->