### PR TITLE
fix(terraform): filter CLI args from output hooks

### DIFF
--- a/docs/fixes/2026-08-24-filter-terraform-cli-args-from-output.md
+++ b/docs/fixes/2026-08-24-filter-terraform-cli-args-from-output.md
@@ -1,0 +1,27 @@
+# Fix: Filter Terraform CLI Arguments from Internal Output Commands
+
+**Date:** 2026-08-24
+
+## Summary
+
+Post-apply output-store hooks now ignore `TF_CLI_ARGS` and `TF_CLI_ARGS_*` values while retrieving Terraform outputs.
+
+## Context
+
+Terraform-exec rejects manually configured command-specific CLI argument environment variables. Atmos filtered inherited process variables but restored those values from the resolved component environment, causing `after-terraform-apply` output-store hooks to fail after a successful apply.
+
+## Changes
+
+The Terraform output environment no longer copies `TF_CLI_ARGS` or `TF_CLI_ARGS_*` entries from component configuration. Other component environment variables, including required `TF_VAR_*` values, are preserved. A regression test covers apply and plan arguments alongside allowed variables.
+
+## Validation
+
+`go test ./pkg/terraform/output -run '^TestDefaultEnvironmentSetup_ComponentCLIArgsFiltered$' -count=1` passed after the fix.
+
+`go test ./pkg/terraform/output -count=1` and `go build ./...` passed with the ambient `TF_PLUGIN_CACHE_DIR` removed because unrelated existing tests require it to be unset.
+
+`atmos test` did not complete: unrelated tests observed the host `AWS_DEFAULT_REGION`, and the CLI suite timed out after five minutes while inspecting fixture state.
+
+## Follow-ups
+
+None.

--- a/pkg/terraform/output/environment.go
+++ b/pkg/terraform/output/environment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	awsCloud "github.com/cloudposse/atmos/pkg/auth/cloud/aws"
 	envpkg "github.com/cloudposse/atmos/pkg/env"
@@ -87,6 +88,10 @@ func (s *defaultEnvironmentSetup) SetupEnvironment(config *ComponentConfig, auth
 			"count", len(config.Env),
 		)
 		for k, v := range config.Env {
+			// Terraform-exec owns CLI arguments for its internal output command.
+			if k == "TF_CLI_ARGS" || strings.HasPrefix(k, "TF_CLI_ARGS_") {
+				continue
+			}
 			environMap[k] = fmt.Sprintf("%v", v)
 		}
 	}

--- a/pkg/terraform/output/environment_test.go
+++ b/pkg/terraform/output/environment_test.go
@@ -273,6 +273,31 @@ func TestDefaultEnvironmentSetup_ComponentEnvOverridesParent(t *testing.T) {
 	assert.Equal(t, "component-value", val, "component env should override parent env")
 }
 
+// TestDefaultEnvironmentSetup_ComponentCLIArgsFiltered verifies command-specific
+// arguments configured for the main Terraform command do not reach terraform-exec's
+// internal output command. Terraform-exec rejects these environment variables.
+func TestDefaultEnvironmentSetup_ComponentCLIArgsFiltered(t *testing.T) {
+	setup := &defaultEnvironmentSetup{}
+	config := &ComponentConfig{
+		Env: map[string]any{
+			"ALLOWED_VAR":       "allowed-value",
+			"TF_CLI_ARGS":       "-no-color",
+			"TF_CLI_ARGS_apply": "-lock-timeout=5m",
+			"TF_CLI_ARGS_plan":  "-compact-warnings",
+			"TF_VAR_region":     "us-east-1",
+		},
+	}
+
+	result, err := setup.SetupEnvironment(config, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "allowed-value", result["ALLOWED_VAR"])
+	assert.Equal(t, "us-east-1", result["TF_VAR_region"])
+	assert.NotContains(t, result, "TF_CLI_ARGS")
+	assert.NotContains(t, result, "TF_CLI_ARGS_apply")
+	assert.NotContains(t, result, "TF_CLI_ARGS_plan")
+}
+
 // TestDefaultEnvironmentSetup_PassVars is a regression test for issue #1412:
 // when components.terraform.init.pass_vars is enabled, the component's vars must
 // be exported as TF_VAR_* so the internal `terraform init` run while resolving


### PR DESCRIPTION
## Summary

`TF_CLI_ARGS_apply` configured through `atmos.yaml` no longer reaches Terraform-exec's internal `output` command. Post-apply output-store hooks can retrieve and publish the declared Terraform output after a successful apply.

## Why

Terraform-exec rejects manual command-specific argument variables during its output invocation. Atmos filtered inherited variables but restored them from the resolved component environment. The output path now ignores `TF_CLI_ARGS` and `TF_CLI_ARGS_*` while preserving normal environment variables and `TF_VAR_*` values.

## Validation

- Added a regression test for apply and plan CLI arguments while preserving `TF_VAR_*`.
- `go build ./...`
- `atmos fix coverage origin/main`
- Patch lint: `0 issues`.

Closes #2990


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Terraform output retrieval failures caused by command-specific CLI argument environment variables.
  - Preserved supported component variables, including `TF_VAR_*` values, while excluding `TF_CLI_ARGS` settings from output processing.

- **Documentation**
  - Added documentation describing the fix and its expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->