### PR TITLE
fix: correct CI base resolution for merged PRs and symlinked repos

### DIFF
--- a/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
+++ b/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
@@ -1,0 +1,101 @@
+# Fix: `describe affected` resolves a wrong base for merged multi-commit PRs
+
+**Date:** 2026-08-27
+
+## Issue
+
+After merging a multi-commit pull request whose **final commit reverted an
+earlier commit** (the earlier commit changed an org-wide stack default — a
+backend setting inherited by every stack; the final commit reverted it and
+added an unrelated CI-workflow tweak, so the PR's *net* diff was two workflow
+files), `atmos describe affected --upload` on the `pull_request closed
+(merged)` event reported **every component in the repository as affected**
+and dispatched a wall of post-merge plan/apply runs.
+
+The same PR's earlier `synchronize` event had correctly reported **zero**
+affected components for the identical head commit. The workflow was the
+documented zero-config setup: `ci.enabled: true`, no base flags, and
+`actions/checkout` pinned to `github.event.pull_request.head.sha` (required
+for Atmos Pro upload correlation) with `fetch-depth: 0`.
+
+The run logs showed the difference directly:
+
+```
+# synchronize event (correct):
+Auto-detected CI base ... source="merge-base(HEAD, origin/main)"
+✓ Uploaded 0 affected component(s)
+
+# closed/merged event (wrong):
+Auto-detected CI base ... source="HEAD~1 (merged PR, merge-base unavailable)"
+✓ Uploaded <every component in the repo> affected component(s)
+```
+
+## Root cause
+
+Two compounding problems in `pkg/ci/providers/github/base.go:resolvePRBase`,
+both instances of the same design flaw: **every strategy in the fallback
+chain is only correct under an *assumed* checkout, and nothing verified which
+checkout the workflow actually did.**
+
+1. **Merge-base against `origin/<target>` degenerates after the merge.** For
+   a merge-commit (or queue) merge, the PR head becomes an ancestor of the
+   target branch, so `merge-base(HEAD, origin/<target>) == HEAD` —
+   `ErrHeadOnTargetBranch` — and the gold-standard tier always falls through
+   on exactly the events where correctness matters most.
+
+2. **The `HEAD~1` fallback assumed the merge commit was checked out.** The
+   documented workflow checks out `head.sha` instead (it must, for Atmos Pro
+   upload correlation — a conflict the PRD had already noted). With the PR
+   head checked out, `HEAD~1` is the PR's *own previous commit*, so the
+   "diff" is the PR's **final commit alone**, not its net change. A final
+   commit that reverts an earlier org-wide change therefore re-reports the
+   entire reverted blast radius as affected. (The same shape can also
+   under-detect: changes in earlier commits become invisible.)
+
+Merge queues do not avoid this: GitHub still fires `pull_request closed
+(merged)` after the queue lands the PR, and a queue merge commit has the PR
+head as an ancestor, triggering the identical chain.
+
+## Fix
+
+Merged PRs (`action == "closed"` && `pull_request.merged`) no longer use the
+open-PR chain. Instead the resolver **classifies what the workflow actually
+checked out** by comparing the local HEAD against the event payload, and
+picks the strategy that is provably correct for that checkout:
+
+| Checkout | Base |
+|---|---|
+| `head.sha` | `merge-base(HEAD, merge_commit_sha^1)` — the true fork point; correct for merge, squash, and rebase strategies; cannot collapse to HEAD. The merge commit is fetched by SHA if a narrow checkout didn't bring it in. |
+| `head.sha`, fast-forward merge (`merge_commit_sha == head.sha`) | `merge-base(HEAD, base.sha)` — for externally-merged/fast-forwarded PRs the merge commit IS the PR head, so anchoring on its parent would silently drop every commit but the last (under-detection, caught in an adversarial field-test pass); the payload's pre-merge `base.sha` still yields the fork point. |
+| merge commit | `HEAD^1` — the pre-merge target tip (the one case the old fallback was right for). |
+| synthetic `refs/pull/<n>/merge` | first parent of HEAD — the target tip the test merge was built on. |
+| unknown | `event.pull_request.base.sha` with a `Warn` — never guess silently. |
+
+This converges merged-PR resolution on the same payload-anchored semantics
+the `merge_group` path already had (`merge_commit_sha^1` is the plain-merge
+analog of `merge_group.base_sha`). Closed-*unmerged* PRs resolve like open
+PRs. The `Auto-detected CI base` log line now includes `checkout=...` so any
+future wrong-base report is diagnosable from a single line.
+
+New helpers: `git.CommitParents`, `git.MergeBaseSHAs`, `git.FetchCommit`
+(`pkg/git/commit.go`).
+
+## Testing
+
+`pkg/ci/providers/github/base_merged_test.go` builds a real git fixture
+reproducing the incident shape (multi-commit PR whose final commit reverts an
+earlier org-wide change, target branch advanced independently) and asserts,
+for every checkout × strategy combination (head.sha × merge/squash, merge
+commit, synthetic merge, unknown, queue-merged closed event), that the
+resolved base is the fork point / pre-merge tip — and explicitly **not** the
+PR's own previous commit (the pre-fix wrong answer). Closed-unmerged PRs are
+verified to stay on the open-PR chain. `pkg/git/commit_test.go` covers the
+new helpers, including the parentless-initial-commit case.
+
+## Lessons
+
+- A fallback chain where each tier is "correct under assumption X" needs to
+  *verify* X, not assume it; otherwise the chain silently picks a strategy
+  whose precondition doesn't hold and reports a confident wrong answer.
+- Log lines should carry enough context (here: the checkout classification)
+  to distinguish "which strategy won" from "was that strategy valid".

--- a/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
+++ b/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
@@ -38,19 +38,19 @@ chain is only correct under an *assumed* checkout, and nothing verified which
 checkout the workflow actually did.**
 
 1. **Merge-base against `origin/<target>` degenerates after the merge.** For
-   a merge-commit (or queue) merge, the PR head becomes an ancestor of the
-   target branch, so `merge-base(HEAD, origin/<target>) == HEAD` —
-   `ErrHeadOnTargetBranch` — and the gold-standard tier always falls through
-   on exactly the events where correctness matters most.
+    a merge-commit (or queue) merge, the PR head becomes an ancestor of the
+    target branch, so `merge-base(HEAD, origin/<target>) == HEAD` —
+    `ErrHeadOnTargetBranch` — and the gold-standard tier always falls through
+    on exactly the events where correctness matters most.
 
 2. **The `HEAD~1` fallback assumed the merge commit was checked out.** The
-   documented workflow checks out `head.sha` instead (it must, for Atmos Pro
-   upload correlation — a conflict the PRD had already noted). With the PR
-   head checked out, `HEAD~1` is the PR's *own previous commit*, so the
-   "diff" is the PR's **final commit alone**, not its net change. A final
-   commit that reverts an earlier org-wide change therefore re-reports the
-   entire reverted blast radius as affected. (The same shape can also
-   under-detect: changes in earlier commits become invisible.)
+    documented workflow checks out `head.sha` instead (it must, for Atmos Pro
+    upload correlation — a conflict the PRD had already noted). With the PR
+    head checked out, `HEAD~1` is the PR's *own previous commit*, so the
+    "diff" is the PR's **final commit alone**, not its net change. A final
+    commit that reverts an earlier org-wide change therefore re-reports the
+    entire reverted blast radius as affected. (The same shape can also
+    under-detect: changes in earlier commits become invisible.)
 
 Merge queues do not avoid this: GitHub still fires `pull_request closed
 (merged)` after the queue lands the PR, and a queue merge commit has the PR

--- a/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
+++ b/docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md
@@ -20,7 +20,7 @@ for Atmos Pro upload correlation) with `fetch-depth: 0`.
 
 The run logs showed the difference directly:
 
-```
+```text
 # synchronize event (correct):
 Auto-detected CI base ... source="merge-base(HEAD, origin/main)"
 ✓ Uploaded 0 affected component(s)

--- a/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
+++ b/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
@@ -46,14 +46,14 @@ wrong answers above.
 `internal/exec/describe_affected_utils.go`:
 
 1. **Symlink normalization**: both sides of the `filepath.Rel` computation
-   are passed through `evalSymlinksBestEffort`, which resolves symlinks even
-   for paths that don't fully exist (resolves the deepest existing ancestor
-   and re-appends the remainder — unused helmfile/packer default dirs
-   routinely don't exist).
+    are passed through `evalSymlinksBestEffort`, which resolves symlinks even
+    for paths that don't fully exist (resolves the deepest existing ancestor
+    and re-appends the remainder — unused helmfile/packer default dirs
+    routinely don't exist).
 2. **Escape guard**: if a computed relative path still starts with `..`
-   after normalization (a config path genuinely outside the repository), the
-   re-basing returns a hard error wrapping `errUtils.ErrGitPathEscapesWorktree`
-   naming both paths — never a silent guess in either direction.
+    after normalization (a config path genuinely outside the repository), the
+    re-basing returns a hard error wrapping `errUtils.ErrGitPathEscapesWorktree`
+    naming both paths — never a silent guess in either direction.
 
 The re-basing block was extracted into testable helpers
 (`rebaseConfigPathsOntoWorktree`, `rebaseOnePathOntoWorktree`,

--- a/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
+++ b/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
@@ -1,0 +1,87 @@
+# Fix: `describe affected` mis-computes BASE paths when the repo is under a symlinked path
+
+**Date:** 2026-08-27
+
+## Issue
+
+Running `atmos describe affected` from a repository whose working directory
+involves a symlink (e.g. macOS `/tmp` → `/private/tmp`, `/var` →
+`/private/var`, a symlinked home or workspace directory) silently produced a
+wrong affected set. Depending on filesystem depth, one of two opposite
+failures occurred:
+
+- **Everything affected**: the BASE stack scan pointed at a nonexistent
+  directory, found no stack manifests, and the greenfield fallback treated
+  BASE as empty — every HEAD component reported as affected, with only a
+  `Warn`.
+- **Nothing affected**: the mis-computed path climbed past the filesystem
+  root, `filepath.Join` clamped it, and it landed back on the **HEAD**
+  repository — BASE silently compared equal to HEAD and real changes were
+  reported as unaffected (silent under-detection).
+
+Discovered during an adversarial field-test pass of the merged-PR base
+resolution fix: the E2E fixture lived under `/tmp` and reported every
+component affected for a diff that touched none.
+
+## Root cause
+
+`internal/exec/describe_affected_utils.go` re-bases the config's absolute
+paths onto the BASE worktree via `filepath.Rel(repoRootAbs, configPathAbs)` +
+`filepath.Join(worktreePath, rel)`. The two inputs come from different
+sources with different symlink treatment:
+
+- the repo root comes from git (go-git reports the **symlink-resolved**
+  path, e.g. `/private/tmp/repo`), while
+- the config paths derive from the CWD as the shell reported it (`$PWD`,
+  **logical/unresolved**, e.g. `/tmp/repo/stacks` — Go's `os.Getwd` honors
+  `$PWD` when it points at the same directory).
+
+`filepath.Rel` between the two forms returns a `../..`-climbing path instead
+of `stacks`, and joining that onto the worktree escapes it entirely. Nothing
+validated the result, so the failure surfaced only as one of the two silent
+wrong answers above.
+
+## Fix
+
+`internal/exec/describe_affected_utils.go`:
+
+1. **Symlink normalization**: both sides of the `filepath.Rel` computation
+   are passed through `evalSymlinksBestEffort`, which resolves symlinks even
+   for paths that don't fully exist (resolves the deepest existing ancestor
+   and re-appends the remainder — unused helmfile/packer default dirs
+   routinely don't exist).
+2. **Escape guard**: if a computed relative path still starts with `..`
+   after normalization (a config path genuinely outside the repository), the
+   re-basing returns a hard error wrapping `errUtils.ErrGitPathEscapesWorktree`
+   naming both paths — never a silent guess in either direction.
+
+The re-basing block was extracted into testable helpers
+(`rebaseConfigPathsOntoWorktree`, `rebaseOnePathOntoWorktree`,
+`evalSymlinksBestEffort`).
+
+The greenfield "treat BASE as empty" fallback was deliberately left
+unchanged: gating it on path existence would break the legitimate case of a
+PR introducing Atmos in a subdirectory that doesn't exist in BASE. The escape
+guard removes the only demonstrated way for a *wrong* path to reach that
+fallback.
+
+## Testing
+
+Red-first: `TestDescribeAffectedCIBaseE2E/repo_under_symlinked_path...`
+(`internal/exec/describe_affected_test.go`) builds a real repo, symlinks it,
+and diffs against a base that genuinely differs in one stack — the assertion
+(`prod-c1`,`prod-c2` exactly) discriminates the correct result from both
+failure modes (empty vs. everything). It failed with an empty affected set
+before the fix. Unit tests cover `evalSymlinksBestEffort` (existing symlink,
+missing-suffix, unresolvable input) and `rebaseOnePathOntoWorktree`
+(plain, symlinked-mixed-forms, and the escape hard-error asserted via
+`errors.Is` against the sentinel).
+
+## Lessons
+
+- Path arithmetic that mixes values from different provenance (git vs. CWD
+  vs. config) must normalize symlinks first; `filepath.Rel` is only correct
+  when both inputs share one canonical form.
+- A fallback that silently absorbs "path not found" turns path bugs into
+  plausible-looking wrong answers in whichever direction the arithmetic
+  happens to land; validate the arithmetic before the fallback can see it.

--- a/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
+++ b/docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md
@@ -5,7 +5,7 @@
 ## Issue
 
 Running `atmos describe affected` from a repository whose working directory
-involves a symlink (e.g. macOS `/tmp` → `/private/tmp`, `/var` →
+involves a symlink (e.g., macOS `/tmp` → `/private/tmp`, `/var` →
 `/private/var`, a symlinked home or workspace directory) silently produced a
 wrong affected set. Depending on filesystem depth, one of two opposite
 failures occurred:

--- a/docs/prd/native-ci/framework/base-resolution.md
+++ b/docs/prd/native-ci/framework/base-resolution.md
@@ -64,11 +64,11 @@ ResolveBase() (*BaseResolution, error)
 
 ## FR-12: GitHub Actions Base Resolution
 
-**Requirement**: The GitHub provider resolves the base commit from GitHub Actions environment variables and event payload. For pull request events, the primary strategy is `git merge-base` — the only approach that is correct regardless of checkout strategy and merge method.
+**Requirement**: The GitHub provider resolves the base commit from GitHub Actions environment variables and event payload. For open and closed-unmerged pull request events, the primary strategy is `git merge-base` — the only approach that is correct regardless of checkout strategy and merge method. Merged pull requests use a different strategy entirely (see "Merged pull requests: checkout classification" below), because merge-base against the target branch degenerates once the target already contains the PR.
 
 ### Why merge-base is the gold standard
 
-The purpose of base resolution is to answer: "what is the fork point — the commit where this PR's changes diverge from the target branch?" This determines which stacks are affected by the PR. `git merge-base HEAD origin/<target>` answers this question correctly in all scenarios.
+The purpose of base resolution is to answer: "what is the fork point — the commit where this PR's changes diverge from the target branch?" This determines which stacks are affected by the PR. For open and closed-unmerged PRs, `git merge-base HEAD origin/<target>` answers this question correctly in all scenarios. Merged PRs are the exception — see "Merged pull requests: checkout classification" below.
 
 ### Rejected approaches
 

--- a/docs/prd/native-ci/framework/base-resolution.md
+++ b/docs/prd/native-ci/framework/base-resolution.md
@@ -72,7 +72,7 @@ The purpose of base resolution is to answer: "what is the fork point — the com
 
 ### Rejected approaches
 
-**`HEAD~1` (parent of checked-out commit)**:
+**`HEAD~1` (parent of checked-out commit)** — rejected as a *blind* strategy; retained only after positively classifying a merge-commit checkout (see "Merged pull requests: checkout classification"):
 - Only correct when the workflow checks out the **merge commit** (not the PR head) AND the merge strategy is merge or squash.
 - **Breaks for rebase merges with multiple commits**: `merge_commit_sha` points to the tip of the rebased commits, so `HEAD~1` is the previous rebased commit — not the target branch state.
 - **Breaks entirely when the workflow checks out `head.sha`**: `HEAD~1` is the parent commit on the PR branch, which for multi-commit PRs is just the second-to-last PR commit — completely wrong.
@@ -99,18 +99,35 @@ The purpose of base resolution is to answer: "what is the fork point — the com
 
 **Edge case**: if the workflow checks out the merge commit, HEAD is *on* the target branch, so `merge-base(HEAD, origin/main) == HEAD`. This is detected (merge-base == HEAD hash) and falls through to the next strategy.
 
+**Merged PRs are excluded from this strategy entirely**: after the merge, `origin/<target>` *contains* the PR, so merge-base against its moving tip degenerates — to HEAD itself for merge-commit merges (the collapse above), and more generally to an anchor that includes the PR's own landing. Merged PRs use the checkout-classified strategy below instead.
+
+### Merged pull requests: checkout classification
+
+For `closed` events with `pull_request.merged == true`, no single strategy is correct for every checkout — `HEAD~1` in particular diffs only the PR's *final* commit when the PR head is checked out, so a multi-commit PR whose last commit reverts an earlier org-wide change re-reports the reverted files as affected after merge (observed in production as a wall of post-merge dispatches). The resolver therefore classifies what the workflow actually checked out, by comparing the local HEAD against the payload, and picks the strategy that is provably correct for that checkout:
+
+| Local HEAD matches | Classification | Base | Why it is correct |
+|---|---|---|---|
+| `pull_request.head.sha` | `head.sha` | `merge-base(HEAD, merge_commit_sha^1)` | First parent of the merge commit is the pre-merge target tip; the merge-base against it is the true fork point for merge, squash, and rebase strategies alike, and cannot collapse to HEAD. Mirrors `merge_group.base_sha` semantics. Fetches `merge_commit_sha` by SHA if a narrow checkout did not bring it in. |
+| `pull_request.head.sha`, fast-forward merge (`merge_commit_sha == head.sha`) | `head.sha` | `merge-base(HEAD, base.sha)` | For externally-merged/fast-forwarded PRs the merge commit IS the PR head, so `merge_commit_sha^1` is the PR's own previous commit — anchoring there silently drops every commit but the last (under-detection). The payload's `base.sha` is a pre-merge target-branch commit; staleness only moves the anchor along the target branch, never onto the PR branch, so the merge-base is still the fork point. |
+| `pull_request.merge_commit_sha` | `merge-commit` | `HEAD^1` | First parent of the real merge/squash commit is the pre-merge target tip — the one case the old `HEAD~1` fallback was actually right for. |
+| 2-parent commit whose 2nd parent is `head.sha` | `synthetic-merge` | first parent of HEAD | GitHub's `refs/pull/<n>/merge` test-merge commit: first parent is the target tip the merge was built on — the exact net-diff base. |
+| anything else | `unknown` | `event.pull_request.base.sha` (Warn) | No strategy is provably correct for an unrecognized checkout; guessing silently is how wrong-base incidents happen. |
+
+Closed-*unmerged* PRs are treated like open PRs (the branch was never folded into the target, so merge-base against `origin/<target>` remains correct).
+
+The classification is included in the "Auto-detected CI base" log line (`checkout=...`) so wrong-base reports are diagnosable from a single line.
+
 ### Implementation: generic utility + provider-specific extraction
 
 The merge-base computation itself is provider-agnostic and lives in `pkg/git/` as a shared utility. The GitHub provider is responsible only for extracting the target branch name from GitHub-specific sources (`event.pull_request.base.ref`, `GITHUB_BASE_REF`).
 
-### Fallback chain for pull request events
+### Fallback chain for open (and closed-unmerged) pull request events
 
-Each strategy is tried in order; the first success is used:
+Each strategy is tried in order; the first success is used. (Merged PRs use the checkout-classified strategy above instead.)
 
 1. **`git merge-base(HEAD, origin/<target>)`** via `MergeBaseWithAutoFetch` — gold standard. Target branch extracted from `event.pull_request.base.ref` (payload) or `GITHUB_BASE_REF` (env var). Self-heals from shallow checkouts by fetching the target branch (and deepening once) before retrying. Skipped if merge-base equals HEAD (merge commit checkout).
-2. **`HEAD~1`** — fallback for closed/merged PRs when merge-base fails. Correct when the merge commit is checked out with merge/squash strategy.
-3. **`event.pull_request.base.sha`** — payload SHA fallback. Frozen at the last PR sync event, so it is never the current tip of `<target>`. Slightly stale on out-of-date PRs but cannot produce the "every component is affected" false positives that returning a *ref* to the current target tip does.
-4. **`GITHUB_BASE_REF` ref** — last resort, only reached when the payload has no `base.sha` (hand-crafted or legacy events). Logs `Warn` because this path compares against the current tip and may include unrelated commits from `<target>`.
+2. **`event.pull_request.base.sha`** — payload SHA fallback. Frozen at the last PR sync event, so it is never the current tip of `<target>`. Slightly stale on out-of-date PRs but cannot produce the "every component is affected" false positives that returning a *ref* to the current target tip does.
+3. **`GITHUB_BASE_REF` ref** — last resort, only reached when the payload has no `base.sha` (hand-crafted or legacy events). Logs `Warn` because this path compares against the current tip and may include unrelated commits from `<target>`.
 
 ### Atmos Pro upload correlation
 
@@ -123,7 +140,8 @@ Push events are rejected when `--upload` is set, since Atmos Pro only processes 
 | Event | Action | Primary Strategy | Fallback | Type | Source |
 |-------|--------|-----------------|----------|------|--------|
 | `pull_request` | opened / synchronize | `MergeBaseWithAutoFetch(HEAD, origin/<target>)` | `event.pull_request.base.sha` → `GITHUB_BASE_REF` ref (warn) | SHA or ref | `event.pull_request.base.ref` → `git merge-base` |
-| `pull_request` | closed (merged) | `MergeBaseWithAutoFetch(HEAD, origin/<target>)` | `HEAD~1` → `event.pull_request.base.sha` → `GITHUB_BASE_REF` ref (warn) | SHA or ref | `event.pull_request.base.ref` → `git merge-base` |
+| `pull_request` | closed (merged) | Checkout-classified: `merge-base(HEAD, merge_commit_sha^1)` (head.sha) / `HEAD^1` (merge-commit) / first parent (synthetic-merge) | `event.pull_request.base.sha` (also for unknown checkout, warn) → `GITHUB_BASE_REF` ref (warn) | SHA or ref | `event.pull_request.merge_commit_sha` → git |
+| `pull_request` | closed (unmerged) | `MergeBaseWithAutoFetch(HEAD, origin/<target>)` | `event.pull_request.base.sha` → `GITHUB_BASE_REF` ref (warn) | SHA or ref | `event.pull_request.base.ref` → `git merge-base` |
 | `pull_request_target` | any | `MergeBaseWithAutoFetch(HEAD, origin/<target>)` | `event.pull_request.base.sha` → `GITHUB_BASE_REF` ref (warn) | SHA or ref | `event.pull_request.base.ref` → `git merge-base` |
 | `push` | normal | `event.before` | — | SHA | `$GITHUB_EVENT_PATH` |
 | `push` | force-push (`event.forced`) | `HEAD~1` | `origin/HEAD` ref | SHA or ref | git resolution |
@@ -140,14 +158,17 @@ Push events are rejected when `--upload` is set, since Atmos Pro only processes 
 
 - `action` — PR action (opened, synchronize, closed).
 - `pull_request.base.ref` — target branch name for merge-base computation.
-- `pull_request.head.sha` — PR head commit SHA for Atmos Pro upload correlation.
+- `pull_request.base.sha` — payload-base fallback SHA.
+- `pull_request.head.sha` — PR head commit SHA for Atmos Pro upload correlation and checkout classification.
+- `pull_request.merged` — routes closed events to the merged-PR strategy (unmerged closes resolve like open PRs).
+- `pull_request.merge_commit_sha` — anchor for merged-PR base resolution and checkout classification.
 - `before` — previous HEAD SHA for push events.
 - `forced` — whether push was a force-push.
 
 ### Validation
 
-- PR open/sync: `MergeBaseWithAutoFetch(HEAD, origin/<target>)` resolves to the fork-point SHA (self-healing fetch on shallow clones); falls back to `event.pull_request.base.sha`, then `refs/remotes/origin/<target>` ref (warn).
-- PR closed/merged: `MergeBaseWithAutoFetch(HEAD, origin/<target>)` resolves to the fork-point SHA; falls back to `HEAD~1`, then `event.pull_request.base.sha`, then `refs/remotes/origin/<target>` ref (warn).
+- PR open/sync (and closed-unmerged): `MergeBaseWithAutoFetch(HEAD, origin/<target>)` resolves to the fork-point SHA (self-healing fetch on shallow clones); falls back to `event.pull_request.base.sha`, then `refs/remotes/origin/<target>` ref (warn).
+- PR closed/merged: checkout is classified against the payload; head.sha checkout resolves `merge-base(HEAD, merge_commit_sha^1)` (fork point), merge-commit checkout resolves `HEAD^1`, synthetic-merge checkout resolves the first parent, unknown checkout falls back to `event.pull_request.base.sha` with a warn. A multi-commit PR whose final commit reverts an earlier commit must resolve the fork point, never the PR's own previous commit.
 - Push: resolves to `before` SHA from event payload.
 - Force-push: falls back to `HEAD~1` when `forced=true`.
 - Missing `$GITHUB_EVENT_PATH`: returns error (file should always exist in GitHub Actions).

--- a/internal/exec/describe_affected.go
+++ b/internal/exec/describe_affected.go
@@ -308,9 +308,10 @@ func includeDependentsFlagValue(flags *pflag.FlagSet) (bool, error) {
 // has opted into CI auto-detect, it is appropriate to mutate the runner's git
 // config (via `EnsureGitSafeDirectory`) so that downstream git commands —
 // `merge-base`, the targeted `git fetch` for shallow clones, and the
-// `HEAD~1` lookup for closed PRs — do not fail with "dubious ownership in
-// repository" inside GitHub Actions container jobs. The helper is a no-op
-// outside GitHub Actions, so it does nothing when running locally.
+// checkout-classified merged-PR lookups (merge-commit parents, payload-anchor
+// fetches) — do not fail with "dubious ownership in repository" inside GitHub
+// Actions container jobs. The helper is a no-op outside GitHub Actions, so it
+// does nothing when running locally.
 func resolveBaseFromCI(describe *DescribeAffectedCmdArgs) {
 	defer perf.Track(nil, "exec.resolveBaseFromCI")()
 
@@ -346,11 +347,19 @@ func resolveBaseFromCI(describe *DescribeAffectedCmdArgs) {
 	if base == "" {
 		base = resolution.Ref
 	}
-	log.Info("Auto-detected CI base",
+	logArgs := []any{
 		"provider", p.Name(),
 		"event", resolution.EventType,
 		"base", base,
-		"source", resolution.Source)
+		"source", resolution.Source,
+	}
+	// The checkout classification tells support which strategy family was
+	// valid for this run — wrong-base incidents are diagnosable from this
+	// one line instead of run-log archaeology.
+	if resolution.Checkout != "" {
+		logArgs = append(logArgs, "checkout", resolution.Checkout)
+	}
+	log.Info("Auto-detected CI base", logArgs...)
 }
 
 // Execute executes `describe affected` command.

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -2642,9 +2642,8 @@ func TestUploadErrorsWhenNoCredentials(t *testing.T) {
 // the retry budget pkg/git/worktree.go uses for the same class of transient
 // Windows lock (a just-exited git/antivirus process briefly holding a handle
 // open on a file inside a just-torn-down git worktree's administrative
-// directory). A failure after the full budget is logged, not fatal — it
-// leaves cleanup to whatever runs next (e.g. t.TempDir()'s own attempt),
-// which is the pre-existing behavior this helper is layered in front of.
+// directory). A failure after the full budget is logged, not fatal. The
+// directory is left for the operating system's temporary-directory reaper.
 func removeAllWithRetry(t *testing.T, dir string) {
 	t.Helper()
 	delay := 200 * time.Millisecond

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -2696,18 +2696,20 @@ func writeIncidentFile(t *testing.T, dir, rel, content string) {
 // Returns the repo dir and the fork/head/advance/merge commit SHAs.
 func buildMergedPRIncidentRepo(t *testing.T) (string, map[string]string) {
 	t.Helper()
-	dir := t.TempDir()
 	// This repo has a real git worktree created and torn down inside it
 	// (ExecuteDescribeAffectedWithTargetRefCheckout). On Windows CI, a
-	// transient antivirus/indexing scan can briefly hold a lock on the
-	// worktree's administrative metadata (.git/worktrees/<name>/commondir)
-	// even after git itself reports the worktree successfully removed —
-	// t.TempDir()'s own cleanup only tries os.RemoveAll once and fails hard
-	// on that lock. Retry the removal proactively (mirroring the backoff
-	// pkg/git/worktree.go already uses for the same class of transient
-	// Windows lock) so the built-in t.TempDir() cleanup finds nothing left
-	// to remove. Registered immediately after t.TempDir(), so it runs
-	// first (t.Cleanup is LIFO).
+	// transient antivirus/indexing scan can hold a lock on the worktree's
+	// administrative metadata (.git/worktrees/<name>/commondir) well past
+	// both the production RemoveWorktree's own 20s retry and a matching
+	// 20s retry here (40s observed combined, in practice). Deliberately
+	// NOT using t.TempDir(): its built-in cleanup is a single-attempt,
+	// fatal-on-error os.RemoveAll that runs unconditionally after ours,
+	// which would turn an already-logged, deliberately-non-fatal leftover
+	// lock back into a failed test. Managing the dir with os.MkdirTemp
+	// keeps our retry-then-log-only cleanup authoritative; a leftover
+	// lock is left for the OS temp-directory reaper, not this test.
+	dir, err := os.MkdirTemp("", "TestDescribeAffectedCIBaseE2E") //nolint:lintroller // t.TempDir()'s own cleanup is fatal-on-error and would race the exact lock removeAllWithRetry exists to tolerate; see comment above.
+	require.NoError(t, err)
 	t.Cleanup(func() { removeAllWithRetry(t, dir) })
 	runIncidentGit(t, dir, "init", "-b", "main")
 	runIncidentGit(t, dir, "remote", "add", "origin", "https://github.com/example/incident.git")

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -2633,4 +2636,197 @@ func TestUploadErrorsWhenNoCredentials(t *testing.T) {
 	assert.Contains(t, allHints, "id-token: write")
 	assert.Contains(t, allHints, "ATMOS_PRO_WORKSPACE_ID")
 	assert.Contains(t, allHints, "atmos.tools/pro")
+}
+
+// runIncidentGit runs a git command in dir for the CI-base E2E fixtures below.
+func runIncidentGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	base := []string{"-c", "commit.gpgsign=false", "-c", "user.name=Test", "-c", "user.email=t@t.co"}
+	cmd := osexec.Command("git", append(base, args...)...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// writeIncidentFile writes a file (creating parents) inside the fixture repo.
+func writeIncidentFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// buildMergedPRIncidentRepo builds a self-contained git repo with a small
+// atmos project reproducing the merged multi-commit PR incident shape:
+//
+//	main:    fork ──────────────── advance ── mergeCommit
+//	     \                                   /
+//	feature:  org-wide change ── revert+README
+//
+// The PR's net diff is README only, so the correct affected set is empty.
+// Returns the repo dir and the fork/head/advance/merge commit SHAs.
+func buildMergedPRIncidentRepo(t *testing.T) (string, map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	runIncidentGit(t, dir, "init", "-b", "main")
+	runIncidentGit(t, dir, "remote", "add", "origin", "https://github.com/example/incident.git")
+
+	writeIncidentFile(t, dir, "atmos.yaml", `
+base_path: "."
+components:
+  terraform:
+    base_path: components/terraform
+stacks:
+  base_path: stacks
+  included_paths:
+    - "deploy/**/*"
+  name_pattern: "{stage}"
+ci:
+  enabled: true
+`)
+	writeIncidentFile(t, dir, "stacks/catalog/defaults.yaml", "terraform:\n  vars:\n    org_tag: dynamodb\n")
+	writeIncidentFile(t, dir, "stacks/deploy/dev.yaml", `
+import:
+  - catalog/defaults
+vars:
+  stage: dev
+components:
+  terraform:
+    c1:
+      vars: {size: small}
+    c2:
+      vars: {size: small}
+`)
+	writeIncidentFile(t, dir, "stacks/deploy/prod.yaml", `
+import:
+  - catalog/defaults
+vars:
+  stage: prod
+components:
+  terraform:
+    c1:
+      vars: {size: large}
+    c2:
+      vars: {size: large}
+`)
+	tf := "variable \"org_tag\" { default = \"\" }\n"
+	writeIncidentFile(t, dir, "components/terraform/c1/main.tf", tf)
+	writeIncidentFile(t, dir, "components/terraform/c2/main.tf", tf)
+	runIncidentGit(t, dir, "add", "-A")
+	runIncidentGit(t, dir, "commit", "-qm", "baseline")
+	fork := runIncidentGit(t, dir, "rev-parse", "HEAD")
+
+	runIncidentGit(t, dir, "checkout", "-qb", "feature")
+	writeIncidentFile(t, dir, "stacks/catalog/defaults.yaml", "terraform:\n  vars:\n    org_tag: s3-lockfile\n")
+	runIncidentGit(t, dir, "add", "-A")
+	runIncidentGit(t, dir, "commit", "-qm", "org-wide change")
+	writeIncidentFile(t, dir, "stacks/catalog/defaults.yaml", "terraform:\n  vars:\n    org_tag: dynamodb\n")
+	writeIncidentFile(t, dir, "README.md", "docs only\n")
+	runIncidentGit(t, dir, "add", "-A")
+	runIncidentGit(t, dir, "commit", "-qm", "revert org-wide change; add README")
+	head := runIncidentGit(t, dir, "rev-parse", "HEAD")
+
+	runIncidentGit(t, dir, "checkout", "-q", "main")
+	writeIncidentFile(t, dir, "stacks/deploy/prod.yaml", `
+import:
+  - catalog/defaults
+vars:
+  stage: prod
+components:
+  terraform:
+    c1:
+      vars: {size: xlarge}
+    c2:
+      vars: {size: xlarge}
+`)
+	runIncidentGit(t, dir, "add", "-A")
+	runIncidentGit(t, dir, "commit", "-qm", "main advance")
+	advance := runIncidentGit(t, dir, "rev-parse", "HEAD")
+	runIncidentGit(t, dir, "merge", "-q", "--no-ff", head, "-m", "merge PR")
+	mergeCommit := runIncidentGit(t, dir, "rev-parse", "HEAD")
+
+	return dir, map[string]string{
+		"fork": fork, "head": head, "advance": advance, "merge": mergeCommit,
+	}
+}
+
+// describeAffectedInRepo initializes the CLI config for the repo at cwdPath
+// and runs the real checkout-based describe-affected flow against baseSHA.
+func describeAffectedInRepo(t *testing.T, cwdPath, baseSHA string) []schema.Affected {
+	t.Helper()
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", cwdPath)
+	t.Setenv("ATMOS_BASE_PATH", cwdPath)
+	atmosConfig, err := cfg.InitCliConfig(schema.ConfigAndStacksInfo{}, true)
+	require.NoError(t, err)
+
+	affected, _, _, _, err := ExecuteDescribeAffectedWithTargetRefCheckout(
+		&atmosConfig, "", baseSHA, "main",
+		false, false, "", false, false, nil, false, nil, true,
+	)
+	require.NoError(t, err)
+	return affected
+}
+
+// TestDescribeAffectedCIBaseE2E exercises the full merged-PR flow end to end:
+// a real git repo, a real GitHub event payload, real base auto-detection, and
+// the real checkout-based affected computation — the wiring no unit test
+// covers on its own.
+func TestDescribeAffectedCIBaseE2E(t *testing.T) {
+	repoDir, shas := buildMergedPRIncidentRepo(t)
+	runIncidentGit(t, repoDir, "checkout", "-q", shas["head"]) // head.sha checkout, like the documented workflow
+
+	t.Run("merged PR resolves fork point and reports zero affected", func(t *testing.T) {
+		ci.Reset()
+		t.Cleanup(ci.Reset)
+		ci.Register(githubCI.NewProvider())
+
+		eventPath := filepath.Join(t.TempDir(), "event.json")
+		payload := `{"action":"closed","pull_request":{"merged":true,"merge_commit_sha":"` + shas["merge"] +
+			`","head":{"sha":"` + shas["head"] + `"},"base":{"ref":"main","sha":"` + shas["advance"] + `"}}}`
+		require.NoError(t, os.WriteFile(eventPath, []byte(payload), 0o644))
+		t.Setenv("GITHUB_ACTIONS", "true")
+		t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+		t.Setenv("GITHUB_EVENT_PATH", eventPath)
+		t.Setenv("GITHUB_BASE_REF", "main")
+		t.Chdir(repoDir)
+
+		describe := &DescribeAffectedCmdArgs{
+			CLIConfig: &schema.AtmosConfiguration{CI: schema.CIConfig{Enabled: true}},
+		}
+		resolveBaseFromCI(describe)
+		assert.Equal(t, shas["fork"], describe.SHA,
+			"merged-PR base must be the fork point, not the PR's previous commit")
+		assert.Equal(t, shas["head"], describe.HeadSHAOverride)
+
+		affected := describeAffectedInRepo(t, repoDir, describe.SHA)
+		assert.Empty(t, affected, "net PR diff is README only — nothing is affected")
+	})
+
+	t.Run("repo under symlinked path re-bases BASE paths correctly", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevation on Windows")
+		}
+		link := filepath.Join(t.TempDir(), "link-repo")
+		require.NoError(t, os.Symlink(repoDir, link))
+		t.Chdir(link)
+
+		// go-git reports the symlink-RESOLVED repo root while the config
+		// paths keep the logical (symlinked) form from the CWD. Mixing the
+		// two makes filepath.Rel produce a `..`-climbing path; depending on
+		// depth, joining it onto the BASE worktree lands on a nonexistent
+		// dir (BASE treated as empty → EVERYTHING affected) or clamps at
+		// the filesystem root and lands back on the HEAD repo (BASE ==
+		// HEAD → NOTHING affected). Diffing against "advance" (which
+		// genuinely differs from HEAD in the prod stack only) discriminates
+		// the correct result from both failure modes.
+		affected := describeAffectedInRepo(t, link, shas["advance"])
+		slugs := make([]string, 0, len(affected))
+		for _, a := range affected {
+			slugs = append(slugs, a.StackSlug)
+		}
+		sort.Strings(slugs)
+		assert.Equal(t, []string{"prod-c1", "prod-c2"}, slugs,
+			"symlinked CWD must yield the same affected set as a plain path: prod only")
+	})
 }

--- a/internal/exec/describe_affected_test.go
+++ b/internal/exec/describe_affected_test.go
@@ -2638,6 +2638,34 @@ func TestUploadErrorsWhenNoCredentials(t *testing.T) {
 	assert.Contains(t, allHints, "atmos.tools/pro")
 }
 
+// removeAllWithRetry removes dir, retrying with backoff on failure. Mirrors
+// the retry budget pkg/git/worktree.go uses for the same class of transient
+// Windows lock (a just-exited git/antivirus process briefly holding a handle
+// open on a file inside a just-torn-down git worktree's administrative
+// directory). A failure after the full budget is logged, not fatal — it
+// leaves cleanup to whatever runs next (e.g. t.TempDir()'s own attempt),
+// which is the pre-existing behavior this helper is layered in front of.
+func removeAllWithRetry(t *testing.T, dir string) {
+	t.Helper()
+	delay := 200 * time.Millisecond
+	const maxDelay = 2 * time.Second
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		err := os.RemoveAll(dir)
+		if err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Logf("removeAllWithRetry: giving up removing %s after retries: %v", dir, err)
+			return
+		}
+		time.Sleep(delay)
+		if delay *= 2; delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+}
+
 // runIncidentGit runs a git command in dir for the CI-base E2E fixtures below.
 func runIncidentGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
@@ -2669,6 +2697,18 @@ func writeIncidentFile(t *testing.T, dir, rel, content string) {
 func buildMergedPRIncidentRepo(t *testing.T) (string, map[string]string) {
 	t.Helper()
 	dir := t.TempDir()
+	// This repo has a real git worktree created and torn down inside it
+	// (ExecuteDescribeAffectedWithTargetRefCheckout). On Windows CI, a
+	// transient antivirus/indexing scan can briefly hold a lock on the
+	// worktree's administrative metadata (.git/worktrees/<name>/commondir)
+	// even after git itself reports the worktree successfully removed —
+	// t.TempDir()'s own cleanup only tries os.RemoveAll once and fails hard
+	// on that lock. Retry the removal proactively (mirroring the backoff
+	// pkg/git/worktree.go already uses for the same class of transient
+	// Windows lock) so the built-in t.TempDir() cleanup finds nothing left
+	// to remove. Registered immediately after t.TempDir(), so it runs
+	// first (t.Cleanup is LIFO).
+	t.Cleanup(func() { removeAllWithRetry(t, dir) })
 	runIncidentGit(t, dir, "init", "-b", "main")
 	runIncidentGit(t, dir, "remote", "add", "origin", "https://github.com/example/incident.git")
 

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -157,6 +157,22 @@ func executeDescribeAffected(
 	currentStacksPackerDirAbsolutePath := atmosConfig.PackerDirAbsolutePath
 	currentStacksStackConfigFilesAbsolutePaths := atmosConfig.StackConfigFilesAbsolutePaths
 
+	// Guarantee atmosConfig's original paths are restored on every return path (including
+	// early errors from re-basing or BASE stack processing below), not just the success
+	// path. Without this, an error return would leave atmosConfig pointing at the BASE
+	// worktree's paths, which are deleted once the worktree is torn down by the caller.
+	// This is redundant with (but does not replace) the explicit restore further below,
+	// which must run before findAffected is called with the original (HEAD) paths.
+	defer func() {
+		atmosConfig.BasePath = currentBasePath
+		atmosConfig.BasePathAbsolute = currentBasePathAbsolute
+		atmosConfig.StacksBaseAbsolutePath = currentStacksBaseAbsolutePath
+		atmosConfig.TerraformDirAbsolutePath = currentStacksTerraformDirAbsolutePath
+		atmosConfig.HelmfileDirAbsolutePath = currentStacksHelmfileDirAbsolutePath
+		atmosConfig.PackerDirAbsolutePath = currentStacksPackerDirAbsolutePath
+		atmosConfig.StackConfigFilesAbsolutePaths = currentStacksStackConfigFilesAbsolutePaths
+	}()
+
 	// Re-base the config's absolute paths onto the BASE checkout, preserving
 	// each path's location relative to the repo root. This handles the case
 	// where atmos is run from a subdirectory (e.g., -C examples/demo-stacks).

--- a/internal/exec/describe_affected_utils.go
+++ b/internal/exec/describe_affected_utils.go
@@ -2,7 +2,9 @@ package exec
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -14,6 +16,79 @@ import (
 	"github.com/cloudposse/atmos/pkg/schema"
 	u "github.com/cloudposse/atmos/pkg/utils"
 )
+
+// evalSymlinksBestEffort resolves symlinks in path even when the full path
+// does not exist, by resolving the deepest existing ancestor and re-appending
+// the non-existent remainder. The plain filepath.EvalSymlinks errors on
+// missing paths, and unused helmfile/packer default dirs routinely do not exist.
+func evalSymlinksBestEffort(path string) string {
+	remainder := ""
+	current := path
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			return filepath.Join(resolved, remainder)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Nothing along the path resolves — return the input unchanged.
+			return path
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+	}
+}
+
+// rebaseOnePathOntoWorktree maps one absolute config path from the local repo
+// onto the BASE worktree checkout.
+//
+// Both sides are symlink-normalized before computing the relative path: the
+// repo root typically comes from git (symlink-resolved) while config paths
+// derive from the CWD as the shell reported it (logical, unresolved), and
+// mixing the two forms makes filepath.Rel produce a `..`-climbing path.
+// Joined onto the worktree, that path either lands on a nonexistent dir (the
+// BASE scan finds no stack manifests and EVERY component is reported as
+// affected) or clamps at the filesystem root and lands back on the HEAD repo
+// (BASE == HEAD and NOTHING is reported as affected). Both are silent, so a
+// path that still escapes after normalization is a hard error — it cannot be
+// represented inside the BASE checkout.
+func rebaseOnePathOntoWorktree(localRepoAbs, currentAbs, worktreePath string) (string, error) {
+	rel, err := filepath.Rel(evalSymlinksBestEffort(localRepoAbs), evalSymlinksBestEffort(currentAbs))
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf(
+			"%w: config path %q is outside the repository root %q and cannot be located in the BASE checkout %q",
+			errUtils.ErrGitPathEscapesWorktree, currentAbs, localRepoAbs, worktreePath,
+		)
+	}
+	return filepath.Join(worktreePath, rel), nil
+}
+
+// rebaseConfigPathsOntoWorktree points atmosConfig's absolute paths at the
+// BASE worktree checkout, preserving each path's location relative to the
+// repository root. The caller saves and restores the original values.
+func rebaseConfigPathsOntoWorktree(atmosConfig *schema.AtmosConfiguration, localRepoAbs, worktreePath string) error {
+	targets := []struct {
+		current string
+		set     func(string)
+	}{
+		{atmosConfig.BasePathAbsolute, func(p string) { atmosConfig.BasePath = p; atmosConfig.BasePathAbsolute = p }},
+		{atmosConfig.StacksBaseAbsolutePath, func(p string) { atmosConfig.StacksBaseAbsolutePath = p }},
+		{atmosConfig.TerraformDirAbsolutePath, func(p string) { atmosConfig.TerraformDirAbsolutePath = p }},
+		{atmosConfig.HelmfileDirAbsolutePath, func(p string) { atmosConfig.HelmfileDirAbsolutePath = p }},
+		{atmosConfig.PackerDirAbsolutePath, func(p string) { atmosConfig.PackerDirAbsolutePath = p }},
+	}
+	for _, target := range targets {
+		rebased, err := rebaseOnePathOntoWorktree(localRepoAbs, target.current, worktreePath)
+		if err != nil {
+			return err
+		}
+		target.set(rebased)
+	}
+	return nil
+}
 
 func executeDescribeAffected(
 	atmosConfig *schema.AtmosConfiguration,
@@ -82,40 +157,15 @@ func executeDescribeAffected(
 	currentStacksPackerDirAbsolutePath := atmosConfig.PackerDirAbsolutePath
 	currentStacksStackConfigFilesAbsolutePaths := atmosConfig.StackConfigFilesAbsolutePaths
 
-	// Compute the relative paths from the git repo root to the current absolute paths.
-	// This handles the case where atmos is run from a subdirectory (e.g., -C examples/demo-stacks).
-	// We need to preserve the subdirectory path when constructing remote paths.
-	baseRelPath, err := filepath.Rel(localRepoFileSystemPathAbs, currentBasePathAbsolute)
-	if err != nil {
+	// Re-base the config's absolute paths onto the BASE checkout, preserving
+	// each path's location relative to the repo root. This handles the case
+	// where atmos is run from a subdirectory (e.g., -C examples/demo-stacks).
+	// BasePath and BasePathAbsolute must be updated so that !include can
+	// resolve files relative to the base path in the remote repo (fix for
+	// GitHub issue #2090).
+	if err := rebaseConfigPathsOntoWorktree(atmosConfig, localRepoFileSystemPathAbs, remoteRepoFileSystemPath); err != nil {
 		return nil, nil, nil, err
 	}
-	stacksRelPath, err := filepath.Rel(localRepoFileSystemPathAbs, currentStacksBaseAbsolutePath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	terraformRelPath, err := filepath.Rel(localRepoFileSystemPathAbs, currentStacksTerraformDirAbsolutePath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	helmfileRelPath, err := filepath.Rel(localRepoFileSystemPathAbs, currentStacksHelmfileDirAbsolutePath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	packerRelPath, err := filepath.Rel(localRepoFileSystemPathAbs, currentStacksPackerDirAbsolutePath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Update paths to point to the remote repo dir using the computed relative paths.
-	// BasePath and BasePathAbsolute must be updated so that !include can resolve files
-	// relative to the base path in the remote repo (fix for GitHub issue #2090).
-	remoteBasePath := filepath.Join(remoteRepoFileSystemPath, baseRelPath)
-	atmosConfig.BasePath = remoteBasePath
-	atmosConfig.BasePathAbsolute = remoteBasePath
-	atmosConfig.StacksBaseAbsolutePath = filepath.Join(remoteRepoFileSystemPath, stacksRelPath)
-	atmosConfig.TerraformDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, terraformRelPath)
-	atmosConfig.HelmfileDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, helmfileRelPath)
-	atmosConfig.PackerDirAbsolutePath = filepath.Join(remoteRepoFileSystemPath, packerRelPath)
 
 	// Re-scan the BASE (remote) directory for stack config files.
 	// This is necessary to detect deleted stacks - files that exist in BASE but not in HEAD.

--- a/internal/exec/describe_affected_utils_test.go
+++ b/internal/exec/describe_affected_utils_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -2055,4 +2056,65 @@ func TestProcessComponentsSourceAndProvisionChanges(t *testing.T) {
 			assert.Equal(t, tt.expectedReason, affected[0].Affected)
 		})
 	}
+}
+
+func TestEvalSymlinksBestEffort(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevation on Windows")
+	}
+
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(real, link))
+	// t.TempDir itself may sit behind symlinks (e.g. /var -> /private/var on
+	// macOS), so compare against the fully resolved form.
+	realResolved, err := filepath.EvalSymlinks(real)
+	require.NoError(t, err)
+
+	t.Run("resolves an existing symlinked path", func(t *testing.T) {
+		assert.Equal(t, realResolved, evalSymlinksBestEffort(link))
+	})
+
+	t.Run("resolves the existing ancestor of a missing path", func(t *testing.T) {
+		missing := filepath.Join(link, "does", "not", "exist")
+		want := filepath.Join(realResolved, "does", "not", "exist")
+		assert.Equal(t, want, evalSymlinksBestEffort(missing))
+	})
+
+	t.Run("returns unresolvable input unchanged", func(t *testing.T) {
+		in := filepath.Join(string(filepath.Separator), "definitely-missing-root-pr2380", "x")
+		assert.Equal(t, in, evalSymlinksBestEffort(in))
+	})
+}
+
+func TestRebaseOnePathOntoWorktree(t *testing.T) {
+	repo := t.TempDir()
+	worktree := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "stacks"), 0o755))
+
+	t.Run("maps a repo-relative path into the worktree", func(t *testing.T) {
+		got, err := rebaseOnePathOntoWorktree(repo, filepath.Join(repo, "stacks"), worktree)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(worktree, "stacks"), got)
+	})
+
+	t.Run("symlinked config path maps to the same worktree location", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevation on Windows")
+		}
+		link := filepath.Join(t.TempDir(), "repo-link")
+		require.NoError(t, os.Symlink(repo, link))
+		// Mixed forms: resolved repo root, logical (symlinked) config path —
+		// the exact mismatch that used to produce a `..`-climbing rel path.
+		got, err := rebaseOnePathOntoWorktree(repo, filepath.Join(link, "stacks"), worktree)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(worktree, "stacks"), got)
+	})
+
+	t.Run("path genuinely outside the repo is a hard error, never a silent guess", func(t *testing.T) {
+		outside := t.TempDir()
+		_, err := rebaseOnePathOntoWorktree(repo, outside, worktree)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errUtils.ErrGitPathEscapesWorktree)
+	})
 }

--- a/internal/exec/describe_affected_utils_test.go
+++ b/internal/exec/describe_affected_utils_test.go
@@ -1251,6 +1251,53 @@ func TestExecuteDescribeAffectedLocalRepoHeadError(t *testing.T) {
 	})
 }
 
+// TestExecuteDescribeAffected_RebaseOntoWorktreeFails verifies that
+// executeDescribeAffected propagates a hard error — rather than silently
+// mis-locating BASE's stacks — when rebaseConfigPathsOntoWorktree fails
+// because the config's absolute paths do not live under the local repo
+// root that ExecuteDescribeStacksWithOptions (the HEAD-side pass) just
+// processed successfully.
+func TestExecuteDescribeAffected_RebaseOntoWorktreeFails(t *testing.T) {
+	// A real, minimal atmos project so the first ExecuteDescribeStacksWithOptions
+	// call (against the original, HEAD-side paths) succeeds and execution reaches
+	// the BASE-worktree re-basing step.
+	atmosConfig := buildDescribeStacksDegradationFixture(t)
+
+	// localRepoFileSystemPath deliberately points at a directory unrelated to
+	// the fixture project atmosConfig's absolute paths were derived from.
+	// rebaseOnePathOntoWorktree then computes those absolute paths relative to
+	// this unrelated directory, which climbs out via "..", and
+	// rebaseConfigPathsOntoWorktree must fail hard.
+	unrelatedRepoDir := t.TempDir()
+
+	localRepo := createMockRepoWithHead(t)
+	remoteRepo := createMockRepoWithHead(t)
+
+	affected, localHead, remoteHead, err := executeDescribeAffected(
+		&atmosConfig,
+		unrelatedRepoDir,
+		t.TempDir(),
+		localRepo,
+		remoteRepo,
+		false,
+		false,
+		"",
+		false,
+		false,
+		nil,
+		false,
+		nil,
+		false,
+		DescribeStacksErrorOptions{},
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrGitPathEscapesWorktree)
+	assert.Nil(t, affected)
+	assert.Nil(t, localHead)
+	assert.Nil(t, remoteHead)
+}
+
 func TestExecuteDescribeAffectedRemoteRepoHeadError(t *testing.T) {
 	t.Run("fails when remote repo Head() returns error", func(t *testing.T) {
 		localRepo := createMockRepoWithHead(t)
@@ -2117,4 +2164,29 @@ func TestRebaseOnePathOntoWorktree(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, errUtils.ErrGitPathEscapesWorktree)
 	})
+}
+
+// TestRebaseConfigPathsOntoWorktree_PathEscapesRepo verifies that
+// rebaseConfigPathsOntoWorktree itself surfaces (rather than swallows) the
+// per-path error from rebaseOnePathOntoWorktree: a config with one absolute
+// path outside the repo root must fail the whole call, not just skip that
+// one field.
+func TestRebaseConfigPathsOntoWorktree_PathEscapesRepo(t *testing.T) {
+	repo := t.TempDir()
+	worktree := t.TempDir()
+	outside := t.TempDir()
+
+	atmosConfig := &schema.AtmosConfiguration{
+		BasePathAbsolute:         filepath.Join(repo, "."),
+		StacksBaseAbsolutePath:   filepath.Join(repo, "stacks"),
+		TerraformDirAbsolutePath: filepath.Join(repo, "components", "terraform"),
+		// This one is genuinely outside repo — the whole call must error.
+		HelmfileDirAbsolutePath: outside,
+		PackerDirAbsolutePath:   filepath.Join(repo, "components", "packer"),
+	}
+
+	err := rebaseConfigPathsOntoWorktree(atmosConfig, repo, worktree)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrGitPathEscapesWorktree)
 }

--- a/pkg/ci/internal/provider/types.go
+++ b/pkg/ci/internal/provider/types.go
@@ -31,6 +31,14 @@ type BaseResolution struct {
 
 	// EventType describes the CI event (e.g., "pull_request", "push").
 	EventType string
+
+	// Checkout classifies what commit the workflow actually checked out,
+	// relative to the event payload (e.g., "head.sha", "merge-commit",
+	// "synthetic-merge", "unknown"). Base-resolution strategies are only
+	// correct for specific checkouts, so surfacing the classification in
+	// logs makes wrong-base incidents diagnosable from a single line.
+	// Empty for events where the distinction does not apply.
+	Checkout string
 }
 
 // Provider represents a CI/CD provider (GitHub Actions, GitLab CI, etc.).

--- a/pkg/ci/providers/github/base.go
+++ b/pkg/ci/providers/github/base.go
@@ -38,6 +38,36 @@ const (
 	eventMergeGroup = "merge_group"
 	// RefsHeadsPrefix is the prefix on fully-qualified branch refs in event payloads.
 	refsHeadsPrefix = "refs/heads/"
+	// ActionClosed is the pull_request action fired when a PR is closed or merged.
+	actionClosed = "closed"
+
+	// Checkout classifications: what commit the workflow actually checked out,
+	// determined by comparing the local HEAD against the event payload. Each
+	// base-resolution strategy is only correct for specific checkouts, so the
+	// classification drives strategy selection and is surfaced in logs.
+	checkoutPRHead         = "head.sha"
+	checkoutMergeCommit    = "merge-commit"
+	checkoutSyntheticMerge = "synthetic-merge"
+	checkoutUnknown        = "unknown"
+
+	// SourceSyntheticMergeParent labels resolution from the first parent of a
+	// synthetic refs/pull/<n>/merge test-merge checkout.
+	sourceSyntheticMergeParent = "first-parent (synthetic-merge checkout)"
+	// SourceMergeCommitParent labels resolution from the first parent of the
+	// real merge commit when the workflow checked it out.
+	sourceMergeCommitParent = "HEAD^1 (merge-commit checkout)"
+	// SourceMergedForkPoint labels resolution via the merge-commit-anchored
+	// fork point for merged PRs with the PR head checked out.
+	sourceMergedForkPoint = "merge-base(HEAD, merge_commit_sha^1)"
+	// SourceFFMergedForkPoint labels resolution via the payload-base-anchored
+	// fork point for fast-forward-merged PRs (merge_commit_sha == head.sha).
+	sourceFFMergedForkPoint = "merge-base(HEAD, base.sha) (fast-forward merge)"
+
+	// CwdRepoDir scopes git operations to the repository containing the
+	// current working directory (the CI checkout).
+	cwdRepoDir = "."
+	// RevisionHead is the git revision name for the checked-out commit.
+	revisionHead = "HEAD"
 )
 
 // ErrEventPathNotSet is returned when $GITHUB_EVENT_PATH is not set.
@@ -45,6 +75,14 @@ var ErrEventPathNotSet = fmt.Errorf("GITHUB_EVENT_PATH is not set")
 
 // ErrNoParentCommit is returned when HEAD has no parents (initial commit).
 var ErrNoParentCommit = fmt.Errorf("HEAD has no parents (initial commit)")
+
+// ErrNoMergeCommitSHA is returned when a merged PR's event payload lacks
+// pull_request.merge_commit_sha, so no merge-commit-anchored base can be computed.
+var ErrNoMergeCommitSHA = fmt.Errorf("event payload has no pull_request.merge_commit_sha")
+
+// ErrNoPayloadBaseSHA is returned when a fast-forward-merged PR's event payload
+// lacks pull_request.base.sha, so no payload-base-anchored base can be computed.
+var ErrNoPayloadBaseSHA = fmt.Errorf("event payload has no pull_request.base.sha")
 
 // ResolveBase returns the base commit for affected detection in GitHub Actions.
 // It reads GitHub Actions environment variables and event payloads to determine
@@ -79,20 +117,26 @@ func (p *Provider) ResolveBase() (*provider.BaseResolution, error) {
 
 // resolvePRBase resolves the base commit for pull request events.
 //
-// Strategy chain (first success wins):
+// The checked-out commit is classified against the event payload first
+// (classifyPRCheckout), because every strategy below is only correct for
+// specific checkouts — trusting HEAD blind is how merged multi-commit PRs
+// used to resolve a wrong base and mark the wrong components affected.
+//
+// Strategy chain for open (and closed-unmerged) PRs, first success wins:
 //  1. merge-base(HEAD, origin/<target>) — gold standard. Self-heals from
 //     shallow CI checkouts via MergeBaseWithAutoFetch (fetches the target
 //     branch and deepens history when needed).
-//  2. HEAD~1 — only for closed/merged PRs when merge-base is unavailable.
-//     Correct when the merge commit is checked out with merge/squash
-//     strategy.
-//  3. event.pull_request.base.sha — payload SHA. Slightly stale (frozen at
+//  2. event.pull_request.base.sha — payload SHA. Slightly stale (frozen at
 //     last sync event) but never compares to the current tip of main, so it
 //     can never produce the "PR is out of date with main" false positives
 //     that returning the origin/<target> ref directly does.
-//  4. refs/remotes/origin/<target> ref — last resort, with a Warn log.
+//  3. refs/remotes/origin/<target> ref — last resort, with a Warn log.
 //     Compares to current tip of target; will produce false positives for
 //     out-of-date PRs.
+//
+// Merged PRs are routed to resolveMergedPRBase instead: after the merge,
+// origin/<target> contains this PR, so merge-base against its moving tip
+// degenerates to HEAD, and a payload-anchored strategy is required.
 //
 // Also extracts the PR head SHA for Atmos Pro upload correlation.
 func resolvePRBase(eventName string) (*provider.BaseResolution, error) {
@@ -104,40 +148,39 @@ func resolvePRBase(eventName string) (*provider.BaseResolution, error) {
 	headSHA := extractPRHeadSHA(payload)
 	targetBranch := extractTargetBranch(payload)
 	action, _ := payload["action"].(string)
+	checkout, parents := classifyPRCheckout(headSHA, extractPRMergeCommitSHA(payload))
 
-	// 1) merge-base — the gold standard. Works regardless of what's
-	// checked out, merge strategy, or number of commits on the PR.
+	if action == actionClosed && extractPRMerged(payload) {
+		return resolveMergedPRBase(eventName, payload, checkout, parents), nil
+	}
+
+	// 1) merge-base — the gold standard for open PRs. Works regardless of
+	// what's checked out, merge strategy, or number of commits on the PR.
 	if targetBranch != "" {
-		if sha, mbErr := git.MergeBaseWithAutoFetch(".", targetBranch); mbErr == nil {
+		if sha, mbErr := git.MergeBaseWithAutoFetch(cwdRepoDir, targetBranch); mbErr == nil {
 			return &provider.BaseResolution{
 				SHA:          sha,
 				HeadSHA:      headSHA,
 				TargetBranch: targetBranch,
 				Source:       "merge-base(HEAD, origin/" + targetBranch + ")",
 				EventType:    eventName,
+				Checkout:     checkout,
 			}, nil
 		} else {
 			log.Debug("merge-base failed, trying fallbacks", "target", targetBranch, "error", mbErr)
 		}
 	}
 
-	// 2) Closed/merged PRs: HEAD~1.
-	// Correct when the merge commit is checked out (merge/squash strategies).
-	if action == "closed" {
-		if sha, parentErr := resolveParentCommit(); parentErr == nil {
-			return &provider.BaseResolution{
-				SHA:          sha,
-				HeadSHA:      headSHA,
-				TargetBranch: targetBranch,
-				Source:       "HEAD~1 (merged PR, merge-base unavailable)",
-				EventType:    eventName,
-			}, nil
-		} else {
-			log.Debug("HEAD~1 failed for merged PR", "error", parentErr)
-		}
-	}
+	return resolvePRBaseFallback(eventName, payload, checkout), nil
+}
 
-	// 3) event.pull_request.base.sha — payload SHA fallback.
+// resolvePRBaseFallback is the shared tail of the PR fallback chain:
+// payload base.sha first, then the last-resort target-branch ref.
+func resolvePRBaseFallback(eventName string, payload map[string]any, checkout string) *provider.BaseResolution {
+	headSHA := extractPRHeadSHA(payload)
+	targetBranch := extractTargetBranch(payload)
+
+	// event.pull_request.base.sha — payload SHA fallback.
 	// This SHA is at worst stale by however many main commits have landed
 	// since the PR was last synced. Crucially, it is not the *current tip*
 	// of main, so it will not silently turn a stale-but-untouched PR into
@@ -149,22 +192,208 @@ func resolvePRBase(eventName string) (*provider.BaseResolution, error) {
 			TargetBranch: targetBranch,
 			Source:       sourcePayloadBaseSHA,
 			EventType:    eventName,
-		}, nil
+			Checkout:     checkout,
+		}
 	}
 
-	// 4) Last-resort: ref to current tip of target branch. Logs Warn
+	// Last-resort: ref to current tip of target branch. Logs Warn
 	// because this is the path that produces false positives for
 	// out-of-date PRs (every commit on main since the fork point shows
 	// up as a tree difference).
 	res := resolveFromBaseRef(eventName)
 	res.HeadSHA = headSHA
 	res.TargetBranch = targetBranch
+	res.Checkout = checkout
 	log.Warn(
 		"Falling back to current tip of target branch for PR base — affected detection may include unrelated commits from the target branch.",
 		"target", targetBranch,
 		"hint", "ensure the workflow checks out enough history (fetch-depth >= 2 or fetch-depth: 0) and that origin/"+targetBranch+" is fetchable",
 	)
-	return res, nil
+	return res
+}
+
+// resolveMergedPRBase resolves the diff base for a merged PR from the event
+// payload's merge commit, independent of which commit the workflow checked out.
+//
+// The pre-fix behavior — merge-base against origin/<target>, then HEAD~1 —
+// is only correct for specific checkouts: after the merge, origin/<target>
+// contains this PR (so merge-base collapses to HEAD for merge-commit
+// strategy), and HEAD~1 with the PR head checked out diffs only the PR's
+// FINAL commit, not its net change. A multi-commit PR whose last commit
+// reverts an earlier one then reports the reverted files (e.g., an org-wide
+// backend change) as affected — the "wall of post-merge dispatches" incident.
+//
+// Per-checkout strategy (mirrors merge_group.base_sha semantics):
+//   - synthetic-merge: first parent of HEAD (the target tip the test merge
+//     was built on) — exact net-diff base.
+//   - merge-commit: HEAD^1 — the pre-merge tip of the target branch.
+//   - head.sha: merge-base(HEAD, merge_commit_sha^1) — the true fork point,
+//     correct for merge, squash, and rebase strategies alike.
+//   - unknown: Warn and fall back to the payload base.sha tier.
+func resolveMergedPRBase(eventName string, payload map[string]any, checkout string, parents []string) *provider.BaseResolution {
+	res := &provider.BaseResolution{
+		HeadSHA:      extractPRHeadSHA(payload),
+		TargetBranch: extractTargetBranch(payload),
+		EventType:    eventName,
+		Checkout:     checkout,
+	}
+
+	switch checkout {
+	case checkoutSyntheticMerge:
+		// classifyPRCheckout guarantees two parents for this class.
+		res.SHA = parents[0]
+		res.Source = sourceSyntheticMergeParent
+		return res
+	case checkoutMergeCommit:
+		if len(parents) > 0 {
+			res.SHA = parents[0]
+			res.Source = sourceMergeCommitParent
+			return res
+		}
+		// A parentless merge commit is degenerate (orphan/rewritten
+		// history) — fall through to the payload fallback below.
+	case checkoutPRHead:
+		if base, source, err := mergedPRHeadAnchoredBase(payload); err == nil {
+			res.SHA = base
+			res.Source = source
+			return res
+		} else {
+			log.Warn(
+				"Could not anchor the merged PR base on the merge commit — falling back to the payload base SHA. Affected detection may be less precise.",
+				"error", err,
+			)
+		}
+	default:
+		log.Warn(
+			"Cannot classify the checked-out commit for a merged PR — falling back to the payload base SHA. Affected detection may be less precise.",
+			"hint", "check out either the PR head SHA or the merge commit in the workflow",
+		)
+	}
+
+	return resolvePRBaseFallback(eventName, payload, checkout)
+}
+
+// classifyPRCheckout inspects the local HEAD and classifies which commit the
+// workflow actually checked out, relative to the PR facts in the event
+// payload. Returns the classification and HEAD's parent SHAs (empty for an
+// initial commit — a valid commit, not an error; callers check length).
+func classifyPRCheckout(headSHA, mergeCommitSHA string) (string, []string) {
+	localHead, parents, err := git.CommitParents(cwdRepoDir, revisionHead)
+	if err != nil {
+		log.Debug("classifying checkout: cannot read local HEAD", "error", err)
+		return checkoutUnknown, nil
+	}
+	switch {
+	case headSHA != "" && localHead == headSHA:
+		return checkoutPRHead, parents
+	case mergeCommitSHA != "" && localHead == mergeCommitSHA:
+		return checkoutMergeCommit, parents
+	case headSHA != "" && len(parents) == 2 && parents[1] == headSHA:
+		// GitHub's synthetic refs/pull/<n>/merge test-merge commit: second
+		// parent is the PR head, first parent is the target-branch tip the
+		// merge was built on.
+		return checkoutSyntheticMerge, parents
+	default:
+		return checkoutUnknown, parents
+	}
+}
+
+// mergedPRHeadAnchoredBase resolves the base for a merged PR whose head SHA
+// is checked out, returning (base, source label, error).
+//
+// Normal merges anchor on the merge commit's first parent (mergedPRForkPoint).
+// Fast-forward merges (branch pushed directly to the target; GitHub reports
+// the PR merged with merge_commit_sha == head.sha) are special-cased: there
+// the merge commit IS the PR head, so its first parent is the PR's own
+// previous commit — anchoring on it would silently drop every commit but the
+// last from the diff. Anchor on the payload's base.sha instead: a pre-merge
+// target-branch commit, so merge-base(HEAD, base.sha) is the fork point even
+// when base.sha is stale (staleness only moves the anchor along the target
+// branch, never onto the PR branch).
+func mergedPRHeadAnchoredBase(payload map[string]any) (string, string, error) {
+	mergeCommitSHA := extractPRMergeCommitSHA(payload)
+	if mergeCommitSHA != "" && mergeCommitSHA == extractPRHeadSHA(payload) {
+		baseSHA := extractBaseSHA(payload)
+		if baseSHA == "" {
+			return "", "", ErrNoPayloadBaseSHA
+		}
+		base, err := forkPointFromAnchor(baseSHA)
+		if err != nil {
+			return "", "", err
+		}
+		return base, sourceFFMergedForkPoint, nil
+	}
+
+	base, err := mergedPRForkPoint(mergeCommitSHA)
+	if err != nil {
+		return "", "", err
+	}
+	return base, sourceMergedForkPoint, nil
+}
+
+// mergedPRForkPoint computes the true fork point of a merged PR whose head
+// SHA is checked out, by anchoring on the merge commit recorded in the event
+// payload: merge-base(HEAD, merge_commit_sha^1). The first parent of the
+// merge commit is the pre-merge tip of the target branch, so the merge-base
+// against it is the fork point — for merge, squash, and rebase strategies
+// alike — and can never degenerate to HEAD the way merge-base against the
+// post-merge origin/<target> tip does.
+func mergedPRForkPoint(mergeCommitSHA string) (string, error) {
+	if mergeCommitSHA == "" {
+		return "", ErrNoMergeCommitSHA
+	}
+
+	_, parents, err := git.CommitParents(cwdRepoDir, mergeCommitSHA)
+	if err != nil {
+		// A narrow head-SHA checkout may not have fetched the merge commit.
+		if fetchErr := git.FetchCommit(cwdRepoDir, mergeCommitSHA); fetchErr != nil {
+			return "", err
+		}
+		_, parents, err = git.CommitParents(cwdRepoDir, mergeCommitSHA)
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(parents) == 0 {
+		return "", git.ErrCommitHasNoParents
+	}
+
+	return git.MergeBaseSHAs(cwdRepoDir, revisionHead, parents[0])
+}
+
+// forkPointFromAnchor computes merge-base(HEAD, anchorSHA), fetching the
+// anchor commit by SHA first when a narrow checkout did not bring it in.
+func forkPointFromAnchor(anchorSHA string) (string, error) {
+	if _, _, err := git.CommitParents(cwdRepoDir, anchorSHA); err != nil {
+		if fetchErr := git.FetchCommit(cwdRepoDir, anchorSHA); fetchErr != nil {
+			return "", err
+		}
+	}
+	return git.MergeBaseSHAs(cwdRepoDir, revisionHead, anchorSHA)
+}
+
+// extractPRMerged reports whether the PR event payload marks the PR as merged
+// (pull_request.merged). Closed-without-merge PRs return false and are treated
+// like open PRs for base resolution.
+func extractPRMerged(payload map[string]any) bool {
+	pr, _ := payload[payloadKeyPullRequest].(map[string]any)
+	if pr == nil {
+		return false
+	}
+	merged, _ := pr["merged"].(bool)
+	return merged
+}
+
+// extractPRMergeCommitSHA extracts pull_request.merge_commit_sha from the
+// event payload. For merged PRs this is the commit that landed on the target
+// branch (merge commit, squash commit, or rebased tip). Empty when absent.
+func extractPRMergeCommitSHA(payload map[string]any) string {
+	pr, _ := payload[payloadKeyPullRequest].(map[string]any)
+	if pr == nil {
+		return ""
+	}
+	sha, _ := pr["merge_commit_sha"].(string)
+	return sha
 }
 
 // extractTargetBranch extracts the target branch name from the PR event payload.

--- a/pkg/ci/providers/github/base_merged_test.go
+++ b/pkg/ci/providers/github/base_merged_test.go
@@ -343,3 +343,129 @@ func TestResolveBase_ClosedUnmergedPR(t *testing.T) {
 	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
 	assert.Equal(t, f.mainAdvance, res.SHA)
 }
+
+// TestResolveMergedPRBase_HeadCheckout_NoMergeCommitSHA covers a merged PR
+// with the head SHA checked out whose event payload has no
+// merge_commit_sha (a degenerate payload): mergedPRForkPoint has nothing to
+// anchor on (ErrNoMergeCommitSHA), mergedPRHeadAnchoredBase propagates the
+// error, and resolveMergedPRBase must Warn and fall back to the payload
+// base.sha tier instead of silently guessing a base.
+func TestResolveMergedPRBase_HeadCheckout_NoMergeCommitSHA(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, "") // No merge_commit_sha in the payload.
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA, "falls back to payload base.sha")
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+}
+
+// TestResolveMergedPRBase_HeadCheckout_MergeCommitNotFetchable covers a
+// merge_commit_sha that names a commit neither present locally nor
+// fetchable (the fixture repo has no "origin" remote): mergedPRForkPoint's
+// CommitParents lookup fails, the FetchCommit recovery attempt also fails,
+// and the original error must propagate rather than falling through with a
+// wrong SHA.
+func TestResolveMergedPRBase_HeadCheckout_MergeCommitNotFetchable(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA, "falls back to payload base.sha when the merge commit can't be resolved or fetched")
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+}
+
+// TestResolveMergedPRBase_HeadCheckout_MergeCommitHasNoParents covers a
+// merge_commit_sha that resolves locally but has no parents — using the
+// fixture's own fork-point commit (its very first, parentless commit) as a
+// stand-in for a degenerate/rewritten-history merge commit — where
+// mergedPRForkPoint must return ErrCommitHasNoParents rather than computing
+// merge-base against a nonexistent parent.
+func TestResolveMergedPRBase_HeadCheckout_MergeCommitHasNoParents(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.forkPoint) // forkPoint has no parent.
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA, "falls back to payload base.sha when the merge commit has no parent to anchor on")
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+}
+
+// TestResolveMergedPRBase_FastForwardMerge_NoPayloadBaseSHA covers a
+// fast-forward-merged PR (merge_commit_sha == head.sha) whose event payload
+// is missing base.sha: mergedPRHeadAnchoredBase has no anchor to compute
+// the fork point from and must return ErrNoPayloadBaseSHA, triggering the
+// Warn-and-fallback path down to the last-resort target-branch ref.
+func TestResolveMergedPRBase_FastForwardMerge_NoPayloadBaseSHA(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.ffHead)
+	t.Chdir(f.dir)
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+	payload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged":           true,
+			"merge_commit_sha": f.ffHead, // == head.sha: the FF signature.
+			"head":             map[string]any{"sha": f.ffHead},
+			"base":             map[string]any{"ref": "main"}, // NOTE: no "sha".
+		},
+	}
+	t.Setenv("GITHUB_EVENT_PATH", writeEventPayload(t, payload))
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Empty(t, res.SHA)
+	assert.Equal(t, "refs/remotes/origin/main", res.Ref)
+	assert.Equal(t, sourceGitHubBaseRef, res.Source)
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+}
+
+// TestResolveMergedPRBase_FastForwardMerge_BaseSHANotFetchable covers a
+// fast-forward-merged PR whose payload base.sha names a commit that is
+// neither present locally nor fetchable: forkPointFromAnchor's CommitParents
+// lookup and FetchCommit recovery both fail, and mergedPRHeadAnchoredBase
+// must propagate that error rather than silently falling through.
+func TestResolveMergedPRBase_FastForwardMerge_BaseSHANotFetchable(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.ffHead)
+	t.Chdir(f.dir)
+
+	const fakeBaseSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+	payload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged":           true,
+			"merge_commit_sha": f.ffHead,
+			"head":             map[string]any{"sha": f.ffHead},
+			"base":             map[string]any{"ref": "main", "sha": fakeBaseSHA},
+		},
+	}
+	t.Setenv("GITHUB_EVENT_PATH", writeEventPayload(t, payload))
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, fakeBaseSHA, res.SHA, "falls back to the payload base.sha itself when its fork-point anchor can't be resolved or fetched")
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+}

--- a/pkg/ci/providers/github/base_merged_test.go
+++ b/pkg/ci/providers/github/base_merged_test.go
@@ -1,0 +1,345 @@
+package github
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mergedPRFixture is a real git repository reproducing the incident shape:
+// a multi-commit PR whose FINAL commit reverts an earlier org-wide change,
+// so the PR's net diff differs from its last commit's diff.
+//
+//	main:    forkPoint ── mainAdvance ─────────── mergeCommit
+//	                 \                           /
+//	feature:          orgWideChange ── revert ──╯   (revert = PR head)
+//
+// Also provides a squash commit (parent: mainAdvance) and a synthetic
+// test-merge commit (parents: mainAdvance, revert) to cover the other
+// merge strategies and checkout modes.
+type mergedPRFixture struct {
+	dir            string
+	forkPoint      string
+	mainAdvance    string
+	orgWideChange  string
+	prHead         string
+	mergeCommit    string
+	squashCommit   string
+	syntheticMerge string
+	// Fast-forward scenario: a 2-commit branch forked from mergeCommit and
+	// fast-forwarded onto the target (merge_commit_sha == head.sha).
+	ffFirstCommit string
+	ffHead        string
+}
+
+// runGitCmd runs a git command in dir and returns trimmed stdout.
+func runGitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	base := []string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}
+	cmd := exec.Command("git", append(base, args...)...)
+	cmd.Dir = dir
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// commitFixtureFile writes a file and commits it, returning the commit SHA.
+func commitFixtureFile(t *testing.T, dir, name, content, msg string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	runGitCmd(t, dir, "add", name)
+	runGitCmd(t, dir, "commit", "-m", msg)
+	return runGitCmd(t, dir, "rev-parse", "HEAD")
+}
+
+func buildMergedPRFixture(t *testing.T) *mergedPRFixture {
+	t.Helper()
+	dir := t.TempDir()
+	f := &mergedPRFixture{dir: dir}
+
+	runGitCmd(t, dir, "init", "-b", "main")
+
+	f.forkPoint = commitFixtureFile(t, dir, "defaults.yaml", "backend: dynamodb\n", "fork point")
+
+	// PR branch: an org-wide change, then a commit that reverts it while
+	// touching an unrelated file — net PR diff is workflow.yaml only.
+	runGitCmd(t, dir, "checkout", "-b", "feature")
+	f.orgWideChange = commitFixtureFile(t, dir, "defaults.yaml", "backend: s3-lockfile\n", "org-wide backend change")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "defaults.yaml"), []byte("backend: dynamodb\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("lock-timeout: 300s\n"), 0o644))
+	runGitCmd(t, dir, "add", "defaults.yaml", "workflow.yaml")
+	runGitCmd(t, dir, "commit", "-m", "add lock-timeout; revert backend change")
+	f.prHead = runGitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Target branch advances independently before the merge.
+	runGitCmd(t, dir, "checkout", "main")
+	f.mainAdvance = commitFixtureFile(t, dir, "unrelated.txt", "x\n", "main moved forward")
+
+	// Merge-commit strategy.
+	runGitCmd(t, dir, "merge", "--no-ff", f.prHead, "-m", "merge PR")
+	f.mergeCommit = runGitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Squash strategy (on a scratch branch so main keeps the merge commit).
+	runGitCmd(t, dir, "checkout", "-b", "squash-target", f.mainAdvance)
+	runGitCmd(t, dir, "merge", "--squash", f.prHead)
+	runGitCmd(t, dir, "commit", "-m", "squash PR")
+	f.squashCommit = runGitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Synthetic refs/pull/<n>/merge-style test merge: same parents as the
+	// real merge commit but a distinct commit.
+	runGitCmd(t, dir, "checkout", "-b", "synthetic-target", f.mainAdvance)
+	runGitCmd(t, dir, "merge", "--no-ff", f.prHead, "-m", "synthetic test merge")
+	f.syntheticMerge = runGitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Fast-forward scenario: 2-commit branch off the merge commit, each
+	// commit touching a different file, fast-forwarded onto main — GitHub
+	// marks such PRs merged with merge_commit_sha == head.sha.
+	runGitCmd(t, dir, "checkout", "-b", "ff-feature", f.mergeCommit)
+	f.ffFirstCommit = commitFixtureFile(t, dir, "dev.yaml", "size: medium\n", "ff: dev change")
+	f.ffHead = commitFixtureFile(t, dir, "prod.yaml", "size: xxlarge\n", "ff: prod change")
+	runGitCmd(t, dir, "checkout", "main")
+	runGitCmd(t, dir, "merge", "--ff-only", f.ffHead)
+
+	return f
+}
+
+// setMergedPREvent points the GitHub event env at a merged-PR payload.
+func setMergedPREvent(t *testing.T, f *mergedPRFixture, mergeCommitSHA string) {
+	t.Helper()
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+	payload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged":           true,
+			"merge_commit_sha": mergeCommitSHA,
+			"head": map[string]any{
+				"sha": f.prHead,
+			},
+			"base": map[string]any{
+				"ref": "main",
+				"sha": f.mainAdvance,
+			},
+		},
+	}
+	t.Setenv("GITHUB_EVENT_PATH", writeEventPayload(t, payload))
+}
+
+// TestResolveBase_MergedPR_HeadSHACheckout_MergeCommitStrategy is the
+// incident regression test: a merged multi-commit PR whose final commit
+// reverts an earlier org-wide change, with the PR head checked out (the
+// documented workflow's checkout) and a merge-commit merge.
+//
+// Pre-fix behavior: merge-base(HEAD, origin/main) collapses to HEAD (the
+// head is an ancestor of the post-merge main), the HEAD~1 fallback then
+// resolves the base to the PR's own previous commit, and the diff reports
+// the reverted org-wide change as affected — dispatching plans/applies for
+// every component after the merge. The correct base is the fork point.
+func TestResolveBase_MergedPR_HeadSHACheckout_MergeCommitStrategy(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.mergeCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.forkPoint, res.SHA,
+		"base must be the fork point (net PR diff), NOT the PR's previous commit (last-commit-only diff)")
+	assert.NotEqual(t, f.orgWideChange, res.SHA,
+		"regression guard: HEAD~1 on a head.sha checkout resolves the reverted commit and re-reports the org-wide change")
+	assert.Equal(t, sourceMergedForkPoint, res.Source)
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+	assert.Equal(t, f.prHead, res.HeadSHA)
+}
+
+// TestResolveBase_MergedPR_HeadSHACheckout_SquashStrategy covers the squash
+// merge: merge_commit_sha is the squash commit, whose first parent is the
+// pre-merge main tip; the merge-base against it is still the fork point.
+func TestResolveBase_MergedPR_HeadSHACheckout_SquashStrategy(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.squashCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.forkPoint, res.SHA)
+	assert.Equal(t, sourceMergedForkPoint, res.Source)
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+}
+
+// TestResolveBase_MergedPR_MergeCommitCheckout covers the checkout the old
+// HEAD~1 fallback was designed for: the merge commit itself is checked out,
+// so its first parent is the pre-merge main tip — the exact net-diff base.
+func TestResolveBase_MergedPR_MergeCommitCheckout(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.mergeCommit)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.mergeCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA, "first parent of the merge commit is the pre-merge main tip")
+	assert.Equal(t, sourceMergeCommitParent, res.Source)
+	assert.Equal(t, checkoutMergeCommit, res.Checkout)
+}
+
+// TestResolveBase_MergedPR_SyntheticMergeCheckout covers workflows that
+// check out GitHub's synthetic refs/pull/<n>/merge test-merge commit: the
+// second parent is the PR head, so the first parent is the target tip the
+// merge was built on — resolved directly, no merge-base needed.
+func TestResolveBase_MergedPR_SyntheticMergeCheckout(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.syntheticMerge)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.mergeCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA)
+	assert.Equal(t, sourceSyntheticMergeParent, res.Source)
+	assert.Equal(t, checkoutSyntheticMerge, res.Checkout)
+}
+
+// TestResolveBase_MergedPR_UnknownCheckout covers a checkout matching none
+// of the payload facts (e.g., the target branch tip): no strategy is provably
+// correct, so resolution falls back to the payload base.sha with a Warn
+// instead of silently guessing.
+func TestResolveBase_MergedPR_UnknownCheckout(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.mainAdvance)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.mergeCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mainAdvance, res.SHA, "payload base.sha fallback")
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+	assert.Equal(t, checkoutUnknown, res.Checkout)
+}
+
+// TestResolveBase_MergedPR_QueueMergedClosedEvent models the closed event
+// GitHub fires after a merge queue lands a PR: structurally a merge-commit
+// merge with the PR head checked out. The merged-PR path must resolve the
+// fork point — merge queues do not exempt the closed event from this bug.
+func TestResolveBase_MergedPR_QueueMergedClosedEvent(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+	setMergedPREvent(t, f, f.mergeCommit)
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.forkPoint, res.SHA)
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+}
+
+// TestResolveBase_MergedPR_FastForwardMerge covers externally-merged /
+// fast-forwarded PRs, where GitHub reports merge_commit_sha == head.sha
+// (e.g. the branch was pushed directly to the target and the PR auto-closed
+// as merged). Anchoring on merge_commit_sha^1 would resolve the PR's OWN
+// previous commit and silently drop every earlier commit's changes from the
+// diff (under-detection). The correct base is the fork point, reached by
+// anchoring on the payload's base.sha instead.
+func TestResolveBase_MergedPR_FastForwardMerge(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.ffHead)
+	t.Chdir(f.dir)
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+	payload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged":           true,
+			"merge_commit_sha": f.ffHead, // == head.sha: the FF signature.
+			"head":             map[string]any{"sha": f.ffHead},
+			"base":             map[string]any{"ref": "main", "sha": f.mergeCommit},
+		},
+	}
+	t.Setenv("GITHUB_EVENT_PATH", writeEventPayload(t, payload))
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, f.mergeCommit, res.SHA,
+		"base must be the fork point (pre-FF target tip), so BOTH commits' changes are in the diff")
+	assert.NotEqual(t, f.ffFirstCommit, res.SHA,
+		"regression guard: anchoring on merge_commit_sha^1 silently drops the first commit's changes")
+	assert.Equal(t, checkoutPRHead, res.Checkout)
+}
+
+// TestClassifyPRCheckout_InitialCommit verifies a parentless initial commit
+// classifies without error: an initial commit is a valid commit (empty
+// parents, nil error from git.CommitParents), and the head.sha match still
+// applies to it.
+func TestClassifyPRCheckout_InitialCommit(t *testing.T) {
+	dir := t.TempDir()
+	runGitCmd(t, dir, "init", "-b", "main")
+	initial := commitFixtureFile(t, dir, "a.txt", "a", "initial")
+	t.Chdir(dir)
+
+	checkout, parents := classifyPRCheckout(initial, "")
+	assert.Equal(t, checkoutPRHead, checkout)
+	assert.Empty(t, parents, "initial commit has no parents — valid, not an error")
+
+	checkout, _ = classifyPRCheckout("someothersha000000000000000000000000dead", "")
+	assert.Equal(t, checkoutUnknown, checkout)
+}
+
+// TestResolveBase_ClosedUnmergedPR verifies closed-without-merge PRs do NOT
+// take the merged-PR path: the branch was never folded into the target, so
+// they resolve like open PRs (merge-base, then payload base.sha).
+func TestResolveBase_ClosedUnmergedPR(t *testing.T) {
+	f := buildMergedPRFixture(t)
+	runGitCmd(t, f.dir, "checkout", f.prHead)
+	t.Chdir(f.dir)
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_BASE_REF", "main")
+	payload := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"merged":           false,
+			"merge_commit_sha": nil,
+			"head":             map[string]any{"sha": f.prHead},
+			"base":             map[string]any{"ref": "main", "sha": f.mainAdvance},
+		},
+	}
+	t.Setenv("GITHUB_EVENT_PATH", writeEventPayload(t, payload))
+
+	res, err := NewProvider().ResolveBase()
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	// No origin remote in the fixture, so merge-base auto-fetch fails and
+	// the open-PR chain lands on the payload base.sha — never on a
+	// merged-PR source.
+	assert.Equal(t, sourcePayloadBaseSHA, res.Source)
+	assert.Equal(t, f.mainAdvance, res.SHA)
+}

--- a/pkg/ci/providers/github/base_merged_test.go
+++ b/pkg/ci/providers/github/base_merged_test.go
@@ -369,8 +369,8 @@ func TestResolveMergedPRBase_HeadCheckout_NoMergeCommitSHA(t *testing.T) {
 // merge_commit_sha that names a commit neither present locally nor
 // fetchable (the fixture repo has no "origin" remote): mergedPRForkPoint's
 // CommitParents lookup fails, the FetchCommit recovery attempt also fails,
-// and the original error must propagate rather than falling through with a
-// wrong SHA.
+// and resolveMergedPRBase must warn and fall back to payload base.sha
+// rather than falling through with a wrong SHA.
 func TestResolveMergedPRBase_HeadCheckout_MergeCommitNotFetchable(t *testing.T) {
 	f := buildMergedPRFixture(t)
 	runGitCmd(t, f.dir, "checkout", f.prHead)
@@ -442,7 +442,8 @@ func TestResolveMergedPRBase_FastForwardMerge_NoPayloadBaseSHA(t *testing.T) {
 // fast-forward-merged PR whose payload base.sha names a commit that is
 // neither present locally nor fetchable: forkPointFromAnchor's CommitParents
 // lookup and FetchCommit recovery both fail, and mergedPRHeadAnchoredBase
-// must propagate that error rather than silently falling through.
+// must fall back to the payload base.sha itself rather than silently
+// guessing a different base.
 func TestResolveMergedPRBase_FastForwardMerge_BaseSHANotFetchable(t *testing.T) {
 	f := buildMergedPRFixture(t)
 	runGitCmd(t, f.dir, "checkout", f.ffHead)

--- a/pkg/ci/providers/github/base_test.go
+++ b/pkg/ci/providers/github/base_test.go
@@ -682,20 +682,33 @@ func TestResolveBase_PullRequest_OpenSync_NoHeadInPayload(t *testing.T) {
 
 // TestExtractPRMerged tests the extractPRMerged helper function.
 func TestExtractPRMerged(t *testing.T) {
-	t.Run("merged true", func(t *testing.T) {
-		payload := map[string]any{"pull_request": map[string]any{"merged": true}}
-		assert.True(t, extractPRMerged(payload))
-	})
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    bool
+	}{
+		{
+			name:    "merged true",
+			payload: map[string]any{"pull_request": map[string]any{"merged": true}},
+			want:    true,
+		},
+		{
+			name:    "merged false",
+			payload: map[string]any{"pull_request": map[string]any{"merged": false}},
+			want:    false,
+		},
+		{
+			name:    "missing pull_request key",
+			payload: map[string]any{"action": "closed"},
+			want:    false, // no pull_request key must not be treated as merged.
+		},
+	}
 
-	t.Run("merged false", func(t *testing.T) {
-		payload := map[string]any{"pull_request": map[string]any{"merged": false}}
-		assert.False(t, extractPRMerged(payload))
-	})
-
-	t.Run("missing pull_request key", func(t *testing.T) {
-		payload := map[string]any{"action": "closed"}
-		assert.False(t, extractPRMerged(payload), "no pull_request key must not be treated as merged")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractPRMerged(tt.payload))
+		})
+	}
 }
 
 // writeEventPayload writes a JSON event payload to a temp file and returns the path.

--- a/pkg/ci/providers/github/base_test.go
+++ b/pkg/ci/providers/github/base_test.go
@@ -680,6 +680,24 @@ func TestResolveBase_PullRequest_OpenSync_NoHeadInPayload(t *testing.T) {
 	assert.Empty(t, res.HeadSHA, "should be empty when pull_request.head.sha is missing from payload")
 }
 
+// TestExtractPRMerged tests the extractPRMerged helper function.
+func TestExtractPRMerged(t *testing.T) {
+	t.Run("merged true", func(t *testing.T) {
+		payload := map[string]any{"pull_request": map[string]any{"merged": true}}
+		assert.True(t, extractPRMerged(payload))
+	})
+
+	t.Run("merged false", func(t *testing.T) {
+		payload := map[string]any{"pull_request": map[string]any{"merged": false}}
+		assert.False(t, extractPRMerged(payload))
+	})
+
+	t.Run("missing pull_request key", func(t *testing.T) {
+		payload := map[string]any{"action": "closed"}
+		assert.False(t, extractPRMerged(payload), "no pull_request key must not be treated as merged")
+	})
+}
+
 // writeEventPayload writes a JSON event payload to a temp file and returns the path.
 func writeEventPayload(t *testing.T, payload map[string]any) string {
 	t.Helper()

--- a/pkg/git/commit.go
+++ b/pkg/git/commit.go
@@ -1,0 +1,134 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	log "github.com/cloudposse/atmos/pkg/logger"
+	"github.com/cloudposse/atmos/pkg/perf"
+)
+
+// ErrCommitHasNoParents is returned when a commit has no parents (initial commit),
+// so a first-parent lookup is impossible.
+var ErrCommitHasNoParents = fmt.Errorf("commit has no parents")
+
+// ErrInvalidCommitSHA indicates a string is not a plausible hex commit SHA.
+var ErrInvalidCommitSHA = fmt.Errorf("invalid commit SHA")
+
+// shaPattern matches a full or abbreviated hex commit SHA. Used to validate
+// SHAs before passing them to the git CLI (defense against argument injection).
+var shaPattern = regexp.MustCompile(`^[0-9a-fA-F]{4,64}$`)
+
+// openRepo opens the repository containing repoDir, tolerating worktrees.
+func openRepo(repoDir string) (*gogit.Repository, error) {
+	repo, err := gogit.PlainOpenWithOptions(repoDir, &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("opening local repo: %w", err)
+	}
+	return repo, nil
+}
+
+// resolveCommit resolves a revision ("HEAD" or a commit SHA) to a commit object.
+func resolveCommit(repo *gogit.Repository, revision string) (*object.Commit, error) {
+	hash, err := repo.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		return nil, fmt.Errorf("resolving revision %q: %w", revision, err)
+	}
+	commit, err := repo.CommitObject(*hash)
+	if err != nil {
+		return nil, fmt.Errorf("getting commit %s: %w", hash, err)
+	}
+	return commit, nil
+}
+
+// CommitParents resolves a revision ("HEAD" or a commit SHA) in the repository
+// at repoDir and returns its full SHA together with the SHAs of its parents
+// (in order — index 0 is the first parent). An initial commit returns an empty
+// parents slice with a nil error; a revision that cannot be resolved locally
+// returns an error.
+func CommitParents(repoDir, revision string) (string, []string, error) {
+	defer perf.Track(nil, "git.CommitParents")()
+
+	repo, err := openRepo(repoDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	commit, err := resolveCommit(repo, revision)
+	if err != nil {
+		return "", nil, err
+	}
+
+	parents := make([]string, 0, commit.NumParents())
+	for _, parentHash := range commit.ParentHashes {
+		parents = append(parents, parentHash.String())
+	}
+
+	return commit.Hash.String(), parents, nil
+}
+
+// MergeBaseSHAs computes the merge-base (common ancestor) of two revisions
+// ("HEAD" or commit SHAs) in the repository at repoDir. Unlike MergeBase, it
+// does not require either side to be a remote-tracking branch ref, so it can
+// anchor on payload-provided commits (e.g., a merged PR's merge commit parent)
+// instead of the moving tip of a branch.
+func MergeBaseSHAs(repoDir, revA, revB string) (string, error) {
+	defer perf.Track(nil, "git.MergeBaseSHAs")()
+
+	repo, err := openRepo(repoDir)
+	if err != nil {
+		return "", err
+	}
+
+	commitA, err := resolveCommit(repo, revA)
+	if err != nil {
+		return "", err
+	}
+	commitB, err := resolveCommit(repo, revB)
+	if err != nil {
+		return "", err
+	}
+
+	bases, err := commitA.MergeBase(commitB)
+	if err != nil {
+		return "", fmt.Errorf("computing merge-base: %w", err)
+	}
+	if len(bases) == 0 {
+		return "", ErrNoCommonAncestor
+	}
+
+	return bases[0].Hash.String(), nil
+}
+
+// FetchCommit fetches a single commit (and its reachable history, subject to
+// the clone's shallow boundary) from the "origin" remote by SHA. GitHub and
+// other major forges allow fetching arbitrary reachable SHAs. Used to
+// materialize payload-provided commits (e.g., a merged PR's merge commit)
+// that a narrow head-SHA checkout did not fetch.
+func FetchCommit(repoDir, sha string) error {
+	defer perf.Track(nil, "git.FetchCommit")()
+
+	if !shaPattern.MatchString(sha) {
+		return fmt.Errorf("%w: %q", ErrInvalidCommitSHA, sha)
+	}
+
+	cmd := exec.Command("git", "fetch", "origin", sha, "--no-tags")
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w\n%s", errUtils.ErrFetchOrigin, sha, err, string(output))
+	}
+
+	log.Debug("Fetched commit from origin", "sha", sha)
+
+	return nil
+}

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -61,6 +61,26 @@ func TestCommitParents(t *testing.T) {
 		_, _, err := CommitParents(dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 		assert.Error(t, err)
 	})
+
+	// NOTE: resolveCommit's CommitObject-fails-after-ResolveRevision-succeeds
+	// branch (the "getting commit %s" error) is not covered by a test: go-git's
+	// ResolveRevision already validates the target is commit-ish internally —
+	// resolving a tree object's hex SHA (verified experimentally) fails at
+	// ResolveRevision itself with "reference not found", never reaching
+	// CommitObject. That branch is unreachable via any real revision string
+	// without corrupting the local object store, so it is intentionally left
+	// untested (defensive code, not a gap in real-world coverage).
+}
+
+// TestCommitParents_OpenRepoFails verifies that CommitParents surfaces a
+// wrapped error (rather than panicking or silently succeeding) when repoDir
+// is not inside any git repository.
+func TestCommitParents_OpenRepoFails(t *testing.T) {
+	dir := t.TempDir() // No `git init` — not a repository.
+
+	_, _, err := CommitParents(dir, "HEAD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening local repo")
 }
 
 func TestMergeBaseSHAs(t *testing.T) {
@@ -90,6 +110,35 @@ func TestMergeBaseSHAs(t *testing.T) {
 		_, err := MergeBaseSHAs(dir, featureSHA, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 		assert.Error(t, err)
 	})
+
+	// Distinct from the revB case above: revA is the one that fails to resolve.
+	t.Run("unresolvable revA errors", func(t *testing.T) {
+		_, err := MergeBaseSHAs(dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", featureSHA)
+		assert.Error(t, err)
+	})
+
+	// Two orphan histories in the same repo are each individually resolvable
+	// but share no common ancestor — MergeBase succeeds without error yet
+	// returns zero results, which MergeBaseSHAs must turn into ErrNoCommonAncestor
+	// rather than an empty-but-successful SHA.
+	t.Run("no common ancestor", func(t *testing.T) {
+		runGit(t, dir, "checkout", "--orphan", "unrelated")
+		runGit(t, dir, "rm", "-rf", ".")
+		unrelatedSHA := commitTestFile(t, dir, "u.txt", "u", "unrelated orphan commit")
+
+		_, err := MergeBaseSHAs(dir, unrelatedSHA, mainSHA)
+		require.ErrorIs(t, err, ErrNoCommonAncestor)
+	})
+}
+
+// TestMergeBaseSHAs_OpenRepoFails verifies that MergeBaseSHAs surfaces a
+// wrapped error when repoDir is not inside any git repository.
+func TestMergeBaseSHAs_OpenRepoFails(t *testing.T) {
+	dir := t.TempDir() // No `git init` — not a repository.
+
+	_, err := MergeBaseSHAs(dir, "HEAD", "HEAD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening local repo")
 }
 
 // gitObjectExists reports whether sha resolves to a commit object already

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -91,10 +92,19 @@ func TestMergeBaseSHAs(t *testing.T) {
 	})
 }
 
+// gitObjectExists reports whether sha resolves to a commit object already
+// present in dir's local object database (loose or packed), without requiring
+// any ref to point at it.
+func gitObjectExists(dir, sha string) bool {
+	cmd := exec.Command("git", gitTestArgs("cat-file", "-e", sha+"^{commit}")...)
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}
+
 func TestFetchCommit(t *testing.T) {
 	originDir := t.TempDir()
 	runGit(t, originDir, "init", "-b", "main")
-	originSHA := commitTestFile(t, originDir, "a.txt", "a", "origin commit")
+	commitTestFile(t, originDir, "a.txt", "a", "origin initial commit")
 	// Local path remotes reject want-by-SHA unless explicitly allowed —
 	// hosted forges (GitHub et al.) allow reachable SHAs.
 	runGit(t, originDir, "config", "uploadpack.allowAnySHA1InWant", "true")
@@ -103,8 +113,22 @@ func TestFetchCommit(t *testing.T) {
 	runGit(t, cloneDir, "clone", originDir, ".")
 
 	t.Run("fetches an existing commit by SHA", func(t *testing.T) {
-		err := FetchCommit(cloneDir, originSHA)
+		// Commit the target object on origin AFTER cloneDir already exists, so the
+		// clone genuinely lacks it — exercising the real "narrow checkout missing
+		// an object" recovery path FetchCommit exists for. Committing it before the
+		// clone (as the original version of this test did) would make the clone
+		// already contain the object, so the assertion would pass even if
+		// FetchCommit were a no-op.
+		targetSHA := commitTestFile(t, originDir, "b.txt", "b", "origin commit added after clone")
+
+		require.False(t, gitObjectExists(cloneDir, targetSHA),
+			"target commit must be missing from the clone before FetchCommit for this test to be meaningful")
+
+		err := FetchCommit(cloneDir, targetSHA)
 		assert.NoError(t, err)
+
+		assert.True(t, gitObjectExists(cloneDir, targetSHA),
+			"target commit should be resolvable in the clone after FetchCommit")
 	})
 
 	t.Run("rejects a malformed SHA before invoking git", func(t *testing.T) {

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -1,0 +1,119 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// commitTestFile writes a file and commits it via the git CLI, returning the SHA.
+func commitTestFile(t *testing.T, dir, name, content, msg string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	runGit(t, dir, "add", name)
+	runGit(t, dir, "commit", "-m", msg)
+	return strings.TrimSpace(runGitOutput(t, dir, "rev-parse", "HEAD"))
+}
+
+func TestCommitParents(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+
+	initial := commitTestFile(t, dir, "a.txt", "a", "initial")
+	second := commitTestFile(t, dir, "b.txt", "b", "second")
+
+	t.Run("initial commit has no parents and no error", func(t *testing.T) {
+		sha, parents, err := CommitParents(dir, initial)
+		require.NoError(t, err)
+		assert.Equal(t, initial, sha)
+		assert.Empty(t, parents, "an initial commit is valid — empty parents, nil error")
+	})
+
+	t.Run("HEAD resolves with its parent", func(t *testing.T) {
+		sha, parents, err := CommitParents(dir, "HEAD")
+		require.NoError(t, err)
+		assert.Equal(t, second, sha)
+		require.Len(t, parents, 1)
+		assert.Equal(t, initial, parents[0])
+	})
+
+	t.Run("merge commit has two parents in order", func(t *testing.T) {
+		runGit(t, dir, "checkout", "-b", "feature", initial)
+		featureSHA := commitTestFile(t, dir, "c.txt", "c", "feature commit")
+		runGit(t, dir, "checkout", "main")
+		runGit(t, dir, "merge", "--no-ff", featureSHA, "-m", "merge feature")
+		mergeSHA := strings.TrimSpace(runGitOutput(t, dir, "rev-parse", "HEAD"))
+
+		sha, parents, err := CommitParents(dir, mergeSHA)
+		require.NoError(t, err)
+		assert.Equal(t, mergeSHA, sha)
+		require.Len(t, parents, 2)
+		assert.Equal(t, second, parents[0], "first parent is the pre-merge target tip")
+		assert.Equal(t, featureSHA, parents[1], "second parent is the merged branch head")
+	})
+
+	t.Run("unresolvable revision errors", func(t *testing.T) {
+		_, _, err := CommitParents(dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		assert.Error(t, err)
+	})
+}
+
+func TestMergeBaseSHAs(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+
+	forkPoint := commitTestFile(t, dir, "a.txt", "a", "fork point")
+	runGit(t, dir, "checkout", "-b", "feature")
+	featureSHA := commitTestFile(t, dir, "f.txt", "f", "feature commit")
+	runGit(t, dir, "checkout", "main")
+	mainSHA := commitTestFile(t, dir, "m.txt", "m", "main moved forward")
+
+	t.Run("finds fork point between two SHAs", func(t *testing.T) {
+		sha, err := MergeBaseSHAs(dir, featureSHA, mainSHA)
+		require.NoError(t, err)
+		assert.Equal(t, forkPoint, sha)
+	})
+
+	t.Run("accepts HEAD as a revision", func(t *testing.T) {
+		// HEAD is on main.
+		sha, err := MergeBaseSHAs(dir, "HEAD", featureSHA)
+		require.NoError(t, err)
+		assert.Equal(t, forkPoint, sha)
+	})
+
+	t.Run("unresolvable revision errors", func(t *testing.T) {
+		_, err := MergeBaseSHAs(dir, featureSHA, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		assert.Error(t, err)
+	})
+}
+
+func TestFetchCommit(t *testing.T) {
+	originDir := t.TempDir()
+	runGit(t, originDir, "init", "-b", "main")
+	originSHA := commitTestFile(t, originDir, "a.txt", "a", "origin commit")
+	// Local path remotes reject want-by-SHA unless explicitly allowed —
+	// hosted forges (GitHub et al.) allow reachable SHAs.
+	runGit(t, originDir, "config", "uploadpack.allowAnySHA1InWant", "true")
+
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", originDir, ".")
+
+	t.Run("fetches an existing commit by SHA", func(t *testing.T) {
+		err := FetchCommit(cloneDir, originSHA)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects a malformed SHA before invoking git", func(t *testing.T) {
+		err := FetchCommit(cloneDir, "not-a-sha; rm -rf /")
+		assert.ErrorIs(t, err, ErrInvalidCommitSHA)
+	})
+
+	t.Run("errors on an unknown commit", func(t *testing.T) {
+		err := FetchCommit(cloneDir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		assert.Error(t, err)
+	})
+}

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -32,7 +32,8 @@ The deprecated `--ref` and `--sha` flags are still supported for backward compat
 
 :::tip Zero-Config CI
 When `ci.enabled` is `true` in `atmos.yaml`, the base commit is automatically resolved from the CI environment:
-- **Pull requests**: Compares against the **fork point** of the PR branch (`git merge-base HEAD origin/<target>`). This works correctly even when the PR is out of date with the target branch — only commits the PR introduced are reported as affected, never commits that landed on `<target>` after the PR was forked. In shallow CI checkouts (`actions/checkout@v6` defaults to `fetch-depth: 1`), Atmos transparently fetches the target branch on demand.
+- **Open pull requests**: Compares against the **fork point** of the PR branch (`git merge-base HEAD origin/<target>`). This works correctly even when the PR is out of date with the target branch — only commits the PR introduced are reported as affected, never commits that landed on `<target>` after the PR was forked. In shallow CI checkouts (`actions/checkout@v6` defaults to `fetch-depth: 1`), Atmos transparently fetches the target branch on demand.
+- **Merged pull requests**: Atmos first classifies which commit the workflow checked out (the PR head, the merge commit, or GitHub's synthetic `refs/pull/<n>/merge` test merge) and picks the strategy that yields the PR's **net** change for that checkout — anchored on `pull_request.merge_commit_sha` from the event payload, never on the moving tip of `<target>` (which already contains the merge). This keeps multi-commit PRs correct: a final commit that reverts an earlier one contributes nothing to the diff.
 - **Push events**: Compares against the previous commit
 - **Merge groups**: Compares against the merge queue base
 
@@ -140,13 +141,25 @@ resolution logic.
 
 | Event | Base Resolution |
 |-------|----------------|
-| `pull_request` (opened/synchronize) | `git merge-base(HEAD, origin/<target>)` — fork point. Falls back to `event.pull_request.base.sha` if merge-base is unavailable. |
-| `pull_request` (closed/merged) | `git merge-base`, then `HEAD~1` for merge-commit checkouts |
+| `pull_request` (opened/synchronize, or closed without merging) | `git merge-base(HEAD, origin/<target>)` — fork point. Falls back to `event.pull_request.base.sha` if merge-base is unavailable. |
+| `pull_request` (closed and merged) | Checkout-classified (see below) — anchored on `event.pull_request.merge_commit_sha`, never on the moving tip of `<target>` |
 | `push` | Previous HEAD from event payload (`before`) |
 | `push` (force-push) | Parent of current commit (`HEAD~1`) |
-| `merge_group` | Target branch (`GITHUB_BASE_REF`) |
+| `merge_group` | Merge queue base (`event.merge_group.base_sha`) |
 
-The `pull_request` strategy uses `git merge-base` as the gold standard. When the local repository is a shallow checkout (the default for `actions/checkout@v6`), Atmos automatically runs a targeted `git fetch origin <target>` and retries — you do not need to set `fetch-depth: 0` on your checkout step. If even the auto-fetch fails (offline runner, deeply orphaned history), Atmos falls back to `event.pull_request.base.sha` from the event payload, which is at worst stale by however many commits have landed on `<target>` since the PR was last synced.
+The open-PR strategy uses `git merge-base` as the gold standard. When the local repository is a shallow checkout (the default for `actions/checkout@v6`), Atmos automatically runs a targeted `git fetch origin <target>` and retries — you do not need to set `fetch-depth: 0` on your checkout step. If even the auto-fetch fails (offline runner, deeply orphaned history), Atmos falls back to `event.pull_request.base.sha` from the event payload, which is at worst stale by however many commits have landed on `<target>` since the PR was last synced.
+
+**Merged pull requests** cannot compare against `origin/<target>` — after the merge, the target branch already contains the PR, so that comparison degenerates. Instead, Atmos classifies which commit the workflow actually checked out and resolves the base that yields the PR's **net** change for that checkout:
+
+| Checked-out commit | Base |
+|--------------------|------|
+| The PR head (`pull_request.head.sha`) | `merge-base(HEAD, merge_commit_sha^1)` — the true fork point, correct for merge, squash, and rebase strategies |
+| The PR head, fast-forward merge (`merge_commit_sha` equals `head.sha`) | `merge-base(HEAD, base.sha)` — the fork point via the payload's pre-merge target commit |
+| The merge commit (`pull_request.merge_commit_sha`) | Its first parent — the pre-merge target tip |
+| GitHub's synthetic `refs/pull/<n>/merge` test merge | Its first parent — the target tip the merge was built on |
+| Anything else | `event.pull_request.base.sha`, with a warning |
+
+The classification is included in the `Auto-detected CI base` log line (`checkout=head.sha|merge-commit|synthetic-merge|unknown`), so an unexpected affected set can be diagnosed from a single log line.
 
 **Example workflow** — no `--ref` or `--sha` needed:
 

--- a/website/docs/cli/commands/describe/describe-affected.mdx
+++ b/website/docs/cli/commands/describe/describe-affected.mdx
@@ -33,7 +33,7 @@ The deprecated `--ref` and `--sha` flags are still supported for backward compat
 :::tip Zero-Config CI
 When `ci.enabled` is `true` in `atmos.yaml`, the base commit is automatically resolved from the CI environment:
 - **Open pull requests**: Compares against the **fork point** of the PR branch (`git merge-base HEAD origin/<target>`). This works correctly even when the PR is out of date with the target branch — only commits the PR introduced are reported as affected, never commits that landed on `<target>` after the PR was forked. In shallow CI checkouts (`actions/checkout@v6` defaults to `fetch-depth: 1`), Atmos transparently fetches the target branch on demand.
-- **Merged pull requests**: Atmos first classifies which commit the workflow checked out (the PR head, the merge commit, or GitHub's synthetic `refs/pull/<n>/merge` test merge) and picks the strategy that yields the PR's **net** change for that checkout — anchored on `pull_request.merge_commit_sha` from the event payload, never on the moving tip of `<target>` (which already contains the merge). This keeps multi-commit PRs correct: a final commit that reverts an earlier one contributes nothing to the diff.
+- **Merged pull requests**: Atmos first classifies which commit the workflow checked out (the PR head, the merge commit, or GitHub's synthetic `refs/pull/<n>/merge` test merge) and picks the strategy that yields the PR's **net** change for that checkout — anchored on `pull_request.merge_commit_sha` from the event payload, never on the moving tip of `<target>` (which already contains the merge). For fast-forward merges (`merge_commit_sha` equals `head.sha`), it anchors on `pull_request.base.sha` instead, since the merge commit's own parent would otherwise be the PR's own previous commit. This keeps multi-commit PRs correct: a final commit that reverts an earlier one contributes nothing to the diff.
 - **Push events**: Compares against the previous commit
 - **Merge groups**: Compares against the merge queue base
 
@@ -142,7 +142,7 @@ resolution logic.
 | Event | Base Resolution |
 |-------|----------------|
 | `pull_request` (opened/synchronize, or closed without merging) | `git merge-base(HEAD, origin/<target>)` — fork point. Falls back to `event.pull_request.base.sha` if merge-base is unavailable. |
-| `pull_request` (closed and merged) | Checkout-classified (see below) — anchored on `event.pull_request.merge_commit_sha`, never on the moving tip of `<target>` |
+| `pull_request` (closed and merged) | Checkout-classified (see below) — anchored on `event.pull_request.merge_commit_sha`, or on `event.pull_request.base.sha` for fast-forward merges, never on the moving tip of `<target>` |
 | `push` | Previous HEAD from event payload (`before`) |
 | `push` (force-push) | Parent of current commit (`HEAD~1`) |
 | `merge_group` | Merge queue base (`event.merge_group.base_sha`) |


### PR DESCRIPTION
## what

- Fix `describe affected` CI base auto-detection resolving a wrong base commit for **merged** pull requests: merged PRs now classify what the workflow actually checked out (PR head, merge commit, or synthetic `refs/pull/<n>/merge`) and anchor the base on event-payload facts (`merge_commit_sha^1`, or `base.sha` for fast-forward merges where `merge_commit_sha == head.sha`), instead of the old `merge-base(HEAD, origin/<target>)` → `HEAD~1` chain that degenerates after the merge.
- Fix `describe affected` mis-computing BASE worktree paths when the repository lives under a symlinked path (e.g. macOS `/tmp`): symlink-normalize both sides of the path re-basing, and hard-error (instead of silently guessing) when a config path cannot be represented inside the BASE checkout.
- Add the checkout classification to the `Auto-detected CI base` log line (`checkout=head.sha|merge-commit|synthetic-merge|unknown`) so wrong-base reports are diagnosable from a single line.
- New `pkg/git` helpers (`CommitParents`, `MergeBaseSHAs`, `FetchCommit`), red-first regression tests for every checkout × merge-strategy combination (merge, squash, fast-forward, queue-merged, synthetic, unknown, closed-unmerged), and a new end-to-end test covering base auto-detection through the full affected computation.
- Update the `describe affected` CLI docs and the native-CI base-resolution PRD to match; add fix-log entries under `docs/fixes/`.

## why

- On a `pull_request closed (merged)` event with the PR head checked out (the documented workflow), `merge-base(HEAD, origin/<target>)` collapses to HEAD (the head is now an ancestor of the target) and the `HEAD~1` fallback diffs only the PR's **final** commit. A multi-commit PR whose last commit reverts an earlier org-wide change then reports **every component as affected** and dispatches a wall of post-merge plan/apply runs; conversely, changes in earlier commits could be silently missed. Observed in production with the zero-config setup.
- Fast-forward/externally-merged PRs (`merge_commit_sha == head.sha`) would hit the same last-commit-only failure through the new anchor, so they get a dedicated payload-`base.sha` anchor — caught in an adversarial field-test pass before release.
- Under a symlinked repo path, `filepath.Rel` mixed git's symlink-resolved repo root with logical CWD-derived config paths, producing an escaping path that — depending on filesystem depth — either scanned a nonexistent BASE (greenfield fallback → everything affected) or clamped back onto the HEAD repo (BASE == HEAD → nothing affected). Both failure modes were silent.
- Every strategy in the old fallback chain was only correct under an *assumed* checkout that nothing verified; classifying the actual checkout makes the strategy selection provably correct per case and loud when it can't be.

## references

- `docs/fixes/2026-08-27-describe-affected-merged-pr-base-resolution.md`
- `docs/fixes/2026-08-27-describe-affected-symlink-base-path-mangling.md`
- `docs/prd/native-ci/framework/base-resolution.md` (updated resolution matrix)
- Builds on the base-resolution self-healing from #2380 and zero-config CI detection from #2241

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `atmos describe affected` accuracy for merged pull requests and varied checkout strategies.
  - Fixed affected-component detection for repositories accessed through symlinked paths.
  - Added safeguards for configuration paths outside the repository worktree.
  - Improved CI base-resolution diagnostics by identifying the detected checkout type.

- **Documentation**
  - Updated CI auto-detection guidance for merged pull requests and merge groups.

- **Tests**
  - Added end-to-end and regression coverage for merged-PR base resolution and symlinked repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->