### PR TITLE
fix: implement MarshalYAML on Condition to make sure it survives marshalling roundtrip

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -163,6 +163,19 @@ func (c Condition) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.node.value())
 }
 
+// MarshalYAML preserves conditions when manifests (e.g. scaffold project
+// records) are marshaled back to YAML, reconstructing the original
+// string/list/map form. Condition's only field (`node`) is unexported, so
+// yaml.v3 has nothing to reflect without this method.
+//
+//nolint:lintroller // This package cannot import perf because schema aliases condition.
+func (c Condition) MarshalYAML() (any, error) {
+	if c.node == nil {
+		return nil, nil
+	}
+	return c.node.value(), nil
+}
+
 // UnmarshalJSON supports JSON config files and internal command cloning.
 //
 //nolint:lintroller // This package cannot import perf because schema aliases condition.

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -604,6 +604,70 @@ func TestConditionJSONEmptyRoundTrip(t *testing.T) {
 	assert.True(t, decoded.IsZero())
 }
 
+// TestConditionYAMLMarshalRoundTrip verifies a Condition survives being
+// marshaled to YAML and decoded back, evaluating identically to the
+// original. The marshaled shape mirrors Condition.MarshalJSON's node.value()
+// reconstruction (a bare CEL string always canonicalizes to the
+// "!cel <expr>" form) -- the same normalization cloneCommand
+// (cmd/cmd_utils.go) relies on when it JSON round-trips a custom command's
+// Task.When on every invocation.
+func TestConditionYAMLMarshalRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		original Condition
+		want     any
+	}{
+		{"predicate", Must("ci"), "ci"},
+		{"cel", Must("answers.topology == 'multi'"), "!cel answers.topology == 'multi'"},
+		{"all", Must([]any{"ci", "success"}), map[string]any{"all": []any{"ci", "success"}}},
+		{
+			"any/not",
+			Must(map[string]any{"any": []any{"ci", map[string]any{"not": "failure"}}}),
+			map[string]any{"any": []any{"ci", map[string]any{"not": "failure"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(conditionConfig{When: tt.original})
+			require.NoError(t, err)
+
+			var generic struct {
+				When any `yaml:"when"`
+			}
+			require.NoError(t, yaml.Unmarshal(data, &generic))
+			assert.Equal(t, tt.want, generic.When)
+
+			var decoded conditionConfig
+			require.NoError(t, yaml.Unmarshal(data, &decoded))
+
+			// The decoded condition must evaluate identically to the original
+			// across representative facts, proving the round trip is lossless.
+			for _, ctx := range []Context{
+				{CI: true, Status: PredicateSuccess, Answers: map[string]any{"topology": "multi"}},
+				{CI: false, Status: PredicateFailure, Answers: map[string]any{"topology": "single"}},
+			} {
+				assert.Equal(t, tt.original.Evaluate(ctx), decoded.When.Evaluate(ctx))
+			}
+		})
+	}
+}
+
+func TestConditionYAMLEmptyMarshalRoundTrip(t *testing.T) {
+	data, err := yaml.Marshal(conditionConfig{})
+	require.NoError(t, err)
+
+	var generic struct {
+		When any `yaml:"when"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &generic))
+	assert.Nil(t, generic.When)
+
+	var decoded conditionConfig
+	require.NoError(t, yaml.Unmarshal(data, &decoded))
+	assert.True(t, decoded.When.IsZero())
+}
+
 func TestConditionJSONRejectsMalformedInput(t *testing.T) {
 	var decoded Condition
 	require.Error(t, json.Unmarshal([]byte("{"), &decoded))

--- a/pkg/project/config/config_baseref_test.go
+++ b/pkg/project/config/config_baseref_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudposse/atmos/pkg/condition"
 	"github.com/cloudposse/atmos/pkg/manifest"
 )
 
@@ -64,6 +65,45 @@ func TestSaveAndLoadProjectRecordWithBaseRef(t *testing.T) {
 	require.Len(t, record.Spec.Fields, 2)
 	assert.Equal(t, "project_name", record.Spec.Fields[0].Name)
 	assert.Equal(t, "aws_region", record.Spec.Fields[1].Name)
+}
+
+// TestSaveAndLoadProjectRecord_FieldWhenSurvivesRoundTrip verifies a
+// field-level `when:` CEL condition survives a full save/load round trip
+// through the project record (.atmos/scaffold.yaml), evaluating correctly
+// after reload. Fields mirror examples/scaffolding/scaffold.yaml's
+// enable_vendoring/vendor_version pair, the repo's existing example of a
+// field-level `when:`.
+func TestSaveAndLoadProjectRecord_FieldWhenSurvivesRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	template := &ScaffoldConfig{
+		APIVersion: manifest.DefaultAPIVersion,
+		Kind:       ScaffoldKind,
+		Metadata:   manifest.Metadata{Name: "whencheck"},
+		Spec: ScaffoldSpec{
+			Fields: []FieldDefinition{
+				{Name: "enable_vendoring", Type: "confirm", Default: true},
+				{
+					Name:    "vendor_version",
+					Type:    "input",
+					Default: "1.536.0",
+					When:    mustCondition(t, "answers.enable_vendoring == true"),
+				},
+			},
+		},
+	}
+
+	values := map[string]interface{}{"enable_vendoring": true}
+	require.NoError(t, SaveProjectRecord(tmpDir, template, "", "", values))
+
+	record, err := LoadProjectRecord(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Len(t, record.Spec.Fields, 2)
+
+	loadedWhen := record.Spec.Fields[1].When
+	assert.True(t, loadedWhen.Evaluate(condition.Context{Answers: map[string]any{"enable_vendoring": true}}))
+	assert.False(t, loadedWhen.Evaluate(condition.Context{Answers: map[string]any{"enable_vendoring": false}}))
 }
 
 func TestSaveProjectRecord_EmptyBaseRef(t *testing.T) {


### PR DESCRIPTION
## what

- Add `Condition.MarshalYAML()` to `pkg/condition/condition.go` so a `when:` condition survives being marshaled back to YAML.
- `pkg/condition/condition_test.go`: add `TestConditionYAMLMarshalRoundTrip` (predicate/CEL/all/any-not shapes) and `TestConditionYAMLEmptyMarshalRoundTrip`, asserting the marshaled-then-decoded value matches the expected shape and evaluates identically to the original across representative facts.
- `pkg/project/config/config_baseref_test.go`: add `TestSaveAndLoadProjectRecord_FieldWhenSurvivesRoundTrip`, exercising the real `SaveProjectRecord`/`LoadProjectRecord` path with a field-level `when:` condition (mirroring `examples/scaffolding/scaffold.yaml`'s `enable_vendoring`/`vendor_version` pair) and asserting the reloaded condition evaluates correctly.
- No change to `condition.Evaluate`, CEL compilation, or the JSON marshal/unmarshal paths — out of scope, and unaffected since the fix reuses the same `node.value()` reconstruction `MarshalJSON` already relies on.

## why

- `Condition`'s only field, `node *Node`, is unexported. `Condition` already implements `UnmarshalYAML`, `UnmarshalJSON`, and `MarshalJSON`, but had no `MarshalYAML`. Without one, `yaml.Marshal` falls back to reflecting the struct, sees zero exported fields, and writes `{}` — silently discarding the condition instead of erroring.
- This corrupted `atmos scaffold generate`'s project record (`.atmos/scaffold.yaml`): a `spec.fields[].when` CEL string (e.g. `"answers.topology == 'multi'"`) rendered correctly on first `generate`, but got written back as `when: {}`. Since `--update` re-reads that same record on every subsequent run, the project was permanently stuck failing schema validation (`expected string, but got object`) with no way to self-heal.
- `spec.files[].when` never showed the same symptom, but not because that path is correct — `SaveProjectRecord` never copies `templateConfig.Spec.Files` into the persisted record at all (only `Fields`, `Delimiters`, `Source`, `BaseRef`, `Values` are copied), so there's nothing there to corrupt. Verified this holds with a `matrix:`-expanded `files[]` entry too: generation succeeds, but `spec.files` is simply absent from the written record.
- The fix reconstructs the original string/list/map form via `node.value()` — the same method `MarshalJSON` already uses. This isn't new behavior: `cloneCommand` (`cmd/cmd_utils.go`) already JSON round-trips every custom command's `Task.When` through this exact normalization on every invocation, so a bare CEL string already canonicalizes to `!cel <expr>` there today. Extending it to `MarshalYAML` just makes YAML and JSON serialization consistent with each other.

## references

- n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved field-level YAML conditions when project records are saved and loaded.
  * Ensured predicate, CEL, compound, and empty conditions retain their values during YAML round trips.

* **Tests**
  * Added coverage confirming condition formatting and evaluation remain consistent after serialization and reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->