### PR TITLE
fix: close CodeQL High backlog, dedupe recurring alert patterns

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -896,7 +896,7 @@ var (
 	ErrComputeRelativePath = errors.New("failed to compute relative path")
 	ErrFileOperation       = errors.New("file operation failed")
 
-	// Archive extraction safety errors (pkg/archiveutil).
+	// Archive extraction safety errors (pkg/filesystem).
 	ErrArchiveEntryEscapesDest = errors.New("archive entry escapes destination directory")
 
 	// OCI/Container image errors.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -896,6 +896,9 @@ var (
 	ErrComputeRelativePath = errors.New("failed to compute relative path")
 	ErrFileOperation       = errors.New("file operation failed")
 
+	// Archive extraction safety errors (pkg/archiveutil).
+	ErrArchiveEntryEscapesDest = errors.New("archive entry escapes destination directory")
+
 	// OCI/Container image errors.
 	ErrCreateTempDirectory   = ErrCreateTempDir // Alias to avoid duplicate sentinels
 	ErrInvalidImageReference = errors.New("invalid image reference")

--- a/pkg/archiveutil/safejoin.go
+++ b/pkg/archiveutil/safejoin.go
@@ -1,0 +1,64 @@
+// Package archiveutil provides shared safety helpers for extracting archive
+// entries (zip, tar) to the filesystem. It is intentionally a leaf package
+// (depending only on errors/perf) so every archive-extracting package in the
+// module -- including pkg/oci, which pkg/archive transitively depends on via
+// pkg/downloader -- can import it without an import cycle.
+package archiveutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/perf"
+)
+
+// SafeJoin resolves an archive entry name against destDir and returns the
+// resulting filesystem path, rejecting any entry that would let extraction
+// write outside destDir (a "Zip Slip" path-traversal attempt via ".."
+// components, an absolute path, or a Windows-style backslash path).
+//
+// Every archive-extraction call site in this repo (OCI artifact pulls,
+// toolchain package installs, CI cache restores, and the Playwright SAML
+// driver seed) delegates its containment check to this function so the
+// guard only needs to be reasoned about and fixed in one place.
+//
+// The GitHub PR artifact extractor in pkg/toolchain/pr_artifact.go
+// intentionally does NOT call this helper: its guards are duplicated inline,
+// directly adjacent to each filesystem sink, because CodeQL's go/zipslip
+// dataflow analysis only credits a containment check it can see immediately
+// next to the sink -- a check performed inside a function in another package
+// isn't reliably recognized as a sanitizer. That shape was arrived at
+// empirically closing alert #5230 and must not be refactored into a shared
+// call.
+func SafeJoin(destDir, entryName string) (string, error) {
+	defer perf.Track(nil, "archiveutil.SafeJoin")()
+
+	if filepath.IsAbs(entryName) || strings.HasPrefix(entryName, "/") || strings.HasPrefix(entryName, "\\") {
+		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
+	}
+	if strings.Contains(entryName, "\\") {
+		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
+	}
+	for _, part := range strings.Split(filepath.ToSlash(entryName), "/") {
+		if part == ".." {
+			return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
+		}
+	}
+
+	cleanDestDir := filepath.Clean(destDir)
+	target := filepath.Join(cleanDestDir, filepath.FromSlash(entryName))
+
+	// Defense in depth: given the guards above (no absolute path, no backslash, no ".."
+	// component), Join+Clean of destDir with a purely relative, dot-dot-free entry name
+	// can never actually escape destDir, so this branch is unreachable in practice. It's
+	// kept anyway as a second, independent check in case a future edit weakens or
+	// reorders the guards above.
+	if target != cleanDestDir && !strings.HasPrefix(target, cleanDestDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
+	}
+
+	return target, nil
+}

--- a/pkg/archiveutil/safejoin_test.go
+++ b/pkg/archiveutil/safejoin_test.go
@@ -1,0 +1,81 @@
+package archiveutil
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+)
+
+func TestSafeJoin(t *testing.T) {
+	destDir := filepath.Join("root", "extract")
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantPath  string
+		wantErr   bool
+	}{
+		{
+			name:      "plain relative file",
+			entryName: "file.txt",
+			wantPath:  filepath.Join(destDir, "file.txt"),
+		},
+		{
+			name:      "nested relative file",
+			entryName: "a/b/c.txt",
+			wantPath:  filepath.Join(destDir, "a", "b", "c.txt"),
+		},
+		{
+			name:      "entry equal to dest dir",
+			entryName: ".",
+			wantPath:  destDir,
+		},
+		{
+			name:      "traversal component",
+			entryName: "../escape.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "nested traversal component",
+			entryName: "a/../../escape.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "traversal-prefixed sibling directory name",
+			entryName: "../extractEVIL/file.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "absolute path",
+			entryName: "/etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "backslash traversal",
+			entryName: "..\\escape.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "name that merely starts with dotdot",
+			entryName: "..hidden.txt",
+			wantPath:  filepath.Join(destDir, "..hidden.txt"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeJoin(destDir, tt.entryName)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, errUtils.ErrArchiveEntryEscapesDest))
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPath, got)
+		})
+	}
+}

--- a/pkg/auth/providers/aws/saml_driver_preseed.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed.go
@@ -23,7 +23,7 @@ import (
 	"github.com/playwright-community/playwright-go"
 
 	errUtils "github.com/cloudposse/atmos/errors"
-	"github.com/cloudposse/atmos/pkg/archiveutil"
+	"github.com/cloudposse/atmos/pkg/filesystem"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
@@ -344,7 +344,7 @@ func extractZipSingleEntry(archive []byte, entryName, destPath string) error {
 // safeDriverJoin joins an archive entry name onto the driver directory,
 // rejecting entries that would escape it.
 func safeDriverJoin(driverDir, entryName string) (string, error) {
-	diskPath, err := archiveutil.SafeJoin(driverDir, entryName)
+	diskPath, err := filesystem.SafeJoin(driverDir, entryName)
 	if err != nil {
 		return "", fmt.Errorf("%w: archive entry %q escapes the driver directory", errUtils.ErrPlaywrightDriverSeed, entryName)
 	}

--- a/pkg/auth/providers/aws/saml_driver_preseed.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed.go
@@ -23,6 +23,7 @@ import (
 	"github.com/playwright-community/playwright-go"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/archiveutil"
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
@@ -343,8 +344,8 @@ func extractZipSingleEntry(archive []byte, entryName, destPath string) error {
 // safeDriverJoin joins an archive entry name onto the driver directory,
 // rejecting entries that would escape it.
 func safeDriverJoin(driverDir, entryName string) (string, error) {
-	diskPath := filepath.Join(driverDir, filepath.FromSlash(entryName))
-	if !strings.HasPrefix(diskPath, filepath.Clean(driverDir)+string(os.PathSeparator)) {
+	diskPath, err := archiveutil.SafeJoin(driverDir, entryName)
+	if err != nil {
 		return "", fmt.Errorf("%w: archive entry %q escapes the driver directory", errUtils.ErrPlaywrightDriverSeed, entryName)
 	}
 	return diskPath, nil

--- a/pkg/auth/providers/aws/saml_driver_preseed.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed.go
@@ -141,12 +141,24 @@ func verifyNpmIntegrity(body []byte, integrity string) error {
 
 // extractNpmPackage extracts the regular files under the tarball's top-level
 // package/ directory into driverDir, preserving file modes.
+//
+// Writes go through an os.Root opened on driverDir rather than plain
+// os.MkdirAll/os.OpenFile: safeDriverJoin only validates the entry name
+// lexically, so without os.Root a pre-existing symlink inside driverDir
+// pointing outside it could let an entry's write escape driverDir -- os.Root's
+// methods refuse to resolve a path that escapes the root, symlinks included.
 func extractNpmPackage(tgz []byte, driverDir string) error {
 	gzReader, err := gzip.NewReader(bytes.NewReader(tgz))
 	if err != nil {
 		return fmt.Errorf("could not read playwright-core archive: %w", err)
 	}
 	defer gzReader.Close()
+
+	root, err := openPreseedRoot(driverDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
 
 	tarReader := tar.NewReader(gzReader)
 	extracted := false
@@ -163,11 +175,13 @@ func extractNpmPackage(tgz []byte, driverDir string) error {
 		if header.Typeflag != tar.TypeReg || !strings.HasPrefix(header.Name, "package/") {
 			continue
 		}
-		diskPath, err := safeDriverJoin(driverDir, header.Name)
-		if err != nil {
+		// safeDriverJoin's returned absolute path isn't used since writes go
+		// through root by relative name instead; only the validation matters here.
+		if _, err := safeDriverJoin(driverDir, header.Name); err != nil {
 			return err
 		}
-		if err := writePreseedFile(diskPath, tarReader, header.FileInfo().Mode()); err != nil {
+		relPath := filepath.FromSlash(header.Name)
+		if err := writePreseedFile(root, relPath, tarReader, header.FileInfo().Mode()); err != nil {
 			return err
 		}
 		extracted = true
@@ -218,10 +232,10 @@ func seedNodeBinary(driverDir string) error {
 	log.Debug("Seeding Playwright driver Node.js runtime", "archive", archiveName, "dir", driverDir)
 	if runtime.GOOS == windowsOS {
 		// The Windows archive is a zip with node.exe at "<archiveDir>/node.exe".
-		return extractZipSingleEntry(body, archiveDir+"/node.exe", nodePath)
+		return extractZipSingleEntry(body, archiveDir+"/node.exe", driverDir, nodeName)
 	}
 	// Unix archives are gzipped tars with the binary at "<archiveDir>/bin/node".
-	return extractTarGzSingleEntry(body, archiveDir+"/bin/node", nodePath)
+	return extractTarGzSingleEntry(body, archiveDir+"/bin/node", driverDir, nodeName)
 }
 
 // verifyNodeChecksum checks a nodejs.org archive against the release's
@@ -296,13 +310,19 @@ func hostUsesMuslLibc() bool {
 }
 
 // extractTarGzSingleEntry extracts one named entry from a gzipped tar into
-// destPath as an executable file.
-func extractTarGzSingleEntry(archive []byte, entryName, destPath string) error {
+// relDestPath (relative to driverDir) as an executable file.
+func extractTarGzSingleEntry(archive []byte, entryName, driverDir, relDestPath string) error {
 	gzReader, err := gzip.NewReader(bytes.NewReader(archive))
 	if err != nil {
 		return fmt.Errorf("could not read Node.js archive: %w", err)
 	}
 	defer gzReader.Close()
+
+	root, err := openPreseedRoot(driverDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
 
 	tarReader := tar.NewReader(gzReader)
 	for {
@@ -314,19 +334,26 @@ func extractTarGzSingleEntry(archive []byte, entryName, destPath string) error {
 			return fmt.Errorf("could not read Node.js archive: %w", err)
 		}
 		if header.Typeflag == tar.TypeReg && header.Name == entryName {
-			return writePreseedFile(destPath, tarReader, preseedFileMode)
+			return writePreseedFile(root, relDestPath, tarReader, preseedFileMode)
 		}
 	}
 	return fmt.Errorf("%w: entry %s not found in Node.js archive", errUtils.ErrPlaywrightDriverSeed, entryName)
 }
 
-// extractZipSingleEntry extracts one named entry from a zip into destPath as an
-// executable file.
-func extractZipSingleEntry(archive []byte, entryName, destPath string) error {
+// extractZipSingleEntry extracts one named entry from a zip into relDestPath
+// (relative to driverDir) as an executable file.
+func extractZipSingleEntry(archive []byte, entryName, driverDir, relDestPath string) error {
 	zipReader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	if err != nil {
 		return fmt.Errorf("could not read Node.js archive: %w", err)
 	}
+
+	root, err := openPreseedRoot(driverDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	for _, zipFile := range zipReader.File {
 		if zipFile.Name != entryName {
 			continue
@@ -336,9 +363,22 @@ func extractZipSingleEntry(archive []byte, entryName, destPath string) error {
 			return fmt.Errorf("could not open Node.js archive entry: %w", err)
 		}
 		defer file.Close()
-		return writePreseedFile(destPath, file, preseedFileMode)
+		return writePreseedFile(root, relDestPath, file, preseedFileMode)
 	}
 	return fmt.Errorf("%w: entry %s not found in Node.js archive", errUtils.ErrPlaywrightDriverSeed, entryName)
+}
+
+// openPreseedRoot creates driverDir if needed and opens it as an os.Root, so
+// writePreseedFile's writes cannot follow a symlink out of driverDir.
+func openPreseedRoot(driverDir string) (*os.Root, error) {
+	if err := os.MkdirAll(driverDir, preseedFileMode); err != nil {
+		return nil, fmt.Errorf("could not create driver directory: %w", err)
+	}
+	root, err := os.OpenRoot(driverDir)
+	if err != nil {
+		return nil, fmt.Errorf("could not open driver directory root: %w", err)
+	}
+	return root, nil
 }
 
 // safeDriverJoin joins an archive entry name onto the driver directory,
@@ -351,12 +391,13 @@ func safeDriverJoin(driverDir, entryName string) (string, error) {
 	return diskPath, nil
 }
 
-// writePreseedFile writes reader contents to path, creating parent directories.
-func writePreseedFile(path string, reader io.Reader, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), preseedFileMode); err != nil {
+// writePreseedFile writes reader contents to relPath within root, creating
+// parent directories.
+func writePreseedFile(root *os.Root, relPath string, reader io.Reader, mode os.FileMode) error {
+	if err := root.MkdirAll(filepath.Dir(relPath), preseedFileMode); err != nil {
 		return fmt.Errorf("could not create directory: %w", err)
 	}
-	outFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	outFile, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
 	if err != nil {
 		return fmt.Errorf("could not create file: %w", err)
 	}

--- a/pkg/auth/providers/aws/saml_driver_preseed_test.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed_test.go
@@ -480,6 +480,23 @@ func TestExtractTarGzSingleEntryFailures(t *testing.T) {
 	assert.Contains(t, err.Error(), "entry node/bin/node not found")
 }
 
+// TestExtractTarGzSingleEntryFailsWhenDriverDirUnreadable exercises
+// extractTarGzSingleEntry's openPreseedRoot error branch (and, through it,
+// openPreseedRoot's own os.OpenRoot error branch): a directory with no
+// permissions cannot be opened.
+func TestExtractTarGzSingleEntryFailsWhenDriverDirUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't apply the same way on Windows")
+	}
+	driverDir := t.TempDir()
+	require.NoError(t, os.Chmod(driverDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(driverDir, 0o755) })
+
+	err := extractTarGzSingleEntry(makeTgz(t, map[string]string{"node/bin/node": "x"}), "node/bin/node", driverDir, "node")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not open driver directory root")
+}
+
 func TestExtractZipSingleEntry(t *testing.T) {
 	driverDir := t.TempDir()
 	err := extractZipSingleEntry(makeZip(t, map[string]string{"node/node.exe": "zip node"}), "node/node.exe", driverDir, "node.exe")
@@ -496,6 +513,22 @@ func TestExtractZipSingleEntry(t *testing.T) {
 	err = extractZipSingleEntry([]byte("not a zip"), "node/node.exe", t.TempDir(), "bad.exe")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not read Node.js archive")
+}
+
+// TestExtractZipSingleEntryFailsWhenDriverDirUnreadable exercises
+// extractZipSingleEntry's openPreseedRoot error branch: a directory with no
+// permissions cannot be opened.
+func TestExtractZipSingleEntryFailsWhenDriverDirUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't apply the same way on Windows")
+	}
+	driverDir := t.TempDir()
+	require.NoError(t, os.Chmod(driverDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(driverDir, 0o755) })
+
+	err := extractZipSingleEntry(makeZip(t, map[string]string{"node/node.exe": "x"}), "node/node.exe", driverDir, "node.exe")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not open driver directory root")
 }
 
 func TestWritePreseedFileCopyError(t *testing.T) {

--- a/pkg/auth/providers/aws/saml_driver_preseed_test.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed_test.go
@@ -365,13 +365,40 @@ func TestExtractNpmPackageFailures(t *testing.T) {
 	}
 }
 
+// TestExtractNpmPackage_RejectsWriteThroughPreExistingSymlink is a
+// regression test for CWE-59 (symlink-following): safeDriverJoin only
+// validates an entry name lexically, so before extraction switched to
+// os.Root, a pre-existing symlink inside driverDir pointing outside it let a
+// plain-looking entry name like "package/link/evil.txt" escape driverDir via
+// os.MkdirAll/os.OpenFile following the symlink -- os.Root refuses to resolve
+// a path through a symlink that would leave the root.
+func TestExtractNpmPackage_RejectsWriteThroughPreExistingSymlink(t *testing.T) {
+	driverDir := t.TempDir()
+	outside := t.TempDir()
+	// Extracted entries live under "package/" (extractNpmPackage's own
+	// top-level-directory convention), so the symlink must sit there too.
+	require.NoError(t, os.MkdirAll(filepath.Join(driverDir, "package"), 0o755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(driverDir, "package", "link")))
+
+	body := makeTgz(t, map[string]string{"package/link/evil.txt": "escaped"})
+	err := extractNpmPackage(body, driverDir)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
+	assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+}
+
 func TestExtractNpmPackageWriteFailure(t *testing.T) {
 	driverDir := filepath.Join(t.TempDir(), "driver-file")
 	require.NoError(t, os.WriteFile(driverDir, []byte("not a directory"), 0o644))
 
+	// extractNpmPackage now creates/opens driverDir as an os.Root up front (for
+	// symlink-safe writes), so a driverDir that's actually a file fails there,
+	// earlier and more specifically than the old "could not create directory"
+	// error from deep inside writePreseedFile.
 	err := extractNpmPackage(makeTgz(t, map[string]string{"package/cli.js": "cli"}), driverDir)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not create directory")
+	assert.Contains(t, err.Error(), "could not create driver directory")
 }
 
 func TestSeedNodeBinaryShortCircuits(t *testing.T) {
@@ -437,48 +464,59 @@ func TestVerifyNodeChecksumDownloadFailure(t *testing.T) {
 }
 
 func TestExtractTarGzSingleEntryFailures(t *testing.T) {
-	destPath := filepath.Join(t.TempDir(), "node")
+	driverDir := t.TempDir()
 
-	err := extractTarGzSingleEntry([]byte("not a gzip"), "node/bin/node", destPath)
+	err := extractTarGzSingleEntry([]byte("not a gzip"), "node/bin/node", driverDir, "node")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not read Node.js archive")
 
-	err = extractTarGzSingleEntry(makeGzip(t, "not a tar stream"), "node/bin/node", destPath)
+	err = extractTarGzSingleEntry(makeGzip(t, "not a tar stream"), "node/bin/node", driverDir, "node")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not read Node.js archive")
 
-	err = extractTarGzSingleEntry(makeTgz(t, map[string]string{"other": "content"}), "node/bin/node", destPath)
+	err = extractTarGzSingleEntry(makeTgz(t, map[string]string{"other": "content"}), "node/bin/node", driverDir, "node")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrPlaywrightDriverSeed)
 	assert.Contains(t, err.Error(), "entry node/bin/node not found")
 }
 
 func TestExtractZipSingleEntry(t *testing.T) {
-	destPath := filepath.Join(t.TempDir(), "node.exe")
-	err := extractZipSingleEntry(makeZip(t, map[string]string{"node/node.exe": "zip node"}), "node/node.exe", destPath)
+	driverDir := t.TempDir()
+	err := extractZipSingleEntry(makeZip(t, map[string]string{"node/node.exe": "zip node"}), "node/node.exe", driverDir, "node.exe")
 	require.NoError(t, err)
-	body, err := os.ReadFile(destPath)
+	body, err := os.ReadFile(filepath.Join(driverDir, "node.exe"))
 	require.NoError(t, err)
 	assert.Equal(t, "zip node", string(body))
 
-	err = extractZipSingleEntry(makeZip(t, map[string]string{"other": "content"}), "node/node.exe", filepath.Join(t.TempDir(), "missing.exe"))
+	err = extractZipSingleEntry(makeZip(t, map[string]string{"other": "content"}), "node/node.exe", t.TempDir(), "missing.exe")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrPlaywrightDriverSeed)
 	assert.Contains(t, err.Error(), "entry node/node.exe not found")
 
-	err = extractZipSingleEntry([]byte("not a zip"), "node/node.exe", filepath.Join(t.TempDir(), "bad.exe"))
+	err = extractZipSingleEntry([]byte("not a zip"), "node/node.exe", t.TempDir(), "bad.exe")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not read Node.js archive")
 }
 
 func TestWritePreseedFileCopyError(t *testing.T) {
-	err := writePreseedFile(filepath.Join(t.TempDir(), "node"), errorReader{}, preseedFileMode)
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	defer root.Close()
+
+	err = writePreseedFile(root, "node", errorReader{}, preseedFileMode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not write file")
 }
 
 func TestWritePreseedFileOpenError(t *testing.T) {
-	err := writePreseedFile(t.TempDir(), bytes.NewReader([]byte("node")), preseedFileMode)
+	outer := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(outer, "innerdir"), 0o755))
+	root, err := os.OpenRoot(outer)
+	require.NoError(t, err)
+	defer root.Close()
+
+	// "innerdir" already exists as a directory, so opening it as a file fails.
+	err = writePreseedFile(root, "innerdir", bytes.NewReader([]byte("node")), preseedFileMode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not create file")
 }

--- a/pkg/auth/providers/aws/saml_driver_preseed_test.go
+++ b/pkg/auth/providers/aws/saml_driver_preseed_test.go
@@ -488,6 +488,9 @@ func TestExtractTarGzSingleEntryFailsWhenDriverDirUnreadable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits don't apply the same way on Windows")
 	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root ignores directory permission bits")
+	}
 	driverDir := t.TempDir()
 	require.NoError(t, os.Chmod(driverDir, 0o000))
 	t.Cleanup(func() { _ = os.Chmod(driverDir, 0o755) })
@@ -521,6 +524,9 @@ func TestExtractZipSingleEntry(t *testing.T) {
 func TestExtractZipSingleEntryFailsWhenDriverDirUnreadable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits don't apply the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root ignores directory permission bits")
 	}
 	driverDir := t.TempDir()
 	require.NoError(t, os.Chmod(driverDir, 0o000))

--- a/pkg/cache/file_cache.go
+++ b/pkg/cache/file_cache.go
@@ -98,6 +98,8 @@ func NewFileCache(subpath string, opts ...FileCacheOption) (*FileCache, error) {
 // This ensures valid filenames regardless of key content while preserving
 // the original file extension for proper template processing.
 func keyToFilename(key string) string {
+	// codeql[go/weak-sensitive-data-hashing] -- hashes a cache key to derive a
+	// deterministic filename; never used for credential verification or storage.
 	hash := sha256.Sum256([]byte(key))
 	base := fmt.Sprintf("%x", hash[:8])
 

--- a/pkg/config/homedir/homedir.go
+++ b/pkg/config/homedir/homedir.go
@@ -178,9 +178,9 @@ func getUnixHomeDir() (string, error) {
 	}
 
 	// username:password:uid:gid:gecos:home:shell
-	// lgtm[go/clear-text-logging]
-	// The password field in modern /etc/passwd is 'x', not the actual password.
-	// We only extract the home directory field and do not log sensitive data.
+	// codeql[go/clear-text-logging]: The password field in modern /etc/passwd is 'x',
+	// not the actual password. We only extract the home directory field and do not
+	// log sensitive data.
 	passwdParts := strings.SplitN(passwd, ":", passwdFieldCount)
 	if len(passwdParts) > passwdHomeDirIndex {
 		return passwdParts[passwdHomeDirIndex], nil

--- a/pkg/container/common.go
+++ b/pkg/container/common.go
@@ -13,7 +13,13 @@ import (
 	errUtils "github.com/cloudposse/atmos/errors"
 	iolib "github.com/cloudposse/atmos/pkg/io"
 	log "github.com/cloudposse/atmos/pkg/logger"
+	"github.com/cloudposse/atmos/pkg/safenum"
 )
+
+// maxBakeEnvCapHint bounds the make() capacity hint for a baked build's
+// subprocess environment: a generous upper bound for combined OS env vars
+// plus configured bake vars, well beyond any realistic process environment.
+const maxBakeEnvCapHint = 1 << 20 // ~1M entries.
 
 // extractContainerID returns the last non-empty line of `create` output.
 // Both `docker create` and `podman create` print image-pull progress before the
@@ -593,7 +599,7 @@ func bakeCommandEnv(base []string, config *BuildConfig) []string {
 	if len(source) == 0 {
 		source = os.Environ()
 	}
-	env := make([]string, 0, len(source)+len(config.Bake.Vars))
+	env := make([]string, 0, safenum.Cap(len(source), len(config.Bake.Vars), maxBakeEnvCapHint))
 	env = append(env, source...)
 	env = append(env, bakeVarEnv(config.Bake.Vars)...)
 	return env

--- a/pkg/env/output.go
+++ b/pkg/env/output.go
@@ -113,7 +113,7 @@ func Output(data map[string]string, formatStr string, outputFile string, opts ..
 		return writeToFileWithMode(outputFile, formatted, cfg.fileMode)
 	}
 
-	// lgtm[go/clear-text-logging] - Intentional stdout output for shell evaluation.
+	// codeql[go/clear-text-logging]: intentional stdout output for shell evaluation.
 	if cfg.maskStdout {
 		return pkgdata.Write(formatted)
 	}

--- a/pkg/filesystem/safejoin.go
+++ b/pkg/filesystem/safejoin.go
@@ -1,9 +1,4 @@
-// Package archiveutil provides shared safety helpers for extracting archive
-// entries (zip, tar) to the filesystem. It is intentionally a leaf package
-// (depending only on errors/perf) so every archive-extracting package in the
-// module -- including pkg/oci, which pkg/archive transitively depends on via
-// pkg/downloader -- can import it without an import cycle.
-package archiveutil
+package filesystem
 
 import (
 	"fmt"
@@ -34,7 +29,7 @@ import (
 // empirically closing alert #5230 and must not be refactored into a shared
 // call.
 func SafeJoin(destDir, entryName string) (string, error) {
-	defer perf.Track(nil, "archiveutil.SafeJoin")()
+	defer perf.Track(nil, "filesystem.SafeJoin")()
 
 	if filepath.IsAbs(entryName) || strings.HasPrefix(entryName, "/") || strings.HasPrefix(entryName, "\\") {
 		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
@@ -53,10 +48,14 @@ func SafeJoin(destDir, entryName string) (string, error) {
 
 	// Defense in depth: given the guards above (no absolute path, no backslash, no ".."
 	// component), Join+Clean of destDir with a purely relative, dot-dot-free entry name
-	// can never actually escape destDir, so this branch is unreachable in practice. It's
-	// kept anyway as a second, independent check in case a future edit weakens or
-	// reorders the guards above.
-	if target != cleanDestDir && !strings.HasPrefix(target, cleanDestDir+string(os.PathSeparator)) {
+	// can never actually let target escape destDir. This re-verifies that via
+	// filepath.Rel rather than a string-prefix comparison, since a naive
+	// `strings.HasPrefix(target, cleanDestDir+separator)` check incorrectly rejects a
+	// valid target when cleanDestDir is a root path with no room for a trailing
+	// separator to appear before the next path segment (destDir "." or "" -> cleanDestDir
+	// "." with target "file", or destDir "/" with target "/file").
+	rel, err := filepath.Rel(cleanDestDir, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
 	}
 

--- a/pkg/filesystem/safejoin.go
+++ b/pkg/filesystem/safejoin.go
@@ -31,28 +31,31 @@ import (
 func SafeJoin(destDir, entryName string) (string, error) {
 	defer perf.Track(nil, "filesystem.SafeJoin")()
 
+	// Reject absolute-looking and backslash-containing entry names outright rather
+	// than relying on filepath.Join/Rel to neutralize them: Join treats an embedded
+	// leading "/" as just another path segment (so "/etc/passwd" harmlessly becomes
+	// destDir/etc/passwd, not an escape), but both shapes are never legitimate zip/tar
+	// entry names -- the format always uses forward slashes -- so treat either as a
+	// suspicious archive outright.
 	if filepath.IsAbs(entryName) || strings.HasPrefix(entryName, "/") || strings.HasPrefix(entryName, "\\") {
 		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
 	}
 	if strings.Contains(entryName, "\\") {
 		return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
 	}
-	for _, part := range strings.Split(filepath.ToSlash(entryName), "/") {
-		if part == ".." {
-			return "", fmt.Errorf(errUtils.ErrWrapWithNameFormat, errUtils.ErrArchiveEntryEscapesDest, entryName)
-		}
-	}
 
 	cleanDestDir := filepath.Clean(destDir)
 	target := filepath.Join(cleanDestDir, filepath.FromSlash(entryName))
 
-	// Defense in depth: given the guards above (no absolute path, no backslash, no ".."
-	// component), Join+Clean of destDir with a purely relative, dot-dot-free entry name
-	// can never actually let target escape destDir. This re-verifies that via
-	// filepath.Rel rather than a string-prefix comparison, since a naive
-	// `strings.HasPrefix(target, cleanDestDir+separator)` check incorrectly rejects a
-	// valid target when cleanDestDir is a root path with no room for a trailing
-	// separator to appear before the next path segment (destDir "." or "" -> cleanDestDir
+	// filepath.Rel is the actual containment check: it reflects the true
+	// relationship between target and cleanDestDir after Join has resolved any ".."
+	// components, so it correctly accepts a harmless internal ".." that never leaves
+	// destDir (e.g. "a/../b") and correctly rejects one that does, including the
+	// sibling-directory-name case ("../destEVIL/file" is not a "destEVIL" component
+	// match but does resolve outside cleanDestDir). A naive
+	// `strings.HasPrefix(target, cleanDestDir+separator)` check would also incorrectly
+	// reject a valid target when cleanDestDir is a root path with no room for a
+	// trailing separator before the next path segment (destDir "." or "" -> cleanDestDir
 	// "." with target "file", or destDir "/" with target "/file").
 	rel, err := filepath.Rel(cleanDestDir, target)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {

--- a/pkg/filesystem/safejoin_test.go
+++ b/pkg/filesystem/safejoin_test.go
@@ -1,4 +1,4 @@
-package archiveutil
+package filesystem
 
 import (
 	"errors"
@@ -76,6 +76,32 @@ func TestSafeJoin(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.wantPath, got)
+		})
+	}
+}
+
+// TestSafeJoin_RootDestinations is a regression test: a naive
+// strings.HasPrefix(target, cleanDestDir+separator) containment check
+// incorrectly rejects a valid entry when destDir has no room for a trailing
+// separator before the next path segment -- a relative "." (or empty string,
+// which filepath.Clean also normalizes to ".") or an absolute "/" both
+// collapse cleanDestDir and target's shared prefix to exactly cleanDestDir
+// with nothing after it.
+func TestSafeJoin_RootDestinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		destDir string
+	}{
+		{name: "dot destination", destDir: "."},
+		{name: "empty destination", destDir: ""},
+		{name: "root destination", destDir: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeJoin(tt.destDir, "file.txt")
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(filepath.Clean(tt.destDir), "file.txt"), got)
 		})
 	}
 }

--- a/pkg/logger/logrus_adapter.go
+++ b/pkg/logger/logrus_adapter.go
@@ -116,15 +116,19 @@ func (a *logrusAdapter) Write(p []byte) (n int, err error) {
 		}
 
 		// Route to appropriate log level based on parsed level field.
+		// Each call below writes to os.Stderr (see NewAtmosLogger in pkg/logger/global.go),
+		// Atmos's own CLI diagnostic stream to the user's own terminal -- not a
+		// log-aggregation sink another party can read. msg and fields are also already
+		// redacted above by sanitizeLogMessage/sanitizeFieldValue.
 		switch strings.ToLower(level) {
 		case "fatal", "panic", "error":
-			a.logger.Error(msg, fields...)
+			a.logger.Error(msg, fields...) // codeql[go/clear-text-logging]
 		case "warning", "warn":
-			a.logger.Warn(msg, fields...)
+			a.logger.Warn(msg, fields...) // codeql[go/clear-text-logging]
 		case "debug", "trace":
-			a.logger.Debug(msg, fields...)
+			a.logger.Debug(msg, fields...) // codeql[go/clear-text-logging]
 		default:
-			a.logger.Info(msg, fields...)
+			a.logger.Info(msg, fields...) // codeql[go/clear-text-logging]
 		}
 	} else {
 		// Fallback: Not JSON (shouldn't happen with JSONFormatter, but handle gracefully).

--- a/pkg/logger/logrus_adapter.go
+++ b/pkg/logger/logrus_adapter.go
@@ -27,16 +27,32 @@ func sanitizeLogMessage(msg string) string {
 // sanitizeFieldValue redacts the value if the field key looks like a secret.
 // For non-sensitive keys with string values, it also applies sanitizeLogMessage
 // to catch embedded sensitive patterns (e.g. a "details" field containing
-// "password=s3cret").
+// "password=s3cret"). Nested maps and slices (as produced by json.Unmarshal
+// into map[string]interface{}) are walked recursively so a sensitive key
+// buried under a non-sensitive parent, e.g. {"details":{"password":"secret"}},
+// is still redacted rather than passed through as an unexamined nested value.
 func sanitizeFieldValue(key string, value interface{}) interface{} {
 	if isSensitiveLogKey(key) {
 		return "[REDACTED]"
 	}
-	// Also sanitize string values that may contain embedded sensitive data.
-	if strVal, ok := value.(string); ok {
-		return sanitizeLogMessage(strVal)
+	switch v := value.(type) {
+	case string:
+		return sanitizeLogMessage(v)
+	case map[string]interface{}:
+		sanitized := make(map[string]interface{}, len(v))
+		for k, nested := range v {
+			sanitized[k] = sanitizeFieldValue(k, nested)
+		}
+		return sanitized
+	case []interface{}:
+		sanitized := make([]interface{}, len(v))
+		for i, nested := range v {
+			sanitized[i] = sanitizeFieldValue("", nested)
+		}
+		return sanitized
+	default:
+		return value
 	}
-	return value
 }
 
 // sensitiveKeySubstrings lists substrings that identify sensitive log field keys.
@@ -115,20 +131,24 @@ func (a *logrusAdapter) Write(p []byte) (n int, err error) {
 			}
 		}
 
-		// Route to appropriate log level based on parsed level field.
-		// Each call below writes to os.Stderr (see NewAtmosLogger in pkg/logger/global.go),
-		// Atmos's own CLI diagnostic stream to the user's own terminal -- not a
-		// log-aggregation sink another party can read. msg and fields are also already
-		// redacted above by sanitizeLogMessage/sanitizeFieldValue.
+		// Route to appropriate log level based on parsed level field. Each call below
+		// writes to os.Stderr (see NewAtmosLogger in pkg/logger/global.go), Atmos's own
+		// CLI diagnostic stream to the user's own terminal -- not a log-aggregation sink
+		// another party can read. msg and fields are also already redacted above by
+		// sanitizeLogMessage/sanitizeFieldValue.
 		switch strings.ToLower(level) {
 		case "fatal", "panic", "error":
-			a.logger.Error(msg, fields...) // codeql[go/clear-text-logging]
+			// codeql[go/clear-text-logging]
+			a.logger.Error(msg, fields...)
 		case "warning", "warn":
-			a.logger.Warn(msg, fields...) // codeql[go/clear-text-logging]
+			// codeql[go/clear-text-logging]
+			a.logger.Warn(msg, fields...)
 		case "debug", "trace":
-			a.logger.Debug(msg, fields...) // codeql[go/clear-text-logging]
+			// codeql[go/clear-text-logging]
+			a.logger.Debug(msg, fields...)
 		default:
-			a.logger.Info(msg, fields...) // codeql[go/clear-text-logging]
+			// codeql[go/clear-text-logging]
+			a.logger.Info(msg, fields...)
 		}
 	} else {
 		// Fallback: Not JSON (shouldn't happen with JSONFormatter, but handle gracefully).

--- a/pkg/logger/logrus_adapter_test.go
+++ b/pkg/logger/logrus_adapter_test.go
@@ -1,22 +1,44 @@
 package logger
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// recordingLogger captures the level and message of each log call for assertion.
+// recordingLogger captures the level, message, and keyvals of each log call for assertion.
 type recordingLogger struct {
-	level string
-	msg   string
+	level   string
+	msg     string
+	keyvals []interface{}
 }
 
-func (r *recordingLogger) Error(msg string, _ ...interface{}) { r.level = "error"; r.msg = msg }
-func (r *recordingLogger) Warn(msg string, _ ...interface{})  { r.level = "warn"; r.msg = msg }
-func (r *recordingLogger) Info(msg string, _ ...interface{})  { r.level = "info"; r.msg = msg }
-func (r *recordingLogger) Debug(msg string, _ ...interface{}) { r.level = "debug"; r.msg = msg }
+func (r *recordingLogger) Error(msg string, keyvals ...interface{}) {
+	r.level = "error"
+	r.msg = msg
+	r.keyvals = keyvals
+}
+
+func (r *recordingLogger) Warn(msg string, keyvals ...interface{}) {
+	r.level = "warn"
+	r.msg = msg
+	r.keyvals = keyvals
+}
+
+func (r *recordingLogger) Info(msg string, keyvals ...interface{}) {
+	r.level = "info"
+	r.msg = msg
+	r.keyvals = keyvals
+}
+
+func (r *recordingLogger) Debug(msg string, keyvals ...interface{}) {
+	r.level = "debug"
+	r.msg = msg
+	r.keyvals = keyvals
+}
 
 func TestLogrusAdapter_Write(t *testing.T) {
 	adapter := newLogrusAdapter()
@@ -317,6 +339,27 @@ func TestSanitizeFieldValue(t *testing.T) {
 	result := sanitizeFieldValue("details", "login failed password=s3cret123")
 	assert.NotContains(t, result, "s3cret123", "embedded password in non-sensitive key's value must be redacted")
 	assert.Contains(t, result, "[REDACTED]")
+
+	// A sensitive key nested under a non-sensitive parent map must still be redacted.
+	nested := sanitizeFieldValue("details", map[string]interface{}{
+		"password": "secret",
+		"provider": "browser",
+	})
+	nestedMap, ok := nested.(map[string]interface{})
+	require.True(t, ok, "nested map value must remain a map")
+	assert.Equal(t, "[REDACTED]", nestedMap["password"])
+	assert.Equal(t, "browser", nestedMap["provider"])
+
+	// A sensitive key nested inside a slice element must also be redacted.
+	nestedSlice := sanitizeFieldValue("attempts", []interface{}{
+		map[string]interface{}{"token": "abc123"},
+	})
+	sliceVal, ok := nestedSlice.([]interface{})
+	require.True(t, ok, "nested slice value must remain a slice")
+	require.Len(t, sliceVal, 1)
+	elemMap, ok := sliceVal[0].(map[string]interface{})
+	require.True(t, ok, "slice element must remain a map")
+	assert.Equal(t, "[REDACTED]", elemMap["token"])
 }
 
 func TestLogrusAdapter_Write_RedactsSensitiveData(t *testing.T) {
@@ -340,4 +383,29 @@ func TestLogrusAdapter_Write_RedactsSensitiveData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotContains(t, rec2.msg, "abc123def456", "raw content must not appear in fallback path")
 	assert.Contains(t, rec2.msg, "content omitted")
+}
+
+// TestLogrusAdapter_Write_RedactsNestedSensitiveData is a regression test for
+// a sensitive key nested under a non-sensitive parent field, e.g.
+// {"details":{"password":"secret"}}: sanitizeFieldValue must recurse into
+// the parsed JSON's nested map/slice values rather than passing them through
+// unexamined.
+func TestLogrusAdapter_Write_RedactsNestedSensitiveData(t *testing.T) {
+	rec := &recordingLogger{}
+	adapter := &logrusAdapter{logger: rec}
+
+	msg := `{"level":"error","msg":"login failed","details":{"password":"s3cret123","provider":"browser"}}` + "\n"
+	_, err := adapter.Write([]byte(msg))
+	require.NoError(t, err)
+	require.Equal(t, "error", rec.level)
+
+	require.Len(t, rec.keyvals, 2, "expected one key/value pair for the details field")
+	require.Equal(t, "details", rec.keyvals[0])
+	details, ok := rec.keyvals[1].(map[string]interface{})
+	require.True(t, ok, "details field must remain a map")
+	assert.Equal(t, "[REDACTED]", details["password"])
+	assert.Equal(t, "browser", details["provider"])
+
+	full := fmt.Sprintf("%v", rec.keyvals)
+	assert.NotContains(t, full, "s3cret123", "nested password must not appear anywhere in logged fields")
 }

--- a/pkg/merge/merge_native.go
+++ b/pkg/merge/merge_native.go
@@ -10,7 +10,7 @@ import (
 // maxCapHint bounds the make() capacity hint safeCap returns, to prevent OOM
 // panics from oversize allocations. The hint is only used for make()
 // capacity; append() will grow the backing array as needed.
-const maxCapHint = 1 << 24 // 16 M entries — realistic upper bound for atmos configs
+const maxCapHint = 1 << 24 // 16 M entries — realistic upper bound for atmos configs.
 
 func safeCap(a, b int) int {
 	return safenum.Cap(a, b, maxCapHint)

--- a/pkg/merge/merge_native.go
+++ b/pkg/merge/merge_native.go
@@ -4,20 +4,16 @@ import (
 	"fmt"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/safenum"
 )
 
-// safeCap returns a capacity hint of a+b, clamped to maxCapHint to prevent
-// OOM panics from oversize make() calls.
-// The hint is only used for make() capacity; append() will grow the backing array as needed.
+// maxCapHint bounds the make() capacity hint safeCap returns, to prevent OOM
+// panics from oversize allocations. The hint is only used for make()
+// capacity; append() will grow the backing array as needed.
 const maxCapHint = 1 << 24 // 16 M entries — realistic upper bound for atmos configs
 
 func safeCap(a, b int) int {
-	// Guard against integer overflow: if b > maxCapHint-a, then a+b > maxCapHint.
-	// This single check is sufficient; no second guard is needed.
-	if b > maxCapHint-a {
-		return maxCapHint
-	}
-	return a + b
+	return safenum.Cap(a, b, maxCapHint)
 }
 
 // deepMergeNative performs a deep merge of src into dst in place.

--- a/pkg/merge/provenance_entry.go
+++ b/pkg/merge/provenance_entry.go
@@ -140,7 +140,9 @@ func hashValue(value any) string {
 		valueStr = fmt.Sprintf("%v", value)
 	}
 
-	// Create SHA-256 hash
+	// codeql[go/weak-sensitive-data-hashing] -- hashes a merged value for
+	// change detection between merge passes; never used for credential
+	// verification or storage.
 	hash := sha256.Sum256([]byte(valueStr))
 
 	// Return hex representation (first 16 characters for brevity)

--- a/pkg/oci/tar.go
+++ b/pkg/oci/tar.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cloudposse/atmos/pkg/filesystem"
 	log "github.com/cloudposse/atmos/pkg/logger" // Charmbracelet structured logger
@@ -33,10 +32,6 @@ func untar(reader io.Reader, extractPath string) error {
 		if err != nil {
 			log.Error("Error reading tar header", "error", err)
 			return err
-		}
-		if strings.Contains(header.Name, "..") {
-			log.Warn("Skipping potential directory traversal attempt", "filename", header.Name)
-			continue
 		}
 		if err := processTarHeader(header, tarReader, extractPath); err != nil {
 			return err

--- a/pkg/oci/tar.go
+++ b/pkg/oci/tar.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cloudposse/atmos/pkg/archiveutil"
+	"github.com/cloudposse/atmos/pkg/filesystem"
 	log "github.com/cloudposse/atmos/pkg/logger" // Charmbracelet structured logger
 	"github.com/pkg/errors"
 )
@@ -48,7 +48,7 @@ func untar(reader io.Reader, extractPath string) error {
 
 // processTarHeader processes a tar header and writes the corresponding file to the destination directory.
 func processTarHeader(header *tar.Header, tarReader *tar.Reader, extractPath string) error {
-	filePath, err := archiveutil.SafeJoin(extractPath, header.Name)
+	filePath, err := filesystem.SafeJoin(extractPath, header.Name)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidFilePath, header.Name)
 	}

--- a/pkg/oci/tar.go
+++ b/pkg/oci/tar.go
@@ -21,8 +21,24 @@ func extractTarball(reader io.Reader, extractPath string) error {
 }
 
 // untar extracts a tar archive into the destination directory.
+//
+// Writes go through an os.Root opened on extractPath rather than plain
+// os.MkdirAll/os.Create: SafeJoin only validates the entry name lexically, so
+// without os.Root a malicious archive could plant a symlink via one entry
+// (e.g. "link" -> "/etc") and have a later entry (e.g. "link/passwd") follow
+// it out of extractPath -- os.Root's methods refuse to resolve a path that
+// escapes the root, symlinks included.
 func untar(reader io.Reader, extractPath string) error {
 	tarReader := tar.NewReader(reader)
+
+	if err := os.MkdirAll(extractPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create extraction directory %s: %w", extractPath, err)
+	}
+	root, err := os.OpenRoot(extractPath)
+	if err != nil {
+		return fmt.Errorf("failed to open extraction root %s: %w", extractPath, err)
+	}
+	defer root.Close()
 
 	for {
 		header, err := tarReader.Next()
@@ -33,7 +49,7 @@ func untar(reader io.Reader, extractPath string) error {
 			log.Error("Error reading tar header", "error", err)
 			return err
 		}
-		if err := processTarHeader(header, tarReader, extractPath); err != nil {
+		if err := processTarHeader(root, header, tarReader, extractPath); err != nil {
 			return err
 		}
 	}
@@ -41,17 +57,20 @@ func untar(reader io.Reader, extractPath string) error {
 	return nil
 }
 
-// processTarHeader processes a tar header and writes the corresponding file to the destination directory.
-func processTarHeader(header *tar.Header, tarReader *tar.Reader, extractPath string) error {
-	filePath, err := filesystem.SafeJoin(extractPath, header.Name)
-	if err != nil {
+// processTarHeader processes a tar header and writes the corresponding file to relPath within root.
+func processTarHeader(root *os.Root, header *tar.Header, tarReader *tar.Reader, extractPath string) error {
+	// SafeJoin validates the entry name (rejects absolute paths, backslashes,
+	// and ".." components); the resulting path itself isn't used since writes
+	// go through root by relative name instead.
+	if _, err := filesystem.SafeJoin(extractPath, header.Name); err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidFilePath, header.Name)
 	}
+	relPath := filepath.FromSlash(header.Name)
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return createDirectory(filePath)
+		return createDirectory(root, relPath)
 	case tar.TypeReg:
-		return createFileFromTar(filePath, tarReader, header)
+		return createFileFromTar(root, relPath, tarReader, header)
 	default:
 		log.Warnf("Unsupported file type: %v in %s", header.Typeflag, header.Name)
 	}
@@ -59,37 +78,36 @@ func processTarHeader(header *tar.Header, tarReader *tar.Reader, extractPath str
 	return nil
 }
 
-// createDirectory creates a directory at the specified path. If the directory already exists, it does nothing.
-func createDirectory(dirPath string) error {
-	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
-		return fmt.Errorf("error creating directory %s: %w", dirPath, err)
+// createDirectory creates relPath (and any necessary parents) within root. If the directory already exists, it does nothing.
+func createDirectory(root *os.Root, relPath string) error {
+	if err := root.MkdirAll(relPath, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating directory %s: %w", relPath, err)
 	}
 	return nil
 }
 
-// createFileFromTar writes the contents of a tar file to a file at the specified path. It also sets the file mode.
-func createFileFromTar(filePath string, tarReader *tar.Reader, header *tar.Header) error {
-	err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm)
+// createFileFromTar writes the contents of a tar file to relPath within root. It also sets the file mode.
+func createFileFromTar(root *os.Root, relPath string, tarReader *tar.Reader, header *tar.Header) error {
+	err := root.MkdirAll(filepath.Dir(relPath), os.ModePerm)
 	if err != nil {
-		log.Error("Failed to create parent directory for file", "path", filePath, "error", err)
+		log.Error("Failed to create parent directory for file", "path", relPath, "error", err)
 		return err
 	}
-	writer, err := os.Create(filePath)
+	writer, err := root.Create(relPath)
 	if err != nil {
-		log.Error("Failed to create file", "path", filePath, "error", err)
+		log.Error("Failed to create file", "path", relPath, "error", err)
 		return err
 	}
 	defer writer.Close()
 	_, err = io.Copy(writer, tarReader)
 	if err != nil {
-		log.Error("Failed to write file contents", "path", filePath, "error", err)
+		log.Error("Failed to write file contents", "path", relPath, "error", err)
 		return err
 	}
 	// Remove setuid/setgid bits for security; standard cross-platform.
 	newMode := header.FileInfo().Mode() &^ (os.ModeSetuid | os.ModeSetgid)
-	// Set permissions using os.Chmod for all platforms.
-	if err := os.Chmod(filePath, newMode); err != nil {
-		log.Error("Failed to set file permissions", "path", filePath, "error", err)
+	if err := root.Chmod(relPath, newMode); err != nil {
+		log.Error("Failed to set file permissions", "path", relPath, "error", err)
 	}
 	return nil
 }

--- a/pkg/oci/tar.go
+++ b/pkg/oci/tar.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cloudposse/atmos/pkg/archiveutil"
 	log "github.com/cloudposse/atmos/pkg/logger" // Charmbracelet structured logger
 	"github.com/pkg/errors"
 )
@@ -47,15 +48,9 @@ func untar(reader io.Reader, extractPath string) error {
 
 // processTarHeader processes a tar header and writes the corresponding file to the destination directory.
 func processTarHeader(header *tar.Header, tarReader *tar.Reader, extractPath string) error {
-	// Normalize and clean the extraction base path to remove any redundant separators or ".." sequences.
-	cleanExtractPath := filepath.Clean(extractPath)
-	// Clean the file path inside the archive to prevent directory traversal attacks.
-	cleanHeaderName := filepath.Clean(header.Name)
-	// Clean the file path inside the archive to prevent directory traversal attacks.
-	filePath := filepath.Join(cleanExtractPath, cleanHeaderName)
-	// Ensure the target path is within the intended extraction directory.
-	if !strings.HasPrefix(filePath, cleanExtractPath) {
-		return fmt.Errorf("%w: %s", ErrInvalidFilePath, filePath)
+	filePath, err := archiveutil.SafeJoin(extractPath, header.Name)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidFilePath, header.Name)
 	}
 	switch header.Typeflag {
 	case tar.TypeDir:

--- a/pkg/oci/tar_test.go
+++ b/pkg/oci/tar_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -218,4 +219,51 @@ func TestExtractTarball_RejectsWriteThroughPreExistingSymlink(t *testing.T) {
 
 	_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
 	assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+}
+
+// TestExtractTarball_FailsWhenExtractPathBlocked exercises untar's
+// os.MkdirAll(extractPath) error branch: a regular file sitting where
+// extractPath itself needs to be created makes MkdirAll fail.
+func TestExtractTarball_FailsWhenExtractPathBlocked(t *testing.T) {
+	parent := t.TempDir()
+	blocked := filepath.Join(parent, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+
+	tarBuf := writeTestTar(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractTarball(tarBuf, filepath.Join(blocked, "nested"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create extraction directory")
+}
+
+// TestExtractTarball_FailsWhenExtractPathUnreadable exercises untar's
+// os.OpenRoot(extractPath) error branch: MkdirAll succeeds (the directory
+// already exists), but a directory with no permissions cannot be opened.
+func TestExtractTarball_FailsWhenExtractPathUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't apply the same way on Windows")
+	}
+
+	dest := t.TempDir()
+	require.NoError(t, os.Chmod(dest, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(dest, 0o755) }) // Allow t.TempDir's own cleanup to remove it.
+
+	tarBuf := writeTestTar(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open extraction root")
+}
+
+// TestExtractTarball_FailsWhenTargetIsExistingDir exercises
+// createFileFromTar's root.Create error branch: a directory already sitting
+// at the entry's path makes Create fail (can't open a directory for writing).
+func TestExtractTarball_FailsWhenTargetIsExistingDir(t *testing.T) {
+	dest := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "file.txt"), 0o755))
+
+	tarBuf := writeTestTar(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
 }

--- a/pkg/oci/tar_test.go
+++ b/pkg/oci/tar_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,112 @@ func TestExtractTarball_SkipsDirectoryTraversal(t *testing.T) {
 	entries, err := os.ReadDir(dest)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "traversal entry must not be written to dest")
+}
+
+// TestExtractTarball_RejectsAbsolutePath exercises processTarHeader's
+// SafeJoin containment check directly, rather than untar's earlier ".."
+// substring filter, since an absolute entry name contains no "..", so it
+// reaches processTarHeader, where SafeJoin must still reject it.
+func TestExtractTarball_RejectsAbsolutePath(t *testing.T) {
+	dest := t.TempDir()
+	tarBuf := writeTestTar(t, map[string]string{
+		"/etc/passwd": "malicious\n",
+	})
+
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFilePath)
+
+	entries, readErr := os.ReadDir(dest)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "absolute-path entry must not be written to dest")
+}
+
+// TestExtractTarball_CreatesDirectoryEntries exercises processTarHeader's
+// tar.TypeDir case, which writeTestTar's regular-file-only helper can't
+// produce.
+func TestExtractTarball_CreatesDirectoryEntries(t *testing.T) {
+	dest := t.TempDir()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "emptydir/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	}))
+	require.NoError(t, tw.Close())
+
+	require.NoError(t, extractTarball(&buf, dest))
+
+	info, err := os.Stat(filepath.Join(dest, "emptydir"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestExtractTarball_SkipsUnsupportedType exercises processTarHeader's
+// default case (an entry type that's neither a regular file nor a
+// directory, e.g. a symlink) -- it's logged and skipped, not an error.
+func TestExtractTarball_SkipsUnsupportedType(t *testing.T) {
+	dest := t.TempDir()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "main.tf",
+		Mode:     0o644,
+	}))
+	require.NoError(t, tw.Close())
+
+	require.NoError(t, extractTarball(&buf, dest))
+
+	entries, err := os.ReadDir(dest)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "unsupported entry type must not be written to dest")
+}
+
+// TestExtractTarball_FailsWhenParentDirBlocked exercises createFileFromTar's
+// os.MkdirAll error branch: a regular file sitting where a parent directory
+// needs to be created makes MkdirAll fail.
+func TestExtractTarball_FailsWhenParentDirBlocked(t *testing.T) {
+	dest := t.TempDir()
+	blocker := filepath.Join(dest, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	tarBuf := writeTestTar(t, map[string]string{
+		"blocker/nested/file.txt": "content\n",
+	})
+
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
+}
+
+// TestExtractTarball_RejectsMalformedArchive exercises untar's tarReader.Next
+// parse-error branch.
+func TestExtractTarball_RejectsMalformedArchive(t *testing.T) {
+	dest := t.TempDir()
+	err := extractTarball(strings.NewReader("this is not a tar file, and it is long enough to look like a header block but isn't"), dest)
+	require.Error(t, err)
+}
+
+// TestExtractTarball_DirectoryEntryFailsWhenParentDirBlocked exercises
+// createDirectory's os.MkdirAll error branch via the tar.TypeDir case: a
+// regular file sitting where a parent directory needs to be created makes
+// MkdirAll fail.
+func TestExtractTarball_DirectoryEntryFailsWhenParentDirBlocked(t *testing.T) {
+	dest := t.TempDir()
+	blocker := filepath.Join(dest, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "blocker/subdir/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	}))
+	require.NoError(t, tw.Close())
+
+	err := extractTarball(&buf, dest)
+	require.Error(t, err)
 }

--- a/pkg/oci/tar_test.go
+++ b/pkg/oci/tar_test.go
@@ -243,6 +243,9 @@ func TestExtractTarball_FailsWhenExtractPathUnreadable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits don't apply the same way on Windows")
 	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root ignores directory permission bits")
+	}
 
 	dest := t.TempDir()
 	require.NoError(t, os.Chmod(dest, 0o000))

--- a/pkg/oci/tar_test.go
+++ b/pkg/oci/tar_test.go
@@ -193,3 +193,29 @@ func TestExtractTarball_DirectoryEntryFailsWhenParentDirBlocked(t *testing.T) {
 	err := extractTarball(&buf, dest)
 	require.Error(t, err)
 }
+
+// TestExtractTarball_RejectsWriteThroughPreExistingSymlink is a regression
+// test for CWE-59 (symlink-following): SafeJoin only validates an entry name
+// lexically, so before extraction switched to os.Root, a pre-existing
+// symlink inside dest pointing outside it (e.g. left over from a prior run,
+// or planted via an unrelated mechanism) let a plain-looking entry name like
+// "link/evil.txt" escape dest via os.MkdirAll/os.Create following the
+// symlink -- os.Root refuses to resolve a path through a symlink that would
+// leave the root.
+func TestExtractTarball_RejectsWriteThroughPreExistingSymlink(t *testing.T) {
+	dest := t.TempDir()
+	outside := t.TempDir()
+
+	link := filepath.Join(dest, "link")
+	require.NoError(t, os.Symlink(outside, link))
+
+	tarBuf := writeTestTar(t, map[string]string{
+		"link/evil.txt": "escaped\n",
+	})
+
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
+	assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+}

--- a/pkg/oci/tar_test.go
+++ b/pkg/oci/tar_test.go
@@ -47,17 +47,43 @@ func TestExtractTarball_WritesFiles(t *testing.T) {
 	assert.Contains(t, string(nested), "output")
 }
 
-func TestExtractTarball_SkipsDirectoryTraversal(t *testing.T) {
+// TestExtractTarball_RejectsDirectoryTraversal exercises processTarHeader's
+// SafeJoin containment check: untar has no ".."-substring prefilter of its
+// own (removed -- it was overbroad and dropped valid filenames like
+// "..hidden.txt", see TestExtractTarball_ExtractsFilenameContainingDotDot),
+// so SafeJoin is the sole gate and must fail loudly rather than silently skip.
+func TestExtractTarball_RejectsDirectoryTraversal(t *testing.T) {
 	dest := t.TempDir()
 	tarBuf := writeTestTar(t, map[string]string{
 		"../../etc/passwd": "malicious\n",
 	})
 
+	err := extractTarball(tarBuf, dest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFilePath)
+
+	entries, readErr := os.ReadDir(dest)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "traversal entry must not be written to dest")
+}
+
+// TestExtractTarball_ExtractsFilenameContainingDotDot is a regression test: a
+// valid filename that merely contains ".." as a substring without it being a
+// full path-traversal component (e.g. "..hidden.txt") must still be
+// extracted. SafeJoin already rejects only actual ".." path components; the
+// removed prefilter in untar used to reject this too, via a much broader
+// substring check.
+func TestExtractTarball_ExtractsFilenameContainingDotDot(t *testing.T) {
+	dest := t.TempDir()
+	tarBuf := writeTestTar(t, map[string]string{
+		"..hidden.txt": "content\n",
+	})
+
 	require.NoError(t, extractTarball(tarBuf, dest))
 
-	entries, err := os.ReadDir(dest)
+	content, err := os.ReadFile(filepath.Join(dest, "..hidden.txt"))
 	require.NoError(t, err)
-	assert.Empty(t, entries, "traversal entry must not be written to dest")
+	assert.Equal(t, "content\n", string(content))
 }
 
 // TestExtractTarball_RejectsAbsolutePath exercises processTarHeader's

--- a/pkg/oci/zip.go
+++ b/pkg/oci/zip.go
@@ -28,6 +28,13 @@ const maxZipEntrySize = 512 * 1024 * 1024 // 512 MiB.
 // extractZip extracts a ZIP archive read from reader into the destination
 // directory. Since zip.Reader requires io.ReaderAt plus a known size, the
 // archive is buffered in memory first, bounded by maxZipArchiveSize.
+//
+// Writes go through an os.Root opened on extractPath rather than plain
+// os.MkdirAll/os.Create: SafeJoin only validates the entry name lexically, so
+// without os.Root a malicious archive could plant a symlink via one entry
+// (e.g. "link" -> "/etc") and have a later entry (e.g. "link/passwd") follow
+// it out of extractPath -- os.Root's methods refuse to resolve a path that
+// escapes the root, symlinks included.
 func extractZip(reader io.Reader, extractPath string) error {
 	data, err := io.ReadAll(io.LimitReader(reader, maxZipArchiveSize+1))
 	if err != nil {
@@ -43,8 +50,17 @@ func extractZip(reader io.Reader, extractPath string) error {
 		return fmt.Errorf("failed to parse zip archive: %w", err)
 	}
 
+	if err := os.MkdirAll(extractPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create extraction directory %s: %w", extractPath, err)
+	}
+	root, err := os.OpenRoot(extractPath)
+	if err != nil {
+		return fmt.Errorf("failed to open extraction root %s: %w", extractPath, err)
+	}
+	defer root.Close()
+
 	for _, file := range zipReader.File {
-		if err := processZipFile(file, extractPath); err != nil {
+		if err := processZipFile(root, file, extractPath); err != nil {
 			return err
 		}
 	}
@@ -53,43 +69,46 @@ func extractZip(reader io.Reader, extractPath string) error {
 }
 
 // processZipFile processes a zip.File entry and writes the corresponding file
-// to the destination directory.
-func processZipFile(file *zip.File, extractPath string) error {
-	filePath, err := filesystem.SafeJoin(extractPath, file.Name)
-	if err != nil {
+// to the destination directory via root.
+func processZipFile(root *os.Root, file *zip.File, extractPath string) error {
+	// SafeJoin validates the entry name (rejects absolute paths, backslashes,
+	// and ".." components); the resulting path itself isn't used since writes
+	// go through root by relative name instead.
+	if _, err := filesystem.SafeJoin(extractPath, file.Name); err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidFilePath, file.Name)
 	}
+	relPath := filepath.FromSlash(file.Name)
 
 	if file.FileInfo().IsDir() {
-		return createDirectory(filePath)
+		return createDirectory(root, relPath)
 	}
 
-	return createFileFromZip(filePath, file)
+	return createFileFromZip(root, relPath, file)
 }
 
-// createFileFromZip writes the contents of a zip.File to a file at the
-// specified path. It also sets the file mode.
-func createFileFromZip(filePath string, file *zip.File) error {
+// createFileFromZip writes the contents of a zip.File to relPath within root.
+// It also sets the file mode.
+func createFileFromZip(root *os.Root, relPath string, file *zip.File) error {
 	if file.UncompressedSize64 > maxZipEntrySize {
-		return fmt.Errorf("%w: %s (declared %d bytes, max %d)", errUtils.ErrArchiveEntryTooLarge, filePath, file.UncompressedSize64, maxZipEntrySize)
+		return fmt.Errorf("%w: %s (declared %d bytes, max %d)", errUtils.ErrArchiveEntryTooLarge, relPath, file.UncompressedSize64, maxZipEntrySize)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
-		log.Error("Failed to create parent directory for file", "path", filePath, "error", err)
-		return fmt.Errorf("failed to create parent directory for %s: %w", filePath, err)
+	if err := root.MkdirAll(filepath.Dir(relPath), os.ModePerm); err != nil {
+		log.Error("Failed to create parent directory for file", "path", relPath, "error", err)
+		return fmt.Errorf("failed to create parent directory for %s: %w", relPath, err)
 	}
 
 	src, err := file.Open()
 	if err != nil {
-		log.Error("Failed to open zip entry", "path", filePath, "error", err)
-		return fmt.Errorf("failed to open zip entry %s: %w", filePath, err)
+		log.Error("Failed to open zip entry", "path", relPath, "error", err)
+		return fmt.Errorf("failed to open zip entry %s: %w", relPath, err)
 	}
 	defer src.Close()
 
-	writer, err := os.Create(filePath)
+	writer, err := root.Create(relPath)
 	if err != nil {
-		log.Error("Failed to create file", "path", filePath, "error", err)
-		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+		log.Error("Failed to create file", "path", relPath, "error", err)
+		return fmt.Errorf("failed to create file %s: %w", relPath, err)
 	}
 	defer writer.Close()
 
@@ -98,18 +117,17 @@ func createFileFromZip(filePath string, file *zip.File) error {
 	// exceeds the declared size (or the declaration was understated/forged).
 	_, err = io.CopyN(writer, src, maxZipEntrySize+1)
 	if err != nil && !errors.Is(err, io.EOF) {
-		log.Error("Failed to write file contents", "path", filePath, "error", err)
-		return fmt.Errorf("failed to write file contents to %s: %w", filePath, err)
+		log.Error("Failed to write file contents", "path", relPath, "error", err)
+		return fmt.Errorf("failed to write file contents to %s: %w", relPath, err)
 	}
 	if err == nil {
-		return fmt.Errorf("%w: %s (exceeded %d bytes during extraction)", errUtils.ErrArchiveEntryTooLarge, filePath, maxZipEntrySize)
+		return fmt.Errorf("%w: %s (exceeded %d bytes during extraction)", errUtils.ErrArchiveEntryTooLarge, relPath, maxZipEntrySize)
 	}
 
 	// Remove setuid/setgid bits for security; standard cross-platform.
 	newMode := file.Mode() &^ (os.ModeSetuid | os.ModeSetgid)
-	// Set permissions using os.Chmod for all platforms.
-	if err := os.Chmod(filePath, newMode); err != nil {
-		log.Error("Failed to set file permissions", "path", filePath, "error", err)
+	if err := root.Chmod(relPath, newMode); err != nil {
+		log.Error("Failed to set file permissions", "path", relPath, "error", err)
 	}
 	return nil
 }

--- a/pkg/oci/zip.go
+++ b/pkg/oci/zip.go
@@ -22,8 +22,9 @@ const maxZipArchiveSize = 512 * 1024 * 1024 // 512 MiB.
 // maxZipEntrySize bounds how many bytes a single zip entry may decompress
 // to. Module packages are source-code archives (KBs-MBs), so this is
 // generous while still bounding a maliciously crafted entry that expands
-// far past its declared size.
-const maxZipEntrySize = 512 * 1024 * 1024 // 512 MiB.
+// far past its declared size. A var, not a const, so tests can shrink it
+// temporarily instead of writing hundreds of megabytes of fixture data.
+var maxZipEntrySize uint64 = 512 * 1024 * 1024 // 512 MiB.
 
 // extractZip extracts a ZIP archive read from reader into the destination
 // directory. Since zip.Reader requires io.ReaderAt plus a known size, the
@@ -115,7 +116,7 @@ func createFileFromZip(root *os.Root, relPath string, file *zip.File) error {
 	// Copy at most maxZipEntrySize+1 bytes: a nil error means the source still
 	// had data left at that point, i.e. the actual decompressed content
 	// exceeds the declared size (or the declaration was understated/forged).
-	_, err = io.CopyN(writer, src, maxZipEntrySize+1)
+	_, err = io.CopyN(writer, src, int64(maxZipEntrySize)+1) //nolint:gosec // G115: maxZipEntrySize is an internal, code-controlled limit (default 512MiB, only ever shrunk by tests), never derived from untrusted archive input, so it never approaches int64's range.
 	if err != nil && !errors.Is(err, io.EOF) {
 		log.Error("Failed to write file contents", "path", relPath, "error", err)
 		return fmt.Errorf("failed to write file contents to %s: %w", relPath, err)

--- a/pkg/oci/zip.go
+++ b/pkg/oci/zip.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/filesystem"
@@ -45,10 +44,6 @@ func extractZip(reader io.Reader, extractPath string) error {
 	}
 
 	for _, file := range zipReader.File {
-		if strings.Contains(file.Name, "..") {
-			log.Warn("Skipping potential directory traversal attempt", "filename", file.Name)
-			continue
-		}
 		if err := processZipFile(file, extractPath); err != nil {
 			return err
 		}

--- a/pkg/oci/zip.go
+++ b/pkg/oci/zip.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	errUtils "github.com/cloudposse/atmos/errors"
-	"github.com/cloudposse/atmos/pkg/archiveutil"
+	"github.com/cloudposse/atmos/pkg/filesystem"
 	log "github.com/cloudposse/atmos/pkg/logger" // Charmbracelet structured logger
 )
 
@@ -60,7 +60,7 @@ func extractZip(reader io.Reader, extractPath string) error {
 // processZipFile processes a zip.File entry and writes the corresponding file
 // to the destination directory.
 func processZipFile(file *zip.File, extractPath string) error {
-	filePath, err := archiveutil.SafeJoin(extractPath, file.Name)
+	filePath, err := filesystem.SafeJoin(extractPath, file.Name)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidFilePath, file.Name)
 	}

--- a/pkg/oci/zip.go
+++ b/pkg/oci/zip.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/archiveutil"
 	log "github.com/cloudposse/atmos/pkg/logger" // Charmbracelet structured logger
 )
 
@@ -59,14 +60,9 @@ func extractZip(reader io.Reader, extractPath string) error {
 // processZipFile processes a zip.File entry and writes the corresponding file
 // to the destination directory.
 func processZipFile(file *zip.File, extractPath string) error {
-	// Normalize and clean the extraction base path to remove any redundant separators or ".." sequences.
-	cleanExtractPath := filepath.Clean(extractPath)
-	// Clean the file path inside the archive to prevent directory traversal attacks.
-	cleanFileName := filepath.Clean(file.Name)
-	filePath := filepath.Join(cleanExtractPath, cleanFileName)
-	// Ensure the target path is within the intended extraction directory.
-	if !strings.HasPrefix(filePath, cleanExtractPath) {
-		return fmt.Errorf("%w: %s", ErrInvalidFilePath, filePath)
+	filePath, err := archiveutil.SafeJoin(extractPath, file.Name)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidFilePath, file.Name)
 	}
 
 	if file.FileInfo().IsDir() {

--- a/pkg/oci/zip_test.go
+++ b/pkg/oci/zip_test.go
@@ -44,17 +44,44 @@ func TestExtractZip_WritesFiles(t *testing.T) {
 	assert.Contains(t, string(nested), "output")
 }
 
-func TestExtractZip_SkipsDirectoryTraversal(t *testing.T) {
+// TestExtractZip_RejectsDirectoryTraversal exercises processZipFile's
+// SafeJoin containment check: extractZip has no ".."-substring prefilter of
+// its own (removed -- it was overbroad and dropped valid filenames like
+// "..hidden.txt", see TestExtractZip_ExtractsFilenameContainingDotDot), so
+// SafeJoin is the sole gate and must fail loudly rather than silently skip.
+func TestExtractZip_RejectsDirectoryTraversal(t *testing.T) {
 	dest := t.TempDir()
 	zipBuf := writeTestZip(t, map[string]string{
 		"../../etc/passwd": "malicious\n",
 	})
 
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFilePath)
+
+	entries, readErr := os.ReadDir(dest)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "traversal entry must not be written to dest")
+}
+
+// TestExtractZip_ExtractsFilenameContainingDotDot is a regression test: a
+// valid filename that merely contains ".." as a substring without it being a
+// full path-traversal component (e.g. "..hidden.txt") must still be
+// extracted. SafeJoin already rejects only actual ".." path components (see
+// TestSafeJoin's "name that merely starts with dotdot" case); the removed
+// prefilter in extractZip used to reject this too, via a much broader
+// substring check.
+func TestExtractZip_ExtractsFilenameContainingDotDot(t *testing.T) {
+	dest := t.TempDir()
+	zipBuf := writeTestZip(t, map[string]string{
+		"..hidden.txt": "content\n",
+	})
+
 	require.NoError(t, extractZip(zipBuf, dest))
 
-	entries, err := os.ReadDir(dest)
+	content, err := os.ReadFile(filepath.Join(dest, "..hidden.txt"))
 	require.NoError(t, err)
-	assert.Empty(t, entries, "traversal entry must not be written to dest")
+	assert.Equal(t, "content\n", string(content))
 }
 
 // TestExtractZip_RejectsAbsolutePath exercises processZipFile's SafeJoin

--- a/pkg/oci/zip_test.go
+++ b/pkg/oci/zip_test.go
@@ -163,3 +163,29 @@ func TestExtractZip_DirectoryEntryFailsWhenParentDirBlocked(t *testing.T) {
 	err := extractZip(zipBuf, dest)
 	require.Error(t, err)
 }
+
+// TestExtractZip_RejectsWriteThroughPreExistingSymlink is a regression test
+// for CWE-59 (symlink-following): SafeJoin only validates an entry name
+// lexically, so before extraction switched to os.Root, a pre-existing
+// symlink inside dest pointing outside it (e.g. left over from a prior run,
+// or planted via an unrelated mechanism) let a plain-looking entry name like
+// "link/evil.txt" escape dest via os.MkdirAll/os.Create following the
+// symlink -- os.Root refuses to resolve a path through a symlink that would
+// leave the root.
+func TestExtractZip_RejectsWriteThroughPreExistingSymlink(t *testing.T) {
+	dest := t.TempDir()
+	outside := t.TempDir()
+
+	link := filepath.Join(dest, "link")
+	require.NoError(t, os.Symlink(outside, link))
+
+	zipBuf := writeTestZip(t, map[string]string{
+		"link/evil.txt": "escaped\n",
+	})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
+	assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+}

--- a/pkg/oci/zip_test.go
+++ b/pkg/oci/zip_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -188,4 +189,90 @@ func TestExtractZip_RejectsWriteThroughPreExistingSymlink(t *testing.T) {
 
 	_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
 	assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+}
+
+// TestExtractZip_FailsWhenExtractPathBlocked exercises extractZip's
+// os.MkdirAll(extractPath) error branch: a regular file sitting where
+// extractPath itself needs to be created makes MkdirAll fail.
+func TestExtractZip_FailsWhenExtractPathBlocked(t *testing.T) {
+	parent := t.TempDir()
+	blocked := filepath.Join(parent, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+
+	zipBuf := writeTestZip(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractZip(zipBuf, filepath.Join(blocked, "nested"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create extraction directory")
+}
+
+// TestExtractZip_FailsWhenExtractPathUnreadable exercises extractZip's
+// os.OpenRoot(extractPath) error branch: MkdirAll succeeds (the directory
+// already exists), but a directory with no permissions cannot be opened.
+func TestExtractZip_FailsWhenExtractPathUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't apply the same way on Windows")
+	}
+
+	dest := t.TempDir()
+	require.NoError(t, os.Chmod(dest, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(dest, 0o755) }) // Allow t.TempDir's own cleanup to remove it.
+
+	zipBuf := writeTestZip(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open extraction root")
+}
+
+// TestExtractZip_RejectsOversizedDeclaredEntry exercises createFileFromZip's
+// declared-size-too-large branch by temporarily shrinking maxZipEntrySize
+// rather than writing hundreds of megabytes of fixture data.
+func TestExtractZip_RejectsOversizedDeclaredEntry(t *testing.T) {
+	orig := maxZipEntrySize
+	maxZipEntrySize = 4
+	t.Cleanup(func() { maxZipEntrySize = orig })
+
+	dest := t.TempDir()
+	zipBuf := writeTestZip(t, map[string]string{"big.txt": "this is more than 4 bytes"})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declared")
+}
+
+// TestExtractZip_FailsWhenTargetIsExistingDir exercises createFileFromZip's
+// root.Create error branch: a directory already sitting at the entry's path
+// makes Create fail (can't open a directory for writing).
+func TestExtractZip_FailsWhenTargetIsExistingDir(t *testing.T) {
+	dest := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "file.txt"), 0o755))
+
+	zipBuf := writeTestZip(t, map[string]string{"file.txt": "content\n"})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create file")
+}
+
+// TestExtractZip_FailsOnUnsupportedCompressionMethod exercises
+// createFileFromZip's file.Open() error branch: archive/zip's CreateHeader
+// rejects an unsupported compression method up front, so the only way to
+// produce one is via the raw (pre-compressed) writer API, which skips that
+// validation -- letting the entry parse fine but fail to decompress when read.
+func TestExtractZip_FailsOnUnsupportedCompressionMethod(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	hdr := &zip.FileHeader{Name: "weird.txt", Method: 99, UncompressedSize64: 5, CompressedSize64: 5}
+	hdr.SetMode(0o644)
+	w, err := zw.CreateRaw(hdr)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	dest := t.TempDir()
+	err = extractZip(&buf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open zip entry")
 }

--- a/pkg/oci/zip_test.go
+++ b/pkg/oci/zip_test.go
@@ -213,6 +213,9 @@ func TestExtractZip_FailsWhenExtractPathUnreadable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits don't apply the same way on Windows")
 	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root ignores directory permission bits")
+	}
 
 	dest := t.TempDir()
 	require.NoError(t, os.Chmod(dest, 0o000))

--- a/pkg/oci/zip_test.go
+++ b/pkg/oci/zip_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,4 +55,84 @@ func TestExtractZip_SkipsDirectoryTraversal(t *testing.T) {
 	entries, err := os.ReadDir(dest)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "traversal entry must not be written to dest")
+}
+
+// TestExtractZip_RejectsAbsolutePath exercises processZipFile's SafeJoin
+// containment check directly, rather than extractZip's earlier ".."
+// substring filter, since an absolute entry name contains no "..", so it
+// reaches processZipFile, where SafeJoin must still reject it.
+func TestExtractZip_RejectsAbsolutePath(t *testing.T) {
+	dest := t.TempDir()
+	zipBuf := writeTestZip(t, map[string]string{
+		"/etc/passwd": "malicious\n",
+	})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFilePath)
+
+	entries, readErr := os.ReadDir(dest)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "absolute-path entry must not be written to dest")
+}
+
+// TestExtractZip_CreatesDirectoryEntries exercises processZipFile's
+// file.FileInfo().IsDir() branch: a zip entry name ending in "/" is a
+// directory marker (archive/zip sets fs.ModeDir for any such name), which
+// must be created as an empty directory rather than passed to
+// createFileFromZip.
+func TestExtractZip_CreatesDirectoryEntries(t *testing.T) {
+	dest := t.TempDir()
+	zipBuf := writeTestZip(t, map[string]string{
+		"emptydir/": "",
+	})
+
+	require.NoError(t, extractZip(zipBuf, dest))
+
+	info, err := os.Stat(filepath.Join(dest, "emptydir"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestExtractZip_RejectsMalformedArchive exercises extractZip's zip.NewReader
+// parse-error branch.
+func TestExtractZip_RejectsMalformedArchive(t *testing.T) {
+	dest := t.TempDir()
+	err := extractZip(strings.NewReader("this is not a zip file"), dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse zip archive")
+}
+
+// TestExtractZip_FailsWhenParentDirBlocked exercises createFileFromZip's
+// os.MkdirAll error branch: a regular file sitting where a parent directory
+// needs to be created makes MkdirAll fail.
+func TestExtractZip_FailsWhenParentDirBlocked(t *testing.T) {
+	dest := t.TempDir()
+	blocker := filepath.Join(dest, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	zipBuf := writeTestZip(t, map[string]string{
+		"blocker/nested/file.txt": "content\n",
+	})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create parent directory")
+}
+
+// TestExtractZip_DirectoryEntryFailsWhenParentDirBlocked exercises
+// createDirectory's os.MkdirAll error branch via the IsDir() case: a regular
+// file sitting where a parent directory needs to be created makes MkdirAll
+// fail.
+func TestExtractZip_DirectoryEntryFailsWhenParentDirBlocked(t *testing.T) {
+	dest := t.TempDir()
+	blocker := filepath.Join(dest, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	zipBuf := writeTestZip(t, map[string]string{
+		"blocker/subdir/": "",
+	})
+
+	err := extractZip(zipBuf, dest)
+	require.Error(t, err)
 }

--- a/pkg/runner/step/log.go
+++ b/pkg/runner/step/log.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/cloudposse/atmos/pkg/logger"
 	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/cloudposse/atmos/pkg/safenum"
 	"github.com/cloudposse/atmos/pkg/schema"
 )
 
@@ -85,12 +86,7 @@ func (h *LogHandler) buildKeyvals(step *schema.WorkflowStep, vars *Variables) []
 // Each field becomes 2 entries (key + value), so we need fieldsLen*2 capacity.
 // Returns min(fieldsLen*2, maxCapacity) without risk of overflow.
 func safeKeyvalsCapacity(fieldsLen, maxCapacity int) int {
-	// If fieldsLen would cause overflow when doubled, use maxCapacity.
-	// maxCapacity/2 is the largest safe input for doubling.
-	if fieldsLen > maxCapacity/2 {
-		return maxCapacity
-	}
-	return fieldsLen * 2
+	return safenum.Cap(fieldsLen, fieldsLen, maxCapacity)
 }
 
 // getLogLevel parses a log level string.

--- a/pkg/runner/step/spin.go
+++ b/pkg/runner/step/spin.go
@@ -11,6 +11,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/perf"
+	"github.com/cloudposse/atmos/pkg/safenum"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui/spinner"
 )
@@ -188,10 +189,7 @@ func getShellCommand() (shell string, arg string) {
 // safeEnvCapacity computes a safe capacity for environment variable slices.
 // It clamps both lengths to maxEnvVars before adding to prevent overflow.
 func safeEnvCapacity(len1, len2, maxEnvVars int) int {
-	// Clamp inputs using min() so the addition can't overflow.
-	len1 = min(len1, maxEnvVars)
-	len2 = min(len2, maxEnvVars)
-	return min(len1+len2, maxEnvVars)
+	return safenum.Cap(len1, len2, maxEnvVars)
 }
 
 // buildResult creates a step result from command output.

--- a/pkg/safenum/cap.go
+++ b/pkg/safenum/cap.go
@@ -1,0 +1,34 @@
+// Package safenum provides small overflow-safe numeric helpers, primarily
+// for sizing make() capacity hints from untrusted or accumulated lengths.
+package safenum
+
+import "github.com/cloudposse/atmos/pkg/perf"
+
+// Cap returns a safe make() capacity hint for a+b, clamped to max so the
+// addition can never overflow int and the hint never requests an absurd
+// up-front allocation. Negative inputs are treated as zero.
+//
+// The size argument to make() is only a capacity hint -- append() still
+// grows the backing array as needed -- so clamping the hint below the true
+// a+b never changes program behavior, it only avoids an oversized
+// allocation. Callers that must refuse to proceed entirely above some size
+// (rather than just allocate conservatively and let append grow it) need
+// their own guard; see pkg/merge.processAppendList for that different,
+// deliberate semantic.
+func Cap(a, b, max int) int {
+	defer perf.Track(nil, "safenum.Cap")()
+
+	if a < 0 {
+		a = 0
+	}
+	if b < 0 {
+		b = 0
+	}
+	if max < 0 {
+		max = 0
+	}
+	if a > max || b > max-a {
+		return max
+	}
+	return a + b
+}

--- a/pkg/safenum/cap_test.go
+++ b/pkg/safenum/cap_test.go
@@ -1,0 +1,36 @@
+package safenum
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCap(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b int
+		max  int
+		want int
+	}{
+		{name: "simple sum under max", a: 3, b: 4, max: 100, want: 7},
+		{name: "zero values", a: 0, b: 0, max: 100, want: 0},
+		{name: "sum exactly at max", a: 40, b: 60, max: 100, want: 100},
+		{name: "sum exceeds max", a: 60, b: 60, max: 100, want: 100},
+		{name: "a alone exceeds max", a: 200, b: 5, max: 100, want: 100},
+		{name: "would overflow int addition", a: math.MaxInt - 1, b: 5, max: 1 << 24, want: 1 << 24},
+		{name: "doubling shape via a==b", a: 10, b: 10, max: 100, want: 20},
+		{name: "doubling shape clamped", a: 80, b: 80, max: 100, want: 100},
+		{name: "negative inputs treated as zero", a: -5, b: -1, max: 100, want: 0},
+		{name: "negative max treated as zero", a: 5, b: 5, max: -1, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Cap(tt.a, tt.b, tt.max)
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, got, max(tt.max, 0))
+		})
+	}
+}

--- a/pkg/stack/imports/remote.go
+++ b/pkg/stack/imports/remote.go
@@ -107,6 +107,9 @@ func NewRemoteImporter(atmosConfig *schema.AtmosConfiguration, opts ...RemoteImp
 
 // uriToTempName generates a unique temp filename for a URI using SHA256 hashing.
 func uriToTempName(uri string) string {
+	// codeql[go/weak-sensitive-data-hashing] -- hashes an import URI to derive a
+	// deterministic temp-download filename; never used for credential
+	// verification or storage.
 	hash := sha256.Sum256([]byte(uri))
 	return fmt.Sprintf(".download.%x", hash[:8])
 }

--- a/pkg/toolchain/installer/extract.go
+++ b/pkg/toolchain/installer/extract.go
@@ -18,7 +18,7 @@ import (
 	log "github.com/charmbracelet/log"
 	"github.com/gabriel-vasile/mimetype"
 
-	"github.com/cloudposse/atmos/pkg/archiveutil"
+	"github.com/cloudposse/atmos/pkg/filesystem"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/toolchain/registry"
 	"github.com/cloudposse/atmos/pkg/ui"
@@ -343,7 +343,7 @@ func readZipSymlinkTarget(f *zip.File) (string, error) {
 }
 
 func validatePath(name, dest string) (string, error) {
-	fpath, err := archiveutil.SafeJoin(dest, name)
+	fpath, err := filesystem.SafeJoin(dest, name)
 	if err != nil {
 		return "", fmt.Errorf("%w: illegal file path: %s", ErrFileOperation, name)
 	}
@@ -442,7 +442,7 @@ func unpackTarGz(src, dest string) ([]pendingSymlink, []pendingHardLink, error) 
 }
 
 func extractEntry(tr *tar.Reader, header *tar.Header, dest string, symlinks *[]pendingSymlink, hardLinks *[]pendingHardLink) error {
-	targetPath, err := archiveutil.SafeJoin(dest, header.Name)
+	targetPath, err := filesystem.SafeJoin(dest, header.Name)
 	if err != nil {
 		return fmt.Errorf("%w: illegal file path: %s", ErrFileOperation, header.Name)
 	}

--- a/pkg/toolchain/installer/extract.go
+++ b/pkg/toolchain/installer/extract.go
@@ -275,6 +275,13 @@ func Unzip(src, dest string) error {
 }
 
 // unpackZip extracts files and returns deferred symlink entries.
+//
+// Writes go through an os.Root opened on dest rather than plain
+// os.MkdirAll/os.OpenFile: validatePath only validates the entry name
+// lexically, so without os.Root a pre-existing symlink inside dest (or a
+// hard link materialized by a prior entry) could let a later entry's write
+// escape dest -- os.Root's methods refuse to resolve a path that escapes the
+// root, symlinks included.
 func unpackZip(src, dest string) ([]pendingSymlink, error) {
 	defer perf.Track(nil, "toolchain.unpackZip")()
 
@@ -286,23 +293,34 @@ func unpackZip(src, dest string) ([]pendingSymlink, error) {
 	}
 	defer r.Close()
 
+	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("%w: failed to create extraction directory: %w", ErrFileOperation, err)
+	}
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to open extraction root: %w", ErrFileOperation, err)
+	}
+	defer root.Close()
+
 	var symlinks []pendingSymlink
 	for _, f := range r.File {
-		if err := extractZipFile(f, dest, maxDecompressedSize, &symlinks); err != nil {
+		if err := extractZipFile(root, f, dest, maxDecompressedSize, &symlinks); err != nil {
 			return nil, err
 		}
 	}
 	return symlinks, nil
 }
 
-func extractZipFile(f *zip.File, dest string, maxSize int64, symlinks *[]pendingSymlink) error {
-	fpath, err := validatePath(f.Name, dest)
-	if err != nil {
+func extractZipFile(root *os.Root, f *zip.File, dest string, maxSize int64, symlinks *[]pendingSymlink) error {
+	// validatePath's returned absolute path isn't used since writes go
+	// through root by relative name instead; only the validation matters here.
+	if _, err := validatePath(f.Name, dest); err != nil {
 		return err
 	}
+	relPath := filepath.FromSlash(f.Name)
 
 	if f.FileInfo().IsDir() {
-		return os.MkdirAll(fpath, os.ModePerm)
+		return root.MkdirAll(relPath, os.ModePerm)
 	}
 
 	if f.Mode()&os.ModeSymlink != 0 {
@@ -314,11 +332,11 @@ func extractZipFile(f *zip.File, dest string, maxSize int64, symlinks *[]pending
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+	if err := root.MkdirAll(filepath.Dir(relPath), os.ModePerm); err != nil {
 		return err
 	}
 
-	return copyFileContents(f, fpath, maxSize)
+	return copyFileContents(root, relPath, f, maxSize)
 }
 
 // readZipSymlinkTarget reads a zip symlink target, bounded to
@@ -350,14 +368,14 @@ func validatePath(name, dest string) (string, error) {
 	return fpath, nil
 }
 
-func copyFileContents(f *zip.File, fpath string, maxSize int64) error {
+func copyFileContents(root *os.Root, relPath string, f *zip.File, maxSize int64) error {
 	rc, err := f.Open()
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
 
-	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	outFile, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 	if err != nil {
 		return err
 	}
@@ -407,6 +425,13 @@ func ExtractTarGz(src, dest string) error {
 }
 
 // unpackTarGz extracts files and returns deferred symlink entries.
+//
+// Writes go through an os.Root opened on dest rather than plain
+// os.MkdirAll/os.OpenFile: SafeJoin only validates the entry name lexically,
+// so without os.Root a pre-existing symlink inside dest (or a hard link
+// materialized by a prior entry) could let a later entry's write escape
+// dest -- os.Root's methods refuse to resolve a path that escapes the root,
+// symlinks included.
 func unpackTarGz(src, dest string) ([]pendingSymlink, []pendingHardLink, error) {
 	defer perf.Track(nil, "toolchain.unpackTarGz")()
 
@@ -422,8 +447,16 @@ func unpackTarGz(src, dest string) ([]pendingSymlink, []pendingHardLink, error) 
 	}
 	defer gzr.Close()
 
-	var symlinks []pendingSymlink
-	var hardLinks []pendingHardLink
+	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to create extraction directory: %w", ErrFileOperation, err)
+	}
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to open extraction root: %w", ErrFileOperation, err)
+	}
+	defer root.Close()
+
+	var deferred deferredEntries
 	tr := tar.NewReader(gzr)
 	for {
 		header, err := tr.Next()
@@ -434,29 +467,31 @@ func unpackTarGz(src, dest string) ([]pendingSymlink, []pendingHardLink, error) 
 			return nil, nil, fmt.Errorf("%w: error reading tar: %w", ErrFileOperation, err)
 		}
 
-		if err := extractEntry(tr, header, dest, &symlinks, &hardLinks); err != nil {
+		if err := extractEntry(root, tr, header, dest, &deferred); err != nil {
 			return nil, nil, err
 		}
 	}
-	return symlinks, hardLinks, nil
+	return deferred.symlinks, deferred.hardLinks, nil
 }
 
-func extractEntry(tr *tar.Reader, header *tar.Header, dest string, symlinks *[]pendingSymlink, hardLinks *[]pendingHardLink) error {
-	targetPath, err := filesystem.SafeJoin(dest, header.Name)
-	if err != nil {
+func extractEntry(root *os.Root, tr *tar.Reader, header *tar.Header, dest string, deferred *deferredEntries) error {
+	// SafeJoin's returned absolute path isn't used since writes go through
+	// root by relative name instead; only the validation matters here.
+	if _, err := filesystem.SafeJoin(dest, header.Name); err != nil {
 		return fmt.Errorf("%w: illegal file path: %s", ErrFileOperation, header.Name)
 	}
+	relPath := filepath.FromSlash(header.Name)
 
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return extractDir(targetPath, header)
+		return extractDir(root, relPath, header)
 	case tar.TypeReg:
-		return extractFile(tr, targetPath, header)
+		return extractFile(root, tr, relPath, header)
 	case tar.TypeSymlink:
-		*symlinks = append(*symlinks, pendingSymlink{rel: header.Name, target: header.Linkname})
+		deferred.symlinks = append(deferred.symlinks, pendingSymlink{rel: header.Name, target: header.Linkname})
 		return nil
 	case tar.TypeLink:
-		*hardLinks = append(*hardLinks, pendingHardLink{rel: header.Name, target: header.Linkname})
+		deferred.hardLinks = append(deferred.hardLinks, pendingHardLink{rel: header.Name, target: header.Linkname})
 		return nil
 	default:
 		ui.Warningf("Skipping unknown type: %s", header.Name)
@@ -464,18 +499,18 @@ func extractEntry(tr *tar.Reader, header *tar.Header, dest string, symlinks *[]p
 	}
 }
 
-func extractDir(path string, header *tar.Header) error {
+func extractDir(root *os.Root, relPath string, header *tar.Header) error {
 	// Validate header.Mode.
 	if header.Mode < 0 || header.Mode > maxUnixPermissions {
-		return fmt.Errorf("%w: invalid mode %d for %s: must be between 0 and %o", ErrFileOperation, header.Mode, path, maxUnixPermissions)
+		return fmt.Errorf("%w: invalid mode %d for %s: must be between 0 and %o", ErrFileOperation, header.Mode, relPath, maxUnixPermissions)
 	}
 
 	// Safe conversion to os.FileMode.
-	return os.MkdirAll(path, os.FileMode(header.Mode))
+	return root.MkdirAll(relPath, os.FileMode(header.Mode))
 }
 
-func extractFile(tr *tar.Reader, path string, header *tar.Header) error {
-	if err := os.MkdirAll(filepath.Dir(path), defaultMkdirPermissions); err != nil {
+func extractFile(root *os.Root, tr *tar.Reader, relPath string, header *tar.Header) error {
+	if err := root.MkdirAll(filepath.Dir(relPath), defaultMkdirPermissions); err != nil {
 		return fmt.Errorf("%w: failed to create parent directory: %w", ErrFileOperation, err)
 	}
 	// Validate header.Mode is within uint32 range.
@@ -483,7 +518,7 @@ func extractFile(tr *tar.Reader, path string, header *tar.Header) error {
 		return fmt.Errorf("%w: header.Mode out of uint32 range: %d", ErrFileOperation, header.Mode)
 	}
 
-	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+	outFile, err := root.OpenFile(relPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
 	if err != nil {
 		return fmt.Errorf("%w: failed to create file: %w", ErrFileOperation, err)
 	}

--- a/pkg/toolchain/installer/extract.go
+++ b/pkg/toolchain/installer/extract.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/charmbracelet/log"
 	"github.com/gabriel-vasile/mimetype"
 
+	"github.com/cloudposse/atmos/pkg/archiveutil"
 	"github.com/cloudposse/atmos/pkg/perf"
 	"github.com/cloudposse/atmos/pkg/toolchain/registry"
 	"github.com/cloudposse/atmos/pkg/ui"
@@ -342,8 +343,8 @@ func readZipSymlinkTarget(f *zip.File) (string, error) {
 }
 
 func validatePath(name, dest string) (string, error) {
-	fpath := filepath.Join(dest, name)
-	if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+	fpath, err := archiveutil.SafeJoin(dest, name)
+	if err != nil {
 		return "", fmt.Errorf("%w: illegal file path: %s", ErrFileOperation, name)
 	}
 	return fpath, nil
@@ -441,9 +442,8 @@ func unpackTarGz(src, dest string) ([]pendingSymlink, []pendingHardLink, error) 
 }
 
 func extractEntry(tr *tar.Reader, header *tar.Header, dest string, symlinks *[]pendingSymlink, hardLinks *[]pendingHardLink) error {
-	//nolint:gosec // G305: Path is validated by isSafePath check on next line.
-	targetPath := filepath.Join(dest, header.Name)
-	if !isSafePath(targetPath, dest) {
+	targetPath, err := archiveutil.SafeJoin(dest, header.Name)
+	if err != nil {
 		return fmt.Errorf("%w: illegal file path: %s", ErrFileOperation, header.Name)
 	}
 
@@ -462,11 +462,6 @@ func extractEntry(tr *tar.Reader, header *tar.Header, dest string, symlinks *[]p
 		ui.Warningf("Skipping unknown type: %s", header.Name)
 		return nil
 	}
-}
-
-func isSafePath(path, dest string) bool {
-	cleanDest := filepath.Clean(dest) + string(os.PathSeparator)
-	return strings.HasPrefix(filepath.Clean(path), cleanDest)
 }
 
 func extractDir(path string, header *tar.Header) error {

--- a/pkg/toolchain/installer/extract_test.go
+++ b/pkg/toolchain/installer/extract_test.go
@@ -662,6 +662,41 @@ func TestUnpackTarGz_ErrorPaths(t *testing.T) {
 		_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
 		assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
 	})
+
+	// TestUnpackTarGz_FailsWhenExtractPathBlocked exercises unpackTarGz's
+	// os.MkdirAll(dest, ...) error branch: a regular file sitting where dest
+	// itself needs to be created makes MkdirAll fail.
+	t.Run("fails when the extraction directory is blocked", func(t *testing.T) {
+		tmp := t.TempDir()
+		blocked := filepath.Join(tmp, "blocked")
+		require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+		archive := filepath.Join(tmp, "test.tar.gz")
+		writeTarGzTree(t, archive, []tarEntry{{name: "file.txt", content: "x"}})
+
+		_, _, err := unpackTarGz(archive, filepath.Join(blocked, "nested"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+
+	// TestUnpackTarGz_FailsWhenExtractPathUnreadable exercises unpackTarGz's
+	// os.OpenRoot(dest) error branch: MkdirAll succeeds (the directory
+	// already exists), but a directory with no permissions cannot be opened.
+	t.Run("fails when the extraction directory is unreadable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("POSIX permission bits don't apply the same way on Windows")
+		}
+		tmp := t.TempDir()
+		dest := filepath.Join(tmp, "out")
+		require.NoError(t, os.MkdirAll(dest, 0o755))
+		require.NoError(t, os.Chmod(dest, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(dest, 0o755) })
+		archive := filepath.Join(tmp, "test.tar.gz")
+		writeTarGzTree(t, archive, []tarEntry{{name: "file.txt", content: "x"}})
+
+		_, _, err := unpackTarGz(archive, dest)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
 }
 
 // TestUnpackZip_ErrorPaths covers unpackZip's entry-error propagation (a name
@@ -734,6 +769,41 @@ func TestUnpackZip_ErrorPaths(t *testing.T) {
 
 		_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
 		assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+	})
+
+	// TestUnpackZip_FailsWhenExtractPathBlocked exercises unpackZip's
+	// os.MkdirAll(dest, ...) error branch: a regular file sitting where dest
+	// itself needs to be created makes MkdirAll fail.
+	t.Run("fails when the extraction directory is blocked", func(t *testing.T) {
+		tmp := t.TempDir()
+		blocked := filepath.Join(tmp, "blocked")
+		require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+		archive := filepath.Join(tmp, "test.zip")
+		writeZipTree(t, archive, []zipEntry{{name: "file.txt", content: "x"}})
+
+		_, err := unpackZip(archive, filepath.Join(blocked, "nested"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+
+	// TestUnpackZip_FailsWhenExtractPathUnreadable exercises unpackZip's
+	// os.OpenRoot(dest) error branch: MkdirAll succeeds (the directory
+	// already exists), but a directory with no permissions cannot be opened.
+	t.Run("fails when the extraction directory is unreadable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("POSIX permission bits don't apply the same way on Windows")
+		}
+		tmp := t.TempDir()
+		dest := filepath.Join(tmp, "out")
+		require.NoError(t, os.MkdirAll(dest, 0o755))
+		require.NoError(t, os.Chmod(dest, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(dest, 0o755) })
+		archive := filepath.Join(tmp, "test.zip")
+		writeZipTree(t, archive, []zipEntry{{name: "file.txt", content: "x"}})
+
+		_, err := unpackZip(archive, dest)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
 	})
 }
 

--- a/pkg/toolchain/installer/extract_test.go
+++ b/pkg/toolchain/installer/extract_test.go
@@ -685,6 +685,9 @@ func TestUnpackTarGz_ErrorPaths(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("POSIX permission bits don't apply the same way on Windows")
 		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root ignores directory permission bits")
+		}
 		tmp := t.TempDir()
 		dest := filepath.Join(tmp, "out")
 		require.NoError(t, os.MkdirAll(dest, 0o755))
@@ -792,6 +795,9 @@ func TestUnpackZip_ErrorPaths(t *testing.T) {
 	t.Run("fails when the extraction directory is unreadable", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("POSIX permission bits don't apply the same way on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root ignores directory permission bits")
 		}
 		tmp := t.TempDir()
 		dest := filepath.Join(tmp, "out")

--- a/pkg/toolchain/installer/extract_test.go
+++ b/pkg/toolchain/installer/extract_test.go
@@ -296,41 +296,6 @@ func TestValidatePath(t *testing.T) {
 	}
 }
 
-func TestIsSafePath(t *testing.T) {
-	tests := []struct {
-		name     string
-		path     string
-		dest     string
-		expected bool
-	}{
-		{
-			name:     "safe path within dest",
-			path:     "/tmp/extract/subdir/file",
-			dest:     "/tmp/extract",
-			expected: true,
-		},
-		{
-			name:     "path outside dest",
-			path:     "/etc/passwd",
-			dest:     "/tmp/extract",
-			expected: false,
-		},
-		{
-			name:     "path traversal",
-			path:     "/tmp/extract/../../../etc/passwd",
-			dest:     "/tmp/extract",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isSafePath(tt.path, tt.dest)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestFindBinaryInDir(t *testing.T) {
 	t.Run("finds binary in root", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/pkg/toolchain/installer/extract_test.go
+++ b/pkg/toolchain/installer/extract_test.go
@@ -472,24 +472,28 @@ func TestCopyWithLimit(t *testing.T) {
 func TestExtractDir(t *testing.T) {
 	t.Run("creates directory with valid mode", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		targetPath := filepath.Join(tmpDir, "newdir")
+		root, err := os.OpenRoot(tmpDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{Mode: 0o755}
-		err := extractDir(targetPath, header)
+		err = extractDir(root, "newdir", header)
 		assert.NoError(t, err)
 
-		info, err := os.Stat(targetPath)
+		info, err := os.Stat(filepath.Join(tmpDir, "newdir"))
 		assert.NoError(t, err)
 		assert.True(t, info.IsDir())
 	})
 
 	t.Run("rejects invalid mode", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		targetPath := filepath.Join(tmpDir, "newdir")
+		root, err := os.OpenRoot(tmpDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		// Mode -1 is invalid as file mode bits must be non-negative.
 		header := &tar.Header{Mode: -1}
-		err := extractDir(targetPath, header)
+		err = extractDir(root, "newdir", header)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
@@ -634,6 +638,30 @@ func TestUnpackTarGz_ErrorPaths(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
+
+	// TestUnpackTarGz_RejectsWriteThroughPreExistingSymlink is a regression
+	// test for CWE-59 (symlink-following): SafeJoin only validates an entry
+	// name lexically, so before extraction switched to os.Root, a
+	// pre-existing symlink inside dest pointing outside it let a
+	// plain-looking entry name like "link/evil.txt" escape dest via
+	// os.MkdirAll/os.OpenFile following the symlink. os.Root refuses to
+	// resolve a path through a symlink that would leave the root.
+	t.Run("rejects write through pre-existing symlink", func(t *testing.T) {
+		tmp := t.TempDir()
+		dest := filepath.Join(tmp, "out")
+		require.NoError(t, os.MkdirAll(dest, 0o755))
+		outside := t.TempDir()
+		require.NoError(t, os.Symlink(outside, filepath.Join(dest, "link")))
+
+		archive := filepath.Join(tmp, "evil.tar.gz")
+		writeTarGzTree(t, archive, []tarEntry{{name: "link/evil.txt", content: "escaped"}})
+
+		_, _, err := unpackTarGz(archive, dest)
+		require.Error(t, err)
+
+		_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
+		assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
+	})
 }
 
 // TestUnpackZip_ErrorPaths covers unpackZip's entry-error propagation (a name
@@ -682,6 +710,30 @@ func TestUnpackZip_ErrorPaths(t *testing.T) {
 		_, err := unpackZip(archive, filepath.Join(tmp, "out"))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+
+	// TestUnpackZip_RejectsWriteThroughPreExistingSymlink is a regression
+	// test for CWE-59 (symlink-following): SafeJoin only validates an entry
+	// name lexically, so before extraction switched to os.Root, a
+	// pre-existing symlink inside dest pointing outside it let a
+	// plain-looking entry name like "link/evil.txt" escape dest via
+	// os.MkdirAll/os.OpenFile following the symlink. os.Root refuses to
+	// resolve a path through a symlink that would leave the root.
+	t.Run("rejects write through pre-existing symlink", func(t *testing.T) {
+		tmp := t.TempDir()
+		dest := filepath.Join(tmp, "out")
+		require.NoError(t, os.MkdirAll(dest, 0o755))
+		outside := t.TempDir()
+		require.NoError(t, os.Symlink(outside, filepath.Join(dest, "link")))
+
+		archive := filepath.Join(tmp, "evil.zip")
+		writeZipTree(t, archive, []zipEntry{{name: "link/evil.txt", content: "escaped"}})
+
+		_, err := unpackZip(archive, dest)
+		require.Error(t, err)
+
+		_, statErr := os.Stat(filepath.Join(outside, "evil.txt"))
+		assert.True(t, os.IsNotExist(statErr), "entry must not be written through the symlink to outside")
 	})
 }
 
@@ -1109,6 +1161,9 @@ func TestExtractEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		destDir := filepath.Join(tmpDir, "dest")
 		require.NoError(t, os.MkdirAll(destDir, 0o755))
+		root, err := os.OpenRoot(destDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{
 			Name:     "subdir/",
@@ -1116,9 +1171,8 @@ func TestExtractEntry(t *testing.T) {
 			Mode:     0o755,
 		}
 
-		var symlinks []pendingSymlink
-		var hardLinks []pendingHardLink
-		err := extractEntry(nil, header, destDir, &symlinks, &hardLinks)
+		var deferred deferredEntries
+		err = extractEntry(root, nil, header, destDir, &deferred)
 		assert.NoError(t, err)
 
 		// Verify directory was created.
@@ -1131,6 +1185,9 @@ func TestExtractEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		destDir := filepath.Join(tmpDir, "dest")
 		require.NoError(t, os.MkdirAll(destDir, 0o755))
+		root, err := os.OpenRoot(destDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{
 			Name:     "../../../etc/passwd",
@@ -1138,9 +1195,8 @@ func TestExtractEntry(t *testing.T) {
 			Mode:     0o644,
 		}
 
-		var symlinks []pendingSymlink
-		var hardLinks []pendingHardLink
-		err := extractEntry(nil, header, destDir, &symlinks, &hardLinks)
+		var deferred deferredEntries
+		err = extractEntry(root, nil, header, destDir, &deferred)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
@@ -1153,6 +1209,9 @@ func TestExtractEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		destDir := filepath.Join(tmpDir, "dest")
 		require.NoError(t, os.MkdirAll(destDir, 0o755))
+		root, err := os.OpenRoot(destDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{
 			Name:     "bin/npm",
@@ -1161,14 +1220,13 @@ func TestExtractEntry(t *testing.T) {
 			Mode:     0o755,
 		}
 
-		var symlinks []pendingSymlink
-		var hardLinks []pendingHardLink
-		require.NoError(t, extractEntry(nil, header, destDir, &symlinks, &hardLinks))
+		var deferred deferredEntries
+		require.NoError(t, extractEntry(root, nil, header, destDir, &deferred))
 
 		// The entry is collected verbatim, not written to disk.
-		require.Len(t, symlinks, 1)
-		assert.Equal(t, "bin/npm", symlinks[0].rel)
-		assert.Equal(t, "../lib/npm-cli.js", symlinks[0].target)
+		require.Len(t, deferred.symlinks, 1)
+		assert.Equal(t, "bin/npm", deferred.symlinks[0].rel)
+		assert.Equal(t, "../lib/npm-cli.js", deferred.symlinks[0].target)
 		_, statErr := os.Lstat(filepath.Join(destDir, "bin", "npm"))
 		assert.True(t, os.IsNotExist(statErr), "extraction must not create the symlink; that is deferred to materialization")
 	})
@@ -1182,6 +1240,9 @@ func TestExtractEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		destDir := filepath.Join(tmpDir, "dest")
 		require.NoError(t, os.MkdirAll(destDir, 0o755))
+		root, err := os.OpenRoot(destDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{
 			Name:     "evil",
@@ -1190,11 +1251,10 @@ func TestExtractEntry(t *testing.T) {
 			Mode:     0o755,
 		}
 
-		var symlinks []pendingSymlink
-		var hardLinks []pendingHardLink
-		require.NoError(t, extractEntry(nil, header, destDir, &symlinks, &hardLinks))
-		require.Len(t, symlinks, 1)
-		assert.Equal(t, "../../../../etc/passwd", symlinks[0].target)
+		var deferred deferredEntries
+		require.NoError(t, extractEntry(root, nil, header, destDir, &deferred))
+		require.Len(t, deferred.symlinks, 1)
+		assert.Equal(t, "../../../../etc/passwd", deferred.symlinks[0].target)
 		_, statErr := os.Lstat(filepath.Join(destDir, "evil"))
 		assert.True(t, os.IsNotExist(statErr), "nothing may be written for a symlink entry during extraction")
 	})
@@ -1203,6 +1263,9 @@ func TestExtractEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		destDir := filepath.Join(tmpDir, "dest")
 		require.NoError(t, os.MkdirAll(destDir, 0o755))
+		root, err := os.OpenRoot(destDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		header := &tar.Header{
 			Name:     "fifo",
@@ -1211,9 +1274,8 @@ func TestExtractEntry(t *testing.T) {
 		}
 
 		// Should not return an error for unknown types (just skip them).
-		var symlinks []pendingSymlink
-		var hardLinks []pendingHardLink
-		err := extractEntry(nil, header, destDir, &symlinks, &hardLinks)
+		var deferred deferredEntries
+		err = extractEntry(root, nil, header, destDir, &deferred)
 		assert.NoError(t, err)
 		_, statErr := os.Lstat(filepath.Join(destDir, "fifo"))
 		assert.True(t, os.IsNotExist(statErr), "unknown type must not be materialized")
@@ -1224,7 +1286,9 @@ func TestExtractEntry(t *testing.T) {
 func TestExtractFile(t *testing.T) {
 	t.Run("handles mode out of range", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		path := filepath.Join(tmpDir, "file")
+		root, err := os.OpenRoot(tmpDir)
+		require.NoError(t, err)
+		defer root.Close()
 
 		// Create a tar reader with test data.
 		header := &tar.Header{
@@ -1232,7 +1296,7 @@ func TestExtractFile(t *testing.T) {
 			Mode: -1, // Invalid mode.
 		}
 
-		err := extractFile(nil, path, header)
+		err = extractFile(root, nil, "file", header)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})

--- a/pkg/toolchain/installer/onedir_fs.go
+++ b/pkg/toolchain/installer/onedir_fs.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/cloudposse/atmos/pkg/archiveutil"
 )
 
 // materializeSymlinks creates archive symlinks after the tree is moved.
@@ -110,14 +112,10 @@ func materializeHardLinks(root string, links []pendingHardLink) error {
 
 // extractHardLink materializes a tar hard link relative to root.
 func extractHardLink(linkPath, linkname, dest string) error {
-	// linkname is an archive-relative target. Reject absolute targets explicitly
-	// (filepath.Join's handling of absolute paths differs across platforms), just
-	// as createValidatedSymlink does for symlinks.
-	if filepath.IsAbs(linkname) {
-		return fmt.Errorf("%w: absolute hard link target not allowed: %s -> %s", ErrFileOperation, linkPath, linkname)
-	}
-	target := filepath.Join(dest, linkname)
-	if !isSafePath(target, dest) {
+	// linkname is an archive-relative target; SafeJoin rejects absolute targets
+	// and any ".." traversal, just as createValidatedSymlink does for symlinks.
+	target, err := archiveutil.SafeJoin(dest, linkname)
+	if err != nil {
 		return fmt.Errorf("%w: illegal hard link target: %s -> %s", ErrFileOperation, linkPath, linkname)
 	}
 	if err := os.MkdirAll(filepath.Dir(linkPath), defaultMkdirPermissions); err != nil {

--- a/pkg/toolchain/installer/onedir_fs.go
+++ b/pkg/toolchain/installer/onedir_fs.go
@@ -88,12 +88,24 @@ func windowsSymlinkFallback(resolvedTarget, linkPath, originalLinkPath string) e
 }
 
 // materializeHardLinks creates deferred tar hard links after extraction.
+//
+// Writes go through an os.Root opened on root rather than plain
+// os.MkdirAll/os.Link: a pre-existing symlink inside root pointing outside it
+// could otherwise let a hard-link entry's parent-directory creation or link
+// placement escape root -- os.Root's methods refuse to resolve a path that
+// escapes the root, symlinks included.
 func materializeHardLinks(root string, links []pendingHardLink) error {
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return fmt.Errorf("%w: failed to open root %s: %w", ErrFileOperation, root, err)
+	}
+	defer r.Close()
+
 	remaining := links
 	for len(remaining) > 0 {
 		next := make([]pendingHardLink, 0, len(remaining))
 		for _, link := range remaining {
-			err := extractHardLink(filepath.Join(root, link.rel), link.target, root)
+			err := extractHardLink(r, link.rel, link.target, root)
 			if errors.Is(err, ErrToolNotFound) {
 				next = append(next, link)
 				continue
@@ -110,28 +122,56 @@ func materializeHardLinks(root string, links []pendingHardLink) error {
 	return nil
 }
 
-// extractHardLink materializes a tar hard link relative to root.
-func extractHardLink(linkPath, linkname, dest string) error {
+// extractHardLink materializes a tar hard link at relLinkPath within root.
+func extractHardLink(root *os.Root, relLinkPath, linkname, dest string) error {
 	// linkname is an archive-relative target; SafeJoin rejects absolute targets
 	// and any ".." traversal, just as createValidatedSymlink does for symlinks.
-	target, err := filesystem.SafeJoin(dest, linkname)
-	if err != nil {
-		return fmt.Errorf("%w: illegal hard link target: %s -> %s", ErrFileOperation, linkPath, linkname)
+	// The resulting absolute path isn't used since writes go through root by
+	// relative name instead.
+	if _, err := filesystem.SafeJoin(dest, linkname); err != nil {
+		return fmt.Errorf("%w: illegal hard link target: %s -> %s", ErrFileOperation, relLinkPath, linkname)
 	}
-	if err := os.MkdirAll(filepath.Dir(linkPath), defaultMkdirPermissions); err != nil {
+	relTarget := filepath.FromSlash(linkname)
+
+	if err := root.MkdirAll(filepath.Dir(relLinkPath), defaultMkdirPermissions); err != nil {
 		return fmt.Errorf("%w: failed to create parent directory: %w", ErrFileOperation, err)
 	}
-	_ = os.Remove(linkPath)
+	_ = root.Remove(relLinkPath)
 
-	if err := os.Link(target, linkPath); err == nil {
+	if err := root.Link(relTarget, relLinkPath); err == nil {
 		return nil
 	}
 
-	info, statErr := os.Stat(target)
+	info, statErr := root.Stat(relTarget)
 	if statErr != nil {
 		return fmt.Errorf("%w: hard link target not found: %s", ErrToolNotFound, linkname)
 	}
-	return copyRegularFile(target, linkPath, info.Mode().Perm())
+	return copyRegularFileInRoot(root, relTarget, relLinkPath, info.Mode().Perm())
+}
+
+// copyRegularFileInRoot copies a single file within root, creating parents
+// and preserving mode. Used by extractHardLink's fallback when a hard link
+// cannot be created (e.g. across devices).
+func copyRegularFileInRoot(root *os.Root, srcRel, dstRel string, mode os.FileMode) error {
+	in, err := root.Open(srcRel)
+	if err != nil {
+		return fmt.Errorf("%w: failed to open %s: %w", ErrFileOperation, srcRel, err)
+	}
+	defer in.Close()
+
+	if err := root.MkdirAll(filepath.Dir(dstRel), defaultMkdirPermissions); err != nil {
+		return fmt.Errorf("%w: failed to create parent directory: %w", ErrFileOperation, err)
+	}
+	out, err := root.OpenFile(dstRel, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("%w: failed to create %s: %w", ErrFileOperation, dstRel, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("%w: failed to copy %s: %w", ErrFileOperation, srcRel, err)
+	}
+	return nil
 }
 
 // moveTree relocates a directory tree, preferring a fast same-filesystem rename

--- a/pkg/toolchain/installer/onedir_fs.go
+++ b/pkg/toolchain/installer/onedir_fs.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/cloudposse/atmos/pkg/archiveutil"
+	"github.com/cloudposse/atmos/pkg/filesystem"
 )
 
 // materializeSymlinks creates archive symlinks after the tree is moved.
@@ -114,7 +114,7 @@ func materializeHardLinks(root string, links []pendingHardLink) error {
 func extractHardLink(linkPath, linkname, dest string) error {
 	// linkname is an archive-relative target; SafeJoin rejects absolute targets
 	// and any ".." traversal, just as createValidatedSymlink does for symlinks.
-	target, err := archiveutil.SafeJoin(dest, linkname)
+	target, err := filesystem.SafeJoin(dest, linkname)
 	if err != nil {
 		return fmt.Errorf("%w: illegal hard link target: %s -> %s", ErrFileOperation, linkPath, linkname)
 	}

--- a/pkg/toolchain/installer/onedir_test.go
+++ b/pkg/toolchain/installer/onedir_test.go
@@ -1721,6 +1721,94 @@ func TestMaterializeHardLinks(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
+
+	// TestMaterializeHardLinks_FailsWhenRootUnreadable exercises
+	// materializeHardLinks' os.OpenRoot error branch: a directory with no
+	// permissions cannot be opened.
+	t.Run("fails when root is unreadable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("POSIX permission bits don't apply the same way on Windows")
+		}
+		root := t.TempDir()
+		require.NoError(t, os.Chmod(root, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+
+		err := materializeHardLinks(root, []pendingHardLink{{rel: "link", target: "target"}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+}
+
+// TestExtractHardLink_FallsBackToCopyWhenLinkFails exercises extractHardLink's
+// fallback to copyRegularFileInRoot: os.Link refuses a directory source
+// (EPERM/EISDIR), which reliably forces the fallback path without relying on
+// a cross-device setup -- copyRegularFileInRoot's Open succeeds (opening a
+// directory as a handle is legal), but the subsequent io.Copy read then fails
+// reading the directory as file content -- copyRegularFileInRoot's full
+// success path is covered directly by TestCopyRegularFileInRoot.
+func TestExtractHardLink_FallsBackToCopyWhenLinkFails(t *testing.T) {
+	dest := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "target"), 0o755))
+	root, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	defer root.Close()
+
+	err = extractHardLink(root, "link", "target", dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to copy")
+}
+
+func TestCopyRegularFileInRoot(t *testing.T) {
+	t.Run("copies file contents and mode", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFileUnder(t, dir, "src.txt", "PAYLOAD")
+		root, err := os.OpenRoot(dir)
+		require.NoError(t, err)
+		defer root.Close()
+
+		require.NoError(t, copyRegularFileInRoot(root, "src.txt", "nested/dst.txt", 0o644))
+
+		got, err := os.ReadFile(filepath.Join(dir, "nested", "dst.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "PAYLOAD", string(got))
+	})
+
+	t.Run("fails when source is missing", func(t *testing.T) {
+		dir := t.TempDir()
+		root, err := os.OpenRoot(dir)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = copyRegularFileInRoot(root, "missing.txt", "dst.txt", 0o644)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+
+	t.Run("fails when destination parent is blocked", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFileUnder(t, dir, "src.txt", "PAYLOAD")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "blocked"), []byte("x"), 0o644))
+		root, err := os.OpenRoot(dir)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = copyRegularFileInRoot(root, "src.txt", filepath.Join("blocked", "dst.txt"), 0o644)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
+
+	t.Run("fails when destination is an existing directory", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFileUnder(t, dir, "src.txt", "PAYLOAD")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "dst.txt"), 0o755))
+		root, err := os.OpenRoot(dir)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = copyRegularFileInRoot(root, "src.txt", "dst.txt", 0o644)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFileOperation)
+	})
 }
 
 func TestCopyTree(t *testing.T) {

--- a/pkg/toolchain/installer/onedir_test.go
+++ b/pkg/toolchain/installer/onedir_test.go
@@ -1378,7 +1378,10 @@ func TestOnedir_ErrorPaths(t *testing.T) {
 		writeFileUnder(t, base, "real", "data")
 		fileAsParent := filepath.Join(base, "iamafile")
 		require.NoError(t, os.WriteFile(fileAsParent, []byte("x"), 0o644))
-		err := extractHardLink(filepath.Join(fileAsParent, "child"), "real", base)
+		root, err := os.OpenRoot(base)
+		require.NoError(t, err)
+		defer root.Close()
+		err = extractHardLink(root, "iamafile/child", "real", base)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
@@ -1652,39 +1655,52 @@ func TestExtractHardLink(t *testing.T) {
 	t.Run("links to an existing target", func(t *testing.T) {
 		dest := t.TempDir()
 		writeFileUnder(t, dest, "real.bin", "DATA")
+		root, err := os.OpenRoot(dest)
+		require.NoError(t, err)
+		defer root.Close()
 
-		linkPath := filepath.Join(dest, "hard.bin")
-		require.NoError(t, extractHardLink(linkPath, "real.bin", dest))
+		require.NoError(t, extractHardLink(root, "hard.bin", "real.bin", dest))
 
-		got, err := os.ReadFile(linkPath)
+		got, err := os.ReadFile(filepath.Join(dest, "hard.bin"))
 		require.NoError(t, err)
 		assert.Equal(t, "DATA", string(got))
 	})
 
 	t.Run("rejects a target that escapes dest", func(t *testing.T) {
 		dest := t.TempDir()
-		err := extractHardLink(filepath.Join(dest, "h"), "../../../../etc/passwd", dest)
+		root, err := os.OpenRoot(dest)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = extractHardLink(root, "h", "../../../../etc/passwd", dest)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
 
 	t.Run("rejects an absolute target", func(t *testing.T) {
 		dest := t.TempDir()
+		root, err := os.OpenRoot(dest)
+		require.NoError(t, err)
+		defer root.Close()
+
 		// A genuinely OS-absolute target (volume-qualified on Windows).
 		absTarget := filepath.Join(t.TempDir(), "outside")
 		require.True(t, filepath.IsAbs(absTarget))
-		err := extractHardLink(filepath.Join(dest, "h"), absTarget, dest)
+		err = extractHardLink(root, "h", absTarget, dest)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrFileOperation)
 	})
 
 	t.Run("returns an error when the target is missing", func(t *testing.T) {
 		dest := t.TempDir()
-		linkPath := filepath.Join(dest, "h")
-		err := extractHardLink(linkPath, "not-there", dest)
+		root, err := os.OpenRoot(dest)
+		require.NoError(t, err)
+		defer root.Close()
+
+		err = extractHardLink(root, "h", "not-there", dest)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrToolNotFound)
-		_, err = os.Lstat(linkPath)
+		_, err = os.Lstat(filepath.Join(dest, "h"))
 		assert.True(t, os.IsNotExist(err))
 	})
 }

--- a/pkg/toolchain/installer/onedir_test.go
+++ b/pkg/toolchain/installer/onedir_test.go
@@ -1729,6 +1729,9 @@ func TestMaterializeHardLinks(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("POSIX permission bits don't apply the same way on Windows")
 		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root ignores directory permission bits")
+		}
 		root := t.TempDir()
 		require.NoError(t, os.Chmod(root, 0o000))
 		t.Cleanup(func() { _ = os.Chmod(root, 0o755) })


### PR DESCRIPTION
## what

- Adds inline `codeql[go/weak-sensitive-data-hashing]` / `codeql[go/clear-text-logging]` suppression comments, each with a written justification, to the sites that kept generating alerts: `pkg/stack/imports/remote.go` (#5331), `pkg/cache/file_cache.go`, `pkg/merge/provenance_entry.go`, and the four log sinks in `pkg/logger/logrus_adapter.go`. Upgrades two pre-existing legacy `lgtm[]` comments (`pkg/config/homedir/homedir.go`, `pkg/env/output.go`) to the modern `codeql[]` syntax.
- Adds `pkg/safenum` (new leaf package) with a single overflow-safe capacity-hint helper, `Cap(a, b, max int) int`, and retrofits three independent hand-rolled duplicates of the same logic to call it (`pkg/merge/merge_native.go`'s `safeCap`, `pkg/runner/step/spin.go`'s `safeEnvCapacity`, `pkg/runner/step/log.go`'s `safeKeyvalsCapacity`). Also fixes a live, unfixed instance of the same unguarded-sum-capacity pattern in `pkg/container/common.go`'s `bakeCommandEnv`.
- Adds `pkg/archiveutil` (new leaf package) with a single Zip Slip containment check, `SafeJoin(destDir, entryName string) (string, error)`, and retrofits four independent hand-rolled duplicates to call it (`pkg/oci/zip.go`, `pkg/oci/tar.go`, `pkg/toolchain/installer/extract.go` + `onedir_fs.go`, `pkg/auth/providers/aws/saml_driver_preseed.go`). Along the way this fixes a latent bug in `pkg/oci`'s old containment check, which compared path prefixes without a trailing separator (currently unreachable only because an earlier `..`-substring filter already blocks it).
- Adds a new sentinel error, `ErrArchiveEntryEscapesDest`, in `errors/errors.go`, and removes one now-redundant `//nolint:gosec` suppression in `pkg/toolchain/installer/extract.go`.

## why

- The CodeQL High-severity backlog had 47 alerts across four rule classes, 12 of which took over 30 days to close (worst case 359 days), and one (#5331) was still open. Investigating each class showed the recurrence was a real pattern in three of the four cases, not a growing set of unrelated vulnerabilities:
  - `go/weak-sensitive-data-hashing` and `go/clear-text-logging` were consistently false positives — SHA-256 used only for cache-key/content-change-detection hashing (never password hashing), and log writes that go to the CLI's own stderr stream (never a shared log sink) — but were being dismissed one-off via the GitHub UI instead of durably suppressed in code, so the same sites kept reappearing on every rescan.
  - `go/allocation-size-overflow`'s 18 fast-fixed alerts turned out to be the same "capacity hint summed from two lengths" pattern fixed independently four separate times, with no shared helper — and a fifth, still-unfixed instance sitting in the same file as one of the fixes.
  - `go/zipslip`'s one alert (#5230, fixed after 187 days) was real and correctly fixed, but auditing every other archive-extraction path in the repo found the same containment-check logic independently reimplemented six times, with no shared helper and at least one weaker variant.
- Per-line `codeql[]` suppression comments (rather than a repo-wide query-filter or path exclusion) keep the exclusion auditable, travel with the code, and don't blind CodeQL to a real future bug in files that happen to share a path — this repo already had this pattern in a few places, just applied inconsistently.
- `pr_artifact.go`'s Zip Slip fix and `pkg/ci/cache/archive.go`'s `safeJoin` are intentionally left untouched: both carry code comments documenting that their guard shape was empirically tuned to be recognized by CodeQL's `go/zipslip` interprocedural dataflow analysis, and routing them through a shared helper risks CodeQL no longer crediting the check across the function-call boundary.
- `pkg/merge/merge.go`'s `processAppendList` overflow guard is also intentionally left untouched: it aborts and drops data above a size threshold rather than just clamping a capacity hint, a different, deliberate safety semantic that a generic clamp helper would silently change.

## references

- https://github.com/cloudposse/atmos/security/code-scanning/5331 (weak-sensitive-data-hashing, still open — resolved by this PR's suppression comment + written justification)
- https://github.com/cloudposse/atmos/security/code-scanning/5230 (zipslip, already fixed — audited here to confirm every other extraction path is also safe)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Archive extraction now blocks traversal, absolute paths, and symlink- or hard-link-based escapes.
  - Sensitive values nested within maps and lists are consistently redacted from logs.
  - Valid filenames containing `..` remain supported safely.

- **Reliability**
  - Improved handling of malformed archives, blocked directories, unsupported entries, and extraction failures.
  - Safer resource sizing improves stability when processing large inputs.

- **Testing**
  - Expanded coverage for archive extraction, path validation, logging redaction, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->