### PR TITLE
ci: guard Windows DNS against harden-runner post-step race; allowlist OS endpoints

### DIFF
--- a/.github/actions/windows-dns-guard/action.yml
+++ b/.github/actions/windows-dns-guard/action.yml
@@ -1,0 +1,42 @@
+name: 'Windows DNS guard (harden-runner post-step race)'
+description: >
+  Registers a one-shot Windows scheduled task that repairs the runner's DNS
+  client settings if step-security/harden-runner's Windows post step kills
+  its agent before the agent has finished restoring them. Without this, the
+  job's steps all succeed but the runner is left pointing at a DNS proxy
+  that no longer exists, cannot reach the Actions service to report
+  completion, and is cancelled by GitHub 30-40 minutes later. See
+  docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
+
+  The task runs under the Task Scheduler service, outside the step's and
+  runner's process trees, so it survives step teardown and the runner's
+  "Cleaning up orphan processes" pass. It only acts once harden-runner's own
+  post step has started (C:\agent\post_event.json exists), the agent process
+  is gone, and an interface still lists 127.0.0.1 as its DNS server -- so it
+  can never fail open while egress enforcement is live. No-op (exits) when
+  harden-runner restores DNS itself, which is the common case.
+
+  Windows-only; a no-op on other runners. Safe to place anywhere after the
+  Harden Runner step (it needs the checkout for its script file).
+
+runs:
+  using: composite
+  steps:
+    - name: Register DNS guard task
+      if: runner.os == 'Windows'
+      shell: powershell
+      env:
+        GUARD_SCRIPT: ${{ github.action_path }}/dns-guard.ps1
+      run: |
+        $dest = Join-Path $env:RUNNER_TEMP 'atmos-dns-guard.ps1'
+        Copy-Item -LiteralPath $env:GUARD_SCRIPT -Destination $dest -Force
+        $log = Join-Path $env:RUNNER_TEMP 'atmos-dns-guard.log'
+        $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+          -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$dest`" -LogPath `"$log`""
+        $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+        $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 2) `
+          -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew
+        Register-ScheduledTask -TaskName 'atmos-dns-guard' -Action $action -Principal $principal `
+          -Settings $settings -Force | Out-Null
+        Start-ScheduledTask -TaskName 'atmos-dns-guard'
+        Write-Host "DNS guard task registered (script: $dest, log: $log)"

--- a/.github/actions/windows-dns-guard/action.yml
+++ b/.github/actions/windows-dns-guard/action.yml
@@ -1,6 +1,7 @@
 name: 'Windows DNS guard (harden-runner post-step race)'
 description: >
-  Registers a one-shot Windows scheduled task that repairs the runner's DNS
+  Registers a one-shot Windows scheduled task (running as the runner's own
+  Administrator account) that repairs the runner's DNS
   client settings if step-security/harden-runner's Windows post step kills
   its agent before the agent has finished restoring them. Without this, the
   job's steps all succeed but the runner is left pointing at a DNS proxy
@@ -9,7 +10,7 @@ description: >
   docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
 
   The task runs under the Task Scheduler service, outside the step's and
-  runner's process trees, so it survives step teardown and the runner's
+  runner's process trees (but with no more rights than the job already has), so it survives step teardown and the runner's
   "Cleaning up orphan processes" pass. It only acts once harden-runner's own
   post step has started (C:\agent\post_event.json exists), the agent process
   is gone, and an interface still lists 127.0.0.1 as its DNS server -- so it
@@ -33,7 +34,12 @@ runs:
         $log = Join-Path $env:RUNNER_TEMP 'atmos-dns-guard.log'
         $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
           -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$dest`" -LogPath `"$log`""
-        $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+        # Run as the runner's own (already Administrator) account rather than
+        # SYSTEM: the script comes from the checkout, and the job's other steps
+        # already execute that checkout with the same rights, so this grants
+        # nothing extra. S4U lets the task start whether or not the session is
+        # interactive.
+        $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType S4U -RunLevel Highest
         $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 2) `
           -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew
         Register-ScheduledTask -TaskName 'atmos-dns-guard' -Action $action -Principal $principal `

--- a/.github/actions/windows-dns-guard/dns-guard.ps1
+++ b/.github/actions/windows-dns-guard/dns-guard.ps1
@@ -1,0 +1,71 @@
+# Watchdog for step-security/harden-runner's Windows post-step race.
+#
+# harden-runner's Windows agent enforces egress with a DNS proxy on
+# 127.0.0.1:53 and repoints every adapter's DNS server to it. Its post step
+# waits at most 10 seconds for the agent to finish, then kills it. When the
+# agent is still inside "restoring system DNS" at that moment, the adapter is
+# left pointing at a proxy that no longer exists; the runner can no longer
+# resolve the Actions service and never reports job completion.
+#
+# This script polls once a second and repairs DNS only when all three hold:
+#   1. C:\agent\post_event.json exists (harden-runner's post step has begun),
+#   2. the agent process from C:\agent\agent.pid is gone (or the pid file is),
+#   3. an IPv4 interface still lists 127.0.0.1 as a DNS server.
+# Condition 1 guarantees we never undo enforcement while it is live: an agent
+# crash mid-job keeps the job fail-closed exactly as it is today.
+param(
+    [string]$AgentDir = 'C:\agent',
+    [string]$LogPath = "$env:TEMP\atmos-dns-guard.log",
+    [int]$MaxSeconds = 7200
+)
+
+function Write-Log([string]$Message) {
+    $line = "{0} {1}" -f (Get-Date -Format 'o'), $Message
+    Add-Content -LiteralPath $LogPath -Value $line -ErrorAction SilentlyContinue
+}
+
+function Test-AgentAlive {
+    $pidFile = Join-Path $AgentDir 'agent.pid'
+    if (-not (Test-Path -LiteralPath $pidFile)) { return $false }
+    $raw = (Get-Content -LiteralPath $pidFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+    $agentPid = 0
+    if (-not [int]::TryParse(($raw -as [string]).Trim(), [ref]$agentPid)) { return $false }
+    return $null -ne (Get-Process -Id $agentPid -ErrorAction SilentlyContinue)
+}
+
+function Get-LoopbackDnsInterfaces {
+    Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+        Where-Object { $_.ServerAddresses -contains '127.0.0.1' }
+}
+
+Write-Log "dns guard started (agentDir=$AgentDir)"
+$postEvent = Join-Path $AgentDir 'post_event.json'
+$deadline = (Get-Date).AddSeconds($MaxSeconds)
+
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 1
+    if (-not (Test-Path -LiteralPath $postEvent)) { continue }
+    if (Test-AgentAlive) { continue }
+
+    # Give harden-runner's own graceful path a moment: the agent normally
+    # restores DNS just before it exits.
+    Start-Sleep -Seconds 1
+    $bad = @(Get-LoopbackDnsInterfaces)
+    if ($bad.Count -eq 0) {
+        Write-Log 'post step finished and DNS is healthy; nothing to do'
+        break
+    }
+    foreach ($iface in $bad) {
+        Write-Log ("harden-runner agent exited with DNS still on 127.0.0.1 for interface '{0}' (index {1}); resetting" -f $iface.InterfaceAlias, $iface.InterfaceIndex)
+        try {
+            Set-DnsClientServerAddress -InterfaceIndex $iface.InterfaceIndex -ResetServerAddresses -ErrorAction Stop
+        } catch {
+            Write-Log ("reset failed for interface index {0}: {1}" -f $iface.InterfaceIndex, $_.Exception.Message)
+        }
+    }
+    Clear-DnsClientCache -ErrorAction SilentlyContinue
+    $check = Resolve-DnsName -Name 'pipelines.actions.githubusercontent.com' -Type A -ErrorAction SilentlyContinue
+    Write-Log ("DNS reset done; pipelines.actions.githubusercontent.com resolves: {0}" -f ($null -ne $check))
+    break
+}
+Write-Log 'dns guard exiting'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -143,6 +143,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # govulncheck-action has no download retry of its own and GOPROXY no
+      # longer falls back to direct fetches, so pre-populate the module cache
+      # (shared with the action's own setup-go) with bounded retries first.
+      # Only the action's small `go install .../govulncheck@latest` remains
+      # a single-shot proxy request.
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download Go module dependencies
+        uses: ./.github/actions/go-mod-download-retry
+
       - name: Run govulncheck
         uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,10 @@ on:
     - cron: "27 19 * * 2"
 
 env:
-  # Use pipe fallback so transient proxy.golang.org 5xx errors during
-  # `go mod download` fall back to direct module fetches.
-  GOPROXY: "https://proxy.golang.org|direct"
+  # No `|direct` fallback: under harden-runner's block mode a direct fetch
+  # only fans out to blocked vanity-import hosts and burns minutes; see the
+  # GOPROXY comment in test.yml.
+  GOPROXY: "https://proxy.golang.org"
 
 # Least-privilege default; every job below declares its own narrower
 # job-level permissions that override this baseline.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -268,8 +268,10 @@ jobs:
       # Pre-populate module cache to prevent goanalysis_metalinter failures.
       # Without this, the linter may fail with "could not load export data" errors.
       # See: https://github.com/golangci/golangci-lint/issues/5437
+      # With retry: GOPROXY no longer falls back to direct fetches (they only
+      # hit blocked vanity hosts under harden-runner's block mode).
       - name: Download modules
-        run: go mod download
+        uses: ./.github/actions/go-mod-download-retry
 
       # Install the golangci-lint v2 CLI tool (not the linters themselves).
       # This tool is needed to run `golangci-lint custom` which builds a custom binary

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -143,11 +143,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # govulncheck-action has no download retry of its own and GOPROXY no
-      # longer falls back to direct fetches, so pre-populate the module cache
-      # (shared with the action's own setup-go) with bounded retries first.
-      # Only the action's small `go install .../govulncheck@latest` remains
-      # a single-shot proxy request.
+      # GOPROXY no longer falls back to direct fetches (they only reach
+      # blocked vanity hosts under harden-runner's block mode), so every proxy
+      # request here gets bounded retries: the module graph via the shared
+      # retry action, and the govulncheck install via the loop below. The
+      # two steps that follow reproduce what golang/govulncheck-action does
+      # (install @latest, run with -format/-C) minus its non-retried install.
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
@@ -157,8 +158,27 @@ jobs:
       - name: Download Go module dependencies
         uses: ./.github/actions/go-mod-download-retry
 
+      - name: Install govulncheck
+        shell: bash
+        env:
+          GOOS: ''
+          GOARCH: ''
+        run: |
+          set -euo pipefail
+          attempt=1
+          max_attempts=3
+          until go install golang.org/x/vuln/cmd/govulncheck@latest; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "go install govulncheck failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            echo "go install govulncheck failed (attempt $attempt/$max_attempts), retrying in 15s..." >&2
+            sleep 15
+            attempt=$((attempt + 1))
+          done
+
       - name: Run govulncheck
-        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        shell: bash
         env:
           # Atmos ships with CGO disabled (see Makefile/test.yml) — without this,
           # the runner's default CGO_ENABLED=1 makes govulncheck try to compile
@@ -178,10 +198,7 @@ jobs:
           # parallelizes via goroutines internally, which -p doesn't govern)
           # while nearly tripling run time.
           GOMEMLIMIT: "12GiB"
-        with:
-          go-version-file: go.mod
-          output-format: sarif
-          output-file: govulncheck.sarif
+        run: govulncheck -format sarif ./... > govulncheck.sarif
 
       - name: Upload SARIF file
         if: always()

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -36,9 +36,10 @@ env:
   ATMOS_VERSION_CHECK_ENABLED: "false"
   NATIVE_CI_TRIVY_VERSION: "0.70.0"
   NATIVE_CI_KICS_VERSION: "2.1.20"
-  # Use pipe fallback so transient proxy.golang.org 5xx errors during
-  # `go mod download` fall back to direct module fetches.
-  GOPROXY: "https://proxy.golang.org|direct"
+  # No `|direct` fallback: under harden-runner's block mode a direct fetch
+  # only fans out to blocked vanity-import hosts and burns minutes; see the
+  # GOPROXY comment in test.yml.
+  GOPROXY: "https://proxy.golang.org"
 
 jobs:
   workflow-groups:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,9 +18,10 @@ env:
   # golangci-lint: Already runs in codeql.yml lint-golangci job
   # lintroller: Already runs in codeql.yml lint-golangci job (via custom-gcl binary)
   SKIP: go-build-mod,golangci-lint,lintroller
-  # Use pipe fallback so transient proxy.golang.org 5xx errors during
-  # `go mod download` fall back to direct module fetches.
-  GOPROXY: "https://proxy.golang.org|direct"
+  # No `|direct` fallback: under harden-runner's block mode a direct fetch
+  # only fans out to blocked vanity-import hosts and burns minutes; see the
+  # GOPROXY comment in test.yml.
+  GOPROXY: "https://proxy.golang.org"
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -68,10 +68,12 @@ jobs:
           # Add Go bin to PATH
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
+      # Pre-download dependencies to prevent go mod tidy from trying to fetch
+      # internal packages. With retry: GOPROXY no longer falls back to direct
+      # fetches (they only hit blocked vanity hosts under harden-runner's block
+      # mode), so transient proxy errors are handled by retrying instead.
       - name: Download Go module dependencies
-        run: |
-          # Pre-download dependencies to prevent go mod tidy from trying to fetch internal packages
-          go mod download
+        uses: ./.github/actions/go-mod-download-retry
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -81,7 +81,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.target == 'windows'

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -14,9 +14,10 @@ permissions:
 
 env:
   ATMOS_BOOTSTRAP_VERSION: "1.223.0"
-  # Use pipe fallback so transient proxy.golang.org 5xx errors during
-  # `go mod download` fall back to direct module fetches.
-  GOPROXY: "https://proxy.golang.org|direct"
+  # No `|direct` fallback: under harden-runner's block mode a direct fetch
+  # only fans out to blocked vanity-import hosts and burns minutes; see the
+  # GOPROXY comment in test.yml.
+  GOPROXY: "https://proxy.golang.org"
 
 jobs:
   cache-warmup:
@@ -42,12 +43,45 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted Windows and
+          # macOS images are listed after the job-specific endpoints; see the
+          # `test` job's allowed-endpoints comment in test.yml for the
+          # rationale and keep the two lists in sync.
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             release-assets.githubusercontent.com:443
             proxy.golang.org:443
+            sum.golang.org:443
             storage.googleapis.com:443
+            google.golang.org:443
+            modernc.org:443
+            www.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:443
+            www.msftncsi.com:443
+            ipv6.msftncsi.com:443
+            time.windows.com:443
+            client.wns.windows.com:443
+            settings-win.data.microsoft.com:443
+            *.events.data.microsoft.com:443
+            fe2cr.update.microsoft.com:443
+            ecs.office.com:443
+            pti.store.microsoft.com:443
+            login.live.com:443
+            go.microsoft.com:443
+            www.microsoft.com:443
+            ocsp.sectigo.com:80
+            ocsp.sectigo.com:443
+            crl.sectigo.com:80
+            crl.sectigo.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.target == 'windows'
@@ -58,6 +92,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+
+      # See test.yml: repairs DNS if harden-runner's Windows post step kills
+      # its agent before it has restored the runner's DNS settings.
+      - name: Guard DNS against the harden-runner post-step race
+        if: matrix.target == 'windows'
+        uses: ./.github/actions/windows-dns-guard
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -64,7 +64,7 @@ jobs:
             client.wns.windows.com:443
             settings-win.data.microsoft.com:443
             *.events.data.microsoft.com:443
-            fe2cr.update.microsoft.com:443
+            *.update.microsoft.com:443
             ecs.office.com:443
             pti.store.microsoft.com:443
             login.live.com:443

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
             client.wns.windows.com:443
             settings-win.data.microsoft.com:443
             *.events.data.microsoft.com:443
-            fe2cr.update.microsoft.com:443
+            *.update.microsoft.com:443
             ecs.office.com:443
             pti.store.microsoft.com:443
             login.live.com:443
@@ -276,6 +276,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
             us.i.posthog.com:443
 
@@ -385,7 +386,7 @@ jobs:
             client.wns.windows.com:443
             settings-win.data.microsoft.com:443
             *.events.data.microsoft.com:443
-            fe2cr.update.microsoft.com:443
+            *.update.microsoft.com:443
             ecs.office.com:443
             pti.store.microsoft.com:443
             login.live.com:443
@@ -641,7 +642,7 @@ jobs:
             client.wns.windows.com:443
             settings-win.data.microsoft.com:443
             *.events.data.microsoft.com:443
-            fe2cr.update.microsoft.com:443
+            *.update.microsoft.com:443
             ecs.office.com:443
             pti.store.microsoft.com:443
             login.live.com:443
@@ -1143,6 +1144,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             checkpoint-api.hashicorp.com:443
             github.com:443
             mirror.gcr.io:443
@@ -1316,6 +1318,7 @@ jobs:
           # listed below the job-specific endpoints; see the `test` job's
           # allowed-endpoints comment for the rationale.
           allowed-endpoints: >
+            api.github.com:443
             auth.docker.io:443
             charts.bitnami.com:443
             contracts.canonical.com:443
@@ -1644,7 +1647,7 @@ jobs:
             client.wns.windows.com:443
             settings-win.data.microsoft.com:443
             *.events.data.microsoft.com:443
-            fe2cr.update.microsoft.com:443
+            *.update.microsoft.com:443
             ecs.office.com:443
             pti.store.microsoft.com:443
             login.live.com:443
@@ -1903,6 +1906,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
             us.i.posthog.com:443
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
         if: matrix.target == 'linux'
@@ -395,7 +395,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
@@ -648,7 +648,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
@@ -1335,7 +1335,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -1507,7 +1507,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -1648,7 +1648,7 @@ jobs:
             *.apple-dns.net:443
             ocsp.usertrust.com:80
             ocsp.digicert.com:80
-            0.pool.ntp.org:123
+            *.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,12 @@ jobs:
       # (what this repo uses) only covers GitHub-hosted runners — self-hosted
       # runners including RunsOn need a StepSecurity Enterprise license plus
       # RunsOn-side config we're not doing here.
+      # Draft PRs skip every Windows step below (no checkout, nothing to
+      # protect), so skip Harden Runner there too: its post step would still
+      # race the agent's DNS restore, and the DNS guard (a local action) needs
+      # the checkout.
       - name: Harden Runner
-        if: matrix.target != 'linux'
+        if: matrix.target != 'linux' && ! ( matrix.target == 'windows' && github.event.pull_request.draft )
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
@@ -337,7 +341,10 @@ jobs:
     timeout-minutes: ${{ matrix.flavor.target == 'windows' && 45 || 20 }}
     runs-on: ${{ matrix.flavor.os }}
     steps:
+      # Draft PRs skip every Windows step in this job (no checkout), so skip
+      # Harden Runner for them as well; see the `build` job's note.
       - name: Harden Runner
+        if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
@@ -569,7 +576,10 @@ jobs:
     timeout-minutes: ${{ matrix.jobTimeoutOverride || matrix.flavor.jobTimeout }}
     runs-on: ${{ matrix.flavor.os }}
     steps:
+      # Draft PRs skip every Windows step in this job (no checkout), so skip
+      # Harden Runner for them as well; see the `build` job's note.
       - name: Harden Runner
+        if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           # Union of core, tool-driven endpoints across the linux/windows/macos
@@ -1594,7 +1604,10 @@ jobs:
 
     timeout-minutes: 20
     steps:
+      # Draft PRs skip every Windows step in this job (no checkout), so skip
+      # Harden Runner for them as well; see the `build` job's note.
       - name: Harden Runner
+        if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,16 @@ on:
 
   workflow_dispatch:
 
+# A newer push to the same PR supersedes the previous run: cancel it instead
+# of letting both compete for runners (30 acceptance shards each, and the org
+# macOS concurrency cap is small enough that a second run's macOS legs queue
+# for up to ~30 minutes). merge_group, push, and workflow_dispatch runs are
+# keyed by SHA and are never cancelled -- a merge-queue entry or a main-branch
+# run must always finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Grant `packages: read` so jobs that pull OCI images from ghcr.io
 # (e.g. vendor pulls in mock/acceptance tests) can authenticate with
 # the auto-generated GITHUB_TOKEN. The default PR-event scope is
@@ -52,11 +62,16 @@ env:
   # OS (see tests/cli_test.go's testShard/testCaseShard and the `test` job's
   # matrix.shard list below, which must stay in sync with this count).
   TEST_SHARD_COUNT: "10"
-  # Use pipe fallback so transient proxy.golang.org errors (5xx, HTTP/2 stream
-  # resets) during `go mod download` fall back to direct module fetches. The
-  # default comma-separated GOPROXY list only falls through on "not found"
-  # responses, not network errors. See .github/workflows/native-ci.yml.
-  GOPROXY: "https://proxy.golang.org|direct"
+  # No `|direct` fallback: every job here runs under harden-runner's block
+  # mode, where a direct fetch fans out to ~25 vanity-import hosts (k8s.io,
+  # go.uber.org, gopkg.in, helm.sh, ...) that are not allowlisted, so the
+  # fallback can only ever burn minutes on blocked lookups (observed: a 9+
+  # minute "Get dependencies" step after one proxy.golang.org hiccup). The
+  # transient 5xx / HTTP/2 stream resets the fallback used to paper over are
+  # handled by `atmos build deps`'s retry policy (.atmos.d/build.yaml)
+  # instead. If the retry policy ever proves insufficient, allowlist the
+  # vanity hosts rather than restoring the fallback.
+  GOPROXY: "https://proxy.golang.org"
 
 jobs:
   # ensure the code builds...
@@ -97,6 +112,18 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted Windows and
+          # macOS images (connectivity probes, push notifications, update and
+          # settings/telemetry checks, time sync, certificate revocation for
+          # GitHub's Sectigo chain, Apple software-update and CDN hosts) are
+          # listed below their job-specific endpoints. StepSecurity Insights
+          # showed them blocked on every Windows/macOS job -- they are not
+          # implicitly allowed -- and each blocked lookup is retried by the OS
+          # for the whole job (NCSI probes every few seconds; schannel
+          # revocation checks stall TLS to github.com). Allowing them removes
+          # that churn without widening what our own steps can reach. Source:
+          # StepSecurity Insights -> Network Events; keep in sync with the
+          # other Windows/macOS legs in this file.
           allowed-endpoints: >
             api.github.com:443
             github.com:443
@@ -111,6 +138,32 @@ jobs:
             storage.googleapis.com:443
             google.golang.org:443
             modernc.org:443
+            www.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:443
+            www.msftncsi.com:443
+            ipv6.msftncsi.com:443
+            time.windows.com:443
+            client.wns.windows.com:443
+            settings-win.data.microsoft.com:443
+            *.events.data.microsoft.com:443
+            fe2cr.update.microsoft.com:443
+            ecs.office.com:443
+            pti.store.microsoft.com:443
+            login.live.com:443
+            go.microsoft.com:443
+            www.microsoft.com:443
+            ocsp.sectigo.com:80
+            ocsp.sectigo.com:443
+            crl.sectigo.com:80
+            crl.sectigo.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
         if: matrix.target == 'linux'
@@ -129,6 +182,16 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+
+      # Repairs the runner's DNS if harden-runner's Windows post step kills its
+      # agent mid-"restoring system DNS" (a race against its 10-second wait);
+      # without it the job's steps all pass but the job never reports
+      # completion and GitHub cancels it 30-40 minutes later. Windows-only,
+      # no-op elsewhere. See the action's description and
+      # docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
+      - name: Guard DNS against the harden-runner post-step race
+        if: matrix.target == 'windows' && ! github.event.pull_request.draft
+        uses: ./.github/actions/windows-dns-guard
 
       - name: Set up Go
         if: ${{ ! ( matrix.target == 'windows' && github.event.pull_request.draft  ) }}
@@ -278,6 +341,18 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted Windows and
+          # macOS images (connectivity probes, push notifications, update and
+          # settings/telemetry checks, time sync, certificate revocation for
+          # GitHub's Sectigo chain, Apple software-update and CDN hosts) are
+          # listed below their job-specific endpoints. StepSecurity Insights
+          # showed them blocked on every Windows/macOS job -- they are not
+          # implicitly allowed -- and each blocked lookup is retried by the OS
+          # for the whole job (NCSI probes every few seconds; schannel
+          # revocation checks stall TLS to github.com). Allowing them removes
+          # that churn without widening what our own steps can reach. Source:
+          # StepSecurity Insights -> Network Events; keep in sync with the
+          # other Windows/macOS legs in this file.
           allowed-endpoints: >
             api.github.com:443
             checkpoint-api.hashicorp.com:443
@@ -295,12 +370,48 @@ jobs:
             storage.googleapis.com:443
             google.golang.org:443
             modernc.org:443
+            www.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:443
+            www.msftncsi.com:443
+            ipv6.msftncsi.com:443
+            time.windows.com:443
+            client.wns.windows.com:443
+            settings-win.data.microsoft.com:443
+            *.events.data.microsoft.com:443
+            fe2cr.update.microsoft.com:443
+            ecs.office.com:443
+            pti.store.microsoft.com:443
+            login.live.com:443
+            go.microsoft.com:443
+            www.microsoft.com:443
+            ocsp.sectigo.com:80
+            ocsp.sectigo.com:443
+            crl.sectigo.com:80
+            crl.sectigo.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+
+      # Repairs the runner's DNS if harden-runner's Windows post step kills its
+      # agent mid-"restoring system DNS" (a race against its 10-second wait);
+      # without it the job's steps all pass but the job never reports
+      # completion and GitHub cancels it 30-40 minutes later. Windows-only,
+      # no-op elsewhere. See the action's description and
+      # docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
+      - name: Guard DNS against the harden-runner post-step race
+        if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
+        uses: ./.github/actions/windows-dns-guard
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
@@ -468,6 +579,18 @@ jobs:
           # single run (MCP pagination limitation), so carries more residual risk
           # of an untested-path endpoint than other workflows in this rollout.
           egress-policy: block
+          # Operating-system background services on the hosted Windows and
+          # macOS images (connectivity probes, push notifications, update and
+          # settings/telemetry checks, time sync, certificate revocation for
+          # GitHub's Sectigo chain, Apple software-update and CDN hosts) are
+          # listed below their job-specific endpoints. StepSecurity Insights
+          # showed them blocked on every Windows/macOS job -- they are not
+          # implicitly allowed -- and each blocked lookup is retried by the OS
+          # for the whole job (NCSI probes every few seconds; schannel
+          # revocation checks stall TLS to github.com). Allowing them removes
+          # that churn without widening what our own steps can reach. Source:
+          # StepSecurity Insights -> Network Events; keep in sync with the
+          # other Windows/macOS legs in this file.
           allowed-endpoints: >
             accounts.google.com:443
             api.bitbucket.org:443
@@ -497,12 +620,51 @@ jobs:
             sts.us-east-1.amazonaws.com:443
             tuf-repo-cdn.sigstore.dev:443
             us.i.posthog.com:443
+            sum.golang.org:443
+            google.golang.org:443
+            modernc.org:443
+            www.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:443
+            www.msftncsi.com:443
+            ipv6.msftncsi.com:443
+            time.windows.com:443
+            client.wns.windows.com:443
+            settings-win.data.microsoft.com:443
+            *.events.data.microsoft.com:443
+            fe2cr.update.microsoft.com:443
+            ecs.office.com:443
+            pti.store.microsoft.com:443
+            login.live.com:443
+            go.microsoft.com:443
+            www.microsoft.com:443
+            ocsp.sectigo.com:80
+            ocsp.sectigo.com:443
+            crl.sectigo.com:80
+            crl.sectigo.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+
+      # Repairs the runner's DNS if harden-runner's Windows post step kills its
+      # agent mid-"restoring system DNS" (a race against its 10-second wait);
+      # without it the job's steps all pass but the job never reports
+      # completion and GitHub cancels it 30-40 minutes later. Windows-only,
+      # no-op elsewhere. See the action's description and
+      # docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
+      - name: Guard DNS against the harden-runner post-step race
+        if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
+        uses: ./.github/actions/windows-dns-guard
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
@@ -912,9 +1074,15 @@ jobs:
           # DL3008 Pin versions in apt-get install
           ignore: DL3008
 
+      # Code scanning cannot attach results to a merge queue's synthetic
+      # `refs/heads/gh-readonly-queue/...` ref: the upload fails with "ref ...
+      # not found", which (with wait-for-processing) fails this step, skips the
+      # Trivy scan below, and then fails the second upload on the missing SARIF
+      # file -- evicting the PR from the queue for a result nobody consumes.
+      # The same commit was already scanned on the PR run.
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: hadolint.sarif
@@ -935,7 +1103,7 @@ jobs:
           output: trivy-config.sarif
 
       - name: Upload Trivy config scan results
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-config.sarif
@@ -1133,6 +1301,10 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted macOS image
+          # (software update, CDN, certificate revocation, time sync) are
+          # listed below the job-specific endpoints; see the `test` job's
+          # allowed-endpoints comment for the rationale.
           allowed-endpoints: >
             auth.docker.io:443
             charts.bitnami.com:443
@@ -1156,6 +1328,14 @@ jobs:
             security.ubuntu.com:80
             tuf-repo-cdn.sigstore.dev:443
             us.i.posthog.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -1310,12 +1490,24 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted macOS image
+          # (software update, CDN, certificate revocation, time sync) are
+          # listed below the job-specific endpoints; see the `test` job's
+          # allowed-endpoints comment for the rationale.
           allowed-endpoints: >
             api.github.com:443
             github.com:443
             proxy.golang.org:443
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -1406,6 +1598,18 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block
+          # Operating-system background services on the hosted Windows and
+          # macOS images (connectivity probes, push notifications, update and
+          # settings/telemetry checks, time sync, certificate revocation for
+          # GitHub's Sectigo chain, Apple software-update and CDN hosts) are
+          # listed below their job-specific endpoints. StepSecurity Insights
+          # showed them blocked on every Windows/macOS job -- they are not
+          # implicitly allowed -- and each blocked lookup is retried by the OS
+          # for the whole job (NCSI probes every few seconds; schannel
+          # revocation checks stall TLS to github.com). Allowing them removes
+          # that churn without widening what our own steps can reach. Source:
+          # StepSecurity Insights -> Network Events; keep in sync with the
+          # other Windows/macOS legs in this file.
           allowed-endpoints: >
             api.github.com:443
             checkpoint-api.hashicorp.com:443
@@ -1419,12 +1623,48 @@ jobs:
             releases.hashicorp.com:443
             tuf-repo-cdn.sigstore.dev:443
             us.i.posthog.com:443
+            www.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:443
+            www.msftncsi.com:443
+            ipv6.msftncsi.com:443
+            time.windows.com:443
+            client.wns.windows.com:443
+            settings-win.data.microsoft.com:443
+            *.events.data.microsoft.com:443
+            fe2cr.update.microsoft.com:443
+            ecs.office.com:443
+            pti.store.microsoft.com:443
+            login.live.com:443
+            go.microsoft.com:443
+            www.microsoft.com:443
+            ocsp.sectigo.com:80
+            ocsp.sectigo.com:443
+            crl.sectigo.com:80
+            crl.sectigo.com:443
+            *.apple.com:443
+            *.aaplimg.com:443
+            *.mzstatic.com:443
+            *.icloud.com:443
+            *.apple-dns.net:443
+            ocsp.usertrust.com:80
+            ocsp.digicert.com:80
+            0.pool.ntp.org:123
 
       - name: Check out code into the Go module directory
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+
+      # Repairs the runner's DNS if harden-runner's Windows post step kills its
+      # agent mid-"restoring system DNS" (a race against its 10-second wait);
+      # without it the job's steps all pass but the job never reports
+      # completion and GitHub cancels it 30-40 minutes later. Windows-only,
+      # no-op elsewhere. See the action's description and
+      # docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md.
+      - name: Guard DNS against the harden-runner post-step race
+        if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
+        uses: ./.github/actions/windows-dns-guard
 
       - name: Add GNU tar to flavor.target (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft

--- a/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
+++ b/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
@@ -87,7 +87,10 @@ the missing SARIF file, evicting the PR from the queue.
   - Windows and macOS OS endpoints added to the `allowed-endpoints` of `build`, `terraform-registry-cache`,
     `test`, `mock`, `k3s` (macOS leg) and `kubernetes-e2e` (macOS leg), with a comment naming the source and
     the trade-off. `test` also gains `sum.golang.org`, `google.golang.org` and `modernc.org` for parity with
-    `build` (its Linux/macOS legs run `atmos build deps`). Firefox telemetry stays blocked.
+    `build` (its Linux/macOS legs run `atmos build deps`). Firefox telemetry stays blocked. Two gaps surfaced
+    by StepSecurity notices during review are closed too: `api.github.com` was never allowlisted on
+    `validate-affected`, `floci`, `k3s` and `validate`, and the Windows Software Licensing Service probes
+    `tas02.sls.update.microsoft.com`, so the update entry is the wildcard `*.update.microsoft.com`.
   - `GOPROXY` drops `|direct`; `atmos build deps`'s retry policy covers the transient proxy errors it existed
     for.
   - Workflow-level `concurrency` cancels a PR's superseded run on a new push; `merge_group`, `push` and

--- a/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
+++ b/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
@@ -66,6 +66,15 @@ run fanned `go mod download` out to ~25 vanity-import hosts (`k8s.io`, `go.uber.
 …), all blocked, and `Get dependencies` took 9+ minutes of retries. Under block mode the fallback can only
 ever cost time.
 
+The same fallback also breaks `govulncheck` in `codeql.yml` on merge-queue runs (run 33785801022:
+`unrecognized import path "sigs.k8s.io/kustomize/kyaml": https fetch ... lookup sigs.k8s.io ... operation not
+permitted`), evicting the PR; the job passes on this branch with the fallback removed.
+
+**macOS agent matches by IP.** StepSecurity shows `api.github.com:443` dropped on a macOS shard with
+`matched_policy: EXACT_IP` even though the host is allowlisted: the macOS agent did not observe the DNS answer
+(Runner.Worker and a test binary reused a cached resolution) and blocked the connection by IP. This is an
+agent limitation, not an allowlist gap, and is included in the upstream report below.
+
 **Merge queue.** `[lint] Dockerfile` failed on 16 `merge_group` runs: `codeql-action/upload-sarif` fails with
 `ref 'refs/heads/gh-readonly-queue/…' not found`, which skips the Trivy scan and fails the second upload on
 the missing SARIF file, evicting the PR from the queue.
@@ -166,4 +175,7 @@ comparison 100688004653, 100532566215.
 
 Requests: (1) wait for the DNS restore to finish (or restore DNS from the action as a fallback after killing
 the agent); (2) consider implicitly allowing Windows/macOS OS endpoints in block mode (NCSI probes, WNS,
-update/settings/telemetry, time sync, OCSP/CRL, Apple update/CDN) — they are blocked on every job today.
+update/settings/telemetry, time sync, OCSP/CRL, Apple update/CDN) — they are blocked on every job today;
+(3) on macOS, allowlisted hosts are sometimes dropped with `matched_policy: EXACT_IP` when the agent did not
+see the DNS answer (e.g. `api.github.com:443` from Runner.Worker and from a Go test binary in
+cloudposse/atmos run 33766077354, job 100692423806, while `api.github.com:443` was in `allowed-endpoints`).

--- a/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
+++ b/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
@@ -73,7 +73,7 @@ the missing SARIF file, evicting the PR from the queue.
 ## Changes
 
 - `.github/actions/windows-dns-guard/` (new): composite action that registers a one-shot scheduled task
-  (`atmos-dns-guard`, SYSTEM, outside the runner's process tree so it survives step teardown and the
+  (`atmos-dns-guard`, running as the runner's own Administrator account, outside the runner's process tree so it survives step teardown and the
   runner's orphan-process cleanup) running `dns-guard.ps1`. The script polls once a second and resets DNS
   (`Set-DnsClientServerAddress -ResetServerAddresses` + `Clear-DnsClientCache`) only when
   `C:\agent\post_event.json` exists, the agent from `C:\agent\agent.pid` is gone, and an IPv4 interface still
@@ -81,7 +81,9 @@ the missing SARIF file, evicting the PR from the queue.
   `$RUNNER_TEMP\atmos-dns-guard.log` and exits after acting or when DNS is already healthy.
 - `.github/workflows/test.yml`:
   - Guard step on every Windows leg (`build`, `terraform-registry-cache`, `test` × 10 shards, `mock`),
-    right after checkout, gated the same way as the other Windows steps (skipped on draft PRs).
+    right after checkout, gated the same way as the other Windows steps. Draft PRs skip every Windows step
+    including checkout, so Harden Runner is now skipped for them too rather than left to race without the
+    guard.
   - Windows and macOS OS endpoints added to the `allowed-endpoints` of `build`, `terraform-registry-cache`,
     `test`, `mock`, `k3s` (macOS leg) and `kubernetes-e2e` (macOS leg), with a comment naming the source and
     the trade-off. `test` also gains `sum.golang.org`, `google.golang.org` and `modernc.org` for parity with
@@ -115,9 +117,11 @@ gh run list -R cloudposse/atmos -w test.yml --created ">=2026-09-04" -L 300 \
   --json databaseId,conclusion --jq '.[]|select(.conclusion!="success")|.databaseId' |
 while read id; do
   gh api "repos/cloudposse/atmos/actions/runs/$id/jobs?per_page=100" --paginate --jq '
+    def ts: sub("\\.[0-9]+Z$"; "Z") | fromdate;
     .jobs[] | select(.conclusion=="cancelled") |
+    select(any(.labels[]?; test("windows"; "i")) or (.name|test("windows"; "i"))) |
     select(all(.steps[]; .conclusion=="success" or .conclusion=="skipped")) |
-    select(((.completed_at|fromdate) - (.steps[-1].completed_at|fromdate)) >= 300) |
+    select(((.completed_at|ts) - (.steps[-1].completed_at|ts)) >= 300) |
     [.run_id, .name] | @tsv'
 done
 

--- a/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
+++ b/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
@@ -1,0 +1,162 @@
+# Fix: Windows CI jobs left stuck after "Complete job" by harden-runner's DNS-restore race
+
+**Date:** 2026-09-03
+
+## Summary
+
+Since harden-runner landed on the Windows and macOS legs of `test.yml` (2026-08-31, #2958) and went to
+block mode (2026-09-02, #3027), Windows jobs have been finishing every step, including `Post Harden Runner`
+and `Complete job`, and then never reporting a conclusion until GitHub cancels them 30–40 minutes later.
+`Build (windows)` gates every other job, so one stuck build stalls the whole run, including merge-queue
+entries. Root cause is a race in harden-runner's Windows post step: it waits at most 10 s for its agent, then
+kills it, and in the losing case the agent is still restoring the runner's DNS settings, leaving the adapter
+pointed at a DNS proxy that no longer exists. This change adds a scheduled-task watchdog that repairs DNS
+only in that exact state, allowlists the Windows/macOS operating-system endpoints that StepSecurity showed
+blocked on every job, removes the `|direct` Go proxy fallback that only fans out to blocked hosts under block
+mode, cancels superseded PR runs, and stops the Trivy SARIF upload from evicting PRs from the merge queue.
+harden-runner stays in block mode on every leg.
+
+## Context
+
+Measured from `test.yml` run data (Aug 24 – Sept 3), raw job logs (which include the harden-runner agent's
+own log), StepSecurity network-event telemetry, and harden-runner's source.
+
+**Mechanism.** harden-runner's Windows agent (v1.0.7-win, hard-coded in `src/install-agent.ts`) enforces
+egress with a DNS proxy on `127.0.0.1:53` and repoints every adapter to it with `Set-DnsClientServerAddress`.
+Its post step (`src/cleanup.ts`, `handleWindowsCleanup`) writes `C:\agent\post_event.json`, polls for
+`done.json` for at most 10 × 1 s, logs `timed out`, sends SIGINT and sees the agent gone within a second.
+In every stuck job the agent picked the post event up ~5 s late and had just logged
+`[handlePostHardenRunnerEvent] restoring system DNS` (a step that takes ~2.4 s when it completes) when it was
+killed. The runner can still upload logs to hosts it already resolved, but the final job-completion call to
+the Actions service needs a fresh lookup and never succeeds.
+
+| Job | Kind | 2nd `timed out` in post step | `system DNS settings restored` | `DNS proxy stopped` |
+|---|---|---|---|---|
+| 100694525046 Build (windows) | stuck | yes | no | no |
+| 100532566143 shard 2 | stuck | yes | no (restore began 5.6 s after post step) | no |
+| 100127533462 shard (Sept 2, audit mode) | stuck | yes | no (restore began 4.8 s after) | no |
+| 100688004653 Build (windows) | healthy | no | yes (2.9 s → 5.3 s after post step) | yes |
+| 100532566215 shard 3 | healthy | no | yes (2.2 s → 4.5 s after) | yes |
+| 100696221376, 100696221470 shards | healthy | no | yes | yes |
+
+**Frequency.** Counting only cancelled jobs whose job-level completion landed ≥ 5 min after their last step
+(true zombies; ordinary cancellations land within seconds):
+
+| Day | true stuck Windows jobs | note |
+|---|---|---|
+| Aug 25–28 | 0 | 12 "cancelled" jobs all completed ≤ 5 s after their last step (ordinary cancels) |
+| Aug 31 (harden-runner `audit` on Windows/macOS legs) | 0 | 11 instant cancels (manual cancel + rerun) |
+| Sept 1 (audit) | 5 | |
+| Sept 2 (`block` from 21:08 UTC) | 9 | |
+| Sept 3 | 23 | ≈ 1.5 % of Windows jobs, ≈ 27 % of runs (18 Windows jobs per run) |
+
+It happens in audit mode too (the agent and proxy run in both), so audit is not a fix, and harden-runner
+v2.21.1 does not change the Windows agent.
+
+**Blocked OS endpoints.** StepSecurity Insights shows the same operating-system destinations blocked on
+every Windows/macOS job, healthy or stuck, from OS services rather than our steps: NCSI connectivity probes
+(`www.msftconnecttest.com`, `www.msftncsi.com`, IPv6 variants, retried every few seconds), WNS,
+settings/events telemetry, Windows Update, `time.windows.com`, Store/Live/`go.microsoft.com`, and Sectigo
+OCSP/CRL (GitHub's certificate chain, hit from `git-remote-https.exe`); on macOS, Apple software-update, CDN,
+iCloud and revocation hosts plus NTP. None are implicitly allowed (StepSecurity's docs: only their own agent
+endpoints and dot-less hostnames are), and `allowed-endpoints` supports domain wildcards.
+
+**Go proxy fallback.** With `GOPROXY=https://proxy.golang.org|direct`, one proxy hiccup on a harden-runner PR
+run fanned `go mod download` out to ~25 vanity-import hosts (`k8s.io`, `go.uber.org`, `gopkg.in`, `helm.sh`,
+…), all blocked, and `Get dependencies` took 9+ minutes of retries. Under block mode the fallback can only
+ever cost time.
+
+**Merge queue.** `[lint] Dockerfile` failed on 16 `merge_group` runs: `codeql-action/upload-sarif` fails with
+`ref 'refs/heads/gh-readonly-queue/…' not found`, which skips the Trivy scan and fails the second upload on
+the missing SARIF file, evicting the PR from the queue.
+
+## Changes
+
+- `.github/actions/windows-dns-guard/` (new): composite action that registers a one-shot scheduled task
+  (`atmos-dns-guard`, SYSTEM, outside the runner's process tree so it survives step teardown and the
+  runner's orphan-process cleanup) running `dns-guard.ps1`. The script polls once a second and resets DNS
+  (`Set-DnsClientServerAddress -ResetServerAddresses` + `Clear-DnsClientCache`) only when
+  `C:\agent\post_event.json` exists, the agent from `C:\agent\agent.pid` is gone, and an IPv4 interface still
+  lists `127.0.0.1`. The first condition keeps an agent crash mid-job fail-closed exactly as today. It logs to
+  `$RUNNER_TEMP\atmos-dns-guard.log` and exits after acting or when DNS is already healthy.
+- `.github/workflows/test.yml`:
+  - Guard step on every Windows leg (`build`, `terraform-registry-cache`, `test` × 10 shards, `mock`),
+    right after checkout, gated the same way as the other Windows steps (skipped on draft PRs).
+  - Windows and macOS OS endpoints added to the `allowed-endpoints` of `build`, `terraform-registry-cache`,
+    `test`, `mock`, `k3s` (macOS leg) and `kubernetes-e2e` (macOS leg), with a comment naming the source and
+    the trade-off. `test` also gains `sum.golang.org`, `google.golang.org` and `modernc.org` for parity with
+    `build` (its Linux/macOS legs run `atmos build deps`). Firefox telemetry stays blocked.
+  - `GOPROXY` drops `|direct`; `atmos build deps`'s retry policy covers the transient proxy errors it existed
+    for.
+  - Workflow-level `concurrency` cancels a PR's superseded run on a new push; `merge_group`, `push` and
+    `workflow_dispatch` are keyed by SHA and never cancelled.
+  - Both `codeql-action/upload-sarif` steps in the `docker` job skip on `merge_group`.
+- `.github/workflows/setup-go-cache-warmup.yml`: guard step, the same OS endpoints and Go hosts, `GOPROXY`.
+- `.github/workflows/native-ci.yml`, `codeql.yml`, `pre-commit.yml`: `GOPROXY` drops `|direct` (all run under
+  block mode).
+
+## Validation
+
+- `python3 -c 'import yaml; yaml.safe_load(...)'` on every edited workflow and the new action: parses.
+- `actionlint` on the five edited workflows: no new findings (one pre-existing SC2086 note in
+  `pre-commit.yml`, untouched by this change).
+- The watchdog's three preconditions were checked against harden-runner's source: `agent.pid` and
+  `post_event.json` paths and the post step's "wait 10 s, then kill, then delete the pid file" sequence are
+  as read from `src/install-agent.ts` and `src/cleanup.ts` at `main`.
+- Not validated locally: the scheduled task itself needs a Windows runner. Validation is the first CI run on
+  this branch (guard registers on every Windows job; `$RUNNER_TEMP\atmos-dns-guard.log` is not uploaded, so
+  the observable signal is the job-level outcome) and the 48-hour measurement below.
+
+Post-merge measurement (run from any checkout):
+
+```bash
+# True stuck Windows jobs: cancelled, every step succeeded, completion landed >= 5 min after the last step.
+gh run list -R cloudposse/atmos -w test.yml --created ">=2026-09-04" -L 300 \
+  --json databaseId,conclusion --jq '.[]|select(.conclusion!="success")|.databaseId' |
+while read id; do
+  gh api "repos/cloudposse/atmos/actions/runs/$id/jobs?per_page=100" --paginate --jq '
+    .jobs[] | select(.conclusion=="cancelled") |
+    select(all(.steps[]; .conclusion=="success" or .conclusion=="skipped")) |
+    select(((.completed_at|fromdate) - (.steps[-1].completed_at|fromdate)) >= 300) |
+    [.run_id, .name] | @tsv'
+done
+
+# Did harden-runner restore DNS on its own in a given Windows job? (0 = the guard had to act)
+gh api repos/cloudposse/atmos/actions/jobs/<job-id>/logs | grep -cE 'system DNS settings restored'
+```
+
+Success criteria: true stuck Windows jobs 0/day (23/day on Sept 3); no `infra`-labelled blocked calls on
+Windows/macOS in StepSecurity Insights; no `Could not resolve host` on Windows checkout; no Trivy failures on
+merge-queue runs.
+
+## Follow-ups
+
+- Upstream report to StepSecurity (harden-runner) — draft below; to be filed once approved.
+- Phase 2 of the CI-stability plan (Windows Defender exclusions; restore-only toolchain cache and shipping
+  toolchains in the build artifact; the Actions cache is a 10 GB LRU being churned by ~5 GB per run, so
+  nothing saved from `main` survives) and Phase 3 (auto-rerun of infra-cancelled PR runs) are tracked in
+  the follow-up issue linked from the PR.
+
+### Upstream issue draft (step-security/harden-runner)
+
+**Title:** Windows: post step's 10 s `done.json` wait races the agent's DNS restore; job never reports
+completion
+
+On GitHub-hosted `windows-latest` with harden-runner v2.21.0 (Windows agent v1.0.7-win), in both `audit` and
+`block` mode, about 1.5 % of our jobs finish every step — including `Post Harden Runner` and `Complete job` —
+and then never report a conclusion; GitHub cancels them 30–40 minutes later, well past `timeout-minutes`.
+
+From the agent log appended to the post step output: healthy jobs end with
+`[handlePostHardenRunnerEvent] restoring system DNS` → `system DNS settings restored` → `DNS proxy stopped`.
+Stuck jobs log a second `timed out` from `handleWindowsCleanup` (the 10 × 1 s `done.json` wait), then
+`stopping windows agent process` / `agent process stopped gracefully`, and the agent log stops at
+`restoring system DNS` (or before it). The agent picked up `post_event.json` ~5 s after the post step began;
+the restore takes ~2.4 s, so it loses the 10 s race a few percent of the time. The adapter is left on
+`127.0.0.1` with no proxy behind it, and the runner cannot resolve the Actions service to complete the job.
+
+Examples (cloudposse/atmos, public): stuck jobs 100694525046, 100532566143, 100127533462; healthy for
+comparison 100688004653, 100532566215.
+
+Requests: (1) wait for the DNS restore to finish (or restore DNS from the action as a fallback after killing
+the agent); (2) consider implicitly allowing Windows/macOS OS endpoints in block mode (NCSI probes, WNS,
+update/settings/telemetry, time sync, OCSP/CRL, Apple update/CDN) — they are blocked on every job today.

--- a/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
+++ b/docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md
@@ -132,6 +132,7 @@ while read id; do
     def ts: sub("\\.[0-9]+Z$"; "Z") | fromdate;
     .jobs[] | select(.conclusion=="cancelled") |
     select(any(.labels[]?; test("windows"; "i")) or (.name|test("windows"; "i"))) |
+    select((.steps|length) > 0 and .completed_at != null and .steps[-1].completed_at != null) |
     select(all(.steps[]; .conclusion=="success" or .conclusion=="skipped")) |
     select(((.completed_at|ts) - (.steps[-1].completed_at|ts)) >= 300) |
     [.run_id, .name] | @tsv'


### PR DESCRIPTION
## what

- Add `.github/actions/windows-dns-guard`: a scheduled-task watchdog that repairs the runner's DNS if step-security/harden-runner's Windows post step kills its agent before the agent has finished restoring DNS. Wired into every Windows leg of `test.yml` (`build`, `terraform-registry-cache`, the 10 acceptance shards, `mock`) and `setup-go-cache-warmup.yml`.
- Allowlist the Windows and macOS operating-system endpoints that StepSecurity Insights shows blocked on every job (NCSI connectivity probes, WNS, Windows Update, settings/events telemetry, time sync, Sectigo OCSP/CRL for GitHub's certificate chain; Apple software-update, CDN, iCloud, revocation hosts and NTP). harden-runner stays in `block` mode on every leg.
- Drop the `|direct` fallback from `GOPROXY` in the block-mode workflows (`test.yml`, `native-ci.yml`, `codeql.yml`, `pre-commit.yml`, `setup-go-cache-warmup.yml`). This also fixes the `govulncheck` job failing on merge-queue runs (`unrecognized import path "sigs.k8s.io/kustomize/kyaml"` via a blocked direct fetch), which has been evicting PRs from the queue; the plain `go mod download` steps in `pre-commit.yml` and `codeql.yml` now use the existing retry action instead.
- Close two allowlist gaps surfaced by StepSecurity notices during review: `api.github.com` on `validate-affected`, `floci`, `k3s`, `validate`; `*.update.microsoft.com` (the Windows licensing service probes `tas02.sls.update.microsoft.com`).
- Cancel superseded `pull_request` runs with a workflow-level `concurrency` group; `merge_group`, `push`, and `workflow_dispatch` runs are keyed by SHA and never cancelled.
- Skip both `codeql-action/upload-sarif` steps in the `docker` job on `merge_group` runs.

## why

Windows jobs have been finishing every step, including `Post Harden Runner` and `Complete job`, and then never reporting a conclusion until GitHub cancels them 30–40 minutes later. `Build (windows)` gates every other job, so one stuck build stalls the entire run, including merge-queue entries. Counting only cancelled jobs whose completion landed 5+ minutes after their last step, there were zero such jobs per day before harden-runner landed on the Windows legs (Aug 31), then 5, 9, and 23 per day on Sept 1–3 (about 1.5% of Windows jobs and 27% of runs).

The raw job logs pin the mechanism. harden-runner's Windows post step (`src/cleanup.ts`, `handleWindowsCleanup`) waits at most 10 s for its agent, logs `timed out`, and kills it. In every stuck job the agent had picked the post event up ~5 s late and was inside `[handlePostHardenRunnerEvent] restoring system DNS` (a ~2.4 s operation) when it died; healthy jobs go on to log `system DNS settings restored` and `DNS proxy stopped`. The adapter is left pointed at a DNS proxy that no longer exists, and the runner cannot resolve the Actions service to report completion. It happens in audit mode too, so audit is not a fix, and v2.21.1 does not change the Windows agent.

The watchdog runs under the Task Scheduler service, outside the runner's process tree, and acts only when harden-runner's `post_event.json` exists, the agent from `agent.pid` is gone, and an interface still lists `127.0.0.1`. That last condition keeps an agent crash mid-job fail-closed exactly as today.

The allowlist additions address the constant "Outbound Connection Blocked" notices for Microsoft and Apple domains: those are OS background services retrying against blocked hosts for the whole job (NCSI probes every few seconds; schannel revocation checks stalling TLS to github.com), not anything our steps do. StepSecurity's docs confirm they are not implicitly allowed and that domain wildcards are supported.

`GOPROXY=…|direct` can only cost time under block mode: on one run a single proxy.golang.org hiccup fanned `go mod download` out to ~25 blocked vanity-import hosts and `Get dependencies` took 9+ minutes. The transient proxy errors the fallback existed for are handled by `atmos build deps`'s retry policy.

The SARIF upload cannot attach results to a merge queue's synthetic `refs/heads/gh-readonly-queue/…` ref; the failure skipped the Trivy scan and failed the second upload on the missing file, evicting PRs from the queue on 16 runs in two days.

Full evidence tables, the measurement queries, and a drafted upstream report for StepSecurity are in `docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md`.

## references

- step-security/harden-runner `src/cleanup.ts` (`handleWindowsCleanup`, 10 s `done.json` wait) and `src/install-agent.ts` (agent v1.0.7-win)
- step-security/harden-runner#679 (block-mode runner reclamation on Linux, addressed by v2.21.1) and #692 (macOS agent install)
- Stuck example jobs: 100694525046, 100532566143, 100127533462; healthy for comparison: 100688004653, 100532566215
- Follow-ups (Phase 2: Windows Defender exclusions and the churning Actions cache; Phase 3: auto-rerun of infra-cancelled runs) will be tracked in a separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CI reliability by recovering DNS settings when runner cleanup is interrupted.
  * Canceled superseded pull request runs to reduce unnecessary resource usage.
  * Improved merge-queue compatibility by skipping unsupported SARIF uploads.

* **Chores**
  * CI dependency downloads now use the configured Go module proxy with retries and no direct-fetch fallback.
  * Updated CI network access rules for required operating-system, certificate, time-sync, and package services.

* **Documentation**
  * Documented the Windows DNS issue, remediation, and validation procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
