### PR TITLE
ci: upload the DNS guard's own log for post-mortem diagnosis

### DIFF
--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -99,6 +99,19 @@ jobs:
         if: matrix.target == 'windows'
         uses: ./.github/actions/windows-dns-guard
 
+      - name: Upload DNS guard log
+        # Best-effort diagnostic for the "guard ran but the job still hung"
+        # case (see docs/fixes/2026-09-04-dns-guard-log-artifact.md): the log
+        # was previously never uploaded, so a residual occurrence of the race
+        # this guard exists for couldn't be root-caused after the fact.
+        if: always() && matrix.target == 'windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dns-guard-log-${{ github.job }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}\atmos-dns-guard.log
+          if-no-files-found: ignore
+          retention-days: 3
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,6 +204,19 @@ jobs:
         if: matrix.target == 'windows' && ! github.event.pull_request.draft
         uses: ./.github/actions/windows-dns-guard
 
+      - name: Upload DNS guard log
+        # Best-effort diagnostic for the "guard ran but the job still hung"
+        # case (see docs/fixes/2026-09-04-dns-guard-log-artifact.md): the log
+        # was previously never uploaded, so a residual occurrence of the race
+        # this guard exists for couldn't be root-caused after the fact.
+        if: always() && (matrix.target == 'windows' && ! github.event.pull_request.draft)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dns-guard-log-${{ github.job }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}\atmos-dns-guard.log
+          if-no-files-found: ignore
+          retention-days: 3
+
       - name: Set up Go
         if: ${{ ! ( matrix.target == 'windows' && github.event.pull_request.draft  ) }}
         # setup-go v6 requires runner v2.327.1+ and can affect toolchain handling.
@@ -427,6 +440,19 @@ jobs:
       - name: Guard DNS against the harden-runner post-step race
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
         uses: ./.github/actions/windows-dns-guard
+
+      - name: Upload DNS guard log
+        # Best-effort diagnostic for the "guard ran but the job still hung"
+        # case (see docs/fixes/2026-09-04-dns-guard-log-artifact.md): the log
+        # was previously never uploaded, so a residual occurrence of the race
+        # this guard exists for couldn't be root-caused after the fact.
+        if: always() && (matrix.flavor.target == 'windows' && ! github.event.pull_request.draft)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dns-guard-log-${{ github.job }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}\atmos-dns-guard.log
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
@@ -673,6 +699,19 @@ jobs:
       - name: Guard DNS against the harden-runner post-step race
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
         uses: ./.github/actions/windows-dns-guard
+
+      - name: Upload DNS guard log
+        # Best-effort diagnostic for the "guard ran but the job still hung"
+        # case (see docs/fixes/2026-09-04-dns-guard-log-artifact.md): the log
+        # was previously never uploaded, so a residual occurrence of the race
+        # this guard exists for couldn't be root-caused after the fact.
+        if: always() && (matrix.flavor.target == 'windows' && ! github.event.pull_request.draft)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dns-guard-log-${{ github.job }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}\atmos-dns-guard.log
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Add GNU tar to PATH (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
@@ -1699,6 +1738,19 @@ jobs:
       - name: Guard DNS against the harden-runner post-step race
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft
         uses: ./.github/actions/windows-dns-guard
+
+      - name: Upload DNS guard log
+        # Best-effort diagnostic for the "guard ran but the job still hung"
+        # case (see docs/fixes/2026-09-04-dns-guard-log-artifact.md): the log
+        # was previously never uploaded, so a residual occurrence of the race
+        # this guard exists for couldn't be root-caused after the fact.
+        if: always() && (matrix.flavor.target == 'windows' && ! github.event.pull_request.draft)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dns-guard-log-${{ github.job }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}\atmos-dns-guard.log
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Add GNU tar to flavor.target (significantly faster than windows tar)
         if: matrix.flavor.target == 'windows' && ! github.event.pull_request.draft

--- a/docs/fixes/2026-09-04-dns-guard-log-artifact.md
+++ b/docs/fixes/2026-09-04-dns-guard-log-artifact.md
@@ -1,0 +1,45 @@
+# Fix: upload the DNS guard's own log so a residual hang is diagnosable
+
+**Date:** 2026-09-04
+
+## Summary
+
+`docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md` shipped `atmos-dns-guard` (a
+scheduled task that resets a Windows runner's DNS if harden-runner's post step kills its agent
+before the restore finishes) and explicitly noted its log (`$RUNNER_TEMP\atmos-dns-guard.log`)
+was not uploaded anywhere - "the observable signal is the job-level outcome" only.
+
+A residual occurrence surfaced on an unrelated PR (#3043, a trivial `runs-on/action` version
+bump): `Acceptance Tests (windows, shard 5/10)` ran every step successfully, then hung during
+post-job cleanup and was cancelled ~15 minutes later - the same symptom the guard exists to
+prevent. The job's own runner-agent log showed the guard's scheduled task had registered and run,
+but with no uploaded guard log, there's no way to tell whether it detected the stuck condition and
+acted, detected it and *failed* to act, or never saw the condition this specific run - i.e.
+whether this is the same race with a residual gap, or a distinct failure mode that only looks the
+same from the outside.
+
+## Fix
+
+Added an `if: always()` `actions/upload-artifact` step immediately after every
+`./.github/actions/windows-dns-guard` invocation (`build`, `terraform-registry-cache`, `test`,
+`mock` in `test.yml`; the cache-warmup workflow's own job), uploading
+`${{ runner.temp }}\atmos-dns-guard.log` as `dns-guard-log-${{ github.job }}-${{
+strategy.job-index }}` (unique per job/shard), `if-no-files-found: ignore` (the guard is a no-op,
+and produces no log, on non-Windows legs or when DNS never needed repair), 3-day retention.
+
+This does not fix a known root cause - none is confirmed yet. It closes the diagnostic gap so the
+next occurrence of "guard ran, job still hung" produces the guard's own log instead of only the
+job-level outcome, which is what's actually needed to tell whether this is the original DNS race
+recurring past the guard's coverage, or something new.
+
+## Validation
+
+- `atmos ci validate .github/workflows/test.yml .github/workflows/setup-go-cache-warmup.yml` -
+  both valid.
+- Not validated live: needs a real Windows job run (ideally one where the guard actually fires) to
+  confirm the artifact uploads as expected.
+
+## Follow-ups
+
+- Once a guard log from an actual hang is captured, revisit whether this is the same DNS race with
+  a coverage gap or a distinct failure mode, and fix accordingly.


### PR DESCRIPTION
## what

Adds an `if: always()` artifact-upload step immediately after every `./.github/actions/windows-dns-guard` invocation (`build`, `terraform-registry-cache`, `test`, `mock` in `test.yml`; `setup-go-cache-warmup.yml`'s own job), uploading `atmos-dns-guard.log` (unique per job/shard, `if-no-files-found: ignore`, 3-day retention).

## why

The guard's own log was never uploaded anywhere - `docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md` says so explicitly ("the observable signal is the job-level outcome"). The exact symptom the guard exists to prevent recurred on an unrelated PR (#3043, a trivial `runs-on/action` version bump): every step passed, then the job hung during post-job cleanup and was cancelled ~15 minutes later. The runner-agent log showed the guard's scheduled task had registered and run - but with no uploaded guard log, there's no way to tell whether it detected the stuck condition and acted, detected it and failed to act, or never saw the condition at all this run.

This PR does not fix a root cause - none is confirmed yet. It closes the diagnostic gap so the next occurrence produces the evidence actually needed to determine whether this is the original race recurring past the guard's coverage, or a distinct failure mode.

## references

- `docs/fixes/2026-09-04-dns-guard-log-artifact.md`
- `docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md` (original guard)
- Observed on cloudposse/atmos#3043, `Acceptance Tests (windows, shard 5/10)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Added automatic collection of Windows DNS guard logs from CI jobs, including cache warmup, builds, tests, and mocks.
  * Logs are retained as downloadable artifacts for three days when available, including after job failures.

* **Documentation**
  * Added a fix note describing DNS guard log collection and validation steps for diagnosing Windows runner hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->