### PR TITLE
ci: allow setup-go's download hosts in rerun-infra-failures

### DIFF
--- a/.github/workflows/rerun-infra-failures.yml
+++ b/.github/workflows/rerun-infra-failures.yml
@@ -76,11 +76,17 @@ jobs:
         with:
           egress-policy: block
           # api.github.com: run/job/PR lookups and the rerun call.
-          # github.com: actions/checkout. The Go hosts are for the module
-          # download behind `go tool mage` (same set as test.yml's build job).
+          # github.com: actions/checkout. release-assets.githubusercontent.com:
+          # where actions/setup-go downloads the Go toolchain (every run
+          # failed here without it, blocked at getaddrinfo); golang.org is
+          # setup-go's fallback download host. The remaining Go hosts are
+          # for the module download behind `go tool mage` (same set as
+          # test.yml's build job).
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            release-assets.githubusercontent.com:443
+            golang.org:443
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443


### PR DESCRIPTION
## what

- Add `release-assets.githubusercontent.com:443` and `golang.org:443` to the harden-runner allowlist of `rerun-infra-failures.yml`.

## why

Every run of the workflow since #3040 merged has failed in the classify step. StepSecurity reported the blocks, and the job log shows `getaddrinfo EAI_AGAIN release-assets.githubusercontent.com` while `actions/setup-go` downloads the toolchain; `golang.org` is setup-go's fallback download host once the first is blocked. test.yml's Go jobs already allowlist the release-assets host.

## references

- #3040
- StepSecurity blocked-connection notice for `rerun-infra-failures.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved infrastructure-failure reruns by allowing required external services for downloading and setting up the Go toolchain.
  - Reduced workflow failures caused by blocked network access during Go environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->