### PR TITLE
ci: let the per-OS acceptance check wait for shard conclusions to settle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -986,8 +986,11 @@ jobs:
     # `gh api .../actions/runs/.../jobs` (below) hits the REST API for this
     # run's job list and needs actions:read - unlike needs.<job>.result, which
     # is ambient but only exposes the whole matrix job's aggregated verdict.
+    # actions: read for the jobs listing; contents: read for the checkout
+    # that `go tool mage` needs.
     permissions:
       actions: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -999,6 +1002,14 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            github.com:443
+            release-assets.githubusercontent.com:443
+            golang.org:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            google.golang.org:443
+            modernc.org:443
 
       # A whole-run cancellation (e.g. superseded by a newer push to the same
       # PR) skips the `test` matrix before it ever dispatches shard jobs, so
@@ -1013,77 +1024,40 @@ jobs:
         if: ${{ cancelled() }}
         run: echo "workflow run was cancelled (e.g. superseded by a newer push); nothing to verify"
 
+      - name: Check out code into the Go module directory
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      # cache: false on purpose - this job compiles only the mage helper, and a
+      # save from here would put a thin archive under the Linux setup-go key
+      # that every other Linux job shares.
+      - name: Set up Go
+        if: ${{ !cancelled() }}
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
+
+      # The check itself lives in internal/ci/acceptance (CheckShardResults):
+      # it lists this attempt's jobs, waits for every "Acceptance Tests
+      # (<os>, shard N/M)" job to have a conclusion - the jobs API is
+      # eventually consistent and has returned an empty conclusion for a
+      # shard that finished minutes earlier - and fails unless all succeeded.
+      # The matrix stays a literal `check: [...]` list of the legacy check
+      # names because internal/ci/acceptance/verify.go's
+      # workflowRequiredCheckPattern requires it; the target OS is derived
+      # from the name in Go.
       - name: Check per-OS test matrix result
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           CHECK: ${{ matrix.check }}
-        run: |
-          set -euo pipefail
-
-          # Derive the OS token (e.g. "linux") from the legacy check name
-          # (e.g. "Acceptance Tests (linux)") instead of a separate matrix
-          # field, so internal/ci/acceptance/verify.go's
-          # workflowRequiredCheckPattern - which requires this job's matrix
-          # to stay a literal `check: [...]` list - keeps matching.
-          target=${CHECK#Acceptance Tests (}
-          target=${target%)}
-          export TARGET="$target"
-
-          list_shards() {
-            gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
-              --paginate \
-              --jq ".jobs[] | select(.name | startswith(\"Acceptance Tests (\" + env.TARGET + \", shard\")) | [.name, (.conclusion // \"\")] | @tsv"
-          }
-
-          # The jobs API is eventually consistent: it has returned an empty
-          # conclusion for a shard that had finished seven minutes earlier,
-          # which this check then reported as "did not succeed". An empty
-          # conclusion means "not settled yet", not "failed": re-poll for a
-          # while and only judge once every shard has a conclusion.
-          settled=0
-          for attempt in $(seq 1 20); do
-            mapfile -t shard_jobs < <(list_shards)
-            unsettled=0
-            for job in "${shard_jobs[@]}"; do
-              [ -z "${job##*$'\t'}" ] && unsettled=$((unsettled + 1))
-            done
-            if [ "$unsettled" -eq 0 ] && [ "${#shard_jobs[@]}" -eq "$TEST_SHARD_COUNT" ]; then
-              settled=1
-              break
-            fi
-            echo "attempt $attempt: ${#shard_jobs[@]} '$TARGET' shard jobs listed, $unsettled without a conclusion yet; retrying in 15s"
-            sleep 15
-          done
-          if [ "$settled" -ne 1 ]; then
-            echo "shard results never settled; last listing:"
-            printf '%s\n' "${shard_jobs[@]}"
-            exit 1
-          fi
-
-          # Fail loudly if the job list itself looks wrong (renamed job, API
-          # hiccup, shard count drift) rather than silently treating a missing
-          # shard as a pass.
-          job_count=${#shard_jobs[@]}
-          if [ "$job_count" -ne "$TEST_SHARD_COUNT" ]; then
-            echo "expected $TEST_SHARD_COUNT '$TARGET' shard jobs, found $job_count"
-            printf '%s\n' "${shard_jobs[@]}"
-            exit 1
-          fi
-
-          failed=()
-          for job in "${shard_jobs[@]}"; do
-            conclusion=${job##*$'\t'}
-            if [ "$conclusion" != "success" ]; then
-              failed+=("$job")
-            fi
-          done
-
-          if [ "${#failed[@]}" -gt 0 ]; then
-            echo "the following '$TARGET' shard jobs did not succeed:"
-            printf '%s\n' "${failed[@]}"
-            exit 1
-          fi
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: go tool mage ci:checkShardResults "$REPO" "$RUN_ID" "$RUN_ATTEMPT" "$CHECK"
 
       - name: Check terraform-registry-cache result
         # terraform-registry-cache only runs a linux/windows matrix (no macos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1030,9 +1030,36 @@ jobs:
           target=${target%)}
           export TARGET="$target"
 
-          mapfile -t shard_jobs < <(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
-            --paginate \
-            --jq ".jobs[] | select(.name | startswith(\"Acceptance Tests (\" + env.TARGET + \", shard\")) | [.name, .conclusion] | @tsv")
+          list_shards() {
+            gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
+              --paginate \
+              --jq ".jobs[] | select(.name | startswith(\"Acceptance Tests (\" + env.TARGET + \", shard\")) | [.name, (.conclusion // \"\")] | @tsv"
+          }
+
+          # The jobs API is eventually consistent: it has returned an empty
+          # conclusion for a shard that had finished seven minutes earlier,
+          # which this check then reported as "did not succeed". An empty
+          # conclusion means "not settled yet", not "failed": re-poll for a
+          # while and only judge once every shard has a conclusion.
+          settled=0
+          for attempt in $(seq 1 20); do
+            mapfile -t shard_jobs < <(list_shards)
+            unsettled=0
+            for job in "${shard_jobs[@]}"; do
+              [ -z "${job##*$'\t'}" ] && unsettled=$((unsettled + 1))
+            done
+            if [ "$unsettled" -eq 0 ] && [ "${#shard_jobs[@]}" -eq "$TEST_SHARD_COUNT" ]; then
+              settled=1
+              break
+            fi
+            echo "attempt $attempt: ${#shard_jobs[@]} '$TARGET' shard jobs listed, $unsettled without a conclusion yet; retrying in 15s"
+            sleep 15
+          done
+          if [ "$settled" -ne 1 ]; then
+            echo "shard results never settled; last listing:"
+            printf '%s\n' "${shard_jobs[@]}"
+            exit 1
+          fi
 
           # Fail loudly if the job list itself looks wrong (renamed job, API
           # hiccup, shard count drift) rather than silently treating a missing

--- a/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
+++ b/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
@@ -7,7 +7,7 @@
 `Acceptance Tests (macos)` (the per-OS aggregate in `test.yml`) failed on PR #3049's run
 33907449514 with:
 
-```
+```text
 the following 'macos' shard jobs did not succeed:
 Acceptance Tests (macos, shard 9/10)
 ```

--- a/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
+++ b/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
@@ -18,10 +18,21 @@ The conclusion column is empty. Every macOS shard had succeeded; shard 9 had com
 
 ## Fix
 
-"Check per-OS test matrix result" now treats an empty conclusion as *not settled yet*: it re-lists
-the shards (up to 20 times, 15 s apart) until every shard has a conclusion and the count matches
-`TEST_SHARD_COUNT`, and only then judges. A shard that truly failed still fails the check; a
-listing that never settles fails loudly with the last listing printed.
+The check moved out of shell into Go, next to the classify step that already lives there:
+`internal/ci/acceptance.CheckShardResults` (with `TargetFromCheckName`), exposed as
+`go tool mage ci:checkShardResults <repo> <run-id> <attempt> <check-name>`. It lists the attempt's
+jobs through the same go-gh `RESTClient` and `rerun.FetchJobs` the classify step uses, keeps the
+"Acceptance Tests (<os>, shard N/M)" ones, and treats an empty conclusion as *not settled yet*:
+it re-lists (up to 20 times, 15 s apart, context-aware) until every shard has a conclusion, then
+judges. A shard that truly failed still fails the check with the offending shards listed; a shard
+count other than `TEST_SHARD_COUNT` fails at once (every job of an attempt exists from the start,
+so a mismatch means the workflow changed shape); a listing that never settles fails loudly with
+the last listing printed. Unit-tested with the generated `MockRESTClient` (settles immediately,
+settles after retries, never settles, failed shards, count mismatch, cancelled context).
+
+The `test-required` job gains a checkout and a `setup-go` (with `cache: false`, so this tiny job
+never writes a thin archive under the Linux setup-go key every other Linux job shares), `contents:
+read`, and the Go download hosts in its egress allowlist. The workflow step is one line.
 
 ## Validation
 

--- a/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
+++ b/docs/fixes/2026-09-04-per-os-check-empty-conclusion.md
@@ -1,0 +1,29 @@
+# Fix: per-OS acceptance check failed on a shard whose conclusion the API had not written yet
+
+**Date:** 2026-09-04
+
+## Summary
+
+`Acceptance Tests (macos)` (the per-OS aggregate in `test.yml`) failed on PR #3049's run
+33907449514 with:
+
+```
+the following 'macos' shard jobs did not succeed:
+Acceptance Tests (macos, shard 9/10)
+```
+
+The conclusion column is empty. Every macOS shard had succeeded; shard 9 had completed at
+19:13:13, seven minutes before the aggregate ran at 19:20:28, yet the jobs API returned it with
+`conclusion: null`. The check compared that empty string against `success` and failed the run.
+
+## Fix
+
+"Check per-OS test matrix result" now treats an empty conclusion as *not settled yet*: it re-lists
+the shards (up to 20 times, 15 s apart) until every shard has a conclusion and the count matches
+`TEST_SHARD_COUNT`, and only then judges. A shard that truly failed still fails the check; a
+listing that never settles fails loudly with the last listing printed.
+
+## Validation
+
+- `actionlint .github/workflows/test.yml`, pre-commit hooks clean.
+- The PR's own `Tests` run exercises all three per-OS aggregates.

--- a/internal/ci/acceptance/shards.go
+++ b/internal/ci/acceptance/shards.go
@@ -1,0 +1,197 @@
+package acceptance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/cloudposse/atmos/internal/ci/rerun"
+	"github.com/cloudposse/atmos/pkg/perf"
+)
+
+const (
+	// DefaultShardPolls bounds how many times CheckShardResults re-lists the
+	// shards while any of them still lacks a conclusion.
+	DefaultShardPolls = 20
+	// DefaultShardPollInterval is the wait between those listings.
+	DefaultShardPollInterval = 15 * time.Second
+
+	checkNamePrefix = "Acceptance Tests ("
+	checkNameSuffix = ")"
+)
+
+var (
+	errShardsNotSettled = errors.New("acceptance: shard results never settled")
+	errShardCount       = errors.New("acceptance: unexpected number of shard jobs")
+	errShardsFailed     = errors.New("acceptance: shard jobs did not succeed")
+	errInvalidCheckName = errors.New("acceptance: check name is not of the form \"Acceptance Tests (<target>)\"")
+	errShardCountValue  = errors.New("acceptance: shard count must be a positive integer")
+)
+
+// TargetFromCheckName derives the OS target ("linux") from the legacy
+// required-check name ("Acceptance Tests (linux)"). The workflow's
+// `test-required` job takes its matrix from those literal names rather than a
+// separate field so verify.go's workflowRequiredCheckPattern keeps matching.
+func TargetFromCheckName(check string) (string, error) {
+	if !strings.HasPrefix(check, checkNamePrefix) || !strings.HasSuffix(check, checkNameSuffix) {
+		return "", fmt.Errorf("%w: %q", errInvalidCheckName, check)
+	}
+	target := strings.TrimSuffix(strings.TrimPrefix(check, checkNamePrefix), checkNameSuffix)
+	if target == "" {
+		return "", fmt.Errorf("%w: %q", errInvalidCheckName, check)
+	}
+	return target, nil
+}
+
+// ShardResultsParams describes which shard jobs CheckShardResults judges and
+// how long it waits for their conclusions to settle.
+type ShardResultsParams struct {
+	Run rerun.RunRef
+	// Target is the OS token in the shard job names ("linux", "macos", "windows").
+	Target string
+	// ShardCount is how many shard jobs the workflow declares (TEST_SHARD_COUNT).
+	ShardCount int
+	// Polls and Interval default to DefaultShardPolls and DefaultShardPollInterval.
+	Polls    int
+	Interval time.Duration
+	// Wait is how the poll loop sleeps; nil means a context-aware time.After.
+	// Tests inject a recorder.
+	Wait func(context.Context, time.Duration) error
+}
+
+// ShardResult is one shard job's name and conclusion. Conclusion is "" while
+// the GitHub jobs API has not written it yet.
+type ShardResult struct {
+	Name       string
+	Conclusion string
+}
+
+// CheckShardResults judges the acceptance shards of one OS target in a
+// workflow-run attempt: it lists the attempt's jobs, keeps the ones named
+// "Acceptance Tests (<target>, shard N/M)", and fails unless every one of them
+// concluded "success".
+//
+// The jobs API is eventually consistent: it has returned an empty conclusion
+// for a shard that had completed seven minutes earlier, and the shell version
+// of this check reported that shard as "did not succeed". So an empty
+// conclusion means "not settled yet", not "failed": the listing is repeated
+// (Polls times, Interval apart) until every shard has a conclusion, and only
+// then judged. A listing that never settles fails with the last listing
+// printed; a shard count other than ShardCount fails at once, since every
+// job of an attempt exists from the start and a mismatch means the workflow
+// changed shape.
+func CheckShardResults(ctx context.Context, client rerun.RESTClient, w io.Writer, p *ShardResultsParams) error {
+	defer perf.Track(nil, "acceptance.CheckShardResults")()
+
+	if p.ShardCount < 1 {
+		return fmt.Errorf("%w: got %d", errShardCountValue, p.ShardCount)
+	}
+	polls, interval, wait := p.polling()
+
+	var shards []ShardResult
+	for attempt := 1; attempt <= polls; attempt++ {
+		jobs, err := rerun.FetchJobs(ctx, client, p.Run.Repo, p.Run.RunID, p.Run.RunAttempt)
+		if err != nil {
+			return err
+		}
+		shards = shardResults(jobs, p.Target)
+		if len(shards) != p.ShardCount {
+			fmt.Fprintf(w, "expected %d %q shard jobs, found %d:\n", p.ShardCount, p.Target, len(shards))
+			writeShardListing(w, shards)
+			return fmt.Errorf("%w: expected %d, found %d", errShardCount, p.ShardCount, len(shards))
+		}
+		unsettled := countUnsettled(shards)
+		if unsettled == 0 {
+			return judgeShards(w, p.Target, shards)
+		}
+		fmt.Fprintf(w, "poll %d/%d: %d of %d %q shard jobs have no conclusion yet; retrying in %s\n",
+			attempt, polls, unsettled, len(shards), p.Target, interval)
+		if attempt < polls {
+			if err := wait(ctx, interval); err != nil {
+				return fmt.Errorf("acceptance: waiting for shard results: %w", err)
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "%q shard results never settled after %d polls; last listing:\n", p.Target, polls)
+	writeShardListing(w, shards)
+	return fmt.Errorf("%w: %q after %d polls", errShardsNotSettled, p.Target, polls)
+}
+
+// polling returns the poll count, interval and wait function with defaults
+// applied.
+func (p *ShardResultsParams) polling() (int, time.Duration, func(context.Context, time.Duration) error) {
+	polls, interval, wait := p.Polls, p.Interval, p.Wait
+	if polls < 1 {
+		polls = DefaultShardPolls
+	}
+	if interval <= 0 {
+		interval = DefaultShardPollInterval
+	}
+	if wait == nil {
+		wait = sleepWithContext
+	}
+	return polls, interval, wait
+}
+
+// shardResults keeps the jobs named "Acceptance Tests (<target>, shard ...)".
+func shardResults(jobs []rerun.Job, target string) []ShardResult {
+	prefix := checkNamePrefix + target + ", shard"
+	var out []ShardResult
+	for _, j := range jobs {
+		if strings.HasPrefix(j.Name, prefix) {
+			out = append(out, ShardResult{Name: j.Name, Conclusion: j.Conclusion})
+		}
+	}
+	return out
+}
+
+func countUnsettled(shards []ShardResult) int {
+	n := 0
+	for _, s := range shards {
+		if s.Conclusion == "" {
+			n++
+		}
+	}
+	return n
+}
+
+func judgeShards(w io.Writer, target string, shards []ShardResult) error {
+	var failed []ShardResult
+	for _, s := range shards {
+		if s.Conclusion != "success" {
+			failed = append(failed, s)
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Fprintf(w, "the following %q shard jobs did not succeed:\n", target)
+		writeShardListing(w, failed)
+		return fmt.Errorf("%w: %d of %d %q shards", errShardsFailed, len(failed), len(shards), target)
+	}
+	fmt.Fprintf(w, "all %d %q shard jobs succeeded\n", len(shards), target)
+	return nil
+}
+
+func writeShardListing(w io.Writer, shards []ShardResult) {
+	for _, s := range shards {
+		conclusion := s.Conclusion
+		if conclusion == "" {
+			conclusion = "(no conclusion yet)"
+		}
+		fmt.Fprintf(w, "  %s\t%s\n", s.Name, conclusion)
+	}
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/ci/acceptance/shards_test.go
+++ b/internal/ci/acceptance/shards_test.go
@@ -1,0 +1,227 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cloudposse/atmos/internal/ci/rerun"
+)
+
+// jobsPage builds one un-paginated jobs API response: conclusion "" is
+// rendered as JSON null, the way the API reports a not-yet-settled job.
+func jobsPage(t *testing.T, jobs ...[2]string) *http.Response {
+	t.Helper()
+	type job struct {
+		Name       string  `json:"name"`
+		Status     string  `json:"status"`
+		Conclusion *string `json:"conclusion"`
+	}
+	page := struct {
+		Jobs []job `json:"jobs"`
+	}{}
+	for _, j := range jobs {
+		var c *string
+		if j[1] != "" {
+			v := j[1]
+			c = &v
+		}
+		page.Jobs = append(page.Jobs, job{Name: j[0], Status: "completed", Conclusion: c})
+	}
+	raw, err := json.Marshal(page)
+	require.NoError(t, err)
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(raw))}
+}
+
+func shard(target string, n int, conclusion string) [2]string {
+	return [2]string{"Acceptance Tests (" + target + ", shard " + string(rune('0'+n)) + "/3)", conclusion}
+}
+
+// recordingWait records each requested wait instead of sleeping.
+type recordingWait struct{ waits []time.Duration }
+
+func (r *recordingWait) wait(_ context.Context, d time.Duration) error {
+	r.waits = append(r.waits, d)
+	return nil
+}
+
+func params(target string, polls int, wait func(context.Context, time.Duration) error) *ShardResultsParams {
+	return &ShardResultsParams{
+		Run:        rerun.RunRef{Repo: "cloudposse/atmos", RunID: "42", RunAttempt: "1"},
+		Target:     target,
+		ShardCount: 3,
+		Polls:      polls,
+		Interval:   time.Second,
+		Wait:       wait,
+	}
+}
+
+func TestTargetFromCheckName(t *testing.T) {
+	tests := []struct {
+		in, want string
+		wantErr  bool
+	}{
+		{in: "Acceptance Tests (linux)", want: "linux"},
+		{in: "Acceptance Tests (macos)", want: "macos"},
+		{in: "Acceptance Tests (windows)", want: "windows"},
+		{in: "Acceptance Tests ()", wantErr: true},
+		{in: "Acceptance Tests (linux", wantErr: true},
+		{in: "Build (linux)", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := TargetFromCheckName(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errInvalidCheckName)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckShardResults_AllSucceeded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := rerun.NewMockRESTClient(ctrl)
+	client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, "repos/cloudposse/atmos/actions/runs/42/attempts/1/jobs?per_page=100", nil).
+		Return(jobsPage(t, [2]string{"Build (linux)", "success"}, shard("linux", 1, "success"), shard("linux", 2, "success"), shard("linux", 3, "success"), //nolint:bodyclose // closed by the code under test, not this fixture.
+			shard("macos", 1, "failure")), nil)
+
+	rw := &recordingWait{}
+	var out bytes.Buffer
+	err := CheckShardResults(context.Background(), client, &out, params("linux", 5, rw.wait))
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), `all 3 "linux" shard jobs succeeded`)
+	assert.Empty(t, rw.waits, "no polling when everything settled on the first listing")
+}
+
+func TestCheckShardResults_WaitsForEmptyConclusion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := rerun.NewMockRESTClient(ctrl)
+	gomock.InOrder(
+		// First listing: shard 3 finished but the API has not written its conclusion.
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+			Return(jobsPage(t, shard("macos", 1, "success"), shard("macos", 2, "success"), shard("macos", 3, "")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+			Return(jobsPage(t, shard("macos", 1, "success"), shard("macos", 2, "success"), shard("macos", 3, "")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+			Return(jobsPage(t, shard("macos", 1, "success"), shard("macos", 2, "success"), shard("macos", 3, "success")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
+	)
+
+	rw := &recordingWait{}
+	var out bytes.Buffer
+	err := CheckShardResults(context.Background(), client, &out, params("macos", 5, rw.wait))
+	require.NoError(t, err)
+	assert.Equal(t, []time.Duration{time.Second, time.Second}, rw.waits)
+	assert.Contains(t, out.String(), `poll 1/5: 1 of 3 "macos" shard jobs have no conclusion yet`)
+	assert.Contains(t, out.String(), `all 3 "macos" shard jobs succeeded`)
+}
+
+func TestCheckShardResults_NeverSettles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := rerun.NewMockRESTClient(ctrl)
+	client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Times(2).
+		DoAndReturn(func(context.Context, string, string, io.Reader) (*http.Response, error) {
+			return jobsPage(t, shard("windows", 1, "success"), shard("windows", 2, ""), shard("windows", 3, "success")), nil
+		})
+
+	rw := &recordingWait{}
+	var out bytes.Buffer
+	err := CheckShardResults(context.Background(), client, &out, params("windows", 2, rw.wait))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errShardsNotSettled)
+	assert.Len(t, rw.waits, 1, "no wait after the final poll")
+	assert.Contains(t, out.String(), "never settled after 2 polls")
+	assert.Contains(t, out.String(), "Acceptance Tests (windows, shard 2/3)\t(no conclusion yet)")
+}
+
+func TestCheckShardResults_FailedShard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := rerun.NewMockRESTClient(ctrl)
+	client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+		Return(jobsPage(t, shard("linux", 1, "success"), shard("linux", 2, "failure"), shard("linux", 3, "cancelled")), nil) //nolint:bodyclose // closed by the code under test, not this fixture.
+
+	var out bytes.Buffer
+	err := CheckShardResults(context.Background(), client, &out, params("linux", 5, (&recordingWait{}).wait))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errShardsFailed)
+	assert.Contains(t, err.Error(), `2 of 3 "linux" shards`)
+	assert.Contains(t, out.String(), "Acceptance Tests (linux, shard 2/3)\tfailure")
+	assert.Contains(t, out.String(), "Acceptance Tests (linux, shard 3/3)\tcancelled")
+	assert.NotContains(t, out.String(), "shard 1/3")
+}
+
+func TestCheckShardResults_ShardCountMismatchFailsAtOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := rerun.NewMockRESTClient(ctrl)
+	client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+		Return(jobsPage(t, shard("linux", 1, "success"), shard("linux", 2, "")), nil) //nolint:bodyclose // closed by the code under test, not this fixture.
+
+	rw := &recordingWait{}
+	var out bytes.Buffer
+	err := CheckShardResults(context.Background(), client, &out, params("linux", 5, rw.wait))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errShardCount)
+	assert.Empty(t, rw.waits, "a shape mismatch is not something waiting fixes")
+	assert.Contains(t, out.String(), `expected 3 "linux" shard jobs, found 2`)
+}
+
+func TestCheckShardResults_Errors(t *testing.T) {
+	t.Run("fetch error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := rerun.NewMockRESTClient(ctrl)
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, assert.AnError)
+
+		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 5, (&recordingWait{}).wait))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+	t.Run("invalid shard count", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		p := params("linux", 5, nil)
+		p.ShardCount = 0
+		err := CheckShardResults(context.Background(), rerun.NewMockRESTClient(ctrl), io.Discard, p)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errShardCountValue)
+	})
+	t.Run("cancelled context stops the wait", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := rerun.NewMockRESTClient(ctrl)
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+			Return(jobsPage(t, shard("linux", 1, ""), shard("linux", 2, "success"), shard("linux", 3, "success")), nil) //nolint:bodyclose // closed by the code under test, not this fixture.
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		p := params("linux", 5, nil) // Real sleepWithContext, which must honor ctx.
+		p.Interval = time.Hour
+		err := CheckShardResults(ctx, client, io.Discard, p)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestSleepWithContext_ReturnsAfterDuration(t *testing.T) {
+	start := time.Now()
+	require.NoError(t, sleepWithContext(context.Background(), 5*time.Millisecond))
+	assert.GreaterOrEqual(t, time.Since(start), 5*time.Millisecond)
+}
+
+func TestWriteShardListing_TabSeparated(t *testing.T) {
+	var out bytes.Buffer
+	writeShardListing(&out, []ShardResult{{Name: "a", Conclusion: "success"}, {Name: "b"}})
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "  a\tsuccess", lines[0])
+	assert.Equal(t, "  b\t(no conclusion yet)", lines[1])
+}

--- a/internal/ci/acceptance/shards_test.go
+++ b/internal/ci/acceptance/shards_test.go
@@ -218,7 +218,11 @@ func TestSleepWithContext_ReturnsAfterDuration(t *testing.T) {
 }
 
 func TestShardResultsParams_Polling(t *testing.T) {
-	customWait := func(context.Context, time.Duration) error { return nil }
+	customWaitCalled := false
+	customWait := func(context.Context, time.Duration) error {
+		customWaitCalled = true
+		return nil
+	}
 
 	tests := []struct {
 		name         string
@@ -240,6 +244,20 @@ func TestShardResultsParams_Polling(t *testing.T) {
 			wantInterval: DefaultShardPollInterval,
 		},
 		{
+			// Only Polls is invalid: proves the two defaults apply
+			// independently rather than as an all-or-nothing pair.
+			name:         "invalid polls preserve explicit interval",
+			params:       ShardResultsParams{Polls: 0, Interval: time.Second},
+			wantPolls:    DefaultShardPolls,
+			wantInterval: time.Second,
+		},
+		{
+			name:         "invalid interval preserves explicit polls",
+			params:       ShardResultsParams{Polls: 3, Interval: 0},
+			wantPolls:    3,
+			wantInterval: DefaultShardPollInterval,
+		},
+		{
 			name:         "explicit values are kept as-is",
 			params:       ShardResultsParams{Polls: 3, Interval: time.Millisecond, Wait: customWait},
 			wantPolls:    3,
@@ -255,7 +273,9 @@ func TestShardResultsParams_Polling(t *testing.T) {
 			assert.Equal(t, tt.wantInterval, interval)
 			require.NotNil(t, wait)
 			if tt.wantCustom {
+				customWaitCalled = false
 				assert.NoError(t, wait(context.Background(), 0))
+				assert.True(t, customWaitCalled, "polling() must return the injected Wait function, not sleepWithContext")
 			}
 		})
 	}

--- a/internal/ci/acceptance/shards_test.go
+++ b/internal/ci/acceptance/shards_test.go
@@ -217,6 +217,50 @@ func TestSleepWithContext_ReturnsAfterDuration(t *testing.T) {
 	assert.GreaterOrEqual(t, time.Since(start), 5*time.Millisecond)
 }
 
+func TestShardResultsParams_Polling(t *testing.T) {
+	customWait := func(context.Context, time.Duration) error { return nil }
+
+	tests := []struct {
+		name         string
+		params       ShardResultsParams
+		wantPolls    int
+		wantInterval time.Duration
+		wantCustom   bool
+	}{
+		{
+			name:         "zero values fall back to defaults",
+			params:       ShardResultsParams{},
+			wantPolls:    DefaultShardPolls,
+			wantInterval: DefaultShardPollInterval,
+		},
+		{
+			name:         "negative values fall back to defaults",
+			params:       ShardResultsParams{Polls: -1, Interval: -1},
+			wantPolls:    DefaultShardPolls,
+			wantInterval: DefaultShardPollInterval,
+		},
+		{
+			name:         "explicit values are kept as-is",
+			params:       ShardResultsParams{Polls: 3, Interval: time.Millisecond, Wait: customWait},
+			wantPolls:    3,
+			wantInterval: time.Millisecond,
+			wantCustom:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			polls, interval, wait := tt.params.polling()
+			assert.Equal(t, tt.wantPolls, polls)
+			assert.Equal(t, tt.wantInterval, interval)
+			require.NotNil(t, wait)
+			if tt.wantCustom {
+				assert.NoError(t, wait(context.Background(), 0))
+			}
+		})
+	}
+}
+
 func TestWriteShardListing_TabSeparated(t *testing.T) {
 	var out bytes.Buffer
 	writeShardListing(&out, []ShardResult{{Name: "a", Conclusion: "success"}, {Name: "b"}})

--- a/magefiles/ci_shards.go
+++ b/magefiles/ci_shards.go
@@ -41,7 +41,7 @@ func (CI) CheckShardResults(repo, runID, runAttempt, check string) error {
 	if err != nil {
 		return fmt.Errorf("mage: create GitHub REST client: %w", err)
 	}
-	return acceptance.CheckShardResults(context.Background(), client, os.Stdout, &acceptance.ShardResultsParams{
+	return acceptance.CheckShardResults(context.Background(), client, os.Stderr, &acceptance.ShardResultsParams{
 		Run:        rerun.RunRef{Repo: repo, RunID: runID, RunAttempt: runAttempt},
 		Target:     target,
 		ShardCount: count,

--- a/magefiles/ci_shards.go
+++ b/magefiles/ci_shards.go
@@ -1,0 +1,60 @@
+//go:build mage
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+
+	"github.com/cloudposse/atmos/internal/ci/acceptance"
+	"github.com/cloudposse/atmos/internal/ci/rerun"
+)
+
+// testShardCountEnv is the workflow-level env test.yml sets for every job.
+const testShardCountEnv = "TEST_SHARD_COUNT"
+
+var errMissingShardCount = errors.New("mage: " + testShardCountEnv + " must be set to the number of acceptance shards")
+
+// CheckShardResults is test.yml's per-OS required check ("Acceptance Tests
+// (linux)" and friends): it lists the run attempt's jobs live via the GitHub
+// REST API, waits for every "Acceptance Tests (<target>, shard N/M)" job to
+// have a conclusion (the jobs API is eventually consistent and has returned
+// an empty conclusion for a shard that finished minutes earlier), then fails
+// unless all of them succeeded. The check argument is the required-check
+// name the matrix carries, e.g. "Acceptance Tests (macos)". See
+// internal/ci/acceptance.
+func (CI) CheckShardResults(repo, runID, runAttempt, check string) error {
+	target, err := acceptance.TargetFromCheckName(check)
+	if err != nil {
+		return err
+	}
+	count, err := shardCountFromEnv(os.Getenv(testShardCountEnv))
+	if err != nil {
+		return err
+	}
+	client, err := api.DefaultRESTClient()
+	if err != nil {
+		return fmt.Errorf("mage: create GitHub REST client: %w", err)
+	}
+	return acceptance.CheckShardResults(context.Background(), client, os.Stdout, &acceptance.ShardResultsParams{
+		Run:        rerun.RunRef{Repo: repo, RunID: runID, RunAttempt: runAttempt},
+		Target:     target,
+		ShardCount: count,
+	})
+}
+
+func shardCountFromEnv(value string) (int, error) {
+	if value == "" {
+		return 0, errMissingShardCount
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("%w: got %q", errMissingShardCount, value)
+	}
+	return n, nil
+}

--- a/magefiles/ci_shards_test.go
+++ b/magefiles/ci_shards_test.go
@@ -1,0 +1,22 @@
+//go:build mage
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardCountFromEnv(t *testing.T) {
+	n, err := shardCountFromEnv("10")
+	require.NoError(t, err)
+	assert.Equal(t, 10, n)
+
+	for _, bad := range []string{"", "0", "-1", "ten"} {
+		_, err := shardCountFromEnv(bad)
+		require.Error(t, err, bad)
+		assert.ErrorIs(t, err, errMissingShardCount)
+	}
+}


### PR DESCRIPTION
## what

- `Check per-OS test matrix result` treats an empty shard conclusion as *not settled yet*: it re-lists the shards (up to 20 times, 15 s apart) until every shard has a conclusion and the count matches `TEST_SHARD_COUNT`, then judges. A shard that really failed still fails the check; a listing that never settles fails loudly with the last listing printed.

## why

On run 33907449514 the aggregate failed with `Acceptance Tests (macos, shard 9/10)` and an empty conclusion column. Every macOS shard had succeeded; shard 9 completed at 19:13:13, seven minutes before the aggregate ran at 19:20:28, and the jobs API still returned it with `conclusion: null`. The check compared the empty string against `success`. This is the jobs API's eventual consistency, not a reporting lag of seconds, so a bounded re-poll is the right response.

## references

- Run 33907449514 (PR #3049); `docs/fixes/2026-09-04-per-os-check-empty-conclusion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Acceptance-test checks now wait for all expected platform results before evaluation.
  - Incomplete job results are no longer incorrectly marked as failures.
  - Failed or cancelled test shards continue to fail the overall check, with diagnostic results reported when polling cannot settle.
  - Added validation for missing, mismatched, or invalid shard configuration.
  - Improved CI workflow access and setup for reliable acceptance-test result checks.

- **Documentation**
  - Added documentation describing the per-platform test-check fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->