### PR TITLE
fix(terraform-state): honor S3 backend profile attribute

### DIFF
--- a/docs/fixes/2026-09-04-terraform-state-honors-backend-profile.md
+++ b/docs/fixes/2026-09-04-terraform-state-honors-backend-profile.md
@@ -1,0 +1,59 @@
+# Fix: `!terraform.state` honors the S3 backend `profile` attribute
+
+**Date:** 2026-09-04
+
+**Issue:** [#3055](https://github.com/cloudposse/atmos/issues/3055)
+
+## Summary
+
+`!terraform.state` now uses the S3 backend's `profile` attribute to select AWS credentials when neither an
+Atmos auth AWS identity nor the component's `env.AWS_PROFILE` does, matching what `terraform init` already
+does with the same attribute in `backend.tf.json`.
+
+## Context
+
+`!terraform.output` resolves credentials through the `terraform` subprocess, whose S3 backend reads `profile`
+from the generated backend config. The in-process reader behind `!terraform.state` only read `region`,
+`bucket`, `key`, `workspace_key_prefix`, `sse_customer_key` and `assume_role.role_arn`; credentials came from
+Atmos auth, the component `env` whitelist added in #2501, or the SDK default chain.
+
+A project whose stages each map to a named profile in a shared backend mixin
+(`profile: '{{ .vars.stage }}:tofu_admin'`) therefore worked with `!terraform.output` and failed with
+`!terraform.state`. With no ambient credentials the SDK fell through to the instance metadata endpoint,
+retried S3 and STS three times each, and surfaced an IMDS timeout about a minute later. The only workaround
+was restating the profile a second time as `env.AWS_PROFILE` on every component.
+
+The GCS reader already builds its client from the backend's own `credentials` attribute, so honoring the S3
+backend `profile` brings the two readers in line rather than adding a new concept.
+
+## Changes
+
+- `internal/terraform_backend/terraform_backend_s3.go`: new `ResolveBackendProfileOverlay` injects the backend
+  `profile` as `AWS_PROFILE` into the env overlay when no Atmos auth AWS context is active and the overlay does
+  not already set `AWS_PROFILE`. `ReadTerraformBackendS3` passes its overlay through it. The overlay already
+  participates in the S3 client cache key, so backends with different profiles never share a client.
+- `internal/terraform_backend/terraform_backend_profile_fallback_test.go`: table of six cases covering the
+  fallback, the no-profile no-op, explicit env precedence, merge without mutating the input, Atmos auth
+  precedence, and an auth context without an AWS section.
+- `website/docs/functions/yaml/terraform.state.mdx`: precedence list gains the backend profile, plus a new
+  "Backend `profile` attribute" subsection with an example.
+
+## Validation
+
+- `go test ./internal/terraform_backend/` passes, including the new test and the existing S3 reader tests.
+- `go vet ./internal/terraform_backend/` and `gofumpt -l` are clean.
+- The repo's custom `golangci-lint` (built via `atmos lint custom-gcl` under the go.mod toolchain, Go 1.26.4)
+  reports zero new issues for the change with `--new-from-rev`; the package's pre-existing findings are untouched.
+- `cd website && pnpm install --frozen-lockfile && pnpm run build` succeeds; the only broken-anchor warnings are on
+  an unrelated changelog page that already exists on `main`.
+- Manual, against a real multi-account layout with `backend.s3.profile` set and no `env` section: a component
+  whose transitive `!terraform.state` closure spans 19 upstream components in three AWS accounts resolved in
+  about 7 seconds with values identical to `!terraform.output`; the debug trace shows each account's profile
+  being loaded and its `assume_role.role_arn` assumed. The unpatched build on the same configuration failed
+  after 68 seconds of credential retries.
+- Not automated: the end-to-end `ReadTerraformBackendS3` path builds a real S3 client, so the credential
+  resolution is covered by the helper's unit tests rather than an integration test.
+
+## Follow-ups
+
+None.

--- a/internal/terraform_backend/terraform_backend_profile_fallback_test.go
+++ b/internal/terraform_backend/terraform_backend_profile_fallback_test.go
@@ -1,0 +1,58 @@
+package terraform_backend_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	tb "github.com/cloudposse/atmos/internal/terraform_backend"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestResolveBackendProfileOverlay verifies that the S3 backend `profile`
+// attribute is honored the way `terraform init` honors it, without overriding
+// an Atmos auth context or an explicit `env.AWS_PROFILE`.
+func TestResolveBackendProfileOverlay(t *testing.T) {
+	backendWithProfile := map[string]any{
+		"bucket":  "my-tfstate",
+		"region":  "us-west-2",
+		"profile": "labs:tofu_admin",
+	}
+	backendWithoutProfile := map[string]any{
+		"bucket": "my-tfstate",
+		"region": "us-west-2",
+	}
+
+	t.Run("backend profile becomes AWS_PROFILE when nothing else selects credentials", func(t *testing.T) {
+		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, nil)
+		assert.Equal(t, map[string]string{"AWS_PROFILE": "labs:tofu_admin"}, got)
+	})
+
+	t.Run("no backend profile keeps the default credential chain", func(t *testing.T) {
+		assert.Nil(t, tb.ResolveBackendProfileOverlay(&backendWithoutProfile, nil, nil))
+	})
+
+	t.Run("explicit env AWS_PROFILE wins over the backend profile", func(t *testing.T) {
+		overlay := map[string]string{"AWS_PROFILE": "from-env"}
+		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, overlay)
+		assert.Equal(t, map[string]string{"AWS_PROFILE": "from-env"}, got)
+	})
+
+	t.Run("backend profile is merged into an env overlay that lacks AWS_PROFILE", func(t *testing.T) {
+		overlay := map[string]string{"AWS_REGION": "eu-west-1"}
+		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, overlay)
+		assert.Equal(t, map[string]string{"AWS_REGION": "eu-west-1", "AWS_PROFILE": "labs:tofu_admin"}, got)
+		assert.Equal(t, map[string]string{"AWS_REGION": "eu-west-1"}, overlay, "input overlay must not be mutated")
+	})
+
+	t.Run("atmos auth AWS context is canonical and untouched", func(t *testing.T) {
+		auth := &schema.AuthContext{AWS: &schema.AWSAuthContext{Profile: "atmos-managed"}}
+		assert.Nil(t, tb.ResolveBackendProfileOverlay(&backendWithProfile, auth, nil))
+	})
+
+	t.Run("auth context without an AWS section still falls back to the backend profile", func(t *testing.T) {
+		auth := &schema.AuthContext{}
+		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, auth, nil)
+		assert.Equal(t, map[string]string{"AWS_PROFILE": "labs:tofu_admin"}, got)
+	})
+}

--- a/internal/terraform_backend/terraform_backend_profile_fallback_test.go
+++ b/internal/terraform_backend/terraform_backend_profile_fallback_test.go
@@ -1,6 +1,7 @@
 package terraform_backend_test
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,8 @@ import (
 
 // TestResolveBackendProfileOverlay verifies that the S3 backend `profile`
 // attribute is honored the way `terraform init` honors it, without overriding
-// an Atmos auth context or an explicit `env.AWS_PROFILE`.
+// an Atmos auth context or an explicit `env.AWS_PROFILE`, and without mutating
+// the caller's overlay.
 func TestResolveBackendProfileOverlay(t *testing.T) {
 	backendWithProfile := map[string]any{
 		"bucket":  "my-tfstate",
@@ -23,36 +25,57 @@ func TestResolveBackendProfileOverlay(t *testing.T) {
 		"region": "us-west-2",
 	}
 
-	t.Run("backend profile becomes AWS_PROFILE when nothing else selects credentials", func(t *testing.T) {
-		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, nil)
-		assert.Equal(t, map[string]string{"AWS_PROFILE": "labs:tofu_admin"}, got)
-	})
+	tests := []struct {
+		name        string
+		backend     map[string]any
+		authContext *schema.AuthContext
+		envOverlay  map[string]string
+		want        map[string]string
+	}{
+		{
+			name:    "backend profile becomes AWS_PROFILE when nothing else selects credentials",
+			backend: backendWithProfile,
+			want:    map[string]string{"AWS_PROFILE": "labs:tofu_admin"},
+		},
+		{
+			name:    "no backend profile keeps the default credential chain",
+			backend: backendWithoutProfile,
+			want:    nil,
+		},
+		{
+			name:       "explicit env AWS_PROFILE wins over the backend profile",
+			backend:    backendWithProfile,
+			envOverlay: map[string]string{"AWS_PROFILE": "from-env"},
+			want:       map[string]string{"AWS_PROFILE": "from-env"},
+		},
+		{
+			name:       "backend profile is merged into an env overlay that lacks AWS_PROFILE",
+			backend:    backendWithProfile,
+			envOverlay: map[string]string{"AWS_REGION": "eu-west-1"},
+			want:       map[string]string{"AWS_REGION": "eu-west-1", "AWS_PROFILE": "labs:tofu_admin"},
+		},
+		{
+			name:        "atmos auth AWS context is canonical and untouched",
+			backend:     backendWithProfile,
+			authContext: &schema.AuthContext{AWS: &schema.AWSAuthContext{Profile: "atmos-managed"}},
+			want:        nil,
+		},
+		{
+			name:        "auth context without an AWS section still falls back to the backend profile",
+			backend:     backendWithProfile,
+			authContext: &schema.AuthContext{},
+			want:        map[string]string{"AWS_PROFILE": "labs:tofu_admin"},
+		},
+	}
 
-	t.Run("no backend profile keeps the default credential chain", func(t *testing.T) {
-		assert.Nil(t, tb.ResolveBackendProfileOverlay(&backendWithoutProfile, nil, nil))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := maps.Clone(tt.envOverlay)
 
-	t.Run("explicit env AWS_PROFILE wins over the backend profile", func(t *testing.T) {
-		overlay := map[string]string{"AWS_PROFILE": "from-env"}
-		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, overlay)
-		assert.Equal(t, map[string]string{"AWS_PROFILE": "from-env"}, got)
-	})
+			got := tb.ResolveBackendProfileOverlay(&tt.backend, tt.authContext, tt.envOverlay)
 
-	t.Run("backend profile is merged into an env overlay that lacks AWS_PROFILE", func(t *testing.T) {
-		overlay := map[string]string{"AWS_REGION": "eu-west-1"}
-		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, nil, overlay)
-		assert.Equal(t, map[string]string{"AWS_REGION": "eu-west-1", "AWS_PROFILE": "labs:tofu_admin"}, got)
-		assert.Equal(t, map[string]string{"AWS_REGION": "eu-west-1"}, overlay, "input overlay must not be mutated")
-	})
-
-	t.Run("atmos auth AWS context is canonical and untouched", func(t *testing.T) {
-		auth := &schema.AuthContext{AWS: &schema.AWSAuthContext{Profile: "atmos-managed"}}
-		assert.Nil(t, tb.ResolveBackendProfileOverlay(&backendWithProfile, auth, nil))
-	})
-
-	t.Run("auth context without an AWS section still falls back to the backend profile", func(t *testing.T) {
-		auth := &schema.AuthContext{}
-		got := tb.ResolveBackendProfileOverlay(&backendWithProfile, auth, nil)
-		assert.Equal(t, map[string]string{"AWS_PROFILE": "labs:tofu_admin"}, got)
-	})
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, before, tt.envOverlay, "input overlay must not be mutated")
+		})
+	}
 }

--- a/internal/terraform_backend/terraform_backend_s3.go
+++ b/internal/terraform_backend/terraform_backend_s3.go
@@ -112,6 +112,10 @@ type S3API interface {
 // It's a map[string]S3API.
 var s3ClientCache sync.Map
 
+// getCachedS3Client returns the S3 client for a backend, building it on first use and
+// caching it under a key derived from the region, the assume-role ARN, the Atmos auth
+// identity, and every env overlay key that changes which credentials or endpoint the
+// client resolves, so distinct identities never alias to the same client.
 func getCachedS3Client(backend *map[string]any, authContext *schema.AuthContext, envOverlay map[string]string) (S3API, error) {
 	region := GetBackendAttribute(backend, "region")
 	roleArn := GetS3BackendAssumeRoleArn(backend)

--- a/internal/terraform_backend/terraform_backend_s3.go
+++ b/internal/terraform_backend/terraform_backend_s3.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"sync"
@@ -186,6 +187,39 @@ func getCachedS3Client(backend *map[string]any, authContext *schema.AuthContext,
 	return s3Client, nil
 }
 
+// ResolveBackendProfileOverlay applies the S3 backend's `profile` attribute as the
+// credential source when nothing more specific selects one, mirroring what
+// `terraform init` does with the same attribute in backend.tf.json. Precedence:
+//   - an Atmos auth AWS context is canonical and is left untouched;
+//   - an explicit `AWS_PROFILE` in the component's `env` section wins;
+//   - otherwise the backend `profile` is injected as `AWS_PROFILE` so that
+//     `!terraform.state` resolves the same credentials `!terraform.output` gets
+//     from the terraform subprocess.
+//
+// The returned overlay feeds the S3 client cache key, so two backends with
+// different profiles never share a client.
+func ResolveBackendProfileOverlay(backend *map[string]any, authContext *schema.AuthContext, envOverlay map[string]string) map[string]string {
+	defer perf.Track(nil, "terraform_backend.ResolveBackendProfileOverlay")()
+
+	if authContext != nil && authContext.AWS != nil {
+		return envOverlay
+	}
+	if envOverlay["AWS_PROFILE"] != "" {
+		return envOverlay
+	}
+	profile := GetBackendAttribute(backend, "profile")
+	if profile == "" {
+		return envOverlay
+	}
+	log.Debug("Using S3 backend profile for AWS SDK credentials", "profile", profile)
+	merged := maps.Clone(envOverlay)
+	if merged == nil {
+		merged = make(map[string]string, 1)
+	}
+	merged["AWS_PROFILE"] = profile
+	return merged
+}
+
 // ReadTerraformBackendS3 reads the Terraform state file from the configured S3 backend.
 // If the state file does not exist in the bucket, the function returns `nil`.
 func ReadTerraformBackendS3(
@@ -198,9 +232,11 @@ func ReadTerraformBackendS3(
 	backend := GetComponentBackend(componentSections)
 
 	// Honor the target component's `env` section for AWS credential resolution,
-	// matching `!terraform.output`'s subprocess behavior. nil overlay preserves
-	// the existing default-credential-chain behavior unchanged.
+	// matching `!terraform.output`'s subprocess behavior, then fall back to the
+	// backend's own `profile` the way `terraform init` does. A nil overlay from
+	// both steps preserves the default-credential-chain behavior unchanged.
 	envOverlay := ExtractComponentEnvOverlay(componentSections, ComponentEnvKeysAWS)
+	envOverlay = ResolveBackendProfileOverlay(&backend, authContext, envOverlay)
 
 	s3Client, err := getCachedS3Client(&backend, authContext, envOverlay)
 	if err != nil {

--- a/website/docs/functions/yaml/terraform.state.mdx
+++ b/website/docs/functions/yaml/terraform.state.mdx
@@ -610,8 +610,32 @@ A component with no whitelisted env key produces no overlay and resolves credent
 When `!terraform.state` constructs its in-process AWS client, credential sources resolve in this order (lowest wins → highest wins):
 
 1. Process environment (whatever `AWS_PROFILE` etc. is set in the shell running Atmos).
-2. The target component's whitelisted `env` overlay (this section).
-3. Atmos auth (`AWSAuthContext`) — wins outright when configured.
+2. The target component's S3 backend `profile` attribute (see below).
+3. The target component's whitelisted `env` overlay (this section).
+4. Atmos auth (`AWSAuthContext`) — wins outright when configured.
+
+### Backend `profile` attribute
+
+If the target component's `backend.s3` section sets `profile`, `!terraform.state` uses it as `AWS_PROFILE` whenever
+neither Atmos auth nor the component's `env.AWS_PROFILE` selects credentials. This is the same precedence
+`terraform init` applies to the `profile` attribute it finds in `backend.tf.json`, so a stack that only sets the
+profile on the backend (a common pattern when every stage maps to its own named profile) resolves the same
+credentials for `!terraform.state` as it already does for `!terraform.output`:
+
+```yaml
+terraform:
+  backend_type: s3
+  backend:
+    s3:
+      bucket: !template '{{ .vars.stage }}-tfstate'
+      region: us-west-2
+      profile: !template '{{ .vars.stage }}:terraform'
+      assume_role:
+        role_arn: !template 'arn:aws:iam::{{ .vars.account_id }}:role/terraform'
+```
+
+With this configuration, `!terraform.state vpc {{ .stack }} vpc_id` loads the `<stage>:terraform` profile and then
+assumes `assume_role.role_arn`, exactly as the backend does during `terraform init`. No `env` section is required.
 
 ### Example: per-namespace AWS profile
 


### PR DESCRIPTION
## what

- `!terraform.state` now honors the S3 backend `profile` attribute when resolving credentials for the in-process state read, the same way `terraform init` honors it from `backend.tf.json`.
- Precedence is unchanged for everyone already selecting credentials explicitly: an Atmos auth AWS context still wins outright, and an explicit `env.AWS_PROFILE` on the component still wins over the backend profile. The backend profile only fills the gap where the reader previously fell through to the SDK default chain.
- New helper `ResolveBackendProfileOverlay` with unit tests; the synthesized overlay already participates in the S3 client cache key, so backends with different profiles never share a client.
- Docs: precedence list and a new "Backend `profile` attribute" subsection on the `!terraform.state` page, plus a `docs/fixes` note.

## why

- `!terraform.output` and `!terraform.state` are documented as interchangeable, but they resolved credentials differently. The output function delegates to the terraform subprocess, whose S3 backend reads `profile` from the generated backend config; the state reader only read `region`, `bucket`, `key`, `workspace_key_prefix`, `sse_customer_key` and `assume_role.role_arn`.
- Projects that map each stage to a named profile in a shared backend mixin (`profile: '{{ .vars.stage }}:terraform'`) therefore worked with `!terraform.output` and failed with `!terraform.state`: the SDK fell through to IMDS, retried S3 and STS three times each, and surfaced a confusing IMDS timeout about a minute later. The only workaround was restating the same profile as `env.AWS_PROFILE` on every component.
- This is the same shape the other backends already have: the GCS reader builds its client from the backend's own `credentials` attribute (`GetGCSBackendCredentials`), and `tfmigrate` writes the S3 backend `profile` straight into the history storage config. S3 was the odd one out in ignoring its own credential attribute for in-process reads.
- Verified against a real multi-account layout (stage account with `profile` + `assume_role`, root account with `profile` only): with this change a component whose transitive `!terraform.state` closure spans 19 upstream components in three accounts resolves in about 6 seconds with values identical to `!terraform.output`, and no `env` section.

## references

- Closes #3055
- Release label: this is a bug fix, so it should carry `patch` (no blog post or roadmap entry). Outside contributors cannot apply labels, so a maintainer will need to add it for the semver-label check.
- Follows #2501, which added the component `env` whitelist so `!terraform.state` matches `!terraform.output` across accounts; this closes the remaining gap for the backend `profile` attribute itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `!terraform.state` now honors the S3 backend’s `profile` setting when selecting AWS credentials.
  * Explicit component `env.AWS_PROFILE` and Atmos authentication continue to take precedence.

* **Documentation**
  * Updated `!terraform.state` credential precedence documentation with the backend profile behavior and configuration example.

* **Tests**
  * Added coverage for credential precedence, fallback behavior, and environment overlay handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->