### PR TITLE
ci: install syft for GoReleaser SBOM generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,27 @@ before:
         cosign version
       fi'
 
+    # Install syft for the `sboms:` block below. Same rationale as the cosign
+    # hook above: the reusable release workflow
+    # (cloudposse/.github/.github/workflows/shared-go-auto-release.yml) sets up
+    # Go before running GoReleaser but does not install syft, so without this
+    # hook the SBOM step fails with
+    # "exec: syft: executable file not found in $PATH" and the whole release
+    # (and therefore the drafted release) fails. `go install` resolves through
+    # the Go module proxy and verifies against sum.golang.org, so this needs no
+    # separate checksum pinning. The binary is copied to /usr/local/bin because
+    # each `before.hooks` entry and the later `sboms:` step run as separate
+    # subprocesses that don't share a modified PATH or GOPATH/bin.
+    - |
+      sh -c 'if [ "$GITHUB_ACTIONS" = "true" ]; then
+        echo "Installing syft for SBOM cataloging..."
+        go install github.com/anchore/syft/cmd/syft@v1.51.1
+        syft_bin_dir="$(go env GOBIN)"
+        if [ -z "$syft_bin_dir" ]; then syft_bin_dir="$(go env GOPATH)/bin"; fi
+        sudo cp "$syft_bin_dir/syft" /usr/local/bin/syft
+        syft version
+      fi'
+
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,20 +51,33 @@ before:
     # Go before running GoReleaser but does not install syft, so without this
     # hook the SBOM step fails with
     # "exec: syft: executable file not found in $PATH" and the whole release
-    # (and therefore the drafted release) fails. `go install` resolves through
-    # the Go module proxy and verifies against sum.golang.org, so this needs no
-    # separate checksum pinning. The binary is copied to /usr/local/bin because
-    # each `before.hooks` entry and the later `sboms:` step run as separate
-    # subprocesses that don't share a modified PATH or GOPATH/bin.
+    # (and therefore the drafted release) fails.
+    #
+    # This is a fallback: workflows that own their GoReleaser job (e.g.
+    # build.yml) install syft with the SHA-pinned anchore/sbom-action/
+    # download-syft step, so the hook skips when syft is already on PATH rather
+    # than compiling a second copy. Where nothing else provides it (the shared
+    # workflow above), `go install` resolves through the Go module proxy and is
+    # verified against sum.golang.org, so it needs no separate checksum pinning.
+    # `set -e` makes an install failure fail the release instead of silently
+    # falling through to a pre-existing syft; the binary is copied to
+    # /usr/local/bin because each `before.hooks` entry and the later `sboms:`
+    # step run as separate subprocesses that don't share a modified PATH or
+    # GOPATH/bin.
     - |
-      sh -c 'if [ "$GITHUB_ACTIONS" = "true" ]; then
+      sh -c 'set -e
+        if [ "${GITHUB_ACTIONS:-}" != "true" ]; then exit 0; fi
+        if command -v syft >/dev/null 2>&1; then
+          echo "syft already on PATH ($(command -v syft)); skipping install."
+          exit 0
+        fi
         echo "Installing syft for SBOM cataloging..."
         go install github.com/anchore/syft/cmd/syft@v1.51.1
         syft_bin_dir="$(go env GOBIN)"
         if [ -z "$syft_bin_dir" ]; then syft_bin_dir="$(go env GOPATH)/bin"; fi
+        test -x "$syft_bin_dir/syft"
         sudo cp "$syft_bin_dir/syft" /usr/local/bin/syft
-        syft version
-      fi'
+        /usr/local/bin/syft version'
 
 builds:
   - env:


### PR DESCRIPTION
## what

- Install `syft` from a `before.hooks` entry in `.goreleaser.yml` (pinned `go install …/syft@v1.51.1` → `/usr/local/bin/syft`), mirroring the existing `cosign` hook.

## why

PR #2958 added an `sboms:` block to `.goreleaser.yml`, but GoReleaser shells out to `syft` to catalog artifacts and nothing installs it in the **drafted release** path. That job runs GoReleaser inside cloudposse's shared reusable workflow (`shared-go-auto-release.yml`), which sets up Go but no extra tooling and can't have steps injected — so every release has been failing with:

```
⨯ release failed  error=exec: "syft": executable file not found in $PATH
  cmd=syft  artifact=dist/atmos_1.228.0_armhf.apk
```

Because the drafted release is gated on the **Tests** workflow succeeding (`Release` runs via `workflow_run` with `if: conclusion == 'success'`), that GoReleaser failure fails the Tests run and no draft/release is ever cut. This has blocked releases since #2958 merged (2026-08-31).

The install has to live in GoReleaser's `before.hooks` because the failing invocation is inside the shared reusable workflow, where a `uses:` step can't be added — this is the same reason `cosign` is installed via a hook there. `build.yml`'s own `sign-and-attest-release` job already installs syft as a SHA-pinned `anchore/sbom-action/download-syft` step because it owns its GoReleaser job; the drafted path cannot. `go install` resolves through the Go module proxy and is verified against `sum.golang.org`, so the version tag needs no separate checksum pinning; the binary is copied to `/usr/local/bin` because each hook and the later `sboms:` step run as separate subprocesses that don't share `PATH`/`GOPATH/bin`.

Verified locally that `go install github.com/anchore/syft/cmd/syft@v1.51.1` resolves and builds a working `syft` binary.

## references

- Introduced the unsatisfied `sboms:` requirement: #2958
- Sibling `build.yml` install (SHA-pinned action, own job): `.github/workflows/build.yml`
- Draft path that lacks syft: `.github/workflows/release.yml` → `cloudposse/.github` `shared-go-auto-release.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Release builds support generating Software Bill of Materials (SBOM) artifacts.
  - GitHub Actions release packaging installs required SBOM tooling only when needed.
  - Installation now verifies the tool is executable and fails fast if setup encounters an error.
  - Release packaging uses the verified installation directly, improving reliability in automated builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->