### PR TITLE
ci: fix three post-release pipeline failures (summarizer egress, goreleaser 422, Homebrew)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,24 @@ jobs:
           # not zero egress. Stays audit until a real run can be sampled.
           egress-policy: audit
 
-      # mislav/bump-homebrew-formula-action is broken: GitHub now returns HTTP 303
-      # instead of 302 for tarball redirects and the action only accepts 302.
-      # See https://github.com/mislav/bump-homebrew-formula-action/issues/340
-      - uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
-        with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          formula: atmos
+      # dawidd6/action-homebrew-bump-formula wraps `brew bump-formula-pr`, but its
+      # Ruby git helper calls Homebrew's `safe_system`, which the Homebrew 5.x now
+      # on GitHub runners no longer exposes to the module scope, so the action dies
+      # with "undefined method 'safe_system' for module Homebrew". Upstream reverted
+      # their Homebrew-5 fix, so bumping the pin to v8 does not help (identical
+      # code). Call the wrapped command directly instead - it is unaffected by the
+      # wrapper bug. atmos lives in Homebrew/homebrew-core; bump-formula-pr forks it
+      # under the bot and opens the version-bump PR. HOMEBREW_NO_INSTALL_FROM_API
+      # forces brew to use the cloned core tap so the formula file is editable.
+      - name: "Bump Homebrew formula"
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_FROM_API: "1"
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          brew bump-formula-pr --no-browse --no-audit --version="${TAG#v}" atmos
 
   docker:
     name: "Build and push Docker image for Atmos CLI"
@@ -210,7 +221,12 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          args: release --clean
+          # This job runs on `release: published`, so the GitHub Release already
+          # exists with its assets from the draft build. `--skip=publish` rebuilds
+          # dist/* locally for provenance attestation without re-PATCHing the
+          # release; without it GoReleaser tries to update target_commitish, which
+          # GitHub rejects on a published release (422 Validation Failed).
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,12 +83,19 @@ jobs:
         with:
           egress-policy: block
           # api.github.com: read/update the release. api.openai.com: the
-          # summarization call. The rest is the module download behind
-          # `go tool mage` (same set as test.yml's build job).
+          # summarization call. golang.org/go.dev/raw.githubusercontent.com/
+          # dl.google.com: actions/setup-go resolving and downloading the Go
+          # toolchain (golang.org was missing, so setup-go failed with
+          # "getaddrinfo EAI_AGAIN golang.org" before the summarizer ran). The
+          # rest is the module download behind `go tool mage`.
           allowed-endpoints: >
             api.github.com:443
             api.openai.com:443
             github.com:443
+            raw.githubusercontent.com:443
+            golang.org:443
+            go.dev:443
+            dl.google.com:443
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
           egress-policy: block
           # api.github.com: read/update the release. api.openai.com: the
           # summarization call. golang.org/go.dev/raw.githubusercontent.com/
-          # dl.google.com: actions/setup-go resolving and downloading the Go
-          # toolchain (golang.org was missing, so setup-go failed with
+          # release-assets.githubusercontent.com/dl.google.com: actions/setup-go
+          # resolving and downloading the Go toolchain (golang.org was missing,
+          # so setup-go failed with
           # "getaddrinfo EAI_AGAIN golang.org" before the summarizer ran). The
           # rest is the module download behind `go tool mage`.
           allowed-endpoints: >
@@ -93,6 +94,7 @@ jobs:
             api.openai.com:443
             github.com:443
             raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             golang.org:443
             go.dev:443
             dl.google.com:443

--- a/docs/fixes/2026-09-06-homebrew-bump-safe-system.md
+++ b/docs/fixes/2026-09-06-homebrew-bump-safe-system.md
@@ -7,7 +7,7 @@
 Publishing `v1.228.0` fired `build.yml`'s `homebrew` job ("Bump Homebrew
 formula"), which failed:
 
-```
+```text
 action-homebrew-bump-formula/main.rb:32:in 'Homebrew.git':
   undefined method 'safe_system' for module Homebrew (NoMethodError)
 ```
@@ -57,8 +57,13 @@ under the bot and opens the version-bump PR.
   the fallback is unchanged.
 - **Immediate, release-independent fallback** (what unblocks a current version
   without waiting for CI): run the same command manually - it bypasses the action
-  entirely:
-  ```
+  entirely. Kept equivalent to the workflow step above:
+  ```bash
   HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) \
-    brew bump-formula-pr --no-browse --version=<version> atmos
+  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 \
+    brew bump-formula-pr --no-browse --no-audit --version=<version> atmos
   ```
+  `HOMEBREW_NO_INSTALL_FROM_API=1` is what matters in CI (brew there defaults to
+  the JSON API and has no editable formula file); on a workstation with the
+  homebrew-core tap already cloned it is a harmless no-op, so the command is safe
+  to run either place.

--- a/docs/fixes/2026-09-06-homebrew-bump-safe-system.md
+++ b/docs/fixes/2026-09-06-homebrew-bump-safe-system.md
@@ -1,0 +1,64 @@
+# Fix: Homebrew formula bump failed - action broke on Homebrew 5.x safe_system
+
+**Date:** 2026-09-06
+
+## Summary
+
+Publishing `v1.228.0` fired `build.yml`'s `homebrew` job ("Bump Homebrew
+formula"), which failed:
+
+```
+action-homebrew-bump-formula/main.rb:32:in 'Homebrew.git':
+  undefined method 'safe_system' for module Homebrew (NoMethodError)
+```
+
+`brew install atmos` therefore stayed on the previous version.
+
+## Root cause
+
+The job used `dawidd6/action-homebrew-bump-formula@v7`. Its Ruby helper
+`Homebrew.git` calls `safe_system`, which the Homebrew 5.x now shipped on GitHub
+runners no longer exposes in the module scope the action runs in. This is an
+unresolved upstream incompatibility, not a stale pin: `v8` has byte-identical
+`git`/`safe_system` code (verified against the tag's `main.rb`), and the
+upstream Homebrew-5 fix was reverted (the pinned `v7` commit is literally
+"Revert 'Fix dev-cmd loading on GitHub Actions with Homebrew 5.0'"). So bumping
+the action does not help.
+
+atmos lives in `Homebrew/homebrew-core` (not a cloudposse tap); the formula is a
+source build from `github.com/cloudposse/atmos/archive/refs/tags/vX.Y.Z.tar.gz`.
+
+## Fix
+
+**`.github/workflows/build.yml`** - drop the broken action and call the command
+it wrapped directly. `brew bump-formula-pr` itself is fine; only the action's git
+wrapper hit `safe_system`:
+
+```yaml
+- name: "Bump Homebrew formula"
+  env:
+    HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+    HOMEBREW_NO_AUTO_UPDATE: "1"
+    HOMEBREW_NO_INSTALL_FROM_API: "1"
+    TAG: ${{ github.event.release.tag_name }}
+  run: |
+    set -euo pipefail
+    brew bump-formula-pr --no-browse --no-audit --version="${TAG#v}" atmos
+```
+
+`HOMEBREW_NO_INSTALL_FROM_API=1` forces brew to use the cloned homebrew-core tap
+so `bump-formula-pr` can edit the formula file. The command forks homebrew-core
+under the bot and opens the version-bump PR.
+
+## Verification / caveats
+
+- Cannot be fully verified until the next release triggers `build.yml` on a real
+  `release: published` event. If the direct command needs additional plumbing,
+  the fallback is unchanged.
+- **Immediate, release-independent fallback** (what unblocks a current version
+  without waiting for CI): run the same command manually - it bypasses the action
+  entirely:
+  ```
+  HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) \
+    brew bump-formula-pr --no-browse --version=<version> atmos
+  ```

--- a/docs/fixes/2026-09-06-release-notes-summarizer-egress-golang-org.md
+++ b/docs/fixes/2026-09-06-release-notes-summarizer-egress-golang-org.md
@@ -8,7 +8,7 @@ The `summarize-notes` job in `.github/workflows/release.yml` (the AI rewrite of
 drafted release notes, added in #3045) failed on the first real release that
 reached it, at the `Set up Go` step - before any summarization ran - with:
 
-```
+```text
 ##[error]getaddrinfo EAI_AGAIN golang.org
 ```
 
@@ -20,8 +20,9 @@ itself (binaries, SBOMs, draft notes) was fine.
 The job runs `step-security/harden-runner` with `egress-policy: block` and a
 fixed `allowed-endpoints` list. `actions/setup-go` resolves and downloads the Go
 toolchain via `golang.org` (redirecting to `go.dev`), the `actions/go-versions`
-manifest on `raw.githubusercontent.com`, and the toolchain archive on
-`dl.google.com` - none of which were in the allow-list. harden-runner blocked the
+manifest on `raw.githubusercontent.com`, and the toolchain archive from the
+`actions/go-versions` GitHub release assets (`release-assets.githubusercontent.com`)
+or `dl.google.com` - none of which were in the allow-list. harden-runner blocked the
 `golang.org` DNS lookup, so `setup-go` died with `EAI_AGAIN`. The allow-list only
 had `proxy.golang.org`/`sum.golang.org`/`google.golang.org` (module proxy +
 checksum DB), which cover `go build` but not toolchain provisioning. The job's
@@ -32,8 +33,9 @@ comment claimed the set mirrored `test.yml`'s build job, but it did not.
 **`.github/workflows/release.yml`** - add the `setup-go` toolchain hosts to the
 `summarize-notes` job's `allowed-endpoints`:
 
-```
+```yaml
 raw.githubusercontent.com:443
+release-assets.githubusercontent.com:443
 golang.org:443
 go.dev:443
 dl.google.com:443

--- a/docs/fixes/2026-09-06-release-notes-summarizer-egress-golang-org.md
+++ b/docs/fixes/2026-09-06-release-notes-summarizer-egress-golang-org.md
@@ -1,0 +1,48 @@
+# Fix: release-notes summarizer failed at "Set up Go" (golang.org egress blocked)
+
+**Date:** 2026-09-06
+
+## Summary
+
+The `summarize-notes` job in `.github/workflows/release.yml` (the AI rewrite of
+drafted release notes, added in #3045) failed on the first real release that
+reached it, at the `Set up Go` step - before any summarization ran - with:
+
+```
+##[error]getaddrinfo EAI_AGAIN golang.org
+```
+
+The overall `Release` run therefore showed `failure`, even though the release
+itself (binaries, SBOMs, draft notes) was fine.
+
+## Root cause
+
+The job runs `step-security/harden-runner` with `egress-policy: block` and a
+fixed `allowed-endpoints` list. `actions/setup-go` resolves and downloads the Go
+toolchain via `golang.org` (redirecting to `go.dev`), the `actions/go-versions`
+manifest on `raw.githubusercontent.com`, and the toolchain archive on
+`dl.google.com` - none of which were in the allow-list. harden-runner blocked the
+`golang.org` DNS lookup, so `setup-go` died with `EAI_AGAIN`. The allow-list only
+had `proxy.golang.org`/`sum.golang.org`/`google.golang.org` (module proxy +
+checksum DB), which cover `go build` but not toolchain provisioning. The job's
+comment claimed the set mirrored `test.yml`'s build job, but it did not.
+
+## Fix
+
+**`.github/workflows/release.yml`** - add the `setup-go` toolchain hosts to the
+`summarize-notes` job's `allowed-endpoints`:
+
+```
+raw.githubusercontent.com:443
+golang.org:443
+go.dev:443
+dl.google.com:443
+```
+
+## Notes
+
+- This was never the 125k release-body overflow the summarizer protects against;
+  the draft body was ~5 KB. When this job fails, release-drafter's categorized
+  skeleton stays as the release body, which is small and safe.
+- The fix only takes effect for `Release` runs built from a commit that contains
+  it; re-running an old run re-checks-out the pre-fix workflow and fails again.

--- a/docs/fixes/2026-09-06-sign-and-attest-goreleaser-skip-publish.md
+++ b/docs/fixes/2026-09-06-sign-and-attest-goreleaser-skip-publish.md
@@ -1,0 +1,52 @@
+# Fix: sign-and-attest release job failed re-publishing a published release (422)
+
+**Date:** 2026-09-06
+
+## Summary
+
+Publishing `v1.228.0` fired `build.yml`'s `sign-and-attest-release` job
+("Rebuild, sign, SBOM, and attest release artifacts"). GoReleaser rebuilt every
+platform and cataloged all SBOMs successfully, then failed at the very end:
+
+```
+release failed after 53m45s
+  error=scm releases: failed to publish artifacts: could not release:
+  PATCH https://api.github.com/repos/cloudposse/atmos/releases/383707212:
+  422 Validation Failed [{Resource:Release Field:target_commitish Code:invalid}]
+```
+
+## Root cause
+
+This job runs on `release: published`, i.e. **after** the GitHub Release already
+exists (with its assets, from the draft build). It ran `goreleaser release
+--clean`, which includes the publish phase: GoReleaser tries to update the
+existing release, sending `target_commitish`. GitHub rejects changing
+`target_commitish` on an already-published release, returning `422 Validation
+Failed`, so GoReleaser exits non-zero and the job fails.
+
+The job does not actually need to re-publish - it rebuilds `dist/*` locally only
+so the following steps can attest build provenance (`subject-path: dist/*`) and
+generate a source-tree SBOM. The publish attempt was pure collateral.
+
+## Fix
+
+**`.github/workflows/build.yml`** - add `--skip=publish` to the GoReleaser args
+in the `sign-and-attest-release` job:
+
+```yaml
+args: release --clean --skip=publish
+```
+
+GoReleaser still builds, signs, and catalogs SBOMs into `dist/*` (what the
+attestation steps consume) but no longer touches the GitHub Release, so the 422
+cannot occur.
+
+## Notes
+
+- The release itself was never at risk: the draft build already attached the
+  cosign-signed checksums and per-artifact SBOMs. Only the extra GitHub-native
+  build-provenance attestation was missing when this job failed.
+- This was the job's first real run - it was added in #2958 (2026-08-31), after
+  the previous publish (v1.227.0, 2026-08-26), and the earlier prerelease
+  failures were a different symptom (missing binaries from the syft break, see
+  #3061).

--- a/docs/fixes/2026-09-06-sign-and-attest-goreleaser-skip-publish.md
+++ b/docs/fixes/2026-09-06-sign-and-attest-goreleaser-skip-publish.md
@@ -8,7 +8,7 @@ Publishing `v1.228.0` fired `build.yml`'s `sign-and-attest-release` job
 ("Rebuild, sign, SBOM, and attest release artifacts"). GoReleaser rebuilt every
 platform and cataloged all SBOMs successfully, then failed at the very end:
 
-```
+```text
 release failed after 53m45s
   error=scm releases: failed to publish artifacts: could not release:
   PATCH https://api.github.com/repos/cloudposse/atmos/releases/383707212:


### PR DESCRIPTION
## what

- **Release-notes summarizer egress** (`.github/workflows/release.yml`): add `golang.org`, `go.dev`, `raw.githubusercontent.com`, and `dl.google.com` to the `summarize-notes` job's harden-runner `allowed-endpoints`.
- **sign-and-attest release** (`.github/workflows/build.yml`): add `--skip=publish` to the GoReleaser step in the `sign-and-attest-release` job.
- **Homebrew formula bump** (`.github/workflows/build.yml`): replace the broken `dawidd6/action-homebrew-bump-formula` with a direct `brew bump-formula-pr` call.
- Each fix ships a note under `docs/fixes/2026-09-06-*.md`.

## why

Publishing `v1.228.0` succeeded (release, binaries, Docker image, website all green), but three downstream jobs failed. None relate to the release contents — they are pre-existing pipeline gaps that were previously masked by the syft break fixed in #3061.

- **Summarizer** died at `Set up Go` with `getaddrinfo EAI_AGAIN golang.org` before any summarization ran: its egress allow-list lacked the toolchain hosts `actions/setup-go` resolves (`golang.org`/`go.dev`) and downloads from (`raw.githubusercontent.com`/`dl.google.com`). (This is not the 125k release-body overflow the summarizer guards against — the draft body was ~5 KB.)
- **sign-and-attest** ran `goreleaser release --clean` against the already-published release; GoReleaser PATCHed `target_commitish`, which GitHub rejects on a published release (`422 Validation Failed`). The job only rebuilds `dist/*` for provenance attestation, so it must not publish — `--skip=publish` fixes it.
- **Homebrew** bump broke on the Homebrew 5.x now on GitHub runners: `undefined method 'safe_system' for module Homebrew`. `v8` has byte-identical code and the upstream Homebrew-5 fix was reverted, so bumping the action does not help. The wrapped command `brew bump-formula-pr` is fine, so this calls it directly (atmos is in `homebrew-core`).

## references

- Follows #3061 (the syft fix that unblocked the release build).
- Fix docs: `docs/fixes/2026-09-06-release-notes-summarizer-egress-golang-org.md`, `docs/fixes/2026-09-06-sign-and-attest-goreleaser-skip-publish.md`, `docs/fixes/2026-09-06-homebrew-bump-safe-system.md`.
- The Homebrew bump for the current release was done manually via https://github.com/Homebrew/homebrew-core/pull/302706 — the same `brew bump-formula-pr` command this PR automates, which pre-validates fix 3.
- Fixes 1 and 2 are deterministic (an egress allow-list entry; a documented GoReleaser flag). Fix 3 (Homebrew) can only be fully verified on the next real `release: published` run; its fix doc records the manual fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Homebrew formula bumping during releases.
  - Release artifact rebuilding no longer attempts to republish an existing GitHub Release, avoiding related failures.
  - Release-note generation can access GitHub-hosted release assets when retrieving Go toolchain resources.

- **Documentation**
  - Added troubleshooting guidance for Homebrew bump and release artifact issues.
  - Updated release-note documentation with asset-download requirements and clearer command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->