### PR TITLE
fix(source): retry DNS/connect failures for JIT sources; clone JIT test fixtures locally

### DIFF
--- a/docs/fixes/2026-09-07-jit-source-network-flakes.md
+++ b/docs/fixes/2026-09-07-jit-source-network-flakes.md
@@ -1,0 +1,84 @@
+# Fix: JIT source provisioning retries DNS/connect failures; JIT tests clone a local repo instead of GitHub
+
+**Date:** 2026-09-07
+
+## Summary
+
+`Acceptance Tests (windows, shard 2/10)` on #3069 failed in `TestJITSource_PackerOutput` with:
+
+```text
+failed to download file: error downloading '***github.com/aws-samples/amazon-eks-custom-amis?depth=1&ref=main':
+git command exited with non-zero status: ... fatal: unable to access
+'https://github.com/aws-samples/amazon-eks-custom-amis/': Failed to connect to github.com:443 after 61 ms:
+Could not connect to server
+```
+
+The same job's checkout step had already hit `Could not resolve host: github.com` seconds earlier and
+recovered on `actions/checkout`'s own retry. Nothing in the PR touched source provisioning. This is the same
+family as `2026-09-02-vendor-pull-dns-resolution-flake.md` and `2026-08-10-github-transient-error-tls-cert-flake.md`,
+and it recurs several times a week across Windows shards.
+
+## Context
+
+On Windows, harden-runner's agent enforces egress with a DNS proxy on `127.0.0.1:53` and a WFP allow-rule per
+resolved IP (`2026-09-03-harden-runner-windows-dns-restore-race.md`). Under the process churn of a test shard
+(the agent logged hundreds of `pid reused` warnings in this job) the proxy occasionally drops a query
+(`Could not resolve host`) or the allow-rule lands after the client already connected — a 61 ms refusal, not a
+network timeout. Both clear on the next attempt.
+
+Two things in this repository turned that blip into a red build:
+
+- The git getter's retry predicate (`isRetryableGitError`, `pkg/downloader/get_git.go`) did not recognise
+  `could not resolve host` or `could not connect to server`, so even a source with `retry:` configured would not
+  have retried. And JIT source provisioning (`pkg/provisioner/source/vendor.go`) only passed a retry policy when
+  the source set `retry:` explicitly — there was no bounded default, unlike the brokered-auth path. A user's
+  `terraform plan` with a JIT source hits the same blip on a laptop or in CI.
+- `TestJITSource_*` (`tests/cli_jit_source_workdir_test.go`) and `TestJITSource_MetadataComponentSubpath*`
+  (`tests/cli_source_provisioner_workdir_test.go`) test the JIT provisioning path, not GitHub; cloning
+  `terraform-null-label`, `helmfiles` and `amazon-eks-custom-amis` from github.com was incidental. The precondition
+  helper `RequireGitHubAccess` only checks connectivity once at the start, so a mid-clone blip still failed the test.
+
+A Gitea/testcontainers stand-in was considered and rejected for these tests: the flake is on Windows, and
+GitHub's Windows and macOS hosted runners cannot run Linux containers, so a container-backed fixture would skip
+exactly where coverage is needed. A local `git::file://` repository exercises the same go-getter git path
+(clone, `ref=`, `depth=1`, `//subpath`) on every OS with no network — the pattern
+`tests/cli_remote_imports_test.go` already uses.
+
+## Changes
+
+- `pkg/downloader/get_git.go`: `isRetryableGitError` also matches `could not resolve host`, `no such host`,
+  `could not connect to server`, `failed to connect to`, `network is unreachable` and `name resolution`.
+  `pkg/downloader/get_git_retry_test.go` covers each, plus a guard that `unable to access ... returned error: 403`
+  is still not retried.
+- `pkg/provisioner/source/vendor.go`: `downloadGoGetterSource` always passes a retry policy —
+  the source's own `retry:` when set, otherwise a bounded default (3 attempts, exponential backoff 1s→8s, 20% jitter).
+  Only the git getter's transient-transport predicate triggers a retry; auth failures and missing refs still fail
+  fast, and `max_attempts: 1` opts out. `retry_default_test.go` covers the default and the explicit-wins case.
+- `tests/jit_source_local_repo_test.go` (new): builds a throwaway git repository with the files the fixtures expect
+  (`exports/context.tf`, `releases/nginx-ingress/helmfile.yaml`, `*.pkr.hcl`), tags `0.25.0` and `0.126.0`, branch
+  `main`, and rewrites the three upstream repository URIs in a test's *sandboxed* copy of the
+  `source-provisioner-workdir` fixture to `git::file://` — subpaths and `version:` untouched. The checked-in
+  fixture keeps its real-world URIs.
+- `tests/cli_jit_source_workdir_test.go`: `setupJITSourceWorkdirFixture` requires `git` and wires the local repo in.
+- `tests/cli_source_provisioner_workdir_test.go`: the two `MetadataComponentSubpath` tests use the same sandbox
+  setup instead of `RequireGitHubAccess` + running in the checked-in fixture directory.
+- Docs: `terraform`/`helmfile`/`packer` `source` pages state the new default retry behaviour under `retry`.
+
+Not changed: `atmos vendor pull` (`pkg/vendor`) still has no default retry; the `vendor` acceptance fixture is
+deliberately real-network (see `2026-09-02-vendor-pull-dns-resolution-flake.md`).
+
+## Validation
+
+- `go test ./tests/ -count=1 -run 'TestJITSource|TestSourceWorkdir'`: all 9 JIT/workdir tests pass in 46 s with
+  no network access (macOS, local).
+- `go test ./pkg/downloader/ ./pkg/provisioner/... -count=1`: pass, including the new predicate cases and
+  `TestEffectiveRetryConfig_*`.
+- `custom-gcl run --new-from-rev=origin/main` (pinned to the go.mod toolchain): 0 issues.
+- `pnpm run build` in `website/`: succeeds; the only broken-anchor warnings are the three pre-existing ones
+  also reported on `main` (`mcp-for-ai-coding-assistants`, `terraform.output`, `terraform.state`).
+- Not validated: the retry default against a real dropped-DNS event (not reproducible on demand); the predicate
+  strings are taken verbatim from the failing job's git output.
+
+## Follow-ups
+
+None.

--- a/pkg/downloader/get_git.go
+++ b/pkg/downloader/get_git.go
@@ -390,6 +390,15 @@ func isRetryableGitError(err error) bool {
 	transientPatterns := []string{
 		"connection reset",
 		"connection refused",
+		// Resolver and connect failures in git's own wording. A hosted CI
+		// runner whose DNS proxy briefly drops a query reports these, and they
+		// clear on the next attempt just like a reset connection does.
+		"could not resolve host",
+		"no such host",
+		"could not connect to server",
+		"failed to connect to",
+		"network is unreachable",
+		"name resolution",
 		"timeout",
 		"timed out",
 		"eof",

--- a/pkg/downloader/get_git_retry_test.go
+++ b/pkg/downloader/get_git_retry_test.go
@@ -48,6 +48,33 @@ func TestIsRetryableGitError(t *testing.T) {
 			expected: true,
 		},
 
+		// Resolver and connect failures as git reports them (should retry).
+		{
+			name:     "could not resolve host",
+			err:      errors.New("fatal: unable to access 'https://github.com/org/repo/': Could not resolve host: github.com"),
+			expected: true,
+		},
+		{
+			name:     "could not connect to server",
+			err:      errors.New("fatal: unable to access 'https://github.com/org/repo/': Failed to connect to github.com:443 after 61 ms: Could not connect to server"),
+			expected: true,
+		},
+		{
+			name:     "no such host",
+			err:      errors.New("dial tcp: lookup github.com: no such host"),
+			expected: true,
+		},
+		{
+			name:     "network is unreachable",
+			err:      errors.New("connect: network is unreachable"),
+			expected: true,
+		},
+		{
+			name:     "temporary failure in name resolution",
+			err:      errors.New("ssh: Could not resolve hostname github.com: Temporary failure in name resolution"),
+			expected: true,
+		},
+
 		// Timeout errors (should retry).
 		{
 			name:     "timeout",
@@ -154,6 +181,13 @@ func TestIsRetryableGitError(t *testing.T) {
 		{
 			name:     "not a git repository",
 			err:      errors.New("fatal: not a git repository"),
+			expected: false,
+		},
+		{
+			// The remote answered; "unable to access" alone must not be treated
+			// as a transport failure or a real 403/404 would be retried.
+			name:     "http 403 from remote",
+			err:      errors.New("fatal: unable to access 'https://github.com/org/repo/': The requested URL returned error: 403"),
 			expected: false,
 		},
 		{

--- a/pkg/downloader/get_git_retry_test.go
+++ b/pkg/downloader/get_git_retry_test.go
@@ -74,6 +74,18 @@ func TestIsRetryableGitError(t *testing.T) {
 			err:      errors.New("ssh: Could not resolve hostname github.com: Temporary failure in name resolution"),
 			expected: true,
 		},
+		// Standalone forms: each of the new patterns must match on its own, without another
+		// pattern (e.g. "failed to connect to" or "temporary failure") also present in the input.
+		{
+			name:     "could not connect to server alone",
+			err:      errors.New("Could not connect to server"),
+			expected: true,
+		},
+		{
+			name:     "name resolution alone",
+			err:      errors.New("getaddrinfo: name resolution error"),
+			expected: true,
+		},
 
 		// Timeout errors (should retry).
 		{

--- a/pkg/provisioner/source/retry_default_test.go
+++ b/pkg/provisioner/source/retry_default_test.go
@@ -1,0 +1,49 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/retry"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestEffectiveRetryConfig_DefaultWhenUnset guards against JIT source
+// provisioning silently running with no retry at all: a source without a
+// `retry:` block must get the bounded default rather than a nil config.
+func TestEffectiveRetryConfig_DefaultWhenUnset(t *testing.T) {
+	for name, spec := range map[string]*schema.VendorComponentSource{
+		"nil spec":           nil,
+		"spec without retry": {Uri: "github.com/org/repo"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := effectiveRetryConfig(spec)
+			require.NotNil(t, cfg)
+			require.NotNil(t, cfg.MaxAttempts)
+			assert.Equal(t, defaultSourceRetryAttempts, *cfg.MaxAttempts)
+			require.NotNil(t, cfg.InitialDelay)
+			assert.Equal(t, defaultSourceRetryInitialDelay, *cfg.InitialDelay)
+			require.NotNil(t, cfg.MaxDelay)
+			assert.Equal(t, defaultSourceRetryMaxDelay, *cfg.MaxDelay)
+			assert.Equal(t, schema.BackoffExponential, cfg.BackoffStrategy)
+			// The default must be a policy the retry executor accepts as-is.
+			assert.NoError(t, retry.Validate(cfg))
+		})
+	}
+}
+
+// TestEffectiveRetryConfig_ExplicitWins guards against the default
+// overriding a source's own policy, including an explicit opt-out
+// (max_attempts: 1).
+func TestEffectiveRetryConfig_ExplicitWins(t *testing.T) {
+	one := 1
+	spec := &schema.VendorComponentSource{
+		Uri:   "github.com/org/repo",
+		Retry: &schema.RetryConfig{MaxAttempts: &one},
+	}
+	cfg := effectiveRetryConfig(spec)
+	assert.Same(t, spec.Retry, cfg)
+	assert.Equal(t, 1, *cfg.MaxAttempts)
+}

--- a/pkg/provisioner/source/retry_default_test.go
+++ b/pkg/provisioner/source/retry_default_test.go
@@ -28,6 +28,10 @@ func TestEffectiveRetryConfig_DefaultWhenUnset(t *testing.T) {
 			require.NotNil(t, cfg.MaxDelay)
 			assert.Equal(t, defaultSourceRetryMaxDelay, *cfg.MaxDelay)
 			assert.Equal(t, schema.BackoffExponential, cfg.BackoffStrategy)
+			require.NotNil(t, cfg.Multiplier)
+			assert.InDelta(t, defaultSourceRetryMultiplier, *cfg.Multiplier, 0)
+			require.NotNil(t, cfg.RandomJitter)
+			assert.InDelta(t, defaultSourceRetryJitter, *cfg.RandomJitter, 0)
 			// The default must be a policy the retry executor accepts as-is.
 			assert.NoError(t, retry.Validate(cfg))
 		})

--- a/pkg/provisioner/source/vendor.go
+++ b/pkg/provisioner/source/vendor.go
@@ -251,10 +251,7 @@ func downloadOCISource(ctx context.Context, atmosConfig *schema.AtmosConfigurati
 
 // downloadGoGetterSource fetches a non-OCI source via the go-getter downloader.
 func downloadGoGetterSource(atmosConfig *schema.AtmosConfiguration, sourceSpec *schema.VendorComponentSource, uri, tempDir string) error {
-	downloadOpts := []downloader.GoGetterOption{}
-	if sourceSpec.Retry != nil {
-		downloadOpts = append(downloadOpts, downloader.WithRetryConfig(sourceSpec.Retry))
-	}
+	downloadOpts := []downloader.GoGetterOption{downloader.WithRetryConfig(effectiveRetryConfig(sourceSpec))}
 	dl := downloader.NewGoGetterDownloader(atmosConfig, downloadOpts...)
 	if err := dl.Fetch(uri, tempDir, downloader.ClientModeAny, DefaultVendorTimeout); err != nil {
 		return errUtils.Build(errUtils.ErrSourceProvision).
@@ -265,6 +262,48 @@ func downloadGoGetterSource(atmosConfig *schema.AtmosConfiguration, sourceSpec *
 			Err()
 	}
 	return nil
+}
+
+// Bounded default retry policy for source downloads that do not configure
+// their own `retry:`. A `terraform plan` that provisions its component source
+// just in time shouldn't fail on a single dropped DNS query or reset
+// connection -- the same blip a hosted CI runner hits a few times a day --
+// so git operations get three attempts with short exponential backoff.
+// Only transient transport failures are retried (see the git getter's
+// retry predicate); authentication and "not found" errors still fail fast.
+const (
+	defaultSourceRetryAttempts     = 3
+	defaultSourceRetryInitialDelay = 1 * time.Second
+	defaultSourceRetryMaxDelay     = 8 * time.Second
+	defaultSourceRetryMultiplier   = 2.0
+	defaultSourceRetryJitter       = 0.2
+)
+
+// defaultSourceRetryConfig returns the policy described above.
+func defaultSourceRetryConfig() *schema.RetryConfig {
+	attempts := defaultSourceRetryAttempts
+	initialDelay := defaultSourceRetryInitialDelay
+	maxDelay := defaultSourceRetryMaxDelay
+	multiplier := defaultSourceRetryMultiplier
+	jitter := defaultSourceRetryJitter
+	return &schema.RetryConfig{
+		MaxAttempts:     &attempts,
+		InitialDelay:    &initialDelay,
+		MaxDelay:        &maxDelay,
+		Multiplier:      &multiplier,
+		RandomJitter:    &jitter,
+		BackoffStrategy: schema.BackoffExponential,
+	}
+}
+
+// effectiveRetryConfig returns the source's own `retry:` when it configured
+// one, otherwise the bounded default. An explicit `max_attempts: 1` is how a
+// source opts out of retrying entirely.
+func effectiveRetryConfig(sourceSpec *schema.VendorComponentSource) *schema.RetryConfig {
+	if sourceSpec != nil && sourceSpec.Retry != nil {
+		return sourceSpec.Retry
+	}
+	return defaultSourceRetryConfig()
 }
 
 func localDirectorySource(uri string) (string, bool, error) {

--- a/tests/cli_jit_source_workdir_test.go
+++ b/tests/cli_jit_source_workdir_test.go
@@ -12,15 +12,19 @@ import (
 	"github.com/cloudposse/atmos/cmd"
 )
 
-// setupJITSourceWorkdirFixture gives each test its own writable fixture.
+// setupJITSourceWorkdirFixture gives each test its own writable fixture whose
+// component sources clone from a local git repository instead of GitHub, so
+// the JIT provisioning path under test never depends on the network.
 func setupJITSourceWorkdirFixture(t *testing.T) {
 	t.Helper()
+	RequireExecutable(t, "git", "JIT source provisioning clones a git repository")
 
 	fixture, err := filepath.Abs(filepath.Join("fixtures", "scenarios", "source-provisioner-workdir"))
 	require.NoError(t, err)
 
 	sandbox := t.TempDir()
 	require.NoError(t, os.CopyFS(sandbox, os.DirFS(fixture)))
+	rewriteJITSourceURIs(t, sandbox, initJITSourceRepo(t))
 	t.Chdir(sandbox)
 }
 

--- a/tests/cli_source_provisioner_workdir_test.go
+++ b/tests/cli_source_provisioner_workdir_test.go
@@ -111,14 +111,7 @@ func TestSourceWorkdir_DeleteMissingForce(t *testing.T) {
 // workdir root. Reverting the fix in tryJITProvision moves the varfile to
 // the wrong location and fails this test.
 func TestJITSource_MetadataComponentSubpath(t *testing.T) {
-	RequireExecutable(t, "git", "JIT source provisioning clones a remote repo")
-	RequireGitHubAccess(t)
-
-	t.Chdir("./fixtures/scenarios/source-provisioner-workdir")
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(".workdir")
-	})
+	setupJITSourceWorkdirFixture(t)
 
 	resetViperState()
 	cmd.RootCmd.SetArgs([]string{
@@ -160,14 +153,7 @@ func TestJITSource_MetadataComponentSubpath(t *testing.T) {
 // path printed by printShellDryRunInfo include the metadata.component
 // subpath. Reverting the fix in terraform_shell.go fails these assertions.
 func TestJITSource_MetadataComponentSubpath_TerraformShell(t *testing.T) {
-	RequireExecutable(t, "git", "JIT source provisioning clones a remote repo")
-	RequireGitHubAccess(t)
-
-	t.Chdir("./fixtures/scenarios/source-provisioner-workdir")
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(".workdir")
-	})
+	setupJITSourceWorkdirFixture(t)
 
 	// Capture stderr (where ui.Writeln output goes) for the dry-run banner.
 	// Drain the pipe in a goroutine that starts BEFORE cmd.Execute so the OS

--- a/tests/jit_source_local_repo_test.go
+++ b/tests/jit_source_local_repo_test.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// jitSourceUpstreams lists the public repositories the source-provisioner
+// fixtures point at. The fixtures keep their real-world URIs (they double as
+// documentation); the tests rewrite only the repository part of each `uri:`
+// in their sandboxed copy, so `//subpath` and `version:` keep working exactly
+// as they do against GitHub.
+var jitSourceUpstreams = []string{
+	"github.com/cloudposse/terraform-null-label",
+	"github.com/cloudposse-archives/helmfiles",
+	"github.com/aws-samples/amazon-eks-custom-amis",
+}
+
+// jitSourceRepoFiles is the content of the local stand-in repository: the
+// `exports/` module the terraform fixtures vendor (only `context.tf` must
+// exist; the README and examples/ exercise excluded_paths), the helmfile
+// release directory, and packer templates at the repository root.
+var jitSourceRepoFiles = map[string]string{
+	"exports/context.tf":                   "variable \"enabled\" {\n  type    = bool\n  default = true\n}\n",
+	"exports/README.md":                    "# exports\n",
+	"exports/examples/complete/main.tf":    "# excluded by examples/**\n",
+	"releases/nginx-ingress/helmfile.yaml": "releases: []\n",
+	"releases/nginx-ingress/README.md":     "# nginx-ingress\n",
+	"main.pkr.hcl":                         "source \"null\" \"example\" {\n  communicator = \"none\"\n}\n",
+	"variables.pkrvars.hcl":                "ami_name = \"example\"\n",
+	"README.md":                            "# stand-in for public sources\n",
+}
+
+// jitSourceRepoTags are the `version:` values the fixtures pin, all pointing
+// at the single commit; `main` (the packer fixture's version) is the branch.
+var jitSourceRepoTags = []string{"0.25.0", "0.126.0"}
+
+// initJITSourceRepo creates the local git repository the source-provisioner
+// tests clone from instead of GitHub, and returns a `git::file://` URI for it.
+// Cloning over the network made these tests fail whenever a hosted runner's
+// DNS blipped mid-clone -- on a code path (git clone through go-getter) that
+// is identical for a file:// remote, minus the network.
+func initJITSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	runJITSourceGit(t, repoDir, "init")
+	runJITSourceGit(t, repoDir, "checkout", "-b", "main")
+	runJITSourceGit(t, repoDir, "config", "user.email", "test@example.com")
+	runJITSourceGit(t, repoDir, "config", "user.name", "Test User")
+	// Never sign commits in throwaway test repos: signing is slow, needs no
+	// verification here, and hangs on dev machines whose global git config
+	// enables commit.gpgsign (e.g. a 1Password agent).
+	runJITSourceGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	for name, content := range jitSourceRepoFiles {
+		path := filepath.Join(repoDir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	runJITSourceGit(t, repoDir, "add", ".")
+	runJITSourceGit(t, repoDir, "commit", "-m", "initial")
+	for _, tag := range jitSourceRepoTags {
+		runJITSourceGit(t, repoDir, "tag", tag)
+	}
+	return "git::" + remoteImportsGitFileURI(repoDir)
+}
+
+func runJITSourceGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}
+
+// rewriteJITSourceURIs points every fixture `uri:` under dir's stack catalog
+// at repoURI, keeping any `//subpath` suffix. It only touches the sandboxed
+// copy a test is about to run against, never the checked-in fixture.
+func rewriteJITSourceURIs(t *testing.T, dir, repoURI string) {
+	t.Helper()
+
+	catalog := filepath.Join(dir, "stacks", "catalog")
+	entries, err := os.ReadDir(catalog)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(catalog, entry.Name())
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		rewritten := string(content)
+		for _, upstream := range jitSourceUpstreams {
+			rewritten = strings.ReplaceAll(rewritten, upstream, repoURI)
+		}
+		if rewritten == string(content) {
+			continue
+		}
+		require.NoError(t, os.WriteFile(path, []byte(rewritten), 0o644))
+	}
+}

--- a/website/docs/cli/commands/helmfile/source/source.mdx
+++ b/website/docs/cli/commands/helmfile/source/source.mdx
@@ -151,6 +151,8 @@ source:
   ```
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
+
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 

--- a/website/docs/cli/commands/helmfile/source/source.mdx
+++ b/website/docs/cli/commands/helmfile/source/source.mdx
@@ -152,7 +152,7 @@ source:
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
 
-  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 attempts in total, with exponential backoff (1s initial delay, 8s maximum, multiplier 2.0, 20% random jitter — each overridable through the matching `retry` field). Missing refs are never retried. Authentication failures fail fast, except when Atmos brokered the credential itself (for example a GitHub App installation token), where a short post-issue retry window applies. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 

--- a/website/docs/cli/commands/packer/source/source.mdx
+++ b/website/docs/cli/commands/packer/source/source.mdx
@@ -153,6 +153,8 @@ source:
   ```
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
+
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 

--- a/website/docs/cli/commands/packer/source/source.mdx
+++ b/website/docs/cli/commands/packer/source/source.mdx
@@ -154,7 +154,7 @@ source:
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
 
-  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 attempts in total, with exponential backoff (1s initial delay, 8s maximum, multiplier 2.0, 20% random jitter — each overridable through the matching `retry` field). Missing refs are never retried. Authentication failures fail fast, except when Atmos brokered the credential itself (for example a GitHub App installation token), where a short post-issue retry window applies. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 

--- a/website/docs/cli/commands/terraform/source/source.mdx
+++ b/website/docs/cli/commands/terraform/source/source.mdx
@@ -156,6 +156,8 @@ source:
   ```
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
+
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 

--- a/website/docs/cli/commands/terraform/source/source.mdx
+++ b/website/docs/cli/commands/terraform/source/source.mdx
@@ -157,7 +157,7 @@ source:
 
   All fields are optional. Recommended: `max_attempts`, `initial_delay`, `max_delay`, `backoff_strategy` (`exponential`, `linear`, `constant`). Additional options: `multiplier`, `random_jitter`, `max_elapsed_time`.
 
-  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 times with exponential backoff (1s initial, 8s maximum). Authentication failures and missing refs are never retried. Set `max_attempts: 1` to disable retrying entirely.
+  When `retry` is omitted, git downloads still retry transient transport failures — a DNS lookup that fails, a connection refused or reset, a timeout, or a TLS handshake error — up to 3 attempts in total, with exponential backoff (1s initial delay, 8s maximum, multiplier 2.0, 20% random jitter — each overridable through the matching `retry` field). Missing refs are never retried. Authentication failures fail fast, except when Atmos brokered the credential itself (for example a GitHub App installation token), where a short post-issue retry window applies. Set `max_attempts: 1` to disable retrying entirely.
   </dd>
 </dl>
 


### PR DESCRIPTION
## what

- `isRetryableGitError` (`pkg/downloader/get_git.go`) now recognises OS-level resolver and connect failures in git's own wording — `could not resolve host`, `no such host`, `could not connect to server`, `failed to connect to`, `network is unreachable`, `name resolution` — with tests for each plus a guard that a real `403` from the remote is still not retried.
- JIT source provisioning (`pkg/provisioner/source/vendor.go`) always passes a retry policy to the git getter: the source's own `retry:` when set, otherwise a bounded default of 3 attempts with exponential backoff (1s→8s, 20% jitter). Only transient transport failures are retried; auth failures and missing refs still fail fast, and `max_attempts: 1` opts out. The `terraform`/`helmfile`/`packer` `source` docs describe the default.
- The `TestJITSource_*` and `TestJITSource_MetadataComponentSubpath*` acceptance tests clone from a throwaway local `git::file://` repository (`tests/jit_source_local_repo_test.go`) instead of `github.com` — same go-getter git path (clone, `ref=`, `depth=1`, `//subpath`), no network, runs on all three OSes. The rewrite happens in each test's sandboxed copy of the fixture; the checked-in fixture keeps its real-world URIs. `RequireGitHubAccess` is dropped from the two tests that used it.
- Fix record: `docs/fixes/2026-09-07-jit-source-network-flakes.md`.

## why

- `Acceptance Tests (windows, shard 2/10)` on #3069 failed in `TestJITSource_PackerOutput` with `Failed to connect to github.com:443 after 61 ms: Could not connect to server`, right after the same job's checkout had hit `Could not resolve host: github.com`. On Windows, harden-runner's agent fronts DNS with a local proxy and installs a firewall allow-rule per resolved IP; under a test shard's process churn it occasionally drops a query or races the allow-rule. These blips recur several times a week (see the `docs/fixes/` entries from 2026-08-10, 2026-09-02, 2026-09-03) and nothing in the affected PRs touches source provisioning.
- Two gaps turned a one-second blip into a red build: the git retry predicate didn't match either message, and JIT provisioning had no retry unless a source configured one — so a user's `terraform plan` with a JIT source fails on the same blip on a laptop or in their CI. Retrying only transport-level failures, with a bounded budget, fixes the user-facing behaviour without masking real errors.
- The JIT tests exist to cover the provisioning path, not GitHub reachability. A Gitea/testcontainers stand-in was rejected because GitHub's Windows and macOS runners can't run Linux containers — the fixture would skip exactly where the flake happens.

## references

- Failing job: https://github.com/cloudposse/atmos/actions/runs/34172538919/job/101897823452 (from #3069)
- Prior records: `docs/fixes/2026-09-02-vendor-pull-dns-resolution-flake.md`, `docs/fixes/2026-09-03-harden-runner-windows-dns-restore-race.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git-based source downloads now automatically retry transient DNS, connection, and network failures up to three times with exponential backoff.
  - Missing references and authentication failures are not retried, except for a short retry window when credentials are brokered by Atmos.
  - Existing custom retry settings remain unchanged, including the option to disable retries.

- **Documentation**
  - Documented default retry behavior across Helmfile, Packer, and Terraform source configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->