### PR TITLE
fix(secret): stop leaking the resolved --stack into viper's override layer

### DIFF
--- a/cmd/secret/init.go
+++ b/cmd/secret/init.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/flags"
@@ -163,6 +162,9 @@ func parseInitScope(cmd *cobra.Command, args []string, all bool) (secretScope, e
 		if promptErr != nil {
 			return facet, promptErr
 		}
+		if err := adoptPromptedStack(cmd, chosen); err != nil {
+			return facet, err
+		}
 		facet.Stack = chosen
 	}
 	if facet.Stack == "" {
@@ -170,7 +172,6 @@ func parseInitScope(cmd *cobra.Command, args []string, all bool) (secretScope, e
 			WithExplanation("--stack is required for secret operations").
 			WithHint("Specify a stack with --stack or -s").Err()
 	}
-	viper.GetViper().Set("stack", facet.Stack)
 	return facet, nil
 }
 

--- a/cmd/secret/init.go
+++ b/cmd/secret/init.go
@@ -159,11 +159,11 @@ func parseInitScope(cmd *cobra.Command, args []string, all bool) (secretScope, e
 	}
 	if facet.Stack == "" {
 		chosen, promptErr := flags.PromptForMissingRequired("stack", "Choose a stack", stackCompletion, cmd, args)
+		if promptErr == nil {
+			promptErr = adoptPromptedStack(cmd, chosen)
+		}
 		if promptErr != nil {
 			return facet, promptErr
-		}
-		if err := adoptPromptedStack(cmd, chosen); err != nil {
-			return facet, err
 		}
 		facet.Stack = chosen
 	}

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -127,7 +127,10 @@ func adoptPromptedStack(cmd *cobra.Command, chosen string) error {
 	if chosen == "" {
 		return nil
 	}
-	return cmd.Flags().Set(cfg.StackStr, chosen)
+	if err := cmd.Flags().Set(cfg.StackStr, chosen); err != nil {
+		return fmt.Errorf("%w: adopting the prompted --%s on %s: %w", errUtils.ErrInvalidFlag, cfg.StackStr, cmd.Name(), err)
+	}
+	return nil
 }
 
 func requireScopeComponent(scope secretScope, cmd *cobra.Command, args []string) (secretScope, error) {

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -98,10 +98,10 @@ func parseScopeStack(cmd *cobra.Command, args []string) (secretScope, error) {
 
 	if scope.Stack == "" {
 		chosen, err := flags.PromptForMissingRequired(cfg.StackStr, "Choose a stack", stackCompletion, cmd, args)
-		if err != nil {
-			return scope, err
+		if err == nil {
+			err = adoptPromptedStack(cmd, chosen)
 		}
-		if err := adoptPromptedStack(cmd, chosen); err != nil {
+		if err != nil {
 			return scope, err
 		}
 		scope.Stack = chosen

--- a/cmd/secret/shared.go
+++ b/cmd/secret/shared.go
@@ -101,6 +101,9 @@ func parseScopeStack(cmd *cobra.Command, args []string) (secretScope, error) {
 		if err != nil {
 			return scope, err
 		}
+		if err := adoptPromptedStack(cmd, chosen); err != nil {
+			return scope, err
+		}
 		scope.Stack = chosen
 	}
 	if scope.Stack == "" {
@@ -109,9 +112,22 @@ func parseScopeStack(cmd *cobra.Command, args []string) (secretScope, error) {
 			WithHint("Specify a stack with --stack or -s").
 			Err()
 	}
-	// Make the chosen stack visible to the component completion (it filters by --stack).
-	v.Set(cfg.StackStr, scope.Stack)
 	return scope, nil
+}
+
+// adoptPromptedStack records a stack chosen at the interactive prompt on the command's own
+// --stack flag, so the component completion that follows (which filters by the selected stack,
+// read through viper's flag binding) sees it exactly as if the user had passed --stack.
+//
+// It deliberately does not write the value into viper's override layer (viper.Set): an override
+// outranks every later flag parse for the life of the process, so a second `secret` command run
+// in the same process would silently keep the first command's stack. An empty choice (no TTY,
+// nothing to choose from) leaves the flag untouched so the required-flag error still fires.
+func adoptPromptedStack(cmd *cobra.Command, chosen string) error {
+	if chosen == "" {
+		return nil
+	}
+	return cmd.Flags().Set(cfg.StackStr, chosen)
 }
 
 func requireScopeComponent(scope secretScope, cmd *cobra.Command, args []string) (secretScope, error) {

--- a/cmd/secret/stack_override_test.go
+++ b/cmd/secret/stack_override_test.go
@@ -1,0 +1,80 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/secrets"
+)
+
+// TestRunSecretSet_StackFlagNotShadowedByEarlierCommand guards against the flake that failed
+// `[race] non-acceptance test suite` on main and PR runs under -shuffle: parseScopeStack used to
+// write the resolved stack into viper's override layer (viper.Set), which outranks every later
+// flag parse, so once any secret command had run with --stack prod, a following command's
+// --stack dev was silently ignored and its global-scope lookup found nothing. Two commands in one
+// process must each see their own --stack.
+func TestRunSecretSet_StackFlagNotShadowedByEarlierCommand(t *testing.T) {
+	svc := newFakeSecretService()
+	svc.declared = map[string]bool{"SHARED_CLIENT_SECRET": true}
+	svc.scopes = map[string]secrets.Scope{"SHARED_TOKEN": secrets.ScopeGlobal}
+	installService(t, svc, nil)
+
+	require.NoError(t, runSecretSubcommand(t, "import", "SHARED_CLIENT_SECRET",
+		"--from-stack", "atmos", "--from-component", "shared",
+		"--stack", "prod", "--component", "api"))
+
+	originalLoadService := loadServiceFn
+	var loadedScope secretScope
+	loadServiceFn = func(scope secretScope) (secretService, error) {
+		loadedScope = scope
+		return originalLoadService(scope)
+	}
+	t.Cleanup(func() { loadServiceFn = originalLoadService })
+	overrideEnumerateScopes(t, []scopeEntry{
+		{
+			Stack:     "dev",
+			Component: "example-service",
+			Section: secretDeclarationSection("SHARED_TOKEN", map[string]any{
+				"store": "example-secrets",
+				"scope": "global",
+			}),
+		},
+	}, nil)
+
+	require.NoError(t, runSecretSubcommand(t, "set", "SHARED_TOKEN=v1", "--stack", "dev"))
+	assert.Equal(t, "dev", loadedScope.Stack, "the second command must use its own --stack, not the first command's")
+	require.Len(t, svc.setCalls, 1)
+}
+
+// TestAdoptPromptedStack_VisibleThroughFlagBinding guards the reason the override existed: a
+// stack chosen at the interactive prompt must still be visible to the component completion,
+// which reads the selected stack through viper's binding to the --stack flag. Setting the flag
+// itself (not a viper override) satisfies that without leaking across commands.
+func TestAdoptPromptedStack_VisibleThroughFlagBinding(t *testing.T) {
+	resetSecretFlags(t)
+	// Cobra merges inherited persistent flags into a subcommand's flag set lazily; trigger it the
+	// same way command execution does so the --stack flag is addressable on setCmd.
+	_ = setCmd.InheritedFlags()
+	require.NoError(t, secretParser.BindFlagsToViper(setCmd, viper.GetViper()))
+
+	require.NoError(t, adoptPromptedStack(setCmd, "staging"))
+	assert.Equal(t, "staging", viper.GetString("stack"))
+
+	// After the flag reset every other test relies on, nothing lingers.
+	resetSecretFlags(t)
+	assert.Empty(t, viper.GetString("stack"))
+}
+
+// TestAdoptPromptedStack_EmptyChoiceIsNoOp guards the non-interactive path: when the prompt
+// yields nothing (no TTY, or no stacks to choose from), the flag stays unset so the standard
+// required-flag error still fires instead of an empty stack being adopted.
+func TestAdoptPromptedStack_EmptyChoiceIsNoOp(t *testing.T) {
+	resetSecretFlags(t)
+	_ = setCmd.InheritedFlags()
+
+	require.NoError(t, adoptPromptedStack(setCmd, ""))
+	assert.False(t, setCmd.Flags().Changed("stack"))
+}

--- a/cmd/secret/stack_override_test.go
+++ b/cmd/secret/stack_override_test.go
@@ -3,10 +3,12 @@ package secret
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/pkg/secrets"
 )
 
@@ -77,4 +79,25 @@ func TestAdoptPromptedStack_EmptyChoiceIsNoOp(t *testing.T) {
 
 	require.NoError(t, adoptPromptedStack(setCmd, ""))
 	assert.False(t, setCmd.Flags().Changed("stack"))
+}
+
+// TestAdoptPromptedStack_MissingFlagErrors guards the helper's only failure mode: a command that
+// does not carry the --stack flag cannot adopt a choice, and the error must surface rather than
+// being swallowed (the secret subcommands all inherit the flag, so this is a programming-error
+// guard, not a user-facing path).
+func TestAdoptPromptedStack_MissingFlagErrors(t *testing.T) {
+	bare := &cobra.Command{Use: "bare"}
+	require.Error(t, adoptPromptedStack(bare, "staging"))
+}
+
+// TestRunSecretInit_MissingStackNonInteractive guards the non-interactive fallback on the init
+// path: with no --stack and no TTY the prompt yields nothing, nothing is adopted, and the standard
+// required-flag error fires instead of a silent empty stack.
+func TestRunSecretInit_MissingStackNonInteractive(t *testing.T) {
+	svc := newFakeSecretService()
+	installService(t, svc, nil)
+
+	err := runSecretSubcommand(t, "init", "--component", "api")
+	require.ErrorIs(t, err, errUtils.ErrRequiredFlagNotProvided)
+	assert.Empty(t, svc.setCalls)
 }

--- a/cmd/secret/stack_override_test.go
+++ b/cmd/secret/stack_override_test.go
@@ -87,7 +87,9 @@ func TestAdoptPromptedStack_EmptyChoiceIsNoOp(t *testing.T) {
 // guard, not a user-facing path).
 func TestAdoptPromptedStack_MissingFlagErrors(t *testing.T) {
 	bare := &cobra.Command{Use: "bare"}
-	require.Error(t, adoptPromptedStack(bare, "staging"))
+	err := adoptPromptedStack(bare, "staging")
+	require.ErrorIs(t, err, errUtils.ErrInvalidFlag)
+	assert.Contains(t, err.Error(), "bare")
 }
 
 // TestRunSecretInit_MissingStackNonInteractive guards the non-interactive fallback on the init

--- a/docs/fixes/2026-09-07-secret-stack-viper-override-leak.md
+++ b/docs/fixes/2026-09-07-secret-stack-viper-override-leak.md
@@ -47,7 +47,10 @@ its stack filter matched nothing, and the global-declaration lookup failed.
   (`import --stack prod`, then `set --stack dev`) and asserts the second command loads its service with
   `Stack == "dev"`; `TestAdoptPromptedStack_VisibleThroughFlagBinding` checks a prompted stack is visible
   through `viper.GetString("stack")` and gone after the flag reset; `TestAdoptPromptedStack_EmptyChoiceIsNoOp`
-  covers the non-interactive path.
+  and `TestRunSecretInit_MissingStackNonInteractive` cover the non-interactive path on both call sites, and
+  `TestAdoptPromptedStack_MissingFlagErrors` the helper's only failure mode. The prompt branches fold the prompt
+  error and the adopt error into the one pre-existing `if err != nil` return, so every changed line is
+  exercised without a TTY.
 
 ## Validation
 

--- a/docs/fixes/2026-09-07-secret-stack-viper-override-leak.md
+++ b/docs/fixes/2026-09-07-secret-stack-viper-override-leak.md
@@ -1,0 +1,66 @@
+# Fix: `secret` commands no longer leak the resolved `--stack` into viper's override layer
+
+**Date:** 2026-09-07
+
+## Summary
+
+`[race] non-acceptance test suite` failed on a `main` push (run 34179504147, head `82f5413e85`) and on
+#3069 (run 34181209571) in `cmd/secret`, each time in one of the two global-scope `secret set` tests:
+
+```text
+--- FAIL: TestRunSecretSet_GlobalScopeWithoutComponent (0.00s)
+    Error: --component is required to set secret "SHARED_TOKEN": no global declaration was found in the stack
+```
+
+The tests themselves are correct. Under `-shuffle=on` they fail whenever any earlier test in the package
+ran a `secret` command with a different `--stack`, because `parseScopeStack` (and `parseInitScope`) wrote
+the resolved stack into the process-global viper with `viper.Set`. An override outranks every later flag
+parse for the life of the process, so the next command's `--stack dev` resolved to the previous `prod`,
+its stack filter matched nothing, and the global-declaration lookup failed.
+
+## Context
+
+- Replayed deterministically with the CI seeds: `go test -race ./cmd/secret/ -shuffle=1788834383053658425`
+  (main's job) fails at `TestRunSecretSet_GlobalScopeWithoutComponent`; the PR job's seed
+  `1788835970504508964` fails its sibling `..._PreservesType`. Unshuffled and 20× unshuffled runs pass.
+- Bisected by pairing candidates in source order: `TestRunSecretImport_FromStoreMode` (runs
+  `import … --stack prod --component api`) followed by the global-scope set test reproduces the failure;
+  `list --stack prod` tests and the completion test that calls `viper.Reset()` do not.
+- A throwaway probe confirmed the mechanism: after `resetSecretFlags` the `--stack` pflag reads `""` but
+  `viper.GetString("stack")` still returns `"prod"`, and `viper.SetDefault("stack", "")` does not change
+  it — so the value lives in the override layer, which only `viper.Set` populates. The only such writes
+  are `cmd/secret/shared.go` (`parseScopeStack`) and `cmd/secret/init.go` (`parseInitScope`); `component`
+  has no equivalent write and does not leak.
+- The override existed so the interactive component prompt's completion (`componentCompletion`, which
+  reads the selected stack through viper) sees a stack chosen at the stack prompt. Setting the command's
+  own `--stack` flag achieves the same thing through viper's flag binding without a process-wide override.
+
+## Changes
+
+- `cmd/secret/shared.go`: `parseScopeStack` no longer calls `v.Set(cfg.StackStr, …)`. A new
+  `adoptPromptedStack(cmd, chosen)` sets the command's `--stack` flag only when the prompt produced a
+  value; an empty choice leaves the flag untouched so the required-flag error still fires.
+- `cmd/secret/init.go`: `parseInitScope` uses the same helper instead of `viper.GetViper().Set("stack", …)`;
+  the `viper` import is dropped.
+- `cmd/secret/stack_override_test.go` (new):
+  `TestRunSecretSet_StackFlagNotShadowedByEarlierCommand` runs the exact failing sequence
+  (`import --stack prod`, then `set --stack dev`) and asserts the second command loads its service with
+  `Stack == "dev"`; `TestAdoptPromptedStack_VisibleThroughFlagBinding` checks a prompted stack is visible
+  through `viper.GetString("stack")` and gone after the flag reset; `TestAdoptPromptedStack_EmptyChoiceIsNoOp`
+  covers the non-interactive path.
+
+## Validation
+
+- `go test -race ./cmd/secret/ -shuffle=1788834383053658425` and `-shuffle=1788835970504508964` (the two
+  failing CI seeds): pass.
+- `go test -race ./cmd/secret/ -count=5 -shuffle=on`: 0 failures.
+- The pair `TestRunSecretImport_FromStoreMode` → `TestRunSecretSet_GlobalScopeWithoutComponent` fails on
+  `main` and passes with the fix (this is what the new regression test encodes).
+- `go build ./cmd/... && go vet ./cmd/secret/`: clean; `custom-gcl run --new-from-rev=origin/main`
+  (pinned to the go.mod toolchain): 0 issues.
+- Not validated interactively: the stack prompt itself needs a TTY (`PromptForMissingRequired` returns
+  `""` in tests); the flag-binding unit test covers the propagation the override used to provide.
+
+## Follow-ups
+
+None.


### PR DESCRIPTION
## what

- `parseScopeStack` (`cmd/secret/shared.go`) and `parseInitScope` (`cmd/secret/init.go`) no longer write the resolved stack into viper's override layer with `viper.Set`. A stack chosen at the interactive prompt is now recorded on the command's own `--stack` flag via a small `adoptPromptedStack` helper, which the component completion still sees through viper's flag binding.
- New regression tests in `cmd/secret/stack_override_test.go`: the exact failing sequence (`import --stack prod`, then `set --stack dev` must load with `dev`), the prompted-stack propagation through the flag binding, and the empty-choice no-op.
- Fix record: `docs/fixes/2026-09-07-secret-stack-viper-override-leak.md`.

## why

- `[race] non-acceptance test suite` failed on a `main` push (run 34179504147) and on #3069 (run 34181209571), each time in one of the two global-scope `secret set` tests with `no global declaration was found in the stack`. Replaying the CI shuffle seeds locally reproduces it deterministically; unshuffled runs pass.
- Root cause: a viper override outranks every later flag parse for the life of the process. After any `secret` command ran with `--stack prod`, the next command's `--stack dev` resolved to `prod`, its stack filter matched nothing, and the lookup failed. Bisected to `TestRunSecretImport_FromStoreMode` → global-scope set; a probe showed the pflag reset to `""` while `viper.GetString("stack")` stayed `"prod"` even after `SetDefault`, i.e. the override layer.
- The override only existed to make a prompted stack visible to the component prompt's completion. Setting the flag gives the same visibility, is reset with every other flag, and removes a real in-process footgun for anything that runs more than one `secret` command per process.

## references

- Failing jobs: https://github.com/cloudposse/atmos/actions/runs/34179504147/job/101915514726 (main), https://github.com/cloudposse/atmos/actions/runs/34181209571/job/101920782810 (#3069)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where interactively selected secret stacks could carry over to subsequent commands.
  - Secret commands now preserve required-flag errors when no stack is selected.
  - Empty interactive stack selections no longer modify command state or secrets.
  - Improved error messages when stack flag handling fails.

- **Tests**
  - Added coverage for repeated commands, interactive stack selection, missing flags, and non-interactive initialization.

- **Documentation**
  - Documented the secret stack selection and command-isolation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->