### PR TITLE
fix(ci): restore-only Go caches with a real warmup writer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,6 @@
       "Bash(git commit -c commit.gpgsign=false:*)",
       "Bash(golangci-lint:*)",
       "Bash(gh pr merge:*)",
-      "Bash(gh workflow:*)",
       "Bash(gh secret:*)",
       "Bash(gh api repos/cloudposse/atmos/pulls/* -X PATCH*)",
       "Bash(gh api repos/cloudposse/atmos/pulls/* -X POST*)",

--- a/.github/actions/setup-atmos-build/action.yml
+++ b/.github/actions/setup-atmos-build/action.yml
@@ -9,10 +9,13 @@ inputs:
 runs:
   using: composite
   steps:
+    # The repo composite (restore-only Go cache, warmed from main by
+    # setup-go-cache-warmup.yml) rather than raw setup-go: building atmos
+    # from source below is exactly the compile the warm cache covers, and
+    # this previously pinned setup-go v6 while the rest of the repo pins
+    # v5.6.0, silently forking the cache lineage.
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-      with:
-        go-version-file: "go.mod"
+      uses: ./.github/actions/setup-go-cache
 
     - name: Set up Atmos bootstrap
       uses: ./.github/actions/setup-atmos-bootstrap

--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -1,8 +1,8 @@
 name: Set up Go with its caches on the fast disk
 description: >-
-  actions/setup-go with caching, plus two Windows-specific fixes applied first: Git's GNU tar goes
-  first on PATH for @actions/cache (see windows-gnu-tar), and Go's build and module caches are
-  relocated onto the runner's work disk. On GitHub's windows-latest runners
+  actions/setup-go plus this repo's Go cache strategy, with two Windows-specific fixes applied
+  first: Git's GNU tar goes first on PATH for @actions/cache (see windows-gnu-tar), and Go's build
+  and module caches are relocated onto the runner's work disk. On GitHub's windows-latest runners
   the work disk (D:, where RUNNER_TEMP and the workspace live) is a separate, much faster disk
   than C:, where Go's default cache locations (%LOCALAPPDATA%, %GOPATH%) sit. Measured on our
   ~1.7 GB go-build+mod archive with .github/workflows/cache-perf.yml: restore 276 s -> 94 s, save
@@ -11,24 +11,46 @@ description: >-
   on the slow one too. No-op on Linux/macOS, and on any Windows image where the work disk and
   LOCALAPPDATA share a drive.
 
+  Caching is restore-only here, replacing setup-go's built-in exact-key-immutable cache, which had
+  two structural problems: any go.sum change cold-started every OS with no fallback, and whichever
+  job saved first froze the entry for that go.sum -- when the nightly warmup (which then ran only
+  `go mod download`) won that race, the frozen entry had an empty GOCACHE and every later build
+  compiled from scratch while logging a cache hit. Instead: this action restores the newest
+  matching entry via restore-keys (preferring same-go.sum entries, falling back to any entry for
+  this OS/arch/Go version), and the only writer is setup-go-cache-warmup.yml, which runs real
+  builds on main's scope (nightly, and on go.sum-changing pushes to main) and saves under a
+  run-unique key. PR jobs never save, which also ends the per-PR 1-1.8 GB duplicate archives and
+  the multi-GB saves that landed on throwaway merge-queue refs.
+
+  The key deliberately excludes ImageOS (unlike setup-go's), so the RunsOn ubuntu22 legs and the
+  ubuntu24 GitHub-hosted jobs share one lineage. That is safe for this repo's builds: atmos builds
+  with CGO_ENABLED=0, and for the cgo-enabled race suite a compiler mismatch just misses those
+  entries in GOCACHE (Go hashes the C compiler identity into cgo action IDs), it never reuses them
+  incorrectly.
+
 inputs:
   go-version-file:
     description: Passed through to actions/setup-go.
     required: false
     default: go.mod
   cache:
-    description: Passed through to actions/setup-go (restore and save GOMODCACHE + GOCACHE).
+    description: Whether to restore GOMODCACHE + GOCACHE ("true"/"false").
     required: false
     default: "true"
   cache-dependency-path:
-    description: Passed through to actions/setup-go (files hashed into the cache key; go.sum by default).
+    description: Glob of files hashed into the cache key; **/go.sum by default.
     required: false
-    default: ""
+    default: "**/go.sum"
 
 outputs:
   cache-hit:
-    description: actions/setup-go's cache-hit output.
-    value: ${{ steps.go.outputs.cache-hit }}
+    description: Whether a cache entry was restored (exact or prefix match).
+    value: ${{ steps.restore.outputs.cache-matched-key != '' }}
+  cache-primary-key:
+    description: >-
+      The rendered primary key (OS/arch/Go version/dependency hash, no run suffix). The warmup
+      workflow appends the run id to this to form its save key.
+    value: ${{ steps.restore.outputs.cache-primary-key }}
   go-version:
     description: actions/setup-go's go-version output.
     value: ${{ steps.go.outputs.go-version }}
@@ -36,17 +58,14 @@ outputs:
 runs:
   using: composite
   steps:
-    # Both of setup-go's cache archives (restore and post-step save) go
+    # The cache archives (restore here, save in the warmup workflow) go
     # through @actions/cache, which picks its tar at that point.
     - name: Use GNU tar for cache archives (Windows)
       uses: ./.github/actions/windows-gnu-tar
 
-    # Must run before setup-go: it reads `go env GOCACHE`/`GOMODCACHE` to
-    # decide both what to restore and what its post step saves, and the
-    # cache *version* hashes those paths - so this also means a fresh cache
-    # entry the first time it runs (a one-time cold start). GITHUB_ENV
-    # written here applies to every later step of the job, post steps
-    # included, so `go build`/`go test` in the job use the same caches.
+    # Must run before the restore step: GITHUB_ENV written here applies to
+    # every later step of the job, so `go build`/`go test` in the job use the
+    # same caches the restore populated.
     - name: Put Go's caches and temp dirs on the runner's work disk (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
@@ -54,11 +73,12 @@ runs:
         $work  = Split-Path -Qualifier $env:RUNNER_TEMP
         $local = Split-Path -Qualifier $env:LOCALAPPDATA
         if ($work -eq $local) {
-          Write-Host "Go caches already on the work disk ($work); keeping Go's defaults"
-          exit 0
+          Write-Host "Work disk and LOCALAPPDATA share a drive ($work); keeping default drive"
+          $root = Join-Path $env:LOCALAPPDATA 'go-caches'
+        } else {
+          $root = Join-Path $env:RUNNER_TEMP 'go'
+          Write-Host "Relocating Go caches from $local to $root ($work is the runner's work disk)"
         }
-        $root = Join-Path $env:RUNNER_TEMP 'go'
-        Write-Host "Relocating Go caches from $local to $root ($work is the runner's work disk)"
         Add-Content $env:GITHUB_ENV "GOCACHE=$root\build"
         Add-Content $env:GITHUB_ENV "GOMODCACHE=$root\pkg\mod"
         # Scratch space too: Go's build temp (GOTMPDIR) and the process temp
@@ -76,17 +96,42 @@ runs:
         Add-Content $env:GITHUB_ENV "TEMP=$tmp"
         Add-Content $env:GITHUB_ENV "TMP=$tmp"
 
+    # Deterministic cache locations on Linux/macOS, so the restore step, the
+    # warmup's save step, and every runner image agree on the paths (macOS
+    # would otherwise default GOCACHE to ~/Library/Caches/go-build).
+    - name: Pin Go's cache locations (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo "GOCACHE=$HOME/.cache/go-build" >> "$GITHUB_ENV"
+        echo "GOMODCACHE=$HOME/go/pkg/mod" >> "$GITHUB_ENV"
+
     - name: Set up Go
       id: go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version-file: ${{ inputs.go-version-file }}
-        # GitHub Actions cache scoping already isolates this: a pull_request
-        # run gets read/write access only to its own branch's cache scope,
-        # gets read-only access to the default branch's cache, and cannot
-        # restore caches from sibling PRs or write into the default branch's
-        # scope at all (only push/workflow_dispatch/schedule etc. can). So
-        # there's no cross-PR or PR->main poisoning path here to guard
-        # against by disabling this.
-        cache: ${{ inputs.cache }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        # Caching is handled by the restore step below (see the description).
+        cache: false
+
+    # GitHub Actions cache scoping isolates this: a pull_request run gets
+    # read-only access to the default branch's cache scope, cannot restore
+    # caches from sibling PRs, and cannot write into the default branch's
+    # scope (only push/workflow_dispatch/schedule can). Since nothing here
+    # ever saves, there is no cross-PR or PR->main poisoning path at all.
+    #
+    # The primary key never exists as saved (the warmup appends its run id),
+    # so restore-keys do the real work: newest same-go.sum entry first, then
+    # the newest entry for this OS/arch/Go version.
+    - name: Restore the Go build and module caches
+      id: restore
+      if: inputs.cache == 'true'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ env.GOCACHE }}
+          ${{ env.GOMODCACHE }}
+        key: go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles(inputs.cache-dependency-path) }}-
+          go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -314,10 +314,25 @@ jobs:
       - name: Download modules
         uses: ./.github/actions/go-mod-download-retry
 
+      # The custom-gcl binary is a full golangci-lint build with the
+      # lintroller plugin compiled in — several minutes of compile on every
+      # run without this cache (the mage target's mtime-based staleness check
+      # can never pass on a fresh checkout). Key on everything that goes into
+      # the binary: its build manifest, the plugin source, the module graph,
+      # and the Go version that compiles it.
+      - name: Cache the custom golangci-lint binary
+        id: custom-gcl-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ./custom-gcl
+          key: custom-gcl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.custom-gcl.yml', 'tools/lintroller/**', 'go.mod', 'go.sum') }}
+
       # Install the golangci-lint v2 CLI tool (not the linters themselves).
       # This tool is needed to run `golangci-lint custom` which builds a custom binary
       # that includes both standard linters AND our custom module plugins.
+      # Skipped on a cache hit: it exists only to build custom-gcl.
       - name: Install golangci-lint v2 for custom build
+        if: steps.custom-gcl-cache.outputs.cache-hit != 'true'
         run: |
           # Pin to commit that fixes "-c advice.detachedHead=false" bug (PR #6206)
           # https://github.com/golangci/golangci-lint/pull/6206
@@ -325,6 +340,7 @@ jobs:
 
       # Build a custom golangci-lint binary with our lintroller plugin compiled in.
       - name: Build custom golangci-lint with lintroller plugin
+        if: steps.custom-gcl-cache.outputs.cache-hit != 'true'
         run: |
           set -e
 
@@ -334,11 +350,15 @@ jobs:
           # Build custom golangci-lint with plugins (staleness-guarded; see magefiles/)
           go tool mage lint:customGCL
 
-          # Verify the custom binary was created
+      - name: Put the custom golangci-lint on PATH
+        run: |
+          set -e
+
+          # Verify the custom binary exists (built above, or cache-restored)
           test -x ./custom-gcl || { echo "Error: custom-gcl not found or not executable"; exit 1; }
 
-          # Replace system binary with our custom one
-          mv ~/go/bin/golangci-lint ~/go/bin/golangci-lint.system
+          # Make our custom build the `golangci-lint` the action below invokes
+          mkdir -p ~/go/bin
           cp ./custom-gcl ~/go/bin/golangci-lint
           chmod +x ~/go/bin/golangci-lint
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
+          # This job runs no Go builds; setup-go's default cache would restore
+          # ~1 GB it never reads and save a thin archive at job end.
+          cache: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -29,6 +29,10 @@ on:
     branches:
       - main
     paths:
+      # Tool pins and the root ci.cache config shape what the toolchain
+      # install puts in the cache; re-warm when either changes.
+      - ".tool-versions"
+      - "atmos.yaml"
       - "tests/fixtures/scenarios/native-ci-e2e/**"
       - ".github/workflows/native-ci.yml"
       - "actions/cache/**"

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -21,6 +21,17 @@ on:
       - "internal/exec/workflow_utils.go"
       - "pkg/runner/step/**"
       - "pkg/workflow/**"
+  # Push runs exist only to write this workflow's cache (the provider mirror
+  # + toolchain, ~700 MB) on main's scope, which pull_request runs can read
+  # but never write. Without this the key only ever existed on per-PR refs,
+  # so every PR re-mirrored from the network and re-saved its own copy.
+  push:
+    branches:
+      - main
+    paths:
+      - "tests/fixtures/scenarios/native-ci-e2e/**"
+      - ".github/workflows/native-ci.yml"
+      - "actions/cache/**"
   workflow_dispatch:
 
 # Least-privilege default; the terraform-plan/terraform-apply jobs below
@@ -44,6 +55,9 @@ env:
 jobs:
   workflow-groups:
     name: "[native ci] workflow groups (${{ matrix.group_mode }})"
+    # Push runs only warm the cache (see the warm-cache job); the E2E jobs
+    # exercise PR-oriented native-CI reporting and stay off the push path.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # This job never sets GITHUB_TOKEN/ATMOS_CI_GITHUB_TOKEN and only formats
@@ -108,6 +122,7 @@ jobs:
 
   terraform-plan:
     name: "[native ci] terraform plan"
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Atmos's native-CI GitHub reporting (pkg/ci/providers/github) posts commit
@@ -163,8 +178,13 @@ jobs:
         with:
           atmos-bootstrap-version: ${{ env.ATMOS_BOOTSTRAP_VERSION }}
 
+      # restore-only: pull_request runs would otherwise each save their own
+      # ~700 MB copy on a per-PR ref no other run can read. The warm-cache
+      # job below is this key's single writer, on main's scope.
       - name: Restore Atmos native CI cache
         uses: ./actions/cache
+        with:
+          mode: restore-only
         env:
           ATMOS_CHDIR: ${{ env.ATMOS_NATIVE_CI_WORKDIR }}
 
@@ -241,8 +261,13 @@ jobs:
         with:
           atmos-bootstrap-version: ${{ env.ATMOS_BOOTSTRAP_VERSION }}
 
+      # restore-only: pull_request runs would otherwise each save their own
+      # ~700 MB copy on a per-PR ref no other run can read. The warm-cache
+      # job below is this key's single writer, on main's scope.
       - name: Restore Atmos native CI cache
         uses: ./actions/cache
+        with:
+          mode: restore-only
         env:
           ATMOS_CHDIR: ${{ env.ATMOS_NATIVE_CI_WORKDIR }}
 
@@ -265,3 +290,70 @@ jobs:
           ATMOS_CI_GITHUB_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: atmos terraform apply bucket -s test -auto-approve
+
+  # The single writer of this workflow's cache key. Runs only on push to main
+  # (whose cache scope every pull_request run can read) and repeats just the
+  # cache-populating steps — toolchain install + provider mirror — without the
+  # PR-oriented plan/apply reporting above.
+  warm-cache:
+    name: "[native ci] warm cache (main)"
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            release-assets.githubusercontent.com:443
+            us.i.posthog.com:443
+            checkpoint-api.hashicorp.com:443
+            registry.terraform.io:443
+            releases.hashicorp.com:443
+            pypi.org:443
+            mirror.gcr.io:443
+            check.trivy.dev:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            google.golang.org:443
+            modernc.org:443
+            raw.githubusercontent.com:443
+            tuf-repo-cdn.sigstore.dev:443
+            rekor.sigstore.dev:443
+
+      - name: Check out code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up and build Atmos
+        uses: ./.github/actions/setup-atmos-build
+        with:
+          atmos-bootstrap-version: ${{ env.ATMOS_BOOTSTRAP_VERSION }}
+
+      - name: Restore and save the Atmos native CI cache
+        uses: ./actions/cache
+        with:
+          mode: restore-and-save
+        env:
+          ATMOS_CHDIR: ${{ env.ATMOS_NATIVE_CI_WORKDIR }}
+
+      - name: Validate native CI fixture
+        working-directory: ${{ env.ATMOS_NATIVE_CI_WORKDIR }}
+        run: atmos validate stacks
+
+      # Populates the cache content the plan/apply jobs restore: the provider
+      # mirror plus the toolchain installs it triggers.
+      - name: Mirror Terraform providers
+        working-directory: ${{ env.ATMOS_NATIVE_CI_WORKDIR }}
+        env:
+          # TFLint release-attestation verification invokes `gh`, which reads
+          # GH_TOKEN (not GITHUB_TOKEN) while installing tool dependencies.
+          GH_TOKEN: ${{ github.token }}
+        run: atmos terraform cache mirror bucket -s test --platform=linux_amd64 --format=json

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -1,4 +1,10 @@
 name: Setup Go Cache Warmup
+# The only writer of the go-cache-* Actions cache entries that
+# .github/actions/setup-go-cache restores everywhere (see that action's
+# description for the full design). Runs on main's cache scope only
+# (schedule / push-to-main / manual dispatch), performs the same compiles the
+# real jobs do so the saved GOCACHE is genuinely warm, and saves under a
+# run-unique key that the composite's restore-keys prefix-match by recency.
 on:
   workflow_dispatch:
   schedule:
@@ -8,6 +14,18 @@ on:
   # • Central Time (CT): 6:35 PM (previous day)
   # • Eastern Time (ET): 7:35 PM (previous day)
     - cron: "35 0 * * *"
+  # Re-warm immediately when a merge changes the module graph (dependency
+  # bumps): without this, every PR running between the merge and the nightly
+  # warmup restores a stale-graph cache and recompiles the delta.
+  push:
+    branches:
+      - main
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "tools/**/go.sum"
+      - ".github/workflows/setup-go-cache-warmup.yml"
+      - ".github/actions/setup-go-cache/**"
 
 permissions:
   contents: read
@@ -22,19 +40,28 @@ env:
 jobs:
   cache-warmup:
     name: Cache warmup (${{ matrix.target }})
-    timeout-minutes: 15
+    # Real compiles now (see the build steps below), not just a module
+    # download: a genuinely cold day (Go version bump) rebuilds everything.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
+          # The hosted ubuntu image (not RunsOn) so the saved key's
+          # Linux-X64 lineage is the one the 10 hosted acceptance shards,
+          # coverage, floci, kubernetes-e2e etc. restore. The RunsOn legs
+          # (build linux, race) share the same lineage on purpose: the
+          # composite's key excludes ImageOS (see its description).
+          - os: ubuntu-latest
+            target: linux
           - os: windows-latest
             target: windows
           - os: macos-latest
             target: macos
-          # Build (macos-intel) uses this Intel runner and has no self-hosted
-          # s3-cache like Linux, so without a nightly warmup here its Go build
-          # cache is always cold — risking the 30m build timeout that a warm
-          # ARM `macos` cache comfortably avoids.
+          # Build (macos-intel) uses this Intel runner and has no other warm
+          # source, so without a nightly warmup here its Go build cache is
+          # always cold — risking the 30m build timeout that a warm ARM
+          # `macos` cache comfortably avoids.
           - os: macos-15-intel
             target: macos-intel
     runs-on: ${{ matrix.os }}
@@ -46,7 +73,8 @@ jobs:
           # Operating-system background services on the hosted Windows and
           # macOS images are listed after the job-specific endpoints; see the
           # `test` job's allowed-endpoints comment in test.yml for the
-          # rationale and keep the two lists in sync.
+          # rationale and keep the two lists in sync. The Ubuntu apt mirrors
+          # are for the linux leg's libudev-dev install (race-namespace warm).
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -56,6 +84,12 @@ jobs:
             storage.googleapis.com:443
             google.golang.org:443
             modernc.org:443
+            azure.archive.ubuntu.com:80
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
             www.msftconnecttest.com:443
             ipv6.msftconnecttest.com:443
             www.msftncsi.com:443
@@ -94,6 +128,9 @@ jobs:
         if: matrix.target == 'windows'
         uses: ./.github/actions/windows-dns-guard
 
+      # Restores yesterday's entry (making today's compiles incremental) and
+      # pins GOCACHE/GOMODCACHE so the save step below archives the same
+      # paths the restore populated.
       - name: Set up Go
         uses: ./.github/actions/setup-go-cache
         id: go
@@ -105,4 +142,53 @@ jobs:
           install-wrapper: false
 
       - name: Get deps
-        run: go mod download
+        uses: ./.github/actions/go-mod-download-retry
+
+      # Warm the same cache namespaces the real jobs compile in. Flags must
+      # match the real invocations or Go's action IDs differ and the warm
+      # entries go unused: atmos builds with CGO_ENABLED=0 + GOFIPS140=latest
+      # (see .goreleaser.yml, magefiles/build.go, docs/prd/fips-140-mode.md).
+      - name: Warm the build cache (go build ./...)
+        env:
+          CGO_ENABLED: "0"
+          GOFIPS140: latest
+        run: go build ./...
+
+      # The same precompile the Build job runs, so the large test binaries'
+      # compilation (coverage-instrumented on their own action-ID namespace)
+      # is warm too. macos-intel skips it exactly like the Build job does
+      # (its only consumer, the k3s macOS job, runs no acceptance shards).
+      - name: Warm the acceptance test binaries
+        if: matrix.target != 'macos-intel'
+        run: go tool mage acceptance:precompile "${{ matrix.target }}"
+
+      # The race job compiles ~400 packages with -race and CGO_ENABLED=1
+      # (its checks need cgo; see the race job in test.yml), a third distinct
+      # cache namespace, and is the slowest single job in the Tests workflow.
+      # Warm it on the linux leg only — that is the only OS the race job runs
+      # on. libudev-dev mirrors the race job's own build-deps step.
+      - name: Install Linux build dependencies (libudev-dev for the race-namespace warm)
+        if: matrix.target == 'linux'
+        run: |
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends libudev-dev pkg-config
+
+      - name: Warm the race-instrumented build cache
+        if: matrix.target == 'linux'
+        env:
+          CGO_ENABLED: "1"
+          GOFIPS140: latest
+        run: go build -race ./...
+
+      # The one and only save of the go-cache-* lineage. The run id makes the
+      # key unique so every warmup lands a fresh entry (GitHub cache keys are
+      # immutable); consumers pick the newest via restore-keys. Old entries
+      # age out through GitHub's 7-day-unused eviction.
+      - name: Save the Go build and module caches
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: ${{ steps.go.outputs.cache-primary-key }}-${{ github.run_id }}

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -183,10 +183,13 @@ jobs:
           # Acquire::EnableSrvRecords=false: apt otherwise resolves
           # _http._tcp.<mirror> SRV records before every fetch, which
           # harden-runner reports as outbound attempts to hosts that are not
-          # (and cannot usefully be) on the allowlist.
+          # (and cannot usefully be) on the allowlist. It goes in apt.conf.d
+          # rather than on the command line because apt's post-update hooks
+          # (ESM, motd) spawn their own apt runs that would not inherit a -o.
+          echo 'Acquire::EnableSrvRecords "false";' | sudo tee /etc/apt/apt.conf.d/99-atmos-no-srv >/dev/null
           sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get -o Acquire::EnableSrvRecords=false -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
-          sudo apt-get -o Acquire::EnableSrvRecords=false -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends libudev-dev pkg-config
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends libudev-dev pkg-config
 
       - name: Warm the race-instrumented build cache
         if: matrix.target == 'linux'

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -73,8 +73,14 @@ jobs:
           # Operating-system background services on the hosted Windows and
           # macOS images are listed after the job-specific endpoints; see the
           # `test` job's allowed-endpoints comment in test.yml for the
-          # rationale and keep the two lists in sync. The Ubuntu apt mirrors
-          # are for the linux leg's libudev-dev install (race-namespace warm).
+          # rationale and keep the two lists in sync. The apt hosts are for
+          # the linux leg's libudev-dev install (race-namespace warm):
+          # `apt-get update` refreshes every source the hosted image ships,
+          # including its Microsoft and Google Chrome repos, not just Ubuntu's
+          # (StepSecurity flagged both on the first run). The Windows Delivery
+          # Optimization (*.prod.do.dsp.mp.microsoft.com) and Windows Update
+          # download hosts were flagged on the same run and belong with the
+          # other Windows background services.
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -90,6 +96,10 @@ jobs:
             esm.ubuntu.com:443
             motd.ubuntu.com:443
             packages.microsoft.com:443
+            dl.google.com:443
+            *.prod.do.dsp.mp.microsoft.com:443
+            au.download.windowsupdate.com:80
+            au.download.windowsupdate.com:443
             www.msftconnecttest.com:443
             ipv6.msftconnecttest.com:443
             www.msftncsi.com:443
@@ -170,9 +180,13 @@ jobs:
       - name: Install Linux build dependencies (libudev-dev for the race-namespace warm)
         if: matrix.target == 'linux'
         run: |
+          # Acquire::EnableSrvRecords=false: apt otherwise resolves
+          # _http._tcp.<mirror> SRV records before every fetch, which
+          # harden-runner reports as outbound attempts to hosts that are not
+          # (and cannot usefully be) on the allowlist.
           sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends libudev-dev pkg-config
+          sudo apt-get -o Acquire::EnableSrvRecords=false -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
+          sudo apt-get -o Acquire::EnableSrvRecords=false -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends libudev-dev pkg-config
 
       - name: Warm the race-instrumented build cache
         if: matrix.target == 'linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,25 +79,25 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     # windows-latest is the slowest target: it compiles this large dependency
-    # tree far slower than the Linux (self-hosted, s3-cache) and macOS runners,
-    # and on top of that the post-job Go cache save (tar + zstd of
-    # GOMODCACHE/GOCACHE) takes several minutes. A cold cache after dependency
-    # changes plus that save pushes the job past a tight limit and the run gets
-    # cancelled mid-save (see #2713's windows build being killed at 30m10s).
-    # Give the slowest target real headroom for build + cache save.
-    #
-    # 45 minutes still wasn't enough after a large merge from main cold-started
-    # the cache: every real step (build, tests, upload) finished by 12:01, but
-    # the "Post Set up Go" cache-save step alone ran another 23+ minutes before
-    # the job timeout cancelled it mid-save (run 33387953802, job 99474734663,
-    # 2026-08-31). Raised further to keep genuine cold-cache saves from
-    # tripping the timeout.
+    # tree far slower than the Linux (self-hosted) and macOS runners. A cold
+    # Go cache after dependency changes used to push the job past a tight
+    # limit and get the run cancelled mid-save (see #2713's windows build
+    # being killed at 30m10s, and run 33387953802 where the post-job cache
+    # save alone ran 23+ minutes). This job no longer saves Go caches at all
+    # (setup-go-cache is restore-only; setup-go-cache-warmup.yml is the sole
+    # writer), but keep headroom for a genuinely cold compile after a Go
+    # version bump.
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: "runs-on=${{github.run_id}}/runner=terraform/tag=atmos/extras=s3-cache/private=false"
+          # No extras=s3-cache: this leg's ci-toolchain save and Go cache
+          # restore must use the same GitHub Actions cache backend as the 10
+          # ubuntu-latest acceptance shards and the other hosted Linux jobs.
+          # With the s3-cache extra, its caches went to RunsOn's S3 where no
+          # hosted job could ever see them.
+          - os: "runs-on=${{github.run_id}}/runner=terraform/tag=atmos/private=false"
             target: linux
           - os: "windows-latest"
             target: windows
@@ -202,8 +202,9 @@ jobs:
         if: matrix.target == 'windows' && ! github.event.pull_request.draft
         uses: ./.github/actions/windows-dns-guard
 
-      # Pinned setup-go with caching, plus Go's caches relocated to the fast
-      # work disk on Windows (see the action for the measurements).
+      # Pinned setup-go with a restore-only Go cache (the warmup workflow is
+      # the sole writer), plus Go's caches relocated to the fast work disk on
+      # Windows (see the action for the measurements and the cache design).
       - name: Set up Go
         if: ${{ ! ( matrix.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: ./.github/actions/setup-go-cache
@@ -683,16 +684,12 @@ jobs:
       # tests assert XDG defaults and Terraform's plugin cache is not safe for
       # shared concurrent use.
       #
-      # Restore-only on the shards. The repo's Actions cache holds 18.9 GB in
-      # 17 entries against a 10 GB LRU quota, every entry scoped to a
-      # refs/pull/N/merge ref and minutes old, so the static key
-      # atmos-toolchain-<os>-<arch>-v2 never hits from main (every shard logs
-      # "Cache not found for input keys"). All 10 shards then raced to save
-      # the same key and logged "Unable to reserve cache with key ..., another
-      # job may be creating this cache", with "Post Cache Atmos toolchain"
-      # costing 43 s avg / 3 min max per shard for nothing. The
-      # terraform-registry-cache job keeps the plain (restore+save) step and is
-      # the single writer of this key per OS.
+      # Restore-only on the shards: ten parallel consumers must not race to
+      # save one key ("Unable to reserve cache with key ...", with "Post
+      # Cache Atmos toolchain" costing 43 s avg / 3 min max per shard for
+      # nothing). The single writer of this key per OS is the build job's
+      # ci-toolchain step (cache: restore-and-save), which runs on the
+      # GitHub cache backend for all targets including linux.
       - name: Set up the CI toolchain
         if: ${{ ! ( matrix.flavor.target == 'windows' && github.event.pull_request.draft  ) }}
         uses: ./.github/actions/ci-toolchain
@@ -869,13 +866,17 @@ jobs:
     # fixed). The RunsOn "terraform" family used elsewhere in this file for
     # Go work (the build job's linux leg) turned out to be an i4i.large: 2
     # cores, 15.7GB RAM -- fewer cores than ubuntu-latest, a downgrade for
-    # this CPU/memory-bound workload. "large" (used by the release job's
-    # goreleaser step) resolves to a 4-core/~32GB instance from that family
-    # (r7a.xlarge or i4i.xlarge, whichever spot capacity RunsOn picks; both
-    # appear in real run logs) -- double the cores and RAM of "terraform", a
-    # real upgrade over ubuntu-latest given -race's extra memory overhead per
-    # test binary.
-    runs-on: "runs-on=${{github.run_id}}/runner=large/tag=atmos/extras=s3-cache/private=false"
+    # this CPU/memory-bound workload. "large" (4 cores/~32GB) was a real
+    # upgrade, but this job stayed the workflow's longest pole at ~27 minutes
+    # of pure test execution, so it now gets "xlarge" (8+ cores/~64GB, per
+    # .github's runs-on.yml): `go test` runs packages concurrently up to
+    # GOMAXPROCS, and -race's per-test memory overhead is what the extra RAM
+    # absorbs.
+    #
+    # No extras=s3-cache: the Go cache restore (setup-go-cache below) must
+    # read the GitHub Actions cache backend, where the warmup workflow saves
+    # a race-instrumented (-race, CGO_ENABLED=1) build cache on main's scope.
+    runs-on: "runs-on=${{github.run_id}}/runner=xlarge/tag=atmos/private=false"
     # Race-instrumented binaries run several times slower and use substantially
     # more memory than normal test binaries; this runs the entire `./...` suite
     # unsharded (unlike the `test` job's acceptance+unit sweep), so budget
@@ -897,16 +898,26 @@ jobs:
         with:
           persist-credentials: false
 
+      # Restores the race-instrumented build cache the warmup workflow saves
+      # (its linux leg runs `go build -race ./...` with this job's env), so
+      # the ~400-package -race compile is mostly incremental.
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version-file: "go.mod"
-          cache: true
+        uses: ./.github/actions/setup-go-cache
 
       - name: Set up Atmos bootstrap
         uses: ./.github/actions/setup-atmos-bootstrap
         with:
           atmos-version: ${{ env.ATMOS_BOOTSTRAP_VERSION }}
+
+      # Restore the toolchain directory before the installs below so they
+      # skip every tool already on disk instead of downloading five tools
+      # from the network on every run (restore-only: the build job's linux
+      # leg is this key's writer).
+      - name: Restore the Atmos toolchain cache
+        continue-on-error: true
+        uses: ./actions/cache
+        with:
+          mode: restore-only
 
       - name: Install Linux build dependencies (libudev-dev for CGO_ENABLED=1 -- see comment above)
         run: |
@@ -1011,9 +1022,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # cache: false on purpose - this job compiles only the mage helper, and a
-      # save from here would put a thin archive under the Linux setup-go key
-      # that every other Linux job shares.
+      # cache: false on purpose - this job compiles only the mage helper; a
+      # restore would download ~1 GB it doesn't need, and setup-go's built-in
+      # save would write a thin archive for nothing.
       - name: Set up Go
         if: ${{ !cancelled() }}
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -1091,11 +1102,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: atmos test coverage download-shards
 
+      # The composite (restore-only) rather than raw setup-go: this thin job
+      # only runs `mage coverage:mergeShards`, and with setup-go's built-in
+      # cache it could win the save race and freeze a near-empty archive
+      # under the shared Linux key (it also pinned setup-go v6 while every
+      # other job pins v5.6.0, silently forking the cache lineage).
       - name: Set up Go for native coverage merge
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: "go.mod"
-          cache: true
+        uses: ./.github/actions/setup-go-cache
 
       - name: Merge native coverage data
         run: go tool mage coverage:mergeShards
@@ -1264,6 +1277,15 @@ jobs:
         with:
           target: linux
 
+      # Restore the toolchain directory first so the installs below skip
+      # tools already on disk (restore-only; the build job's linux leg is
+      # this key's writer).
+      - name: Restore the Atmos toolchain cache
+        continue-on-error: true
+        uses: ./actions/cache
+        with:
+          mode: restore-only
+
       - name: Install Terraform and OpenTofu with Atmos toolchain
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1353,6 +1375,15 @@ jobs:
 
       - name: Set up Go
         uses: ./.github/actions/setup-go-cache
+
+      # Restore the toolchain directory first so the install below skips
+      # tools already on disk (restore-only; the build job's linux leg is
+      # this key's writer).
+      - name: Restore the Atmos toolchain cache
+        continue-on-error: true
+        uses: ./actions/cache
+        with:
+          mode: restore-only
 
       - name: Install OpenTofu with Atmos toolchain
         env:
@@ -1688,7 +1719,10 @@ jobs:
 
       - name: Run Kubernetes end-to-end tests
         env:
-          GOCACHE: ${{ runner.temp }}/go-build
+          # No GOCACHE override here: setup-go-cache above restored the warm
+          # build cache into the default GOCACHE, and a previous
+          # `GOCACHE: runner.temp/go-build` override made the test compile
+          # into an empty directory — nullifying the restore entirely.
           GOTMPDIR: ${{ runner.temp }}/go-tmp
           TMPDIR: ${{ runner.temp }}/tmp
           # Atmos builds with CGO disabled. Match that here so the
@@ -1699,7 +1733,7 @@ jobs:
           # than silently skipping all coverage.
           ATMOS_ENVTEST_REQUIRED: "true"
         run: |
-          mkdir -p "$GOCACHE" "$GOTMPDIR" "$TMPDIR"
+          mkdir -p "$GOTMPDIR" "$TMPDIR"
           go test -tags envtest -count=1 ./pkg/component/kubernetes/... -run TestEnvtest
 
   # run other demo tests
@@ -1934,6 +1968,15 @@ jobs:
         with:
           target: linux
 
+      # Restore the toolchain directory first so the installs below skip
+      # tools already on disk instead of downloading them on every run
+      # (restore-only: the build job's linux leg is this key's writer).
+      - name: Restore the Atmos toolchain cache
+        continue-on-error: true
+        uses: ./actions/cache
+        with:
+          mode: restore-only
+
       - name: Install OpenTofu and TFLint with Atmos toolchain
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1982,6 +2025,15 @@ jobs:
         uses: ./.github/actions/setup-atmos-install
         with:
           target: linux
+
+      # Restore the toolchain directory first so the installs below skip
+      # tools already on disk instead of downloading them on every run
+      # (restore-only: the build job's linux leg is this key's writer).
+      - name: Restore the Atmos toolchain cache
+        continue-on-error: true
+        uses: ./actions/cache
+        with:
+          mode: restore-only
 
       - name: Install OpenTofu and TFLint with Atmos toolchain
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,13 @@ jobs:
           # ubuntu-latest acceptance shards and the other hosted Linux jobs.
           # With the s3-cache extra, its caches went to RunsOn's S3 where no
           # hosted job could ever see them.
-          - os: "runs-on=${{github.run_id}}/runner=terraform/tag=atmos/private=false"
+          #
+          # "large" (4 cores/~32GB), not "terraform": the latter resolves to
+          # a 2-core i4i.large, and this leg is the critical path every
+          # acceptance shard waits on. Measured cold (run 34228937998): the
+          # `atmos build binary` step took 721s on "terraform" against ~350s
+          # on the 4-core hosted macOS/Windows legs compiling the same tree.
+          - os: "runs-on=${{github.run_id}}/runner=large/tag=atmos/private=false"
             target: linux
           - os: "windows-latest"
             target: windows

--- a/.github/workflows/website-deploy-prod.yml
+++ b/.github/workflows/website-deploy-prod.yml
@@ -63,15 +63,21 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version-file: "website/.nvmrc"
-
+      # pnpm before Node: setup-node's pnpm-store cache needs the pnpm binary
+      # on PATH to locate the store. Previously nothing cached the store and
+      # `pnpm install --frozen-lockfile` downloaded the full dependency tree
+      # on every run.
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: "website/.nvmrc"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Set up Go
         # setup-go v6 requires runner v2.327.1+ and can affect toolchain handling.

--- a/.github/workflows/website-preview-build.yml
+++ b/.github/workflows/website-preview-build.yml
@@ -46,15 +46,21 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version-file: "website/.nvmrc"
-
+      # pnpm before Node: setup-node's pnpm-store cache needs the pnpm binary
+      # on PATH to locate the store. Previously nothing cached the store and
+      # `pnpm install --frozen-lockfile` downloaded the full dependency tree
+      # on every run.
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: "website/.nvmrc"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Set up Go
         # setup-go v6 requires runner v2.327.1+ and can affect toolchain handling.

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -304,15 +304,19 @@ docs:
 #
 # The cache is purely an accelerator: the workflow always installs exact pinned
 # versions, so it stays correct no matter what the cache already holds. The
-# trailing version token is a manual cache-bust — bump it to start from a clean
-# cache. restore_keys lets a bumped token still seed from the previous blob.
+# .tool-versions hash rolls the key automatically when tool pins change
+# (GitHub Actions cache entries are immutable, so without it a bump kept
+# serving the stale blob until someone hand-bumped the version token). The
+# version token remains as a manual cache-bust for anything the hash misses.
+# restore_keys let a rolled key still seed from the previous blob.
 ci:
   # Enable native CI summaries and failure annotations for repository validation.
   enabled: true
   cache:
     enabled: true
-    key: 'atmos-toolchain-{{.OS}}-{{.Arch}}-v2'
+    key: 'atmos-toolchain-{{.OS}}-{{.Arch}}-v2-{{ hashFiles ".tool-versions" }}'
     restore_keys:
+      - 'atmos-toolchain-{{.OS}}-{{.Arch}}-v2-'
       - 'atmos-toolchain-{{.OS}}-{{.Arch}}-'
 toolchain:
   registries:

--- a/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
+++ b/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
@@ -1,0 +1,90 @@
+# Fix: CI Go caches were hollow or unreachable; warmup is now the sole writer
+
+**Date:** 2026-09-07
+
+## Summary
+
+The Tests workflow's Go caches worked at the storage layer (writes succeeded, no LRU thrash) but
+were functionally broken in several ways: the nightly warmup saved caches with an empty GOCACHE
+that then froze (setup-go entries are immutable per go.sum hash), any go.sum change cold-started
+every OS (no restore-keys), the Linux build job saved its warm cache to RunsOn's S3 where the 10
+GitHub-hosted Linux shards could never read it, the kubernetes-e2e job nullified its own restored
+cache with a `GOCACHE` override, and native-ci's ~700 MB provider-mirror cache only ever existed
+on per-PR refs. The result was measured live: `go build` took 504 s and the race job 27 minutes
+on every run despite "warm" caches, and each PR re-saved 1-1.8 GB per platform after any
+dependency merge.
+
+## Context
+
+Investigated from the live GitHub cache API (92 entries / ~99 GB active on the repo) plus job/step
+timings from run 34179823625. Root causes, in order of impact:
+
+- `actions/setup-go`'s built-in cache is exact-key-only and immutable per key. Whichever job saved
+  first froze the entry for that go.sum; when `setup-go-cache-warmup.yml` (which ran only
+  `go mod download`) won that race, the frozen entry had a full module cache but an empty build
+  cache, and every later build compiled from scratch while logging a cache hit.
+- The warmup had no Linux leg at all, and no fallback existed for go.sum changes.
+- The Build job's Linux leg ran with `extras=s3-cache` (RunsOn S3 backend), so the warmest cache
+  in the run — and the only writer of the `atmos-toolchain-linux-amd64-v2` key — was invisible to
+  every `ubuntu-latest` job restoring from GitHub's cache backend.
+- `kubernetes-e2e` restored the Go cache and then set `GOCACHE: runner.temp/go-build` on the test
+  step, compiling into an empty directory.
+- `native-ci.yml` ran only on pull_request, so its cache key was saved on per-PR refs that no
+  other PR can read; every PR re-mirrored providers from the network and saved its own copy.
+- Multi-GB setup-go saves also landed on throwaway `gh-readonly-queue/*` merge-queue refs, and
+  no-Go-work jobs (dependency-review) saved thin archives.
+
+## Changes
+
+- `.github/actions/setup-go-cache/action.yml`: replaced setup-go's built-in cache with an explicit
+  `actions/cache/restore` (restore-only) using a custom key
+  (`go-cache-<OS>-<arch>-go<version>-<go.sum hash>`) with restore-keys fallback (same-go.sum
+  prefix first, then any same-OS/arch/Go-version entry). The key excludes ImageOS so RunsOn
+  ubuntu22 legs and ubuntu24 hosted jobs share one lineage. GOCACHE/GOMODCACHE are pinned to
+  deterministic paths on all platforms (the Windows D:-work-disk relocation is unchanged). No job
+  using the composite ever saves.
+- `.github/workflows/setup-go-cache-warmup.yml`: now the sole writer. Added a Linux leg; each leg
+  runs the real compiles (`go build ./...` with CGO_ENABLED=0 + GOFIPS140=latest,
+  `mage acceptance:precompile`, and on Linux `go build -race ./...` with CGO_ENABLED=1 to warm
+  the race job's namespace) and saves under a run-unique key via `actions/cache/save`. Added a
+  `push: main` trigger on go.mod/go.sum changes to close the post-dependency-merge cold window.
+- `.github/workflows/test.yml`: Build linux leg and race job dropped `extras=s3-cache` (unifying
+  on the GitHub cache backend); race job upgraded `runner=large` → `runner=xlarge` and switched
+  to the composite plus a restore-only toolchain cache; coverage job switched from setup-go v6 to
+  the composite; kubernetes-e2e's `GOCACHE` override removed; restore-only Atmos toolchain cache
+  added to the `lint` matrix, `hooks-tflint`, `floci`, `floci-go`, and `race` jobs; stale cache
+  comments rewritten.
+- `.github/workflows/native-ci.yml`: PR cache steps are now restore-only; a new push-to-main
+  `warm-cache` job (validate + provider mirror only, no PR-oriented plan/apply reporting) is the
+  key's single writer on main's scope.
+- `.github/workflows/codeql.yml`: the custom-gcl binary (a full golangci-lint build with the
+  lintroller plugin) is cached keyed on `.custom-gcl.yml`, `tools/lintroller/**`, and the module
+  graph; build steps are skipped on a hit.
+- `.github/workflows/website-preview-build.yml`, `website-deploy-prod.yml`: pnpm setup moved
+  before setup-node and the pnpm store is cached (`cache: pnpm`).
+- `.github/workflows/dependency-review.yml`: `cache: false` (no Go work; the default restored
+  ~1 GB it never read and saved a thin archive).
+- `.github/actions/setup-atmos-build/action.yml`: switched from raw setup-go v6 to the composite.
+- `atmos.yaml`: the `ci.cache` toolchain key now includes `hashFiles ".tool-versions"` so tool-pin
+  bumps roll the key automatically instead of requiring a manual `-v2` → `-v3` bump.
+
+Deliberately not done: relocating atmos's own cache root (the toolchain directory) to the Windows
+work disk. The acceptance shards assert XDG-default paths (see the comment on the shards'
+toolchain step), and the cache's saver and restorers must agree on the root, so the writer can't
+move without moving every consumer.
+
+## Validation
+
+- `python3 -c yaml.safe_load` and `actionlint` pass on every edited workflow/action file.
+- `go build ./...` and `go build -o build/atmos .` succeed; `./build/atmos ci cache paths
+  --format=github` renders the new toolchain key
+  (`atmos-toolchain-darwin-arm64-v2-5f174099f5f046d3`) with both restore-keys.
+- `atmos test` (short suite) run locally.
+- Post-merge verification (requires main's cache scope, cannot be validated from a PR):
+  dispatch `setup-go-cache-warmup.yml` and confirm multi-GB `go-cache-*` entries on
+  `refs/heads/main` via the caches API, then compare Build(linux) `go build` time (expect
+  ~504 s → well under 2 minutes) and race-job duration (expect ~27 m → ~10-15 m) on the next PRs.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
+++ b/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
@@ -75,7 +75,8 @@ move without moving every consumer.
 
 ## Validation
 
-- `python3 -c yaml.safe_load` and `actionlint` pass on every edited workflow/action file.
+- Every edited workflow/action file parses with PyYAML (`python3 -c "import yaml; yaml.safe_load(open(f))"`
+  looped over the files) and `actionlint` passes on every edited workflow.
 - `go build ./...` and `go build -o build/atmos .` succeed; `./build/atmos ci cache paths
   --format=github` renders the new toolchain key
   (`atmos-toolchain-darwin-arm64-v2-5f174099f5f046d3`) with both restore-keys.

--- a/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
+++ b/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
@@ -81,6 +81,14 @@ move without moving every consumer.
   --format=github` renders the new toolchain key
   (`atmos-toolchain-darwin-arm64-v2-5f174099f5f046d3`) with both restore-keys.
 - `atmos test` (short suite) run locally.
+- Dispatching the warmup on the PR branch (`gh workflow run ... --ref <branch>`) proved the
+  workflow end-to-end (all four legs saved 1.7-2.5 GB entries) but does NOT warm that PR's own
+  runs: a `pull_request` run reads only its merge ref and the base branch's scope, never the head
+  branch's, so the PR's Tests run still logged "Cache not found" on every platform. The design is
+  unaffected (main's scope is readable by every PR); it just cannot be measured pre-merge.
+- The same cold run also showed the Build linux leg's compile at 721 s on the 2-core RunsOn
+  `terraform` runner versus ~350 s on the 4-core hosted legs; that leg is the critical path every
+  acceptance shard waits on, so it now runs on `large` (4 cores).
 - Post-merge verification (requires main's cache scope, cannot be validated from a PR):
   dispatch `setup-go-cache-warmup.yml` and confirm multi-GB `go-cache-*` entries on
   `refs/heads/main` via the caches API, then compare Build(linux) `go build` time (expect

--- a/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
+++ b/docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md
@@ -68,6 +68,13 @@ timings from run 34179823625. Root causes, in order of impact:
 - `atmos.yaml`: the `ci.cache` toolchain key now includes `hashFiles ".tool-versions"` so tool-pin
   bumps roll the key automatically instead of requiring a manual `-v2` → `-v3` bump.
 
+- `internal/ci/rerun/fetch.go`, `internal/ci/acceptance/shards.go`: the per-OS "Acceptance Tests
+  (<os>)" aggregate check failed a run whose shards had all passed because one jobs-API request
+  answered HTTP 502 (observed on the rerun of run 34234932427). `rerun.IsTransient` classifies 5xx
+  and transport errors, and `CheckShardResults` now treats a transient listing failure like an
+  unsettled poll (report, wait, retry) instead of failing the attempt; 4xx and cancelled contexts
+  still fail at once, and a transient error on the final poll fails with `errShardListingFails`.
+
 Deliberately not done: relocating atmos's own cache root (the toolchain directory) to the Windows
 work disk. The acceptance shards assert XDG-default paths (see the comment on the shards'
 toolchain step), and the cache's saver and restorers must agree on the root, so the writer can't

--- a/internal/ci/acceptance/shards.go
+++ b/internal/ci/acceptance/shards.go
@@ -24,11 +24,12 @@ const (
 )
 
 var (
-	errShardsNotSettled = errors.New("acceptance: shard results never settled")
-	errShardCount       = errors.New("acceptance: unexpected number of shard jobs")
-	errShardsFailed     = errors.New("acceptance: shard jobs did not succeed")
-	errInvalidCheckName = errors.New("acceptance: check name is not of the form \"Acceptance Tests (<target>)\"")
-	errShardCountValue  = errors.New("acceptance: shard count must be a positive integer")
+	errShardsNotSettled  = errors.New("acceptance: shard results never settled")
+	errShardListingFails = errors.New("acceptance: listing shard jobs kept failing")
+	errShardCount        = errors.New("acceptance: unexpected number of shard jobs")
+	errShardsFailed      = errors.New("acceptance: shard jobs did not succeed")
+	errInvalidCheckName  = errors.New("acceptance: check name is not of the form \"Acceptance Tests (<target>)\"")
+	errShardCountValue   = errors.New("acceptance: shard count must be a positive integer")
 )
 
 // TargetFromCheckName derives the OS target ("linux") from the legacy
@@ -83,6 +84,12 @@ type ShardResult struct {
 // printed; a shard count other than ShardCount fails at once, since every
 // job of an attempt exists from the start and a mismatch means the workflow
 // changed shape.
+//
+// A listing that fails transiently (a 5xx from the jobs API, or a transport
+// error - see rerun.IsTransient) is treated like an unsettled one: it spends a
+// poll and is retried, so a single HTTP 502 does not fail a required check
+// whose shards all passed. A definitive error (4xx, cancelled context) or a
+// transient one on the final poll fails at once.
 func CheckShardResults(ctx context.Context, client rerun.RESTClient, w io.Writer, p *ShardResultsParams) error {
 	defer perf.Track(nil, "acceptance.CheckShardResults")()
 
@@ -95,7 +102,13 @@ func CheckShardResults(ctx context.Context, client rerun.RESTClient, w io.Writer
 	for attempt := 1; attempt <= polls; attempt++ {
 		jobs, err := rerun.FetchJobs(ctx, client, p.Run.Repo, p.Run.RunID, p.Run.RunAttempt)
 		if err != nil {
-			return err
+			if failure := listingFailure(w, p.Target, err, pollStep{attempt, polls, interval}); failure != nil {
+				return failure
+			}
+			if err := waitForNextPoll(ctx, wait, interval); err != nil {
+				return err
+			}
+			continue
 		}
 		shards = shardResults(jobs, p.Target)
 		if len(shards) != p.ShardCount {
@@ -110,8 +123,8 @@ func CheckShardResults(ctx context.Context, client rerun.RESTClient, w io.Writer
 		fmt.Fprintf(w, "poll %d/%d: %d of %d %q shard jobs have no conclusion yet; retrying in %s\n",
 			attempt, polls, unsettled, len(shards), p.Target, interval)
 		if attempt < polls {
-			if err := wait(ctx, interval); err != nil {
-				return fmt.Errorf("acceptance: waiting for shard results: %w", err)
+			if err := waitForNextPoll(ctx, wait, interval); err != nil {
+				return err
 			}
 		}
 	}
@@ -119,6 +132,37 @@ func CheckShardResults(ctx context.Context, client rerun.RESTClient, w io.Writer
 	fmt.Fprintf(w, "%q shard results never settled after %d polls; last listing:\n", p.Target, polls)
 	writeShardListing(w, shards)
 	return fmt.Errorf("%w: %q after %d polls", errShardsNotSettled, p.Target, polls)
+}
+
+// pollStep is where the poll loop is: which attempt of how many, and the
+// wait before the next one.
+type pollStep struct {
+	attempt  int
+	polls    int
+	interval time.Duration
+}
+
+// listingFailure decides what a failed jobs listing at step means: a
+// definitive error is returned as-is, a transient one on the final poll is
+// wrapped in errShardListingFails, and any other transient one is reported to
+// w and returns nil so the caller waits and polls again.
+func listingFailure(w io.Writer, target string, err error, step pollStep) error {
+	if !rerun.IsTransient(err) {
+		return err
+	}
+	if step.attempt == step.polls {
+		return fmt.Errorf("%w: %w", errShardListingFails, err)
+	}
+	fmt.Fprintf(w, "poll %d/%d: listing %q shard jobs failed (%v); retrying in %s\n",
+		step.attempt, step.polls, target, err, step.interval)
+	return nil
+}
+
+func waitForNextPoll(ctx context.Context, wait func(context.Context, time.Duration) error, interval time.Duration) error {
+	if err := wait(ctx, interval); err != nil {
+		return fmt.Errorf("acceptance: waiting for shard results: %w", err)
+	}
+	return nil
 }
 
 // polling returns the poll count, interval and wait function with defaults

--- a/internal/ci/acceptance/shards_test.go
+++ b/internal/ci/acceptance/shards_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -178,14 +179,47 @@ func TestCheckShardResults_ShardCountMismatchFailsAtOnce(t *testing.T) {
 }
 
 func TestCheckShardResults_Errors(t *testing.T) {
-	t.Run("fetch error propagates", func(t *testing.T) {
+	t.Run("definitive fetch error propagates at once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		client := rerun.NewMockRESTClient(ctrl)
-		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, assert.AnError)
+		notFound := &api.HTTPError{StatusCode: http.StatusNotFound, Message: "Not Found"}
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, notFound)
 
-		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 5, (&recordingWait{}).wait))
+		rw := &recordingWait{}
+		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 5, rw.wait))
 		require.Error(t, err)
+		assert.ErrorIs(t, err, notFound)
+		assert.Empty(t, rw.waits, "a 4xx is not something waiting fixes")
+	})
+	t.Run("transient fetch error is retried on the next poll", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := rerun.NewMockRESTClient(ctrl)
+		badGateway := &api.HTTPError{StatusCode: http.StatusBadGateway, Message: "Server Error"}
+		gomock.InOrder(
+			client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, badGateway),
+			client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+				Return(jobsPage(t, shard("linux", 1, "success"), shard("linux", 2, "success"), shard("linux", 3, "success")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
+		)
+
+		rw := &recordingWait{}
+		var out bytes.Buffer
+		err := CheckShardResults(context.Background(), client, &out, params("linux", 5, rw.wait))
+		require.NoError(t, err)
+		assert.Len(t, rw.waits, 1, "one poll spent on the 502")
+		assert.Contains(t, out.String(), `poll 1/5: listing "linux" shard jobs failed (`)
+		assert.Contains(t, out.String(), "HTTP 502")
+	})
+	t.Run("transient fetch error that never clears fails after the last poll", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := rerun.NewMockRESTClient(ctrl)
+		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Times(3).Return(nil, assert.AnError)
+
+		rw := &recordingWait{}
+		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 3, rw.wait))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errShardListingFails)
 		assert.ErrorIs(t, err, assert.AnError)
+		assert.Len(t, rw.waits, 2, "no wait after the final poll")
 	})
 	t.Run("invalid shard count", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/internal/ci/acceptance/shards_test.go
+++ b/internal/ci/acceptance/shards_test.go
@@ -178,49 +178,79 @@ func TestCheckShardResults_ShardCountMismatchFailsAtOnce(t *testing.T) {
 	assert.Contains(t, out.String(), `expected 3 "linux" shard jobs, found 2`)
 }
 
+// TestCheckShardResults_FetchErrors covers what a failed jobs listing means:
+// definitive errors fail at once, transient ones spend a poll and are retried,
+// and a transient one that never clears fails after the last poll.
+func TestCheckShardResults_FetchErrors(t *testing.T) {
+	notFound := &api.HTTPError{StatusCode: http.StatusNotFound, Message: "Not Found"}
+	badGateway := &api.HTTPError{StatusCode: http.StatusBadGateway, Message: "Server Error"}
+
+	tests := []struct {
+		name       string
+		polls      int
+		expect     func(t *testing.T, client *rerun.MockRESTClient)
+		wantErrs   []error // Each must satisfy errors.Is; empty means success.
+		wantWaits  int
+		wantOutput []string
+	}{
+		{
+			name:  "definitive fetch error propagates at once",
+			polls: 5,
+			expect: func(_ *testing.T, client *rerun.MockRESTClient) {
+				client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, notFound)
+			},
+			wantErrs:  []error{notFound},
+			wantWaits: 0, // A 4xx is not something waiting fixes.
+		},
+		{
+			name:  "transient fetch error is retried on the next poll",
+			polls: 5,
+			expect: func(t *testing.T, client *rerun.MockRESTClient) {
+				t.Helper()
+				gomock.InOrder(
+					client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, badGateway),
+					client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
+						Return(jobsPage(t, shard("linux", 1, "success"), shard("linux", 2, "success"), shard("linux", 3, "success")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
+				)
+			},
+			wantWaits:  1, // One poll spent on the 502.
+			wantOutput: []string{`poll 1/5: listing "linux" shard jobs failed (`, "HTTP 502"},
+		},
+		{
+			name:  "transient fetch error that never clears fails after the last poll",
+			polls: 3,
+			expect: func(_ *testing.T, client *rerun.MockRESTClient) {
+				client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Times(3).Return(nil, assert.AnError)
+			},
+			wantErrs:  []error{errShardListingFails, assert.AnError},
+			wantWaits: 2, // No wait after the final poll.
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := rerun.NewMockRESTClient(ctrl)
+			tt.expect(t, client)
+
+			rw := &recordingWait{}
+			var out bytes.Buffer
+			err := CheckShardResults(context.Background(), client, &out, params("linux", tt.polls, rw.wait))
+
+			if len(tt.wantErrs) == 0 {
+				require.NoError(t, err)
+			}
+			for _, want := range tt.wantErrs {
+				assert.ErrorIs(t, err, want)
+			}
+			assert.Len(t, rw.waits, tt.wantWaits)
+			for _, want := range tt.wantOutput {
+				assert.Contains(t, out.String(), want)
+			}
+		})
+	}
+}
+
 func TestCheckShardResults_Errors(t *testing.T) {
-	t.Run("definitive fetch error propagates at once", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		client := rerun.NewMockRESTClient(ctrl)
-		notFound := &api.HTTPError{StatusCode: http.StatusNotFound, Message: "Not Found"}
-		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, notFound)
-
-		rw := &recordingWait{}
-		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 5, rw.wait))
-		require.Error(t, err)
-		assert.ErrorIs(t, err, notFound)
-		assert.Empty(t, rw.waits, "a 4xx is not something waiting fixes")
-	})
-	t.Run("transient fetch error is retried on the next poll", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		client := rerun.NewMockRESTClient(ctrl)
-		badGateway := &api.HTTPError{StatusCode: http.StatusBadGateway, Message: "Server Error"}
-		gomock.InOrder(
-			client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Return(nil, badGateway),
-			client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).
-				Return(jobsPage(t, shard("linux", 1, "success"), shard("linux", 2, "success"), shard("linux", 3, "success")), nil), //nolint:bodyclose // closed by the code under test, not this fixture.
-		)
-
-		rw := &recordingWait{}
-		var out bytes.Buffer
-		err := CheckShardResults(context.Background(), client, &out, params("linux", 5, rw.wait))
-		require.NoError(t, err)
-		assert.Len(t, rw.waits, 1, "one poll spent on the 502")
-		assert.Contains(t, out.String(), `poll 1/5: listing "linux" shard jobs failed (`)
-		assert.Contains(t, out.String(), "HTTP 502")
-	})
-	t.Run("transient fetch error that never clears fails after the last poll", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		client := rerun.NewMockRESTClient(ctrl)
-		client.EXPECT().RequestWithContext(gomock.Any(), http.MethodGet, gomock.Any(), nil).Times(3).Return(nil, assert.AnError)
-
-		rw := &recordingWait{}
-		err := CheckShardResults(context.Background(), client, io.Discard, params("linux", 3, rw.wait))
-		require.Error(t, err)
-		assert.ErrorIs(t, err, errShardListingFails)
-		assert.ErrorIs(t, err, assert.AnError)
-		assert.Len(t, rw.waits, 2, "no wait after the final poll")
-	})
 	t.Run("invalid shard count", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		p := params("linux", 5, nil)

--- a/internal/ci/rerun/fetch.go
+++ b/internal/ci/rerun/fetch.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/cli/go-gh/v2/pkg/api"
+
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
@@ -54,6 +56,23 @@ func FetchJobs(ctx context.Context, client RESTClient, repo, runID, runAttempt s
 		path = nextLink(resp.Header.Get("Link"))
 	}
 	return jobs, nil
+}
+
+// IsTransient reports whether an error from a RESTClient request is worth
+// retrying: a 5xx response from GitHub (the jobs API has answered HTTP 502
+// mid-run, failing a required check on a run whose jobs had all passed) or a
+// transport-level failure that never produced a response. 4xx responses are
+// definitive, and a cancelled or expired context must stop the caller, so
+// neither counts as transient.
+func IsTransient(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var httpErr *api.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= http.StatusInternalServerError
+	}
+	return true
 }
 
 func decodeJobsResponse(resp *http.Response) ([]Job, error) {

--- a/internal/ci/rerun/fetch_test.go
+++ b/internal/ci/rerun/fetch_test.go
@@ -3,11 +3,13 @@ package rerun
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -86,6 +88,30 @@ func TestFetchJobs(t *testing.T) {
 		_, err := FetchJobs(context.Background(), client, "cloudposse/atmos", "1", "1")
 		require.Error(t, err)
 	})
+}
+
+func TestIsTransient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "5xx from the API", err: &api.HTTPError{StatusCode: http.StatusBadGateway}, want: true},
+		{name: "wrapped 5xx", err: fmt.Errorf("rerun: fetch jobs: %w", &api.HTTPError{StatusCode: http.StatusServiceUnavailable}), want: true},
+		{name: "4xx from the API", err: &api.HTTPError{StatusCode: http.StatusNotFound}, want: false},
+		{name: "transport error", err: assert.AnError, want: true},
+		{name: "cancelled context", err: fmt.Errorf("wrapped: %w", context.Canceled), want: false},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsTransient(tt.err))
+		})
+	}
 }
 
 func TestNextLink(t *testing.T) {


### PR DESCRIPTION
## what

- Replace `actions/setup-go`'s built-in cache with a restore-only custom cache (restore-keys fallback, ImageOS-free key) in `.github/actions/setup-go-cache`; no CI job ever saves Go caches anymore
- Make `setup-go-cache-warmup.yml` the sole cache writer: adds a Linux leg, runs the real compiles (`go build ./...`, `mage acceptance:precompile`, and a `-race`/CGO warm for the race job's namespace), saves under run-unique keys, and triggers on go.mod/go.sum pushes to `main`
- Move the Build linux leg and the race job off `extras=s3-cache` so all Linux jobs share the GitHub cache backend; upgrade the race job to `runner=xlarge`
- Fix `kubernetes-e2e` nullifying its restored cache with a `GOCACHE` override
- Give native-ci's ~700MB provider-mirror cache a main-scope writer (new push-triggered `warm-cache` job); PR runs are now restore-only
- Cache the `custom-gcl` binary (full golangci-lint rebuild every run today), the pnpm store in both website workflows, and add restore-only toolchain caches to `lint`, `hooks-tflint`, `floci`, `floci-go`, and `race`
- Roll the toolchain cache key automatically on `.tool-versions` changes (`hashFiles` in `atmos.yaml` `ci.cache.key`)

## why

Storage-level caching works (92 entries / ~99GB active, no eviction thrash), but the caches were functionally hollow: setup-go entries are immutable per go.sum hash, and the old warmup only ran `go mod download` — so whenever it saved first, the frozen entry had an empty GOCACHE and every later build compiled from scratch while logging a cache hit. Measured live on run 34179823625: 504s `go build` in Build(linux), a 27-minute race job, and 1-1.8GB re-saved per platform per PR after every dependency merge. The Linux split-brain (build job on RunsOn S3, shards on GitHub cache) meant the warmest cache in the run was invisible to the ten Linux acceptance shards.

Deliberately not done: relocating atmos's own cache root to the Windows work disk — the acceptance shards assert XDG-default paths, and the cache's saver and restorers must agree on the root.

Post-merge verification: dispatch `setup-go-cache-warmup.yml`, confirm multi-GB `go-cache-*` entries on `refs/heads/main`, then compare Build(linux) `go build` time (expect ~504s → well under 2 min) and race-job duration (expect ~27m → ~10-15m).

## references

- docs/fixes/2026-09-07-ci-go-cache-restore-only-warmup-writer.md (full investigation and change record)
- docs/fixes/2026-08-19-restore-go-build-cache-in-ci.md, docs/fixes/2026-08-31-terraform-registry-cache-windows-runner-degradation.md (prior incidents this builds on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Improved Go, Terraform, provider, and toolchain cache restoration for faster, more consistent checks.
  * Added main-branch cache warmups and reduced unnecessary cache writes.
  * Improved linting and test performance through reusable cached tools and increased capacity for race-enabled testing.
  * Cache invalidation now responds automatically to pinned tool version changes.

* **Website Builds**
  * Added pnpm dependency caching to production and preview builds.

* **Bug Fixes**
  * Acceptance checks now retry transient shard-listing failures while continuing to fail promptly on permanent errors.

* **Documentation**
  * Documented the updated CI caching behavior and verification process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->