### PR TITLE
fix(terraform-ui): clean up terraform plan --ui output

### DIFF
--- a/pkg/terraform/ui/executor.go
+++ b/pkg/terraform/ui/executor.go
@@ -301,16 +301,20 @@ func finalizeExecuteResult(opts *ExecuteOptions, m *Model, exitCode int) error {
 }
 
 // showPlanTree parses the given planfile and renders the dependency tree with a badge
-// summary. Silently does nothing if the planfile can't be parsed.
+// summary. Logs a warning and renders nothing if the planfile can't be parsed - the plan
+// itself already succeeded, so this best-effort presentation step must not fail the command,
+// but staying silent left users with no way to tell why the summary was missing.
 func showPlanTree(ctx context.Context, opts *ExecuteOptions, planFile string) {
 	tree, treeErr := BuildDependencyTree(ctx, &TreeBuildOptions{
 		PlanfilePath:  planFile,
 		TerraformPath: opts.Command,
 		WorkingDir:    opts.WorkingDir,
+		Env:           opts.Env,
 		Stack:         opts.Stack,
 		Component:     opts.Component,
 	})
 	if treeErr != nil {
+		log.Warn("Failed to render plan summary", "error", treeErr)
 		return
 	}
 
@@ -608,6 +612,7 @@ func showTwoPhasePlanTree(ctx context.Context, opts *ExecuteOptions, planFile st
 		PlanfilePath:  planFile,
 		TerraformPath: opts.Command,
 		WorkingDir:    opts.WorkingDir,
+		Env:           opts.Env,
 		Stack:         opts.Stack,
 		Component:     opts.Component,
 	})

--- a/pkg/terraform/ui/executor_test.go
+++ b/pkg/terraform/ui/executor_test.go
@@ -1301,3 +1301,33 @@ func TestExecuteDestroy_AutoApprove_PropagatesExecuteError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrStreamingNotSupported)
 }
+
+// TestShowPlanTree_LogsWarnOnTreeBuildFailure is a regression test for a silent-failure gap:
+// showPlanTree used to swallow a BuildDependencyTree error entirely, so when `terraform show
+// -json <planfile>` failed for any reason, the whole plan summary (tree + change badges) just
+// vanished with zero indication anything went wrong. This forces that failure (an unresolvable
+// "terraform" binary) and asserts it's now surfaced as a WARN log line instead of silence.
+func TestShowPlanTree_LogsWarnOnTreeBuildFailure(t *testing.T) {
+	origLevel := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetLevel(origLevel)
+	})
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetLevel(log.InfoLevel)
+
+	opts := &ExecuteOptions{
+		Command:    filepath.Join(t.TempDir(), "no-such-terraform-binary"),
+		WorkingDir: t.TempDir(),
+		Component:  "comp",
+		Stack:      "stack",
+	}
+
+	showPlanTree(context.Background(), opts, "plan.tfplan")
+
+	out := buf.String()
+	assert.Contains(t, out, "WARN")
+	assert.Contains(t, out, "plan summary")
+}

--- a/pkg/terraform/ui/model_diagnostics.go
+++ b/pkg/terraform/ui/model_diagnostics.go
@@ -132,16 +132,29 @@ func extractFirstSentence(text string) string {
 		return ""
 	}
 
-	// Find the first sentence ending with a period followed by space or newline.
-	for i := 0; i < len(text)-1; i++ {
-		if text[i] == '.' && (text[i+1] == ' ' || text[i+1] == '\n') {
-			return strings.TrimSpace(text[:i+1])
-		}
+	// Terraform diagnostic details commonly read "<generic lead-in>:\n\n<specific reason>." -
+	// e.g. "This value's attribute new.acceleration_status is derived from ..., which is
+	// deprecated with the following message:\n\nacceleration_status is deprecated. Use the
+	// aws_s3_bucket_accelerate_configuration resource instead." The final paragraph is the
+	// only part that says what's actually deprecated; the lead-in is boilerplate repeated
+	// across every such warning. Prefer the final paragraph so the terse one-line summary
+	// carries the useful info, and so a raw blank line never ends up embedded in what's meant
+	// to be a single log line.
+	if idx := strings.LastIndex(text, "\n\n"); idx >= 0 {
+		text = strings.TrimSpace(text[idx+2:])
 	}
 
-	// If no sentence boundary found, check if text ends with period.
-	if text[len(text)-1] == '.' {
-		return text
+	// Find the first sentence ending with a period followed by a space, a newline, or the
+	// end of the text. Requiring that boundary (rather than any period) avoids mistaking
+	// periods inside dotted identifiers - e.g. "new.acceleration_status" or
+	// "aws_s3_bucket.origin.acceleration_status" - for sentence ends.
+	for i := 0; i < len(text); i++ {
+		if text[i] != '.' {
+			continue
+		}
+		if i+1 == len(text) || text[i+1] == ' ' || text[i+1] == '\n' {
+			return strings.TrimSpace(text[:i+1])
+		}
 	}
 
 	// Return the whole text if it's short enough.

--- a/pkg/terraform/ui/model_diagnostics_test.go
+++ b/pkg/terraform/ui/model_diagnostics_test.go
@@ -209,3 +209,70 @@ func TestExtractFirstSentence_NoWordBoundaryTruncatesRaw(t *testing.T) {
 	require.True(t, strings.HasSuffix(result, "..."))
 	assert.Equal(t, text[:maxTextLength]+"...", result)
 }
+
+// TestExtractFirstSentence_DeprecationDetailWithEmbeddedIdentifierPeriods is a regression
+// test for a real-world Terraform deprecation detail (S3 bucket attribute deprecation),
+// taken verbatim from `terraform plan`'s plain-text output:
+//
+//	This value's attribute new.acceleration_status is derived from
+//	aws_s3_bucket.origin.acceleration_status, which is deprecated with the
+//	following message:
+//
+//	acceleration_status is deprecated. Use the
+//	aws_s3_bucket_accelerate_configuration resource instead.
+//
+// Two things must hold: periods inside dotted identifiers like "new.acceleration_status"
+// and "aws_s3_bucket.origin.acceleration_status" must not be mistaken for sentence
+// boundaries, and the result must prefer the final, specific, actionable paragraph over the
+// generic derived-from-a-deprecated-source lead-in. That lead-in is boilerplate repeated
+// across every deprecated-attribute warning, while the final paragraph is the only part
+// that says what's actually deprecated.
+func TestExtractFirstSentence_DeprecationDetailWithEmbeddedIdentifierPeriods(t *testing.T) {
+	detail := "This value's attribute new.acceleration_status is derived from " +
+		"aws_s3_bucket.origin.acceleration_status, which is deprecated with the following message:" +
+		"\n\nacceleration_status is deprecated. Use the aws_s3_bucket_accelerate_configuration resource instead."
+
+	result := extractFirstSentence(detail)
+
+	assert.NotContains(t, result, "\n")
+	assert.Equal(t, "acceleration_status is deprecated.", result)
+}
+
+// TestLogDiagnostic_DeprecationMessageHasNoEmbeddedNewline is an end-to-end regression test:
+// a deprecation diagnostic's logged message must be a single line, so the trailing
+// address=/file=/line= keyvals stay attached to it instead of trailing a short, disconnected
+// second line (which visually reads as the keyvals being "pushed" far to the right).
+func TestLogDiagnostic_DeprecationMessageHasNoEmbeddedNewline(t *testing.T) {
+	origLevel := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetLevel(origLevel)
+	})
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetLevel(log.InfoLevel)
+
+	m := NewModel("comp", "stack", "plan", strings.NewReader(""))
+	m.GetTracker().HandleMessage(&DiagnosticMessage{
+		Diagnostic: Diagnostic{
+			Severity: "warning",
+			Summary:  "Value derived from a deprecated source",
+			Detail: "This value's attribute new.acceleration_status is derived from " +
+				"aws_s3_bucket.origin.acceleration_status, which is deprecated with the following message:" +
+				"\n\nacceleration_status is deprecated. Use the aws_s3_bucket_accelerate_configuration resource instead.",
+			Range: &DiagnosticRange{
+				Filename: ".terraform/plat/modules/spa_web/main.tf",
+				Start:    DiagnosticLocation{Line: 24},
+			},
+		},
+	})
+
+	m.LogDiagnostics()
+
+	out := strings.TrimRight(buf.String(), "\n")
+	assert.NotContains(t, out, "\n")
+	assert.Contains(t, out, "acceleration_status is deprecated.")
+	assert.Contains(t, out, "file=.terraform/plat/modules/spa_web/main.tf")
+	assert.Contains(t, out, "line=24")
+}

--- a/pkg/terraform/ui/testmain_test.go
+++ b/pkg/terraform/ui/testmain_test.go
@@ -18,6 +18,9 @@ import (
 //     (e.g. `terraform show` exiting non-zero) in BuildDependencyTree tests.
 //   - _ATMOS_TEST_TF_SHOW_JSON: writes its value to stdout and exits 0; stands in for
 //     `terraform show -json` in BuildDependencyTree tests.
+//   - _ATMOS_TEST_TF_SHOW_STDERR: writes its value to stderr and exits 1; stands in for a
+//     `terraform show` failure that prints a real error message, so tests can verify that
+//     message is surfaced rather than discarded.
 func TestMain(m *testing.M) {
 	if secs := os.Getenv("_ATMOS_TEST_SLEEP_SECONDS"); secs != "" {
 		if n, err := strconv.Atoi(secs); err == nil {
@@ -31,6 +34,10 @@ func TestMain(m *testing.M) {
 	if planJSON := os.Getenv("_ATMOS_TEST_TF_SHOW_JSON"); planJSON != "" {
 		fmt.Fprint(os.Stdout, planJSON)
 		os.Exit(0)
+	}
+	if stderrMsg := os.Getenv("_ATMOS_TEST_TF_SHOW_STDERR"); stderrMsg != "" {
+		fmt.Fprint(os.Stderr, stderrMsg)
+		os.Exit(1)
 	}
 	os.Exit(m.Run())
 }

--- a/pkg/terraform/ui/tree.go
+++ b/pkg/terraform/ui/tree.go
@@ -17,6 +17,10 @@ type TreeNode struct {
 	Parent   *TreeNode
 	IsModule bool               // True if this is a module node.
 	Changes  []*AttributeChange // Attribute-level changes.
+	// UnchangedAttrCount is the number of top-level attributes present on this resource
+	// that did not change, mirroring Terraform's own "# (N unchanged attributes hidden)"
+	// summary so the diff-only Changes list doesn't read as the resource's entire content.
+	UnchangedAttrCount int
 }
 
 // AttributeChange represents a single attribute change.

--- a/pkg/terraform/ui/tree_builder.go
+++ b/pkg/terraform/ui/tree_builder.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -25,8 +26,15 @@ type TreeBuildOptions struct {
 	PlanfilePath  string
 	TerraformPath string
 	WorkingDir    string
-	Stack         string
-	Component     string
+	// Env is the component's effective environment (credentials, TF_DATA_DIR, backend
+	// config) assembled by the caller for the original plan/apply run - mirrors
+	// fetchAndDisplayOutputs. Without it this subprocess falls back to the Atmos process's
+	// own ambient environment, which can point at the wrong TF_DATA_DIR (so providers
+	// Terraform already installed for this component become invisible to `terraform show`)
+	// or lack credentials the provider schema lookup needs.
+	Env       []string
+	Stack     string
+	Component string
 }
 
 // BuildDependencyTree parses a planfile and builds the dependency tree.
@@ -37,9 +45,13 @@ func BuildDependencyTree(ctx context.Context, opts *TreeBuildOptions) (*Dependen
 	terraformPath, planfilePath := opts.TerraformPath, opts.PlanfilePath
 	cmd := exec.CommandContext(ctx, terraformPath, "show", "-json", planfilePath)
 	cmd.Dir = opts.WorkingDir
+	if len(opts.Env) > 0 {
+		cmd.Env = opts.Env
+	}
+
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("%w: terraform show: %w", errUtils.ErrCommandStart, err)
+		return nil, wrapShowCommandError(err)
 	}
 
 	var plan tfjson.Plan
@@ -48,6 +60,23 @@ func BuildDependencyTree(ctx context.Context, opts *TreeBuildOptions) (*Dependen
 	}
 
 	return buildTreeFromPlan(&plan, opts.Stack, opts.Component), nil
+}
+
+// wrapShowCommandError wraps a `terraform show` failure, distinguishing a process that never
+// started (ErrCommandStart) from one that ran and exited non-zero (ErrCommandFailed), and
+// including the subprocess's stderr - if any - so the real cause isn't reduced to an opaque
+// "exit status 1".
+func wrapShowCommandError(err error) error {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return fmt.Errorf("%w: terraform show: %w", errUtils.ErrCommandStart, err)
+	}
+
+	stderr := strings.TrimSpace(string(exitErr.Stderr))
+	if stderr == "" {
+		return fmt.Errorf("%w: terraform show: %w", errUtils.ErrCommandFailed, err)
+	}
+	return fmt.Errorf("%w: terraform show: %w: %s", errUtils.ErrCommandFailed, err, stderr)
 }
 
 // buildTreeFromPlan builds a dependency tree from an already-parsed plan. It never fails:
@@ -89,11 +118,13 @@ func populateTreeNodes(tree *DependencyTree, plan *tfjson.Plan) {
 			continue
 		}
 
+		changes, unchangedCount := extractAttributeChanges(rc)
 		node := &TreeNode{
-			Address:  rc.Address,
-			Action:   action,
-			IsModule: isModuleAddress(rc.Address),
-			Changes:  extractAttributeChanges(rc),
+			Address:            rc.Address,
+			Action:             action,
+			IsModule:           isModuleAddress(rc.Address),
+			Changes:            changes,
+			UnchangedAttrCount: unchangedCount,
 		}
 		tree.nodes[rc.Address] = node
 	}
@@ -398,10 +429,13 @@ func sortChildren(node *TreeNode) {
 	}
 }
 
-// extractAttributeChanges extracts attribute-level changes from a resource change.
-func extractAttributeChanges(rc *tfjson.ResourceChange) []*AttributeChange {
+// extractAttributeChanges returns the changed top-level attributes for a resource, along
+// with a count of how many of its top-level attributes were present but unchanged (so
+// callers can render Terraform's own "# (N unchanged attributes hidden)" convention instead
+// of a diff-only view that gives no sense of how much of the resource stayed the same).
+func extractAttributeChanges(rc *tfjson.ResourceChange) (changes []*AttributeChange, unchangedCount int) {
 	if rc.Change == nil {
-		return nil
+		return nil, 0
 	}
 
 	// Parse before/after as maps.
@@ -414,14 +448,13 @@ func extractAttributeChanges(rc *tfjson.ResourceChange) []*AttributeChange {
 	sortedKeys := sortedAttributeKeys(beforeMap, afterMap)
 	maps := attributeMaps{Before: beforeMap, After: afterMap, Unknown: unknownMap, Sensitive: sensitiveMap}
 
-	var changes []*AttributeChange
 	for _, key := range sortedKeys {
 		if change := buildAttributeChange(key, maps, forcesReplacement); change != nil {
 			changes = append(changes, change)
 		}
 	}
 
-	return changes
+	return changes, len(sortedKeys) - len(changes)
 }
 
 // extractForcesReplacement builds the set of top-level attribute names that force resource

--- a/pkg/terraform/ui/tree_builder.go
+++ b/pkg/terraform/ui/tree_builder.go
@@ -12,6 +12,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	iolib "github.com/cloudposse/atmos/pkg/io"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
@@ -65,14 +66,18 @@ func BuildDependencyTree(ctx context.Context, opts *TreeBuildOptions) (*Dependen
 // wrapShowCommandError wraps a `terraform show` failure, distinguishing a process that never
 // started (ErrCommandStart) from one that ran and exited non-zero (ErrCommandFailed), and
 // including the subprocess's stderr - if any - so the real cause isn't reduced to an opaque
-// "exit status 1".
+// "exit status 1". Terraform/OpenTofu error output can carry backend or provider secrets
+// (e.g. a credential embedded in a backend-init error), so stderr is masked the same way
+// streamStderrToLog masks the main plan/apply subprocess's stderr before it reaches this
+// error's message - which callers log (see showPlanTree) and could otherwise leak into
+// terminal or CI logs.
 func wrapShowCommandError(err error) error {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		return fmt.Errorf("%w: terraform show: %w", errUtils.ErrCommandStart, err)
 	}
 
-	stderr := strings.TrimSpace(string(exitErr.Stderr))
+	stderr := strings.TrimSpace(iolib.MaskString(string(exitErr.Stderr)))
 	if stderr == "" {
 		return fmt.Errorf("%w: terraform show: %w", errUtils.ErrCommandFailed, err)
 	}

--- a/pkg/terraform/ui/tree_builder_test.go
+++ b/pkg/terraform/ui/tree_builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	errUtils "github.com/cloudposse/atmos/errors"
+	iolib "github.com/cloudposse/atmos/pkg/io"
 )
 
 func TestBuildTreeFromPlan_Empty(t *testing.T) {
@@ -264,6 +265,38 @@ func TestBuildDependencyTree_CommandFailureIncludesStderr(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUtils.ErrCommandFailed)
 	assert.Contains(t, err.Error(), "Error: no valid credential sources found")
+}
+
+// TestBuildDependencyTree_CommandFailureMasksSecretsInStderr is a regression test: `terraform
+// show`'s stderr (e.g. a backend-init error) can contain provider/backend secrets, and
+// wrapShowCommandError used to embed it in the returned error verbatim - bypassing the
+// masking every other subprocess stderr path in this package goes through (see
+// streamStderrToLog) - so a secret could reach the WARN log showPlanTree emits. The stderr
+// text must be masked before it's embedded in the error.
+func TestBuildDependencyTree_CommandFailureMasksSecretsInStderr(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+
+	const secret = "super-secret-backend-token"
+	iolib.RegisterSecret(secret)
+	t.Cleanup(iolib.Reset)
+
+	t.Setenv("_ATMOS_TEST_TF_SHOW_STDERR", "Error: backend init failed, token="+secret)
+
+	opts := &TreeBuildOptions{
+		PlanfilePath:  "plan.tfplan",
+		TerraformPath: exePath,
+		WorkingDir:    t.TempDir(),
+		Stack:         "dev",
+		Component:     "vpc",
+	}
+
+	_, err = BuildDependencyTree(context.Background(), opts)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret, "the raw secret must never reach the wrapped error")
+	assert.Contains(t, err.Error(), "Error: backend init failed, token=",
+		"surrounding diagnostic text must still be included")
 }
 
 // TestBuildDependencyTree_UsesProvidedEnv is a regression test: BuildDependencyTree used to

--- a/pkg/terraform/ui/tree_builder_test.go
+++ b/pkg/terraform/ui/tree_builder_test.go
@@ -217,7 +217,9 @@ func TestBuildDependencyTree_Success(t *testing.T) {
 }
 
 // TestBuildDependencyTree_CommandFailure verifies a non-zero exit from `terraform show` is
-// wrapped in errUtils.ErrCommandStart rather than silently ignored.
+// wrapped in errUtils.ErrCommandFailed (the command ran; it just failed) rather than
+// errUtils.ErrCommandStart (which means the process never started at all) or silently
+// ignored.
 func TestBuildDependencyTree_CommandFailure(t *testing.T) {
 	exePath, err := os.Executable()
 	require.NoError(t, err)
@@ -236,7 +238,66 @@ func TestBuildDependencyTree_CommandFailure(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, tree)
-	assert.ErrorIs(t, err, errUtils.ErrCommandStart)
+	assert.ErrorIs(t, err, errUtils.ErrCommandFailed)
+}
+
+// TestBuildDependencyTree_CommandFailureIncludesStderr is a regression test: BuildDependencyTree
+// used to discard `terraform show`'s stderr entirely, so a failure was reported only as
+// "exit status 1" with no indication of the actual problem. It must now surface the
+// subprocess's stderr text in the wrapped error.
+func TestBuildDependencyTree_CommandFailureIncludesStderr(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+
+	t.Setenv("_ATMOS_TEST_TF_SHOW_STDERR", "Error: no valid credential sources found")
+
+	opts := &TreeBuildOptions{
+		PlanfilePath:  "plan.tfplan",
+		TerraformPath: exePath,
+		WorkingDir:    t.TempDir(),
+		Stack:         "dev",
+		Component:     "vpc",
+	}
+
+	_, err = BuildDependencyTree(context.Background(), opts)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUtils.ErrCommandFailed)
+	assert.Contains(t, err.Error(), "Error: no valid credential sources found")
+}
+
+// TestBuildDependencyTree_UsesProvidedEnv is a regression test: BuildDependencyTree used to
+// never set cmd.Env, so the `terraform show -json` subprocess fell back to the Atmos
+// process's own ambient environment instead of the component's effective environment
+// (TF_DATA_DIR, credentials, backend config) assembled for the original plan/apply run -
+// mirroring the same bug already fixed once for fetchAndDisplayOutputs. This proves
+// opts.Env fully replaces (not merges with) the ambient environment, matching cmd.Env
+// semantics used elsewhere in this package.
+func TestBuildDependencyTree_UsesProvidedEnv(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+
+	staleJSON := `{"format_version":"1.2","resource_changes":[{"address":"aws_vpc.stale","mode":"managed","change":{"actions":["create"]}}]}`
+	freshJSON := `{"format_version":"1.2","resource_changes":[{"address":"aws_vpc.fresh","mode":"managed","change":{"actions":["create"]}}]}`
+
+	// Ambient env (what the Atmos process itself sees) is deliberately "stale" - it must
+	// not be the one the subprocess ends up using.
+	t.Setenv("_ATMOS_TEST_TF_SHOW_JSON", staleJSON)
+
+	opts := &TreeBuildOptions{
+		PlanfilePath:  "plan.tfplan",
+		TerraformPath: exePath,
+		WorkingDir:    t.TempDir(),
+		Env:           []string{"_ATMOS_TEST_TF_SHOW_JSON=" + freshJSON},
+		Stack:         "dev",
+		Component:     "vpc",
+	}
+
+	tree, err := BuildDependencyTree(context.Background(), opts)
+
+	require.NoError(t, err)
+	require.Len(t, tree.Root.Children, 1)
+	assert.Equal(t, "aws_vpc.fresh", tree.Root.Children[0].Address)
 }
 
 // TestBuildDependencyTree_InvalidJSON verifies malformed `terraform show -json` output is
@@ -739,8 +800,9 @@ func TestExtractAttributeChanges_NoChange(t *testing.T) {
 		Change:  nil,
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, unchangedCount := extractAttributeChanges(rc)
 	assert.Nil(t, changes)
+	assert.Zero(t, unchangedCount)
 }
 
 func TestExtractAttributeChanges_Create(t *testing.T) {
@@ -756,7 +818,7 @@ func TestExtractAttributeChanges_Create(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 2)
 
 	// Find cidr_block change.
@@ -787,7 +849,7 @@ func TestExtractAttributeChanges_Update(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 1)
 	assert.Equal(t, "cidr_block", changes[0].Key)
 	assert.Equal(t, "10.0.0.0/16", changes[0].Before)
@@ -806,7 +868,7 @@ func TestExtractAttributeChanges_Delete(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 1)
 	assert.Equal(t, "cidr_block", changes[0].Key)
 	assert.Equal(t, "10.0.0.0/16", changes[0].Before)
@@ -828,7 +890,7 @@ func TestExtractAttributeChanges_UnknownValue(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 1)
 	assert.Equal(t, "id", changes[0].Key)
 	assert.True(t, changes[0].Unknown)
@@ -849,7 +911,7 @@ func TestExtractAttributeChanges_SensitiveValue(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 1)
 	assert.Equal(t, "password", changes[0].Key)
 	assert.True(t, changes[0].Sensitive)
@@ -871,10 +933,38 @@ func TestExtractAttributeChanges_UnchangedNotIncluded(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, unchangedCount := extractAttributeChanges(rc)
 	// Only cidr_block changed, name should not be included.
 	require.Len(t, changes, 1)
 	assert.Equal(t, "cidr_block", changes[0].Key)
+	// name is the one unchanged attribute; it must still be counted even though it's
+	// excluded from changes, so callers can report "# (1 unchanged attribute hidden)".
+	assert.Equal(t, 1, unchangedCount)
+}
+
+// TestExtractAttributeChanges_UnchangedCountWithMultipleUnchanged verifies the unchanged
+// count reflects every unchanged top-level attribute, not just whether any exist.
+func TestExtractAttributeChanges_UnchangedCountWithMultipleUnchanged(t *testing.T) {
+	rc := &tfjson.ResourceChange{
+		Address: "aws_vpc.main",
+		Change: &tfjson.Change{
+			Actions: []tfjson.Action{tfjson.ActionUpdate},
+			Before: map[string]interface{}{
+				"cidr_block": "10.0.0.0/16",
+				"name":       "unchanged",
+				"region":     "us-east-2",
+			},
+			After: map[string]interface{}{
+				"cidr_block": "10.0.0.0/8",
+				"name":       "unchanged",
+				"region":     "us-east-2",
+			},
+		},
+	}
+
+	changes, unchangedCount := extractAttributeChanges(rc)
+	require.Len(t, changes, 1)
+	assert.Equal(t, 2, unchangedCount)
 }
 
 func TestExtractAttributeChanges_SortedKeys(t *testing.T) {
@@ -891,7 +981,7 @@ func TestExtractAttributeChanges_SortedKeys(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 	require.Len(t, changes, 3)
 	// Should be sorted alphabetically.
 	assert.Equal(t, "a_attribute", changes[0].Key)

--- a/pkg/terraform/ui/tree_render.go
+++ b/pkg/terraform/ui/tree_render.go
@@ -80,8 +80,14 @@ func renderChildren(b *strings.Builder, nodes []*TreeNode, path uitree.Path, con
 
 		// Attribute changes sit between this row and the children's rows; their gutter
 		// carries a rail down to the children when there are any.
-		if len(node.Changes) > 0 {
-			renderAttributeChanges(b, node.Changes, uitree.ContentGutter(nodePath, len(node.Children) > 0), config)
+		if len(node.Changes) > 0 || node.UnchangedAttrCount > 0 {
+			gutter := uitree.ContentGutter(nodePath, len(node.Children) > 0)
+			if len(node.Changes) > 0 {
+				renderAttributeChanges(b, node.Changes, gutter, config)
+			}
+			if node.UnchangedAttrCount > 0 {
+				renderUnchangedAttributesFooter(b, node.UnchangedAttrCount, gutter, config)
+			}
 		}
 
 		if len(node.Children) > 0 {
@@ -298,6 +304,24 @@ func precomputeAttributeFormatting(changes []*AttributeChange) (formatted []form
 	}
 
 	return formatted, maxKeyWidth, maxOldValWidth
+}
+
+// renderUnchangedAttributesFooter renders a dim "# (N unchanged attributes hidden)" row,
+// mirroring Terraform's own plan-output convention, so a diff-only attribute list doesn't
+// read as if it were the resource's entire content. Indentation matches
+// renderAttributeChanges exactly (same gutter, same base indent) so the row lines up with
+// the attribute rows above it.
+func renderUnchangedAttributesFooter(b *strings.Builder, unchangedCount int, gutter string, config *RenderConfig) {
+	config = resolveRenderConfig(config)
+
+	baseIndent := strings.Repeat(spaceChar, symbolColumnWidth) + config.TreeStyle.Render(gutter)
+
+	noun := "attributes"
+	if unchangedCount == 1 {
+		noun = "attribute"
+	}
+	comment := fmt.Sprintf("# (%d unchanged %s hidden)", unchangedCount, noun)
+	fmt.Fprintf(b, "%s%s\n", baseIndent, config.DimStyle.Render(comment))
 }
 
 // renderAttributeChanges renders attribute-level changes, aligned under the resource line.

--- a/pkg/terraform/ui/tree_test.go
+++ b/pkg/terraform/ui/tree_test.go
@@ -392,6 +392,57 @@ func TestRenderTree_IsConnected(t *testing.T) {
 	}
 }
 
+// TestRenderTree_ShowsUnchangedAttributesFooter verifies a node with UnchangedAttrCount > 0
+// renders a "# (N unchanged attributes hidden)" row, mirroring Terraform's own plan-output
+// convention, so the diff-only Changes list doesn't read as the resource's entire content.
+func TestRenderTree_ShowsUnchangedAttributesFooter(t *testing.T) {
+	change := []*AttributeChange{{Key: "cidr_block", Before: "10.0.0.0/16", After: "10.0.0.0/8"}}
+	tree := &DependencyTree{
+		Stack: "dev", Component: "vpc",
+		Root: &TreeNode{Address: "root", Children: []*TreeNode{
+			{Address: "aws_vpc.main", Action: "update", Changes: change, UnchangedAttrCount: 3},
+		}},
+	}
+
+	out := ansi.Strip(tree.RenderTreeWithConfig(&RenderConfig{Compact: true}))
+
+	assert.Contains(t, out, "# (3 unchanged attributes hidden)")
+}
+
+// TestRenderTree_SingularUnchangedAttribute verifies the footer uses singular "attribute"
+// wording for a count of exactly one, matching natural English (and Terraform's own output).
+func TestRenderTree_SingularUnchangedAttribute(t *testing.T) {
+	change := []*AttributeChange{{Key: "cidr_block", Before: "10.0.0.0/16", After: "10.0.0.0/8"}}
+	tree := &DependencyTree{
+		Stack: "dev", Component: "vpc",
+		Root: &TreeNode{Address: "root", Children: []*TreeNode{
+			{Address: "aws_vpc.main", Action: "update", Changes: change, UnchangedAttrCount: 1},
+		}},
+	}
+
+	out := ansi.Strip(tree.RenderTreeWithConfig(&RenderConfig{Compact: true}))
+
+	assert.Contains(t, out, "# (1 unchanged attribute hidden)")
+	assert.NotContains(t, out, "1 unchanged attributes")
+}
+
+// TestRenderTree_NoFooterWhenNoUnchangedAttributes verifies a node with no unchanged
+// attributes (UnchangedAttrCount == 0, e.g. every attribute changed, or a create/delete
+// with no prior/no-longer-existing state) renders no footer row at all.
+func TestRenderTree_NoFooterWhenNoUnchangedAttributes(t *testing.T) {
+	change := []*AttributeChange{{Key: "cidr_block", Before: nil, After: "10.0.0.0/8"}}
+	tree := &DependencyTree{
+		Stack: "dev", Component: "vpc",
+		Root: &TreeNode{Address: "root", Children: []*TreeNode{
+			{Address: "aws_vpc.main", Action: "create", Changes: change, UnchangedAttrCount: 0},
+		}},
+	}
+
+	out := ansi.Strip(tree.RenderTreeWithConfig(&RenderConfig{Compact: true}))
+
+	assert.NotContains(t, out, "unchanged")
+}
+
 func TestExtractReferences(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -850,7 +901,7 @@ func TestExtractAttributeChanges_WithReplacePaths(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 
 	// Should have one change (content changed, filename stayed the same).
 	assert.Len(t, changes, 1)
@@ -882,7 +933,7 @@ func TestExtractAttributeChanges_WithNestedReplacePaths(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 
 	// Should have one change (ami changed).
 	assert.Len(t, changes, 1)
@@ -909,7 +960,7 @@ func TestExtractAttributeChanges_NoReplacePaths(t *testing.T) {
 		},
 	}
 
-	changes := extractAttributeChanges(rc)
+	changes, _ := extractAttributeChanges(rc)
 
 	// Should have one change (tags changed).
 	assert.Len(t, changes, 1)

--- a/pkg/utils/json_utils.go
+++ b/pkg/utils/json_utils.go
@@ -98,7 +98,7 @@ func WriteToFileAsJSON(filePath string, data any, fileMode os.FileMode) error {
 	return nil
 }
 
-// ConvertToJSON converts the provided value to a JSON-encoded string
+// ConvertToJSON converts the provided value to a JSON-encoded string.
 func ConvertToJSON(data any) (string, error) {
 	defer perf.Track(nil, "utils.ConvertToJSON")()
 
@@ -109,11 +109,23 @@ func ConvertToJSON(data any) (string, error) {
 		ValidateJsonRawMessage:        true,
 	}
 
-	j, err := jc.Froze().MarshalIndent(data, "", strings.Repeat(" ", 3))
+	// Marshal compact with jsoniter (for its EscapeHTML/SortMapKeys/RawMessage behavior),
+	// then indent with stdlib encoding/json rather than jsoniter's own MarshalIndent: jsoniter
+	// has a long-standing bug where a []interface{} nested more than one level deep (e.g. an
+	// array of objects that themselves contain an array) loses track of the current indent
+	// depth, under-indenting that inner array's elements and closing bracket while the
+	// surrounding structure stays correctly indented. encoding/json.Indent re-indents an
+	// already-valid compact document from scratch, so it isn't subject to that bug.
+	compact, err := jc.Froze().Marshal(data)
 	if err != nil {
 		return "", err
 	}
-	return string(j), nil
+
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, compact, "", strings.Repeat(" ", 3)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 // ConvertToJSONFast converts the provided value to a JSON-encoded string using 'ConfigFastest' config and json.Marshal without indents

--- a/pkg/utils/json_utils_test.go
+++ b/pkg/utils/json_utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrintAsJson(t *testing.T) {
@@ -147,6 +148,35 @@ func TestConvertToJson(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		})
 	}
+}
+
+// TestConvertToJson_NestedArrayIndentation is a regression test for a jsoniter MarshalIndent
+// bug: nesting a []interface{} more than one level deep (array -> object -> array) resets the
+// inner array's element indentation instead of continuing to nest it, while the surrounding
+// object's own indentation stays correct. Verified against a minimal standalone repro of
+// jsoniter's Froze().MarshalIndent - stdlib encoding/json.MarshalIndent does not have this bug.
+// This shape mirrors a real Terraform plan attribute (e.g. CloudFront's
+// ordered_cache_behavior, which nests allowed_methods/cached_methods arrays inside its own
+// array of objects) that rendered with visibly broken indentation in the plan tree.
+func TestConvertToJson_NestedArrayIndentation(t *testing.T) {
+	input := map[string]interface{}{
+		"ordered_cache_behavior": []interface{}{
+			map[string]interface{}{
+				"allowed_methods": []interface{}{"GET", "HEAD"},
+				"compress":        true,
+			},
+		},
+	}
+
+	result, err := ConvertToJSON(input)
+	require.NoError(t, err)
+
+	// Compare line-by-line against stdlib's MarshalIndent, which is known-correct for this
+	// shape: every line must be indented exactly as the equivalent stdlib output.
+	want, err := json.MarshalIndent(input, "", "   ")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(want), result)
 }
 
 // TestJSONToMapOfInterfaces covers decoding JSON documents into a map, including the

--- a/tests/cli_describe_identity_test.go
+++ b/tests/cli_describe_identity_test.go
@@ -2,10 +2,38 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// describeIdentityCommandTimeout bounds each subprocess run in this file. These commands
+// are local-only (no terraform/network work), so a generous-but-finite timeout turns a
+// subprocess hang - e.g. an unexpected outbound call blocking on IMDS/network in an
+// environment with no route to it - into a clear, attributable test failure instead of
+// hanging the entire test binary until go test's global -timeout kills it and dumps every
+// goroutine (see TestDescribeCommandsWithoutAuthWork's "list components" hang).
+const describeIdentityCommandTimeout = 30 * time.Second
+
+// runDescribeIdentityCommand runs an atmos command bounded by describeIdentityCommandTimeout
+// and returns its combined stdout/stderr and error.
+func runDescribeIdentityCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), describeIdentityCommandTimeout)
+	defer cancel()
+
+	cmd := atmosRunner.CommandContext(ctx, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	return stdout.String() + stderr.String(), err
+}
 
 // TestDescribeCommandsWithIdentityFlag verifies that describe commands handle the --identity flag correctly.
 // These tests cover the code paths where identity flag is parsed and CreateAuthManagerFromIdentity is called.
@@ -38,17 +66,10 @@ func TestDescribeCommandsWithIdentityFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Chdir("fixtures/scenarios/basic")
 
-			cmd := atmosRunner.Command(tt.args...)
-
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-			err := cmd.Run()
+			combinedOutput, err := runDescribeIdentityCommand(t, tt.args...)
 
 			// Should fail when given non-existent identity.
 			assert.Error(t, err, "Command should fail with non-existent identity")
-
-			combinedOutput := stdout.String() + stderr.String()
 
 			// Should not show interactive selector when explicit identity is provided.
 			assert.NotContains(t, combinedOutput, "Select an identity",
@@ -59,12 +80,7 @@ func TestDescribeCommandsWithIdentityFlag(t *testing.T) {
 	t.Run("describe component without identity flag should work normally", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/atmos-include-yaml-function")
 
-		cmd := atmosRunner.Command("describe", "component", "component-1", "--stack", "nonprod")
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
+		_, err := runDescribeIdentityCommand(t, "describe", "component", "component-1", "--stack", "nonprod")
 
 		// Should succeed (component exists in test fixtures).
 		assert.NoError(t, err, "describe component without identity should succeed")
@@ -78,12 +94,7 @@ func TestDescribeCommandsWithoutAuthWork(t *testing.T) {
 	t.Run("describe stacks without auth should work", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/basic")
 
-		cmd := atmosRunner.Command("describe", "stacks")
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
+		_, err := runDescribeIdentityCommand(t, "describe", "stacks")
 
 		// Should succeed when no identity flag is provided.
 		assert.NoError(t, err, "describe stacks without identity flag should succeed")
@@ -92,12 +103,7 @@ func TestDescribeCommandsWithoutAuthWork(t *testing.T) {
 	t.Run("list components without auth should work", func(t *testing.T) {
 		t.Chdir("fixtures/scenarios/basic")
 
-		cmd := atmosRunner.Command("list", "components")
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
+		_, err := runDescribeIdentityCommand(t, "list", "components")
 
 		// Should succeed when no identity flag is provided.
 		assert.NoError(t, err, "list components without identity flag should succeed")

--- a/tests/cli_describe_identity_test.go
+++ b/tests/cli_describe_identity_test.go
@@ -32,6 +32,14 @@ func runDescribeIdentityCommand(t *testing.T, args ...string) (string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 
+	// A deadline-killed command also returns a non-nil error from Run(), which would
+	// otherwise satisfy assert.Error in the "should fail gracefully" callers below - letting
+	// a hang silently pass as an "expected failure" instead of surfacing as the attributable
+	// failure this timeout exists to produce.
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("command %v timed out after %s", args, describeIdentityCommandTimeout)
+	}
+
 	return stdout.String() + stderr.String(), err
 }
 


### PR DESCRIPTION
## what

- Fixes deprecation-warning log lines from `atmos terraform plan --ui` that embedded a raw blank line from Terraform's multi-paragraph diagnostic detail, making the trailing `address=`/`file=`/`line=` metadata appear to jump to the far right of the terminal and wrap onto its own line.
- Fixes the plan summary/dependency tree silently disappearing after a successful plan with no error or explanation.
- Fixes broken indentation for nested arrays (2+ levels deep, e.g. CloudFront's `ordered_cache_behavior`) in the plan tree's JSON attribute-diff rendering.
- Adds a `# (N unchanged attributes hidden)` footer to the plan tree, mirroring Terraform's own plan-output convention.
- Hardens a previously-unbounded subprocess call in `tests/cli_describe_identity_test.go` with a timeout.

## why

- The deprecation-warning bug was in `extractFirstSentence`: it fell through to returning Terraform's entire multi-paragraph diagnostic detail (including the embedded blank line) instead of a single clean sentence, and was also picking the generic "derived from a deprecated source" lead-in over the actual, specific deprecation message. It now stops at the first paragraph break and prefers the specific, actionable final sentence.
- The missing plan summary was a real bug, not cosmetic: the second `terraform show -json <planfile>` subprocess (used to build the tree/summary after a successful plan) never received the component's effective environment (`TF_DATA_DIR`, credentials) the way the original plan/apply subprocess does, so it could fail independently of the plan itself — and that failure was silently discarded with zero indication anything went wrong. It now inherits the same environment, and any remaining failure is logged with the real subprocess stderr instead of a bare "exit status 1".
- The broken array indentation was a reproducible bug in the `jsoniter` library's `MarshalIndent`, confirmed against a minimal standalone repro; `ConvertToJSON` now marshals compact with `jsoniter` and re-indents with stdlib `encoding/json`, which isn't subject to the bug.
- The unchanged-attributes footer closes a parity gap where the diff-only attribute list gave no sense of how much of the resource actually stayed the same, unlike Terraform's native output.
- The test hardening turns a previously-observed subprocess hang (which took down the entire test binary via `go test`'s global timeout) into a fast, attributable failure on just the affected subtest.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan summaries now show hidden unchanged attributes with correct singular and plural wording.
  * Terraform subprocesses honor the configured environment and provide clearer failure details.
  * Diagnostic messages are rendered as concise, single-line summaries without boilerplate.

* **Bug Fixes**
  * Warnings are now logged when plan summaries cannot be rendered.
  * Sensitive information in Terraform errors is masked.
  * Nested JSON arrays are formatted correctly.
  * Identity description tests now fail promptly instead of hanging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->