### PR TITLE
fix(auth): clear Azure realm MSAL cache on logout so re-login is fresh

### DIFF
--- a/docs/fixes/2026-09-08-azure-logout-msal-cache-stale-session.md
+++ b/docs/fixes/2026-09-08-azure-logout-msal-cache-stale-session.md
@@ -1,0 +1,84 @@
+# Fix: `atmos auth logout` now clears the Azure realm MSAL cache so re-login is fresh
+
+**Date:** 2026-09-08
+
+## Summary
+
+`atmos auth logout` (including `--all --force`) left the realm-scoped Azure MSAL token
+cache on disk. Because the device-code / interactive providers attempt a **silent** MSAL
+token acquisition before any interactive flow, the next `atmos auth login` reused the
+previous session's cached account and refresh token — a stale token that predates a role or
+PIM change — so newly granted access never took effect and the user kept getting
+`403 AuthorizationFailed`. Logout now removes the realm MSAL cache
+(`~/.azure/atmos/{realm}/msal_token_cache.json`), forcing a genuine re-authentication, while
+preserving the shared Azure CLI cache (`~/.azure/msal_token_cache.json`) that is co-owned
+with a user's own `az login` session.
+
+## Context
+
+Reported from the field: an operator elevated their Azure role via PIM, then ran an AKS
+integration and got `403` — `"The client '...' does not have authorization to perform action
+'Microsoft.ContainerService/managedClusters/read' ... If access was recently granted, please
+refresh your credentials."` They ran `atmos auth logout --all --force` (which reported
+`Logout all completed`, `Logged out all 4 identities`) and `atmos auth login` again, but the
+403 persisted and `atmos auth whoami` showed the credential expiring in ~41 minutes — i.e.
+still the **same pre-PIM session**, not a fresh login. The manual workaround was
+`rm ~/.azure/atmos/cw/msal_token_cache.json`, after which a fresh login succeeded.
+
+Root cause — two distinct caches, only one cleared on logout:
+
+- **Login** (`deviceCodeProvider.createMSALClient`, `pkg/auth/providers/azure/device_code.go`)
+  builds its MSAL public client from `NewMSALCache("", p.realm)` →
+  `~/.azure/atmos/{realm}/msal_token_cache.json`. `Authenticate` then calls
+  `client.Accounts()` + `trySilentTokenAcquisition()` **before** any interactive flow, so a
+  populated realm cache yields a silently-refreshed token from the old session.
+- **Logout** (`deviceCodeProvider.Logout` → `deleteCachedToken` → `getTokenCachePath`) only
+  removed the Atmos device-code token at
+  `~/.cache/atmos/azure-device-code/<provider>/token.json` (an XDG cache path) — a
+  **different file**. The realm MSAL cache was never touched, so silent re-login kept
+  serving the stale account/refresh token.
+
+The `azure/interactive` provider (the one in the report) embeds `deviceCodeProvider` and
+inherits the same `Logout`, so it had the same defect. The `azure/cli` and `azure/oidc`
+providers do not create a realm MSAL cache (`NewMSALCache` is only used by the device-code
+path), so they are unaffected.
+
+## Changes
+
+- `pkg/auth/cloud/azure/msal_cache.go`
+  - Extracted the realm→path logic into `resolveMSALCachePath(realm)` as the single source
+    of truth shared by the cache constructor and remover; `NewMSALCache` now delegates to it.
+  - Added `RemoveMSALCache(realm)`: deletes `~/.azure/atmos/{realm}/msal_token_cache.json`,
+    treating a missing file as success. It **refuses to delete the empty-realm path**
+    (`~/.azure/msal_token_cache.json`) because that cache is co-owned with the user's own
+    `az login` session — clearing it on an Atmos logout would sign the user out of `az` too.
+- `pkg/auth/providers/azure/device_code.go`
+  - `deviceCodeProvider.Logout` now removes the realm MSAL cache via
+    `azureCloud.RemoveMSALCache(p.realm)` in addition to the existing device-code token
+    deletion. This flows through `Logout`, `LogoutProvider`, and `LogoutAll`, which all call
+    `provider.Logout(ctx)`, and is inherited by the embedded `interactiveProvider`.
+- Tests
+  - `pkg/auth/providers/azure/logout_msal_cache_test.go` (new): logout removes the realm MSAL
+    cache for both device-code and interactive providers, preserves the shared Azure CLI
+    cache, and treats a missing cache as a clean no-op.
+  - `pkg/auth/cloud/azure/msal_cache_test.go`: `TestRemoveMSALCache` covers realm-cache
+    removal, the missing-file no-op, and the empty-realm safety guard.
+
+## Validation
+
+- Wrote the reproducing tests first and confirmed they **failed** against the unpatched code
+  (realm MSAL cache survived logout: `realm MSAL cache should be removed by logout, got
+  err=<nil>`), then pass after the fix.
+- `go test ./pkg/auth/cloud/azure/ ./pkg/auth/providers/azure/ -count=1` — both packages pass.
+- `go test ./pkg/auth/ -run Logout -count=1` — manager-level logout tests pass (they exercise
+  the provider `Logout` through `LogoutAll`).
+- `go build ./pkg/auth/...`, `go vet ./pkg/auth/cloud/azure/ ./pkg/auth/providers/azure/`, and
+  `gofumpt -l` on the changed files are all clean.
+- `golangci-lint` was not run from this session (blocked by the sandbox); to be run via the
+  `lint` skill / CI before merge.
+- Not re-verified end-to-end against a live tenant in this session; the field report plus the
+  manual `rm` workaround already established the on-disk root cause, which the tests pin.
+
+## Follow-ups
+
+None.

--- a/pkg/auth/cloud/azure/msal_cache.go
+++ b/pkg/auth/cloud/azure/msal_cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	log "github.com/cloudposse/atmos/pkg/logger"
+	"github.com/cloudposse/atmos/pkg/perf"
 )
 
 // msalCache implements cache.ExportReplace for MSAL token cache.
@@ -16,21 +17,38 @@ type msalCache struct {
 	cachePath string
 }
 
+// resolveMSALCachePath returns the on-disk MSAL token cache path for a realm.
+// An empty realm resolves to the shared Azure CLI cache (~/.azure/msal_token_cache.json);
+// a non-empty realm resolves to the isolated Atmos cache
+// (~/.azure/atmos/{realm}/msal_token_cache.json). This is the single source of truth for
+// the path shared by NewMSALCache and RemoveMSALCache.
+func resolveMSALCachePath(realm string) (string, error) {
+	// os.UserHomeDir (not homedir.Dir) intentionally: every sibling realm-cache resolver in
+	// this package (device_code_cache.go, setup.go, refresh_token.go) uses it, and the realm
+	// cache path must stay in lockstep with those writers. homedir.Dir's process-wide cache
+	// could resolve a different home than the live-$HOME writers and would break the package's
+	// $HOME-swapping test isolation.
+	homeDir, err := os.UserHomeDir() //nolint:forbidigo // See comment above: package-consistency and cache-desync avoidance.
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	// Include realm in path for credential isolation.
+	if realm != "" {
+		return filepath.Join(homeDir, ".azure", "atmos", realm, "msal_token_cache.json"), nil
+	}
+	return filepath.Join(homeDir, ".azure", "msal_token_cache.json"), nil
+}
+
 // NewMSALCache creates a new MSAL cache instance.
 // If cachePath is empty, uses the default Azure CLI location (~/.azure/atmos/{realm}/msal_token_cache.json).
 // The realm parameter provides credential isolation between different repositories.
 func NewMSALCache(cachePath string, realm string) (cache.ExportReplace, error) {
 	if cachePath == "" {
-		homeDir, err := os.UserHomeDir()
+		resolved, err := resolveMSALCachePath(realm)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %w", err)
+			return nil, err
 		}
-		// Include realm in path for credential isolation.
-		if realm != "" {
-			cachePath = filepath.Join(homeDir, ".azure", "atmos", realm, "msal_token_cache.json")
-		} else {
-			cachePath = filepath.Join(homeDir, ".azure", "msal_token_cache.json")
-		}
+		cachePath = resolved
 	}
 
 	// Ensure cache directory exists.
@@ -42,6 +60,37 @@ func NewMSALCache(cachePath string, realm string) (cache.ExportReplace, error) {
 	return &msalCache{
 		cachePath: cachePath,
 	}, nil
+}
+
+// RemoveMSALCache deletes the realm-scoped MSAL token cache so a subsequent login cannot
+// silently reuse the previous session's cached account and refresh token. Without this, a
+// role or PIM change never takes effect after `atmos auth login` because Authenticate()
+// tries a silent MSAL acquisition from this cache first and gets back the stale token —
+// producing persistent 403s until the file is removed by hand. A missing file is not an
+// error (the steady state after a prior logout).
+//
+// It refuses to touch the shared Azure CLI cache (~/.azure/msal_token_cache.json, the
+// empty-realm path): that file is co-owned with a user's own `az login` session, and
+// clearing it on an Atmos logout would sign the user out of az as well.
+func RemoveMSALCache(realm string) error {
+	defer perf.Track(nil, "azure.RemoveMSALCache")()
+
+	if realm == "" {
+		log.Debug("Skipping MSAL cache removal for empty realm (shared Azure CLI cache is co-owned with `az login`)")
+		return nil
+	}
+
+	cachePath, err := resolveMSALCachePath(realm)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(cachePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove MSAL token cache: %w", err)
+	}
+
+	log.Debug("Removed MSAL token cache", "path", cachePath, "realm", realm)
+	return nil
 }
 
 // Replace loads the cache from disk into memory.

--- a/pkg/auth/cloud/azure/msal_cache_test.go
+++ b/pkg/auth/cloud/azure/msal_cache_test.go
@@ -12,6 +12,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRemoveMSALCache(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	realmCache := filepath.Join(tmpHome, ".azure", "atmos", "cw", "msal_token_cache.json")
+	sharedCache := filepath.Join(tmpHome, ".azure", "msal_token_cache.json")
+
+	writeFile := func(t *testing.T, path string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte("{}"), 0o600))
+	}
+
+	t.Run("removes realm-scoped cache", func(t *testing.T) {
+		writeFile(t, realmCache)
+
+		require.NoError(t, RemoveMSALCache("cw"))
+
+		_, err := os.Stat(realmCache)
+		assert.True(t, os.IsNotExist(err), "realm cache should be removed")
+	})
+
+	t.Run("missing file is not an error", func(t *testing.T) {
+		require.NoError(t, RemoveMSALCache("does-not-exist"))
+	})
+
+	t.Run("empty realm never touches the shared Azure CLI cache", func(t *testing.T) {
+		writeFile(t, sharedCache)
+
+		require.NoError(t, RemoveMSALCache(""))
+
+		_, err := os.Stat(sharedCache)
+		assert.NoError(t, err, "shared Azure CLI cache (empty realm) must be preserved")
+	})
+
+	t.Run("non-removable cache path surfaces the error", func(t *testing.T) {
+		// Make the cache "file" a non-empty directory so os.Remove fails with a real
+		// error that is not os.IsNotExist (e.g. ENOTEMPTY), exercising the error branch.
+		blockedCache := filepath.Join(tmpHome, ".azure", "atmos", "blocked", "msal_token_cache.json")
+		require.NoError(t, os.MkdirAll(blockedCache, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(blockedCache, "child"), []byte("x"), 0o600))
+
+		err := RemoveMSALCache("blocked")
+		require.Error(t, err, "a real os.Remove failure must be surfaced")
+	})
+}
+
 func TestNewMSALCache(t *testing.T) {
 	// Redirect HOME/USERPROFILE so the default-path case creates its cache
 	// directory under a temp home instead of the real ~/.azure.

--- a/pkg/auth/providers/azure/device_code.go
+++ b/pkg/auth/providers/azure/device_code.go
@@ -600,11 +600,24 @@ func (p *deviceCodeProvider) PrepareEnvironment(ctx context.Context, environ map
 	}), nil
 }
 
-// Logout removes cached device code tokens from disk by deleting the MSAL token cache file.
-// Returns an error if the cache deletion fails.
+// Logout removes this provider's cached credentials from disk by clearing two distinct
+// caches. The first is the Atmos device-code token
+// (~/.cache/atmos/azure-device-code/<provider>/token.json), removed by deleteCachedToken().
+// The second is the realm-scoped MSAL token cache
+// (~/.azure/atmos/{realm}/msal_token_cache.json), removed by RemoveMSALCache(): createMSALClient()
+// seeds its public client from it and Authenticate() reads it for a silent acquisition first,
+// so leaving it behind is what let the next `atmos auth login` reuse the previous session's
+// account and refresh token — a stale token that predates any role/PIM change — producing
+// persistent 403s. The shared Azure CLI cache (~/.azure/msal_token_cache.json) is intentionally
+// preserved so a user's own `az login` session survives.
 func (p *deviceCodeProvider) Logout(ctx context.Context) error {
 	log.Debug("Logout Azure device code provider", "provider", p.name)
-	return p.deleteCachedToken()
+
+	if err := p.deleteCachedToken(); err != nil {
+		return err
+	}
+
+	return azureCloud.RemoveMSALCache(p.realm)
 }
 
 // Paths returns credential files/directories used by this provider.

--- a/pkg/auth/providers/azure/logout_msal_cache_test.go
+++ b/pkg/auth/providers/azure/logout_msal_cache_test.go
@@ -1,0 +1,132 @@
+package azure
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// realmMSALCachePath returns the on-disk path of the realm-scoped MSAL token cache
+// that createMSALClient() seeds and Authenticate() reads for silent token reuse.
+func realmMSALCachePath(home, realm string) string {
+	return filepath.Join(home, ".azure", "atmos", realm, "msal_token_cache.json")
+}
+
+// sharedAzureCLICachePath returns the path of the Azure CLI's own MSAL cache, which is
+// co-owned with a user's `az login` session and must survive an Atmos logout.
+func sharedAzureCLICachePath(home string) string {
+	return filepath.Join(home, ".azure", "msal_token_cache.json")
+}
+
+func writeCacheFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(`{"Account":{},"RefreshToken":{}}`), 0o600))
+}
+
+// TestDeviceCodeProvider_Logout_RemovesRealmMSALCache reproduces the bug where
+// `atmos auth logout` leaves the realm-scoped MSAL token cache
+// (~/.azure/atmos/{realm}/msal_token_cache.json) on disk. Because
+// Authenticate() tries a silent MSAL acquisition from that cache first, the next
+// `atmos auth login` reuses the previous session's account and refresh token —
+// a stale token that predates any role/PIM change — producing persistent 403s.
+//
+// Logout must remove the realm MSAL cache (forcing a fresh interactive login) while
+// leaving the shared Azure CLI cache (~/.azure/msal_token_cache.json) untouched, so a
+// user's separate `az login` session is not destroyed.
+func TestDeviceCodeProvider_Logout_RemovesRealmMSALCache(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	const realm = "test-realm"
+
+	provider, err := NewDeviceCodeProvider("test-provider", &schema.Provider{
+		Kind: "azure/device-code",
+		Spec: map[string]interface{}{"tenant_id": "tenant-123"},
+	})
+	require.NoError(t, err)
+	provider.SetRealm(realm)
+
+	realmCache := realmMSALCachePath(tmpHome, realm)
+	sharedCache := sharedAzureCLICachePath(tmpHome)
+
+	// Simulate the post-login on-disk state: MSAL persisted the realm cache, and the
+	// login wrote back into the shared Azure CLI cache.
+	writeCacheFile(t, realmCache)
+	writeCacheFile(t, sharedCache)
+
+	require.NoError(t, provider.Logout(context.Background()))
+
+	// The realm MSAL cache must be gone so the next login is fresh.
+	_, err = os.Stat(realmCache)
+	require.True(t, os.IsNotExist(err), "realm MSAL cache should be removed by logout, got err=%v", err)
+
+	// The shared Azure CLI cache must survive — it is co-owned with `az login`.
+	_, err = os.Stat(sharedCache)
+	require.NoError(t, err, "shared Azure CLI cache must NOT be removed by Atmos logout")
+}
+
+// TestInteractiveProvider_Logout_RemovesRealmMSALCache verifies the interactive
+// provider (which embeds deviceCodeProvider) inherits the realm-cache cleanup, since
+// it is the provider that most commonly hits the stale-token bug.
+func TestInteractiveProvider_Logout_RemovesRealmMSALCache(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	const realm = "cw"
+
+	provider, err := NewInteractiveProvider("azure-interactive", &schema.Provider{
+		Kind: "azure/interactive",
+		Spec: map[string]interface{}{"tenant_id": "tenant-123"},
+	})
+	require.NoError(t, err)
+	provider.SetRealm(realm)
+
+	realmCache := realmMSALCachePath(tmpHome, realm)
+	writeCacheFile(t, realmCache)
+
+	require.NoError(t, provider.Logout(context.Background()))
+
+	_, err = os.Stat(realmCache)
+	require.True(t, os.IsNotExist(err), "interactive provider logout should remove the realm MSAL cache, got err=%v", err)
+}
+
+// TestDeviceCodeProvider_Logout_DeleteCachedTokenError verifies that when the device-code
+// token cache removal fails (here, an unresolvable XDG cache dir), Logout surfaces that error
+// and short-circuits before touching the MSAL cache.
+func TestDeviceCodeProvider_Logout_DeleteCachedTokenError(t *testing.T) {
+	// A zero-value mock returns an error from GetXDGCacheDir (xdgCacheDir unset), so
+	// deleteCachedToken -> getTokenCachePath fails.
+	provider := &deviceCodeProvider{
+		name:         "test-provider",
+		realm:        "test-realm",
+		cacheStorage: &mockCacheStorage{},
+	}
+
+	err := provider.Logout(context.Background())
+	require.Error(t, err, "Logout should surface a device-code token cache removal failure")
+}
+
+// TestDeviceCodeProvider_Logout_MSALCacheMissingIsNotAnError verifies the steady-state
+// logout (no cache present) is a clean no-op rather than a failure.
+func TestDeviceCodeProvider_Logout_MSALCacheMissingIsNotAnError(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	provider, err := NewDeviceCodeProvider("test-provider", &schema.Provider{
+		Kind: "azure/device-code",
+		Spec: map[string]interface{}{"tenant_id": "tenant-123"},
+	})
+	require.NoError(t, err)
+	provider.SetRealm("test-realm")
+
+	require.NoError(t, provider.Logout(context.Background()))
+}


### PR DESCRIPTION
## what

- `atmos auth logout` (including `--all --force`) now removes the realm-scoped Azure MSAL token cache (`~/.azure/atmos/{realm}/msal_token_cache.json`) in addition to the keyring entry and the Atmos device-code token it already cleared.
- The shared Azure CLI cache (`~/.azure/msal_token_cache.json`) is intentionally **preserved** — it is co-owned with a user's own `az login` session.
- Applies to the `azure/device-code` and `azure/interactive` providers (interactive embeds device-code); `azure/cli` and `azure/oidc` never create a realm MSAL cache and are unaffected.

## why

- After a role or PIM change, users found that `atmos auth logout` followed by `atmos auth login` did **not** pick up the new access — they kept getting `403 AuthorizationFailed` (e.g. `Microsoft.ContainerService/managedClusters/read`), and `atmos auth whoami` showed the credential still expiring on the *old* session's clock.
- Root cause: the device-code/interactive providers build their MSAL client from the realm cache and attempt a **silent** token acquisition *before* any interactive flow. Logout removed the Atmos device-code token (`~/.cache/atmos/azure-device-code/<provider>/token.json`) but never the realm MSAL cache — a **different file** — so the next login silently re-minted a token from the stale cached account/refresh token, which predated the PIM elevation.
- The only workaround was to delete the realm cache by hand (`rm ~/.azure/atmos/<realm>/msal_token_cache.json`). This makes logout actually forget the session, so re-login is genuinely fresh.

### tests / validation

- Reproducing tests written first and confirmed failing on the unpatched code, now passing: logout removes the realm MSAL cache for both device-code and interactive providers, preserves the shared `az` cache, and treats a missing cache as a clean no-op. Added a direct `RemoveMSALCache` unit test (realm removal, missing-file no-op, empty-realm safety guard, real `os.Remove` failure) and a `Logout` error-path test.
- Changed functions fully covered (`resolveMSALCachePath` 100%, `NewMSALCache` 100%, `Logout` 100%, `RemoveMSALCache` 90.9% — only the untestable `os.UserHomeDir` error return remains).
- `go test ./pkg/auth/...` green; `atmos fix lint` (patch-scoped CI gate) reports 0 issues.

## references

- Fix doc: `docs/fixes/2026-09-08-azure-logout-msal-cache-stale-session.md`
- Follows the Azure auth line: #2862 (`azure/interactive`), #2861 / #2890 (Azure CLI cache fixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure logout now removes realm-specific cached authentication data for device-code and interactive sign-ins.
  * Shared Azure CLI authentication remains available after logout.
  * Logout succeeds cleanly when no realm-specific cache exists and reports cache-removal failures when they occur.

* **Documentation**
  * Added documentation describing Azure logout behavior, cache handling, provider differences, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->