### PR TITLE
fix: terraform --all bootstrap, list-command lazy eval, init/UI polish

### DIFF
--- a/cmd/list/components.go
+++ b/cmd/list/components.go
@@ -265,7 +265,12 @@ func initAndExtractComponents(cmd *cobra.Command, args []string, opts *Component
 	// Without closure flags, --tags/--labels also scope the describe pass
 	// (early-skip): components excluded by the selectors never evaluate
 	// templates/YAML functions/auth.
-	stacksMap, err := e.ExecuteDescribeStacksScoped(
+	//
+	// evalSections narrows evaluation to the sections the final column set (plus `metadata`,
+	// which extract.UniqueComponents and buildComponentFilters always need for
+	// enabled/locked/tags/labels/type/status) actually reads — see resolveComponentsEvalSections.
+	evalSections := resolveComponentsEvalSections(&atmosConfig, opts)
+	stacksMap, err := e.ExecuteDescribeStacksWithEvalSections(
 		&atmosConfig, "", nil, nil, nil,
 		false, // ignoreMissingFiles
 		opts.ProcessTemplates,
@@ -277,6 +282,7 @@ func initAndExtractComponents(cmd *cobra.Command, args []string, opts *Component
 		opts.Tags,
 		labels,
 		errOpts,
+		evalSections,
 	)
 	if err != nil {
 		return componentsExtractResult{}, fmt.Errorf("%w: %w", errUtils.ErrExecuteDescribeStacks, err)
@@ -430,6 +436,26 @@ func buildComponentFilters(opts *ComponentsOptions) ([]filter.Filter, error) {
 	}
 
 	return filters, nil
+}
+
+// resolveComponentsEvalSections computes the evaluation-scope filter (see
+// column.RequiredSections/e.ExecuteDescribeStacksWithEvalSections) for the column set this
+// invocation will actually render, resolved from the same flag + atmos.yaml merge
+// getComponentColumns uses. `metadata` is unconditionally folded in: extract.UniqueComponents
+// always reads it (enabled/locked/type/tags/labels/status derive from it, and abstract-component
+// filtering depends on metadata.type), independent of which columns are displayed — see
+// enrichUniqueComponentMetadata in pkg/list/extract/components.go. Returns nil (full eager
+// evaluation, the historical behavior) whenever RequiredSections can't statically prove which
+// sections are safe to skip.
+func resolveComponentsEvalSections(atmosConfig *schema.AtmosConfiguration, opts *ComponentsOptions) []string {
+	defer perf.Track(nil, "list.components.resolveComponentsEvalSections")()
+
+	columns := getComponentColumns(atmosConfig, opts.Columns)
+	sections, ok := column.RequiredSections(columns)
+	if !ok {
+		return nil
+	}
+	return column.EnsureSection(sections, "metadata")
 }
 
 // getComponentColumns returns column configuration for unique components listing.

--- a/cmd/list/components_test.go
+++ b/cmd/list/components_test.go
@@ -454,6 +454,56 @@ func TestGetComponentColumns(t *testing.T) {
 	}
 }
 
+// TestResolveComponentsEvalSections verifies the evaluation-scope filter derived from the
+// resolved column set. `metadata` is always folded in (extract.UniqueComponents and the
+// enabled/locked/tags/labels filters always read it, regardless of which columns are shown).
+func TestResolveComponentsEvalSections(t *testing.T) {
+	testCases := []struct {
+		name        string
+		atmosConfig *schema.AtmosConfiguration
+		opts        *ComponentsOptions
+		expectNil   bool
+		expectExact []string
+	}{
+		{
+			name: "default columns require only metadata",
+			atmosConfig: &schema.AtmosConfiguration{
+				Components: schema.Components{List: schema.ListConfig{}},
+			},
+			opts:        &ComponentsOptions{},
+			expectExact: []string{"metadata"},
+		},
+		{
+			name: "--columns referencing vars requires vars and metadata",
+			atmosConfig: &schema.AtmosConfiguration{
+				Components: schema.Components{List: schema.ListConfig{}},
+			},
+			opts:        &ComponentsOptions{Columns: []string{"Component={{ .component }}", "Region={{ .vars.region }}"}},
+			expectExact: []string{"metadata", "vars"},
+		},
+		{
+			name: "--columns referencing raw falls back to nil",
+			atmosConfig: &schema.AtmosConfiguration{
+				Components: schema.Components{List: schema.ListConfig{}},
+			},
+			opts:      &ComponentsOptions{Columns: []string{"Raw={{ .raw }}"}},
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveComponentsEvalSections(tc.atmosConfig, tc.opts)
+			if tc.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			assert.ElementsMatch(t, tc.expectExact, result)
+		})
+	}
+}
+
 // TestBuildComponentSorters tests sorter building.
 func TestBuildComponentSorters(t *testing.T) {
 	testCases := []struct {

--- a/cmd/list/stacks.go
+++ b/cmd/list/stacks.go
@@ -297,7 +297,14 @@ func executeAndExtractStacks(
 	// Without closure flags, --tags/--labels also scope the describe pass
 	// (early-skip): components excluded by the selectors never evaluate
 	// templates/YAML functions/auth.
-	stacksMap, err := e.ExecuteDescribeStacksScoped(
+	//
+	// evalSections narrows evaluation to the sections the final column set actually reads (see
+	// resolveStacksEvalSections): the default `{{ .stack }}`-only column needs none, so no
+	// !terraform.state/!terraform.output/atmos.Component call anywhere in vars/settings/etc. ever
+	// runs, and no "(computed)" degradation warning fires for a value no column would display —
+	// see https://github.com/cloudposse/atmos/issues/3068.
+	evalSections := resolveStacksEvalSections(atmosConfig, opts)
+	stacksMap, err := e.ExecuteDescribeStacksWithEvalSections(
 		atmosConfig, "", nil, nil, nil,
 		false, // ignoreMissingFiles
 		opts.ProcessTemplates,
@@ -309,6 +316,7 @@ func executeAndExtractStacks(
 		opts.Tags,
 		labels,
 		errOpts,
+		evalSections,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: %w", errUtils.ErrExecuteDescribeStacks, err)
@@ -491,6 +499,23 @@ func buildStackFilters(opts *StacksOptions) []filter.Filter {
 	// renderer-level filters here in the future.
 
 	return filters
+}
+
+// resolveStacksEvalSections computes the evaluation-scope filter (see
+// column.RequiredSections/e.ExecuteDescribeStacksWithEvalSections) for the column set this
+// invocation will actually render. Resolved from the same flag + atmos.yaml merge getStackColumns
+// uses, so the filter always matches the columns that end up on screen. Returns nil (full eager
+// evaluation, the historical behavior) whenever RequiredSections can't statically prove which
+// sections are safe to skip.
+func resolveStacksEvalSections(atmosConfig *schema.AtmosConfiguration, opts *StacksOptions) []string {
+	defer perf.Track(nil, "list.stacks.resolveStacksEvalSections")()
+
+	columns := getStackColumns(atmosConfig, opts.Columns, opts.Component != "")
+	sections, ok := column.RequiredSections(columns)
+	if !ok {
+		return nil
+	}
+	return sections
 }
 
 // getStackColumns returns column configuration.

--- a/cmd/list/stacks_test.go
+++ b/cmd/list/stacks_test.go
@@ -280,6 +280,59 @@ func TestGetStackColumns(t *testing.T) {
 	}
 }
 
+// TestResolveStacksEvalSections verifies the evaluation-scope filter derived from the resolved
+// column set: default columns (`.stack`/`.component` only) need no section, a `.vars.X` column
+// requires "vars", and an unresolvable column template (a catch-all `.raw`) falls back to nil
+// (full eager evaluation) rather than under-computing what is required.
+func TestResolveStacksEvalSections(t *testing.T) {
+	baseConfig := &schema.AtmosConfiguration{Stacks: schema.Stacks{List: schema.ListConfig{}}}
+
+	testCases := []struct {
+		name        string
+		atmosConfig *schema.AtmosConfiguration
+		opts        *StacksOptions
+		expectNil   bool
+		expectExact []string
+	}{
+		{
+			name:        "default columns without component require no section",
+			atmosConfig: baseConfig,
+			opts:        &StacksOptions{},
+			expectExact: []string{},
+		},
+		{
+			name:        "default columns with component require no section",
+			atmosConfig: baseConfig,
+			opts:        &StacksOptions{Component: "vpc"},
+			expectExact: []string{},
+		},
+		{
+			name:        "--columns referencing vars requires vars",
+			atmosConfig: baseConfig,
+			opts:        &StacksOptions{Columns: []string{"Stack={{ .stack }}", "Region={{ .vars.region }}"}},
+			expectExact: []string{"vars"},
+		},
+		{
+			name:        "--columns referencing raw falls back to nil",
+			atmosConfig: baseConfig,
+			opts:        &StacksOptions{Columns: []string{"Raw={{ .raw }}"}},
+			expectNil:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveStacksEvalSections(tc.atmosConfig, tc.opts)
+			if tc.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			assert.ElementsMatch(t, tc.expectExact, result)
+		})
+	}
+}
+
 // TestBuildStackSorters tests sorter building.
 func TestBuildStackSorters(t *testing.T) {
 	testCases := []struct {

--- a/internal/exec/deferred_contexts.go
+++ b/internal/exec/deferred_contexts.go
@@ -55,12 +55,18 @@ func cloneComponentSectionWithOverrides(raw, overrides map[string]any) map[strin
 // (configAndStacksInfo.DeferredMergeContexts), resolve them with a real
 // TemplateAwareYAMLProcessor and deep-merge the result into configAndStacksInfo.ComponentSection,
 // in place. See the call site in processStacks (utils.go) for why this must run where it does.
+//
+// The evalSections parameter is the opt-in evaluation-scope filter described on
+// isSectionRequired: nil (every caller except the `list` commands) resolves every section,
+// exactly as before this parameter was added; a non-nil filter skips sections outside it
+// entirely, leaving their deferred function strings unresolved.
 func resolveDeferredYamlFunctions(
 	atmosConfig *schema.AtmosConfiguration,
 	configAndStacksInfo *schema.ConfigAndStacksInfo,
 	settingsSectionStruct *schema.Settings,
 	componentTemplateContext map[string]any,
 	skip []string,
+	evalSections []string,
 ) error {
 	defer perf.Track(atmosConfig, "exec.resolveDeferredYamlFunctions")()
 
@@ -87,6 +93,9 @@ func resolveDeferredYamlFunctions(
 
 	for sectionName, sectionDctx := range compDctx {
 		if sectionDctx == nil || !sectionDctx.HasDeferredValues() {
+			continue
+		}
+		if !isSectionRequired(evalSections, sectionName) {
 			continue
 		}
 		sectionMap, ok := configAndStacksInfo.ComponentSection[sectionName].(map[string]any)

--- a/internal/exec/deferred_contexts_test.go
+++ b/internal/exec/deferred_contexts_test.go
@@ -38,7 +38,7 @@ func TestResolveDeferredYamlFunctions_NoDeferredContexts(t *testing.T) {
 			}
 			settingsStruct := &schema.Settings{}
 
-			err := resolveDeferredYamlFunctions(atmosConfig, info, settingsStruct, nil, nil)
+			err := resolveDeferredYamlFunctions(atmosConfig, info, settingsStruct, nil, nil, nil)
 
 			require.NoError(t, err)
 			vars, ok := info.ComponentSection[cfg.VarsSectionName].(map[string]any)
@@ -76,7 +76,7 @@ func TestResolveDeferredYamlFunctions_SkipsSectionMissingFromComponentSection(t 
 	}
 	settingsStruct := &schema.Settings{}
 
-	err := resolveDeferredYamlFunctions(atmosConfig, info, settingsStruct, map[string]any{}, nil)
+	err := resolveDeferredYamlFunctions(atmosConfig, info, settingsStruct, map[string]any{}, nil, nil)
 	require.NoError(t, err)
 
 	vars, ok := info.ComponentSection[cfg.VarsSectionName].(map[string]any)

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -276,6 +276,37 @@ func ExecuteDescribeStacksWithMocks(
 	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, DescribeStacksErrorOptions{})
 }
 
+// ExecuteDescribeStacksWithMocksAndOptions is ExecuteDescribeStacksWithMocks plus opt-in
+// graceful degradation for recoverable per-value YAML function errors (see
+// DescribeStacksErrorOptions). Used by Terraform's `--all` preflight so that a component
+// whose `!terraform.state`/`!terraform.output` dependency hasn't been applied yet (e.g. a
+// fresh environment) doesn't abort dependency-graph resolution before the scheduler gets a
+// chance to apply that dependency first; other error classes (e.g. a missing `!secret`)
+// are not in the recoverable set and keep failing the preflight exactly as before.
+//
+//nolint:revive // Signature intentionally mirrors ExecuteDescribeStacksWithMocks with one added options parameter.
+func ExecuteDescribeStacksWithMocksAndOptions(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	useMocks bool,
+	tagsFilter []string,
+	labelsFilter map[string]string,
+	errOptions DescribeStacksErrorOptions,
+) (map[string]any, error) {
+	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithMocksAndOptions")()
+
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, errOptions)
+}
+
 // ExecuteDescribeStacksWithAuthDisabled processes stack manifests with auth explicitly disabled.
 //
 //nolint:revive // Signature intentionally mirrors ExecuteDescribeStacks with one compatibility parameter.

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -161,6 +161,15 @@ type DescribeStacksErrorOptions struct {
 	// convenience — it shares the same threading path as OnError/OnWarning. Optional; a nil
 	// OnProgress is a no-op, matching every existing caller's behavior exactly.
 	OnProgress func(stackFile string, index, total int)
+	// StrictAuth, when true, keeps a component-specific auth-manager construction failure
+	// fatal even under OnErrorWarn (see describeStacksProcessor.resolveComponentAuthManager) --
+	// only the recoverable per-value YAML-function errors (e.g. !terraform.state hitting a
+	// not-yet-provisioned backend) degrade. The zero value (false) preserves the original
+	// list/describe --error-mode=warn behavior, where a component whose own declared identity
+	// can't be resolved gracefully falls back to the parent AuthManager instead of aborting --
+	// appropriate for merely listing/describing stacks, but not for a Terraform preflight
+	// about to run real commands with whatever credentials it resolves.
+	StrictAuth bool
 }
 
 // ResolveErrorMode determines the effective --error-mode value using the documented
@@ -252,7 +261,15 @@ func ExecuteDescribeStacks(
 // When non-empty, tagsFilter/labelsFilter let out-of-scope components be skipped
 // before auth/template/YAML-function evaluation (see
 // describeStacksProcessor.scopeDecision) instead of only being filtered after the
-// fact by pkg/scheduler/adapters/terraform.go's post-filter.
+// fact by pkg/scheduler/adapters/terraform.go's post-filter. The errOptions parameter opts
+// a caller into graceful degradation for recoverable per-value YAML function errors (see
+// DescribeStacksErrorOptions) -- used by Terraform's `--all` preflight so that a
+// component whose `!terraform.state`/`!terraform.output` dependency hasn't been
+// applied yet (e.g. a fresh environment) doesn't abort dependency-graph resolution
+// before the scheduler gets a chance to apply that dependency first; other error
+// classes (e.g. a missing `!secret`) are not in the recoverable set and keep failing
+// the preflight exactly as before. The zero value (DescribeStacksErrorOptions{}) is
+// strict, matching every caller's behavior before errOptions was added.
 //
 //nolint:revive // Signature intentionally mirrors ExecuteDescribeStacks with compatibility parameters.
 func ExecuteDescribeStacksWithMocks(
@@ -270,39 +287,9 @@ func ExecuteDescribeStacksWithMocks(
 	useMocks bool,
 	tagsFilter []string,
 	labelsFilter map[string]string,
-) (map[string]any, error) {
-	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithMocks")()
-
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, DescribeStacksErrorOptions{})
-}
-
-// ExecuteDescribeStacksWithMocksAndOptions is ExecuteDescribeStacksWithMocks plus opt-in
-// graceful degradation for recoverable per-value YAML function errors (see
-// DescribeStacksErrorOptions). Used by Terraform's `--all` preflight so that a component
-// whose `!terraform.state`/`!terraform.output` dependency hasn't been applied yet (e.g. a
-// fresh environment) doesn't abort dependency-graph resolution before the scheduler gets a
-// chance to apply that dependency first; other error classes (e.g. a missing `!secret`)
-// are not in the recoverable set and keep failing the preflight exactly as before.
-//
-//nolint:revive // Signature intentionally mirrors ExecuteDescribeStacksWithMocks with one added options parameter.
-func ExecuteDescribeStacksWithMocksAndOptions(
-	atmosConfig *schema.AtmosConfiguration,
-	filterByStack string,
-	components []string,
-	componentTypes []string,
-	sections []string,
-	ignoreMissingFiles bool,
-	processTemplates bool,
-	processYamlFunctions bool,
-	includeEmptyStacks bool,
-	skip []string,
-	authManager auth.AuthManager,
-	useMocks bool,
-	tagsFilter []string,
-	labelsFilter map[string]string,
 	errOptions DescribeStacksErrorOptions,
 ) (map[string]any, error) {
-	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithMocksAndOptions")()
+	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithMocks")()
 
 	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, errOptions)
 }
@@ -456,6 +443,9 @@ func executeDescribeStacks(
 	processor.deferredContexts = deferredContexts
 	if errOptions.OnError == OnErrorWarn {
 		processor.withDegradation(errOptions.OnWarning)
+		if errOptions.StrictAuth {
+			processor.withStrictAuth()
+		}
 	}
 
 	totalStackFiles := len(stacksMap)

--- a/internal/exec/describe_stacks.go
+++ b/internal/exec/describe_stacks.go
@@ -252,7 +252,7 @@ func ExecuteDescribeStacks(
 	skip []string,
 	authManager auth.AuthManager,
 ) (map[string]any, error) {
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, false, false, nil, nil, DescribeStacksErrorOptions{})
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, false, false, nil, nil, DescribeStacksErrorOptions{}, nil)
 }
 
 // ExecuteDescribeStacksWithMocks processes stacks with Terraform lookup mocks enabled.
@@ -291,7 +291,7 @@ func ExecuteDescribeStacksWithMocks(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithMocks")()
 
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, errOptions)
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, false, useMocks, true, tagsFilter, labelsFilter, errOptions, nil)
 }
 
 // ExecuteDescribeStacksWithAuthDisabled processes stack manifests with auth explicitly disabled.
@@ -313,7 +313,7 @@ func ExecuteDescribeStacksWithAuthDisabled(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithAuthDisabled")()
 
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, nil, nil, DescribeStacksErrorOptions{})
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, nil, nil, DescribeStacksErrorOptions{}, nil)
 }
 
 // ExecuteDescribeStacksWithAuthDisabledAndMocks is the auth-disabled variant used
@@ -337,7 +337,7 @@ func ExecuteDescribeStacksWithAuthDisabledAndMocks(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithAuthDisabledAndMocks")()
 
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, useMocks, true, nil, nil, DescribeStacksErrorOptions{})
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, useMocks, true, nil, nil, DescribeStacksErrorOptions{}, nil)
 }
 
 // ExecuteDescribeStacksWithOptions is ExecuteDescribeStacksWithAuthDisabled plus opt-in
@@ -365,7 +365,7 @@ func ExecuteDescribeStacksWithOptions(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithOptions")()
 
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, nil, nil, errOptions)
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, nil, nil, errOptions, nil)
 }
 
 // ExecuteDescribeStacksScoped is ExecuteDescribeStacksWithOptions plus the
@@ -395,7 +395,50 @@ func ExecuteDescribeStacksScoped(
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksScoped")()
 
-	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, tagsFilter, labelsFilter, errOptions)
+	return executeDescribeStacks(atmosConfig, filterByStack, components, componentTypes, sections, ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks, skip, authManager, authDisabled, false, false, tagsFilter, labelsFilter, errOptions, nil)
+}
+
+// ExecuteDescribeStacksWithEvalSections is the most general opt-in describe-stacks entry point:
+// authDisabled + tags/labels early-skip scope + graceful error-mode degradation + the
+// evaluation-sections gate, all in one call.
+//
+// The evalSections parameter is DELIBERATELY separate from `sections`: `sections` only trims the
+// OUTPUT after full evaluation (unaffected by this call, exactly as every other Execute* variant
+// leaves it); evalSections additionally restricts WHICH top-level component sections get
+// Go-template rendering and YAML-function resolution at all -- see isSectionRequired. A nil
+// evalSections reproduces the exact eager-evaluation behavior of every other Execute* variant.
+// Used by the `list stacks`/`list components`/`list instances` commands (via
+// column.RequiredSections) to avoid evaluating expensive
+// `!terraform.state`/`!terraform.output`/`atmos.Component` values that no requested column will
+// ever display -- see https://github.com/cloudposse/atmos/issues/3068.
+//
+//nolint:revive // Signature intentionally mirrors ExecuteDescribeStacksScoped with the eval-sections parameter added.
+func ExecuteDescribeStacksWithEvalSections(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+	tagsFilter []string,
+	labelsFilter map[string]string,
+	errOptions DescribeStacksErrorOptions,
+	evalSections []string,
+) (map[string]any, error) {
+	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacksWithEvalSections")()
+
+	return executeDescribeStacks(
+		atmosConfig, filterByStack, components, componentTypes, sections,
+		ignoreMissingFiles, processTemplates, processYamlFunctions, includeEmptyStacks,
+		skip, authManager, authDisabled, false, false, tagsFilter, labelsFilter, errOptions,
+		evalSections,
+	)
 }
 
 //nolint:revive // Internal wrapper preserves the existing ExecuteDescribeStacks call shape.
@@ -417,6 +460,7 @@ func executeDescribeStacks(
 	tagsFilter []string,
 	labelsFilter map[string]string,
 	errOptions DescribeStacksErrorOptions,
+	evalSections []string,
 ) (map[string]any, error) {
 	defer perf.Track(atmosConfig, "exec.ExecuteDescribeStacks")()
 
@@ -438,6 +482,7 @@ func executeDescribeStacks(
 	processor.resolveSecrets = resolveSecrets
 	processor.tagsFilter = tagsFilter
 	processor.labelsFilter = labelsFilter
+	processor.evalSections = evalSections
 	// Recover per-component deferred-merge contexts from the FindStacksMap cache so Stage 3
 	// (resolveDeferredYamlFunctions) can run below — see processComponentEntry.
 	processor.deferredContexts = deferredContexts

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -107,6 +107,13 @@ type describeStacksProcessor struct {
 	// nil and reported here instead of aborting the whole describe-stacks call. See
 	// ProcessCustomYamlTagsLenient and ExecuteDescribeStacksWithOptions.
 	onWarning func(DegradationWarning)
+	// degradeAuthErrors mirrors onWarning's lenient/strict split specifically for
+	// resolveComponentAuthManager's own construction failures. withDegradation defaults this
+	// to true (matching the original, single-flag list/describe --error-mode=warn behavior);
+	// withStrictAuth flips it back to false for callers (the Terraform --all/--query preflight)
+	// that want YAML-function values to degrade but a component's own unresolvable identity to
+	// stay fatal.
+	degradeAuthErrors bool
 	// deferredContexts holds every component's deferred-merge contexts, recovered from the
 	// FindStacksMap cache in ExecuteDescribeStacks. processComponentEntry looks up each
 	// component's entry to run Stage 3 (resolveDeferredYamlFunctions) after Stage 2 — this
@@ -118,10 +125,23 @@ type describeStacksProcessor struct {
 // withDegradation switches the processor to lenient YAML-function processing: recoverable
 // per-value errors are substituted with nil and reported via onWarning instead of failing
 // the whole describe-stacks call. Passing a nil onWarning restores the default strict
-// behavior (equivalent to not calling withDegradation at all).
+// behavior (equivalent to not calling withDegradation at all). A non-nil onWarning also
+// defaults degradeAuthErrors to true (the original, single-flag behavior); chain
+// withStrictAuth to opt back out just for component-specific auth-manager failures.
 func (p *describeStacksProcessor) withDegradation(onWarning func(DegradationWarning)) *describeStacksProcessor {
 	p.onWarning = onWarning
+	p.degradeAuthErrors = onWarning != nil
 	return p
+}
+
+// withStrictAuth keeps a component-specific auth-manager construction failure fatal even
+// though withDegradation has enabled lenient YAML-function processing. Used by the
+// Terraform --all/--query preflight (DescribeStacksErrorOptions.StrictAuth): a not-yet-applied
+// dependency's `!terraform.state` value should degrade, but a component whose own identity
+// can't be resolved should still abort before real Terraform commands run with the wrong
+// (or a merely inherited) credential set.
+func (p *describeStacksProcessor) withStrictAuth() {
+	p.degradeAuthErrors = false
 }
 
 // newDescribeStacksProcessor creates a processor with an empty result map.
@@ -230,7 +250,7 @@ func (p *describeStacksProcessor) resolveComponentAuthManager(
 	}
 	resolved, createErr := resolver(p.atmosConfig, componentSection, componentName, stackName, p.authManager)
 	if createErr != nil {
-		if p.onWarning != nil {
+		if p.onWarning != nil && p.degradeAuthErrors {
 			p.onWarning(DegradationWarning{
 				Stack:     stackName,
 				Component: componentName,

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -120,6 +120,16 @@ type describeStacksProcessor struct {
 	// processor does not go through processStacks (utils.go), so it must resolve deferred
 	// YAML functions itself instead of silently losing their contribution (#2888).
 	deferredContexts AllStacksDeferredContexts
+	// evalSections is the opt-in evaluation-scope filter set by
+	// ExecuteDescribeStacksWithEvalSections: when non-nil, template rendering and YAML-function
+	// resolution (Stages 2/3, plus Go-template rendering) only run for these top-level component
+	// sections -- see isSectionRequired. This is DELIBERATELY separate from `sections` (which
+	// only trims the OUTPUT after full evaluation and is unaffected by this field): the two solve
+	// different problems and reusing `sections` for both would silently change the long-standing
+	// behavior of `atmos describe stacks --sections=X` (today a pure output filter that never
+	// skips evaluation). Only the `list` commands ever set evalSections; every other caller
+	// leaves it nil and gets exactly the eager-evaluation behavior that predates this field.
+	evalSections []string
 }
 
 // withDegradation switches the processor to lenient YAML-function processing: recoverable
@@ -548,7 +558,7 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 
 	// Process Go templates.
 	if p.processTemplates {
-		componentSection, err = processComponentSectionTemplates(p.atmosConfig, &info, componentSection, secs.settings)
+		componentSection, err = processComponentSectionTemplates(p.atmosConfig, &info, componentSection, secs.settings, p.evalSections)
 		if err != nil {
 			return err
 		}
@@ -574,6 +584,7 @@ func (p *describeStacksProcessor) processComponentEntry( //nolint:gocognit,reviv
 			skip,
 			p.onWarning,
 			!p.resolveSecrets && iolib.MaskingEnabled(),
+			p.evalSections,
 		)
 		if err != nil {
 			return err
@@ -634,7 +645,7 @@ func (p *describeStacksProcessor) resolveDeferredForComponent(
 	for k, v := range info.ComponentSection {
 		componentTemplateContext[k] = v
 	}
-	if err := resolveDeferredYamlFunctions(p.atmosConfig, info, &settingsSectionStruct, componentTemplateContext, skip); err != nil {
+	if err := resolveDeferredYamlFunctions(p.atmosConfig, info, &settingsSectionStruct, componentTemplateContext, skip, p.evalSections); err != nil {
 		return nil, err
 	}
 
@@ -1049,16 +1060,40 @@ func addSectionsToComponentEntry(
 
 // processComponentSectionTemplates applies Go template processing to a component section
 // and returns the rendered section as a map.
+//
+// The evalSections parameter is the opt-in evaluation-scope filter (see isSectionRequired): when
+// non-nil, only the top-level sections it names are serialized into the template SOURCE that
+// text/template actually parses and executes -- any atmos.Component/atmos.GomplateDatasource/etc.
+// call embedded in a skipped section's raw text is never invoked, which is the actual fix for
+// https://github.com/cloudposse/atmos/issues/3068. The template CONTEXT (the "." root available
+// to {{ }} expressions) is still built from the full, unfiltered componentSection below, so a
+// required section's template can still plain-field-access into a skipped section's raw (merged
+// but unrendered) value -- see the accepted cross-section limitation documented on
+// isSectionRequired's callers.
 func processComponentSectionTemplates(
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
 	componentSection map[string]any,
 	settingsSection map[string]any,
+	evalSections []string,
 ) (map[string]any, error) {
+	evalInput, evalExcluded := splitSectionsByRequirement(componentSection, evalSections)
+
 	// Sections computed from Terraform source code (`component_info`) are not Atmos
 	// configuration and must not be rendered as `Go` templates. They stay in the template
 	// context below, only the rendered input excludes them. See #2145.
-	templateInput, nonTemplatedSections := splitNonTemplatedSections(componentSection)
+	templateInput, nonTemplatedSections := splitNonTemplatedSections(evalInput)
+
+	if len(templateInput) == 0 {
+		// Nothing needs template rendering (e.g. no column references any section). Skip
+		// ProcessTmplWithDatasources and the YAML round-trip entirely and hand back every section
+		// untouched -- this is the fast path that avoids the atmos.Component/GomplateDatasource
+		// slow path in #3068 when it isn't needed at all.
+		result := make(map[string]any, len(nonTemplatedSections)+len(evalExcluded))
+		restoreNonTemplatedSections(result, nonTemplatedSections)
+		restoreNonTemplatedSections(result, evalExcluded)
+		return result, nil
+	}
 
 	componentSectionStr, err := atmosYaml.ConvertToYAMLPreservingDelimiters(
 		templateInput,
@@ -1120,6 +1155,7 @@ func processComponentSectionTemplates(
 	}
 
 	restoreNonTemplatedSections(converted, nonTemplatedSections)
+	restoreNonTemplatedSections(converted, evalExcluded)
 
 	return converted, nil
 }
@@ -1128,6 +1164,14 @@ func processComponentSectionTemplates(
 // When onWarning is non-nil, recoverable per-value errors are tolerated — see
 // ProcessCustomYamlTagsLenient. For example, a Terraform backend might not yet be provisioned.
 // The secretsMaskOnly parameter selects the inspection behavior that replaces !secret values without a backend lookup.
+//
+// The evalSections parameter is the opt-in evaluation-scope filter (see isSectionRequired): when
+// non-nil, only the top-level sections it names are walked for
+// `!terraform.state`/`!terraform.output`/`!store`/etc. YAML functions. Skipped sections are
+// restored untouched afterward. Stage 2's YAML-function resolution has no cross-section
+// dependency -- each tag resolves independently of its siblings (only a shared ResolutionContext
+// exists, for cycle detection) -- so narrowing its input map is safe without needing a separate
+// "context" the way Go-template rendering does.
 func processComponentSectionYAMLFunctions(
 	atmosConfig *schema.AtmosConfiguration,
 	info *schema.ConfigAndStacksInfo,
@@ -1135,14 +1179,18 @@ func processComponentSectionYAMLFunctions(
 	skip []string,
 	onWarning func(DegradationWarning),
 	secretsMaskOnly bool,
+	evalSections []string,
 ) (map[string]any, error) {
 	info.SecretsMaskOnly = secretsMaskOnly
+
+	evalInput, evalExcluded := splitSectionsByRequirement(componentSection, evalSections)
+
 	var converted map[string]any
 	var err error
 	if onWarning != nil {
 		converted, err = ProcessCustomYamlTagsLenient(
 			atmosConfig,
-			componentSection,
+			evalInput,
 			info.Stack,
 			skip,
 			info,
@@ -1151,7 +1199,7 @@ func processComponentSectionYAMLFunctions(
 	} else {
 		converted, err = ProcessCustomYamlTags(
 			atmosConfig,
-			componentSection,
+			evalInput,
 			info.Stack,
 			skip,
 			info,
@@ -1160,6 +1208,7 @@ func processComponentSectionYAMLFunctions(
 	if err != nil {
 		return nil, err
 	}
+	restoreNonTemplatedSections(converted, evalExcluded)
 	return converted, nil
 }
 

--- a/internal/exec/describe_stacks_component_processor.go
+++ b/internal/exec/describe_stacks_component_processor.go
@@ -1089,7 +1089,10 @@ func processComponentSectionTemplates(
 		// ProcessTmplWithDatasources and the YAML round-trip entirely and hand back every section
 		// untouched -- this is the fast path that avoids the atmos.Component/GomplateDatasource
 		// slow path in #3068 when it isn't needed at all.
-		result := make(map[string]any, len(nonTemplatedSections)+len(evalExcluded))
+		//
+		// Size the map from a single len() — CodeQL's allocation-size-overflow rule flags
+		// len(nonTemplatedSections)+len(evalExcluded); the map grows as needed for the rest.
+		result := make(map[string]any, len(nonTemplatedSections))
 		restoreNonTemplatedSections(result, nonTemplatedSections)
 		restoreNonTemplatedSections(result, evalExcluded)
 		return result, nil

--- a/internal/exec/describe_stacks_component_processor_auth_test.go
+++ b/internal/exec/describe_stacks_component_processor_auth_test.go
@@ -366,6 +366,46 @@ func TestResolveComponentAuthManager_ResolverErrorDegradesInWarnMode(t *testing.
 	assert.Contains(t, warnings[0].Reason, assert.AnError.Error())
 }
 
+// TestResolveComponentAuthManager_ResolverErrorFatalUnderStrictAuth is the regression guard
+// for the Terraform --all/--query preflight: withDegradation alone (used by list/describe
+// --error-mode=warn) falls back to the parent AuthManager on a resolver error, but chaining
+// withStrictAuth (DescribeStacksErrorOptions.StrictAuth) must keep that same error fatal even
+// though YAML-function values still degrade -- otherwise the preflight silently proceeds with
+// the wrong (inherited) credentials instead of reporting the real "can't resolve this
+// component's own identity" failure (e.g. its local emulator isn't running).
+func TestResolveComponentAuthManager_ResolverErrorFatalUnderStrictAuth(t *testing.T) {
+	t.Parallel()
+
+	parentMgr := auth.AuthManager(nil)
+	spy := &componentAuthResolverSpy{
+		returnMgr: nil,
+		returnErr: assert.AnError,
+	}
+
+	var warnings []DegradationWarning
+	p := &describeStacksProcessor{
+		atmosConfig:           &schema.AtmosConfiguration{},
+		processTemplates:      true,
+		processYamlFunctions:  false,
+		authManager:           parentMgr,
+		componentAuthResolver: spy.resolver(),
+		finalStacksMap:        make(map[string]any),
+	}
+	p.withDegradation(func(w DegradationWarning) { warnings = append(warnings, w) })
+	p.withStrictAuth()
+
+	got, err := p.resolveComponentAuthManager(
+		componentSectionWithAuth(authSectionWithDefault()),
+		"test-component",
+		"test-stack",
+	)
+
+	require.Error(t, err, "StrictAuth must keep a component's own auth-manager failure fatal")
+	assert.ErrorIs(t, err, errUtils.ErrAuthManager)
+	assert.Nil(t, got)
+	assert.Empty(t, warnings, "a fatal error must not also report a degradation warning")
+}
+
 func TestProcessComponentEntry_ComponentAuthResolverErrorIsFatal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/exec/describe_stacks_component_processor_test.go
+++ b/internal/exec/describe_stacks_component_processor_test.go
@@ -1147,7 +1147,7 @@ func TestProcessComponentSectionTemplates_ConvertToYAMLError(t *testing.T) {
 		"key": yamlMarshalError{},
 	}
 
-	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{})
+	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, nil)
 	require.Error(t, err)
 }
 
@@ -1167,7 +1167,7 @@ func TestProcessComponentSectionTemplates_MapstructureDecodeError(t *testing.T) 
 		},
 	}
 
-	_, err := processComponentSectionTemplates(ac, info, componentSection, settingsSection)
+	_, err := processComponentSectionTemplates(ac, info, componentSection, settingsSection, nil)
 	require.Error(t, err)
 }
 
@@ -1192,7 +1192,7 @@ func TestProcessComponentSectionTemplates_ProcessTmplError(t *testing.T) {
 		},
 	}
 
-	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{})
+	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, nil)
 	require.Error(t, err)
 }
 
@@ -1223,7 +1223,7 @@ func TestProcessComponentSectionTemplates_UnmarshalYAMLError(t *testing.T) {
 		`{{ "\n- list_item" }}`: "value",
 	}
 
-	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{})
+	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, nil)
 	require.Error(t, err)
 }
 
@@ -1245,7 +1245,7 @@ func TestProcessComponentSectionTemplates_AddTemplateContextError(t *testing.T) 
 		},
 	}
 
-	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{})
+	_, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, nil)
 	require.Error(t, err)
 }
 
@@ -1341,7 +1341,7 @@ func TestProcessComponentSectionYAMLFunctions_Error(t *testing.T) {
 		},
 	}
 
-	_, err := processComponentSectionYAMLFunctions(ac, info, componentSection, nil, nil, false)
+	_, err := processComponentSectionYAMLFunctions(ac, info, componentSection, nil, nil, false, nil)
 	require.Error(t, err)
 }
 
@@ -1541,7 +1541,7 @@ func TestProcessComponentSectionTemplates_TemplatesDisabledSuccess(t *testing.T)
 		},
 	}
 
-	result, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{})
+	result, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	vars, ok := result["vars"].(map[string]any)
@@ -1754,7 +1754,7 @@ func TestProcessComponentSectionYAMLFunctions_Lenient_Warn(t *testing.T) {
 	var warnings []DegradationWarning
 	result, err := processComponentSectionYAMLFunctions(ac, info, componentSection, nil, func(w DegradationWarning) {
 		warnings = append(warnings, w)
-	}, false)
+	}, false, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/internal/exec/eval_sections.go
+++ b/internal/exec/eval_sections.go
@@ -1,0 +1,50 @@
+package exec
+
+import "slices"
+
+// isSectionRequired reports whether sectionName must be evaluated (rendered as a Go template
+// and/or have its YAML functions resolved) given an eval-sections filter.
+//
+// A nil filter disables gating entirely: every section is required, matching the historical
+// eager-evaluation behavior exactly. This is what every existing caller gets (describe stacks,
+// terraform, helmfile, hooks, etc.) since only the `list stacks`/`list components`/
+// `list instances` commands ever construct a non-nil filter (see column.RequiredSections). A
+// non-nil filter (even an empty one, meaning "no column needs any section") gates by membership.
+//
+// Deliberately checks `sections == nil`, NOT `len(sections) == 0`: an empty-but-non-nil slice is
+// a real, valid "nothing is required" filter and must NOT be treated the same as "no filter" --
+// collapsing the two (as a bare len() check would) would silently disable gating exactly when it
+// matters most (default `list stacks` columns, which reference no section at all). Do not
+// "simplify" this to `len(sections) == 0` -- that reintroduces the spurious eager-evaluation bug
+// this file exists to fix.
+func isSectionRequired(sections []string, sectionName string) bool {
+	if sections == nil {
+		return true
+	}
+	return slices.Contains(sections, sectionName)
+}
+
+// splitSectionsByRequirement returns a shallow copy of componentSection restricted to the
+// top-level sections isSectionRequired approves, plus the sections that were left out so the
+// caller can restore them untouched afterward (see restoreNonTemplatedSections, reused here
+// generically since "copy excluded keys back in" is identical for both use cases).
+//
+// A nil filter (gating disabled) returns the input unchanged with a nil excluded map -- the same
+// "nothing was split" shape splitNonTemplatedSections uses for its own no-op case, so both
+// exclusion sources can be restored through the same helper without special-casing nil.
+func splitSectionsByRequirement(componentSection map[string]any, sections []string) (filtered, excluded map[string]any) {
+	if sections == nil {
+		return componentSection, nil
+	}
+
+	filtered = make(map[string]any, len(componentSection))
+	excluded = make(map[string]any, len(componentSection))
+	for key, value := range componentSection {
+		if isSectionRequired(sections, key) {
+			filtered[key] = value
+		} else {
+			excluded[key] = value
+		}
+	}
+	return filtered, excluded
+}

--- a/internal/exec/eval_sections_test.go
+++ b/internal/exec/eval_sections_test.go
@@ -1,0 +1,268 @@
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	errUtils "github.com/cloudposse/atmos/errors"
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+func TestIsSectionRequired(t *testing.T) {
+	tests := []struct {
+		name        string
+		sections    []string
+		sectionName string
+		want        bool
+	}{
+		{name: "nil filter requires everything (vars)", sections: nil, sectionName: "vars", want: true},
+		{name: "nil filter requires everything (settings)", sections: nil, sectionName: "settings", want: true},
+		{name: "empty non-nil filter requires nothing", sections: []string{}, sectionName: "vars", want: false},
+		{name: "non-nil filter matches member", sections: []string{"vars"}, sectionName: "vars", want: true},
+		{name: "non-nil filter rejects non-member", sections: []string{"vars"}, sectionName: "settings", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSectionRequired(tt.sections, tt.sectionName))
+		})
+	}
+}
+
+func TestSplitSectionsByRequirement(t *testing.T) {
+	componentSection := map[string]any{
+		"vars":     map[string]any{"region": "us-east-1"},
+		"settings": map[string]any{"foo": "bar"},
+		"metadata": map[string]any{"type": "real"},
+	}
+
+	t.Run("nil filter returns the input unchanged and a nil excluded map", func(t *testing.T) {
+		filtered, excluded := splitSectionsByRequirement(componentSection, nil)
+		assert.Equal(t, componentSection, filtered)
+		assert.Nil(t, excluded)
+	})
+
+	t.Run("empty filter excludes everything", func(t *testing.T) {
+		filtered, excluded := splitSectionsByRequirement(componentSection, []string{})
+		assert.Empty(t, filtered)
+		assert.Equal(t, componentSection, excluded)
+	})
+
+	t.Run("filter splits required from excluded", func(t *testing.T) {
+		filtered, excluded := splitSectionsByRequirement(componentSection, []string{"vars"})
+		assert.Equal(t, map[string]any{"vars": componentSection["vars"]}, filtered)
+		assert.Equal(t, map[string]any{
+			"settings": componentSection["settings"],
+			"metadata": componentSection["metadata"],
+		}, excluded)
+	})
+}
+
+// TestProcessComponentSectionTemplates_EvalSections_SkipsExcludedSection proves the fast path
+// added to processComponentSectionTemplates: when evalSections excludes every section, template
+// rendering (ProcessTmplWithDatasources) is skipped entirely and every section is returned
+// byte-for-byte untouched -- including a literal `{{ }}` expression, which would otherwise have
+// been rendered (and, if it were an atmos.Component call, executed).
+func TestProcessComponentSectionTemplates_EvalSections_SkipsExcludedSection(t *testing.T) {
+	ac := templatingEnabledConfig()
+	info := &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}
+	componentSection := map[string]any{
+		"vars": map[string]any{
+			"region": "{{ .settings.owner }}", // would render to "acme" if evaluated.
+		},
+		"settings": map[string]any{
+			"owner": "acme",
+		},
+	}
+
+	result, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, []string{})
+	require.NoError(t, err)
+
+	vars, ok := result["vars"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "{{ .settings.owner }}", vars["region"], "vars was excluded from evalSections, so its template must never be rendered")
+}
+
+// TestProcessComponentSectionTemplates_EvalSections_RendersRequiredSection proves the
+// complementary case: a required section IS rendered normally, and can read a skipped sibling
+// section's raw (unrendered) value through the template context, which is always built from the
+// full, unfiltered componentSection -- see processComponentSectionTemplates' doc comment. This is
+// the accepted cross-section limitation: since `settings` is excluded and therefore never
+// rendered, `owner` in the context is whatever raw value it already had (here a plain string, but
+// see the YAML-tag variant below for the more interesting case).
+func TestProcessComponentSectionTemplates_EvalSections_RendersRequiredSection(t *testing.T) {
+	ac := templatingEnabledConfig()
+	info := &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}
+	componentSection := map[string]any{
+		"vars": map[string]any{
+			"region": "{{ .settings.owner }}",
+		},
+		"settings": map[string]any{
+			"owner": "acme",
+		},
+	}
+
+	result, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, []string{"vars"})
+	require.NoError(t, err)
+
+	vars, ok := result["vars"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "acme", vars["region"], "vars is required, so its template renders normally against the full (unfiltered) context")
+
+	settings, ok := result["settings"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "acme", settings["owner"], "settings was excluded from evalSections, so it must be restored completely untouched")
+}
+
+// TestProcessComponentSectionTemplates_EvalSections_CrossSectionLimitation is the dedicated test
+// for the accepted limitation documented on processComponentSectionTemplates: a required
+// section's template reads a field from a skipped section, and that field's raw value is itself
+// an un-rendered `!terraform.state` YAML-function string (i.e. the skipped section needed
+// processing too, but was never touched because it wasn't required). The required section's
+// output contains that literal unresolved substring instead of the real backend value -- the same
+// "deferred but never resolved = literal string" class of behavior already documented at
+// internal/exec/stack_processor_merge.go:114-122, reached here via a new path (evalSections
+// gating) rather than a new failure mode. This must not panic or corrupt any other section.
+func TestProcessComponentSectionTemplates_EvalSections_CrossSectionLimitation(t *testing.T) {
+	ac := templatingEnabledConfig()
+	info := &schema.ConfigAndStacksInfo{ComponentSection: map[string]any{}}
+	const unresolvedTag = "!terraform.state vpc dev bucket_name"
+	componentSection := map[string]any{
+		"vars": map[string]any{
+			"combined": "{{ .settings.foo }}-suffix",
+		},
+		"settings": map[string]any{
+			// settings is excluded below, so Stage 2 (YAML-tag resolution) never runs over
+			// this value either -- it stays exactly this literal string throughout.
+			"foo": unresolvedTag,
+		},
+		"metadata": map[string]any{
+			"owner": "unaffected",
+		},
+	}
+
+	result, err := processComponentSectionTemplates(ac, info, componentSection, map[string]any{}, []string{"vars"})
+	require.NoError(t, err)
+
+	vars, ok := result["vars"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, unresolvedTag+"-suffix", vars["combined"],
+		"required vars template reads .settings.foo -- since settings was skipped, the raw unresolved YAML-tag string is substituted literally")
+
+	settings, ok := result["settings"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, unresolvedTag, settings["foo"], "the skipped settings section itself must be restored completely untouched")
+
+	metadata, ok := result["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "unaffected", metadata["owner"], "an unrelated skipped section must not be corrupted by the cross-section read")
+}
+
+// TestExecuteDescribeStacksWithEvalSections_SkipsUnrequiredSection is the exec-layer proof behind
+// the `list stacks`/`list components`/`list instances` fix for
+// https://github.com/cloudposse/atmos/issues/3068 and the spurious "(computed)" warning: when
+// evalSections excludes "vars" (mirroring a default `list stacks` invocation, whose only column
+// is `{{ .stack }}`), the `!terraform.state` call embedded in vars.bucket is never invoked at all
+// -- zero degradation warnings AND zero backend calls (proven via the mock's strict
+// unexpected-call failure, not just a Times(0) on one arg combination) -- while a filter that DOES
+// require "vars" (mirroring `--columns` referencing `.vars`) degrades exactly like the unfiltered
+// (nil evalSections) path.
+func TestExecuteDescribeStacksWithEvalSections_SkipsUnrequiredSection(t *testing.T) {
+	atmosConfig := buildDescribeStacksDegradationFixture(t)
+
+	t.Run("evalSections excludes vars: zero warnings, GetState never called", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockStateGetter := NewMockTerraformStateGetter(ctrl)
+		originalGetter := stateGetter
+		stateGetter = mockStateGetter
+		defer func() { stateGetter = originalGetter }()
+		// No EXPECT() registered on GetState: gomock fails the test on any unexpected call,
+		// which is exactly the assertion this test needs -- the expensive backend lookup must
+		// never run at all when no column requires `vars`.
+
+		var warnings []DegradationWarning
+		result, err := ExecuteDescribeStacksWithEvalSections(
+			&atmosConfig, "", nil, nil, nil, false,
+			false, // processTemplates
+			true,  // processYamlFunctions
+			false, // includeEmptyStacks
+			nil, nil, false, nil, nil,
+			DescribeStacksErrorOptions{
+				OnError:   OnErrorWarn,
+				OnWarning: func(w DegradationWarning) { warnings = append(warnings, w) },
+			},
+			[]string{}, // evalSections: no section required, mirrors default `list stacks` columns.
+		)
+
+		require.NoError(t, err)
+		assert.Empty(t, warnings, "no column needs `vars`, so the !terraform.state call must never even run")
+		assert.NotEmpty(t, result)
+	})
+
+	t.Run("evalSections includes vars: degrades exactly like the unfiltered path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockStateGetter := NewMockTerraformStateGetter(ctrl)
+		originalGetter := stateGetter
+		stateGetter = mockStateGetter
+		defer func() { stateGetter = originalGetter }()
+
+		recoverableErr := fmt.Errorf("%w for component `vpc` in stack `dev`", errUtils.ErrTerraformStateNotProvisioned)
+		mockStateGetter.EXPECT().
+			GetState(gomock.Any(), gomock.Any(), "dev", "vpc", "bucket_name", false, gomock.Any(), gomock.Any()).
+			Return(nil, recoverableErr).
+			Times(1)
+
+		var warnings []DegradationWarning
+		_, err := ExecuteDescribeStacksWithEvalSections(
+			&atmosConfig, "", nil, nil, nil, false,
+			false, true, false, nil, nil, false, nil, nil,
+			DescribeStacksErrorOptions{
+				OnError:   OnErrorWarn,
+				OnWarning: func(w DegradationWarning) { warnings = append(warnings, w) },
+			},
+			[]string{"vars"},
+		)
+
+		require.NoError(t, err)
+		require.Len(t, warnings, 1)
+	})
+
+	// Regression: nil evalSections (every existing caller -- describe stacks, terraform,
+	// helmfile, hooks, etc.) must behave identically to the pre-existing, unfiltered
+	// ExecuteDescribeStacksWithOptions path (see
+	// TestExecuteDescribeStacks_OnErrorWarn_DegradesRecoverableError) -- full eager evaluation,
+	// one degradation warning, no gating whatsoever.
+	t.Run("nil evalSections: identical to full eager evaluation", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockStateGetter := NewMockTerraformStateGetter(ctrl)
+		originalGetter := stateGetter
+		stateGetter = mockStateGetter
+		defer func() { stateGetter = originalGetter }()
+
+		recoverableErr := fmt.Errorf("%w for component `vpc` in stack `dev`", errUtils.ErrTerraformStateNotProvisioned)
+		mockStateGetter.EXPECT().
+			GetState(gomock.Any(), gomock.Any(), "dev", "vpc", "bucket_name", false, gomock.Any(), gomock.Any()).
+			Return(nil, recoverableErr).
+			Times(1)
+
+		var warnings []DegradationWarning
+		_, err := ExecuteDescribeStacksWithEvalSections(
+			&atmosConfig, "", nil, nil, nil, false,
+			false, true, false, nil, nil, false, nil, nil,
+			DescribeStacksErrorOptions{
+				OnError:   OnErrorWarn,
+				OnWarning: func(w DegradationWarning) { warnings = append(warnings, w) },
+			},
+			nil,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, warnings, 1, "nil evalSections must reproduce the exact eager-evaluation behavior of every other Execute* variant")
+	})
+}

--- a/internal/exec/stacks_processor.go
+++ b/internal/exec/stacks_processor.go
@@ -131,3 +131,47 @@ func (d *DefaultStacksProcessor) ExecuteDescribeStacksWithAuthDisabled(
 		authDisabled,
 	)
 }
+
+// ExecuteDescribeStacksWithEvalSections delegates to the package-level
+// ExecuteDescribeStacksWithEvalSections function. It is the optional, richer variant consumed by
+// callers (see pkg/list/list_instances.go's evalSectionsStacksProcessor type assertion) that need
+// the evaluation-sections gate on top of the auth-disabled + tags/labels-scoped behavior the other
+// methods on this type provide individually.
+//
+//nolint:revive // Signature matches ExecuteDescribeStacksWithEvalSections.
+func (d *DefaultStacksProcessor) ExecuteDescribeStacksWithEvalSections(
+	atmosConfig *schema.AtmosConfiguration,
+	filterByStack string,
+	components []string,
+	componentTypes []string,
+	sections []string,
+	ignoreMissingFiles bool,
+	processTemplates bool,
+	processYamlFunctions bool,
+	includeEmptyStacks bool,
+	skip []string,
+	authManager auth.AuthManager,
+	authDisabled bool,
+	tagsFilter []string,
+	labelsFilter map[string]string,
+	evalSections []string,
+) (map[string]any, error) {
+	return ExecuteDescribeStacksWithEvalSections(
+		atmosConfig,
+		filterByStack,
+		components,
+		componentTypes,
+		sections,
+		ignoreMissingFiles,
+		processTemplates,
+		processYamlFunctions,
+		includeEmptyStacks,
+		skip,
+		authManager,
+		authDisabled,
+		tagsFilter,
+		labelsFilter,
+		DescribeStacksErrorOptions{},
+		evalSections,
+	)
+}

--- a/internal/exec/terraform.go
+++ b/internal/exec/terraform.go
@@ -36,10 +36,11 @@ const (
 	// can run a terraform subcommand against the live env, RC, and working directory.
 	afterTerraformInitEvent = "after.terraform.init"
 
-	subcommandApply     = "apply"
-	subcommandDeploy    = "deploy"
-	subcommandInit      = "init"
-	subcommandWorkspace = "workspace"
+	subcommandApply         = "apply"
+	subcommandDeploy        = "deploy"
+	subcommandInit          = "init"
+	subcommandWorkspace     = "workspace"
+	subcommandProvidersLock = "providers-lock"
 
 	autoApproveFlag           = "-auto-approve"
 	outFlag                   = "-out"

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -110,7 +110,7 @@ func terraformClosureRequested(info *schema.ConfigAndStacksInfo) bool {
 // resulting graph, so the evaluation scope and execution set always agree.
 func describeTerraformStacksForExecution(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, authManager auth.AuthManager, components []string) (map[string]any, error) {
 	describe := func(stackName string, closureComponents []string, processTemplates, processFunctions bool) (map[string]any, error) {
-		return ExecuteDescribeStacksWithMocksAndOptions(
+		return ExecuteDescribeStacksWithMocks(
 			atmosConfig,
 			stackName,
 			closureComponents, // engine-supplied closure members (nil = all); never the caller's own selection.
@@ -165,7 +165,7 @@ func describeTerraformStacksForExecution(atmosConfig *schema.AtmosConfiguration,
 // describeTerraformStacksNarrowed is the historical (no-closure) describe:
 // narrowed by -s/--components and the tags/labels early-skip, bit for bit.
 func describeTerraformStacksNarrowed(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, authManager auth.AuthManager, components []string) (map[string]any, error) {
-	return ExecuteDescribeStacksWithMocksAndOptions(
+	return ExecuteDescribeStacksWithMocks(
 		atmosConfig,
 		info.Stack,
 		components,
@@ -193,9 +193,16 @@ func describeTerraformStacksNarrowed(atmosConfig *schema.AtmosConfiguration, inf
 // re-resolves its own vars fresh immediately before its own plan/apply, so a degraded
 // placeholder value here is never reused for a real apply. Other error classes (e.g. a
 // missing `!secret`) are not in the recoverable set and still fail the preflight as before.
+//
+// StrictAuth is set so a component whose own declared identity can't be resolved (e.g. its
+// local emulator isn't running) still fails the preflight immediately, instead of silently
+// falling back to a parent AuthManager and going on to attempt a real, and much slower and
+// more confusing, network call with the wrong credentials — the list/describe --error-mode=warn
+// behavior that plain YAML-function degradation shares this mechanism with.
 func terraformPreflightErrorOptions() DescribeStacksErrorOptions {
 	return DescribeStacksErrorOptions{
-		OnError: OnErrorWarn,
+		OnError:    OnErrorWarn,
+		StrictAuth: true,
 		OnWarning: func(w DegradationWarning) {
 			log.Debug(
 				"Deferring unresolved value until its dependency is applied",

--- a/internal/exec/terraform_all.go
+++ b/internal/exec/terraform_all.go
@@ -110,7 +110,7 @@ func terraformClosureRequested(info *schema.ConfigAndStacksInfo) bool {
 // resulting graph, so the evaluation scope and execution set always agree.
 func describeTerraformStacksForExecution(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, authManager auth.AuthManager, components []string) (map[string]any, error) {
 	describe := func(stackName string, closureComponents []string, processTemplates, processFunctions bool) (map[string]any, error) {
-		return ExecuteDescribeStacksWithMocks(
+		return ExecuteDescribeStacksWithMocksAndOptions(
 			atmosConfig,
 			stackName,
 			closureComponents, // engine-supplied closure members (nil = all); never the caller's own selection.
@@ -125,6 +125,7 @@ func describeTerraformStacksForExecution(atmosConfig *schema.AtmosConfiguration,
 			info.UseMocks,
 			nil, // tagsFilter: see above.
 			nil, // labelsFilter: see above.
+			terraformPreflightErrorOptions(),
 		)
 	}
 
@@ -164,7 +165,7 @@ func describeTerraformStacksForExecution(atmosConfig *schema.AtmosConfiguration,
 // describeTerraformStacksNarrowed is the historical (no-closure) describe:
 // narrowed by -s/--components and the tags/labels early-skip, bit for bit.
 func describeTerraformStacksNarrowed(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, authManager auth.AuthManager, components []string) (map[string]any, error) {
-	return ExecuteDescribeStacksWithMocks(
+	return ExecuteDescribeStacksWithMocksAndOptions(
 		atmosConfig,
 		info.Stack,
 		components,
@@ -179,7 +180,32 @@ func describeTerraformStacksNarrowed(atmosConfig *schema.AtmosConfiguration, inf
 		info.UseMocks,
 		info.Tags,
 		info.Labels,
+		terraformPreflightErrorOptions(),
 	)
+}
+
+// terraformPreflightErrorOptions makes the `--all` preflight describe pass tolerant of
+// recoverable per-value YAML function errors (e.g. `!terraform.state`/`!terraform.output`
+// against a component that hasn't been applied yet). This is not the user-facing
+// `--error-mode` choice used by `list`/`describe` — it's intrinsic to how `--all` bootstraps
+// dependency order: the preflight only builds the dependency graph from static
+// `dependencies`/`settings.depends_on`/`metadata` (never from resolved vars), and every node
+// re-resolves its own vars fresh immediately before its own plan/apply, so a degraded
+// placeholder value here is never reused for a real apply. Other error classes (e.g. a
+// missing `!secret`) are not in the recoverable set and still fail the preflight as before.
+func terraformPreflightErrorOptions() DescribeStacksErrorOptions {
+	return DescribeStacksErrorOptions{
+		OnError: OnErrorWarn,
+		OnWarning: func(w DegradationWarning) {
+			log.Debug(
+				"Deferring unresolved value until its dependency is applied",
+				cfg.ComponentStr, w.Component,
+				cfg.StackStr, w.Stack,
+				"function", w.Function,
+				"reason", w.Reason,
+			)
+		},
+	}
 }
 
 // terraformPreflightDescribeError preserves structured errors from stack resolution

--- a/internal/exec/terraform_all_dependency_bootstrap_test.go
+++ b/internal/exec/terraform_all_dependency_bootstrap_test.go
@@ -1,0 +1,66 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/schema"
+)
+
+// TestExecuteTerraformAll_UnprovisionedDependencyDoesNotFailPreflight reproduces the reported
+// regression: on a fresh environment, `atmos terraform apply --all` failed during the
+// describe-stacks preflight because a dependent component's `!terraform.state` reference to a
+// not-yet-applied component (e.g. `kms`) was resolved strictly, before the scheduler ever got a
+// chance to apply that dependency. The dependency graph itself is built from the static
+// `dependencies`/`settings.depends_on` sections (see TestBuildTerraformDependencyGraph), never
+// from resolved vars, so the preflight only needs to tolerate — not correctly resolve — this
+// kind of reference. DryRun keeps the test hermetic: no Terraform binary is invoked, and no
+// state file exists for either component, matching a genuinely fresh environment.
+func TestExecuteTerraformAll_UnprovisionedDependencyDoesNotFailPreflight(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stacks"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "components", "terraform", "kms"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "components", "terraform", "audit-trail"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "atmos.yaml"), []byte(`
+base_path: "."
+components:
+  terraform:
+    base_path: components/terraform
+stacks:
+  base_path: stacks
+  included_paths:
+    - "**/*"
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "stacks", "dev.yaml"), []byte(`
+components:
+  terraform:
+    kms:
+      vars: {}
+    audit-trail:
+      dependencies:
+        components:
+          - name: kms
+      vars:
+        kms_key_arn: !terraform.state kms dev key_arn
+`), 0o600))
+
+	t.Setenv("ATMOS_BASE_PATH", "")
+	t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
+	os.Unsetenv("ATMOS_BASE_PATH")
+	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+	t.Chdir(root)
+
+	err := ExecuteTerraformAll(&schema.ConfigAndStacksInfo{
+		Stack:            "dev",
+		ComponentType:    "terraform",
+		SubCommand:       "apply",
+		DryRun:           true,
+		ProcessTemplates: true,
+		ProcessFunctions: true,
+	})
+	assert.NoError(t, err)
+}

--- a/internal/exec/terraform_all_dependency_bootstrap_test.go
+++ b/internal/exec/terraform_all_dependency_bootstrap_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/schema"
+	"github.com/cloudposse/atmos/pkg/secrets"
 )
 
-// TestExecuteTerraformAll_UnprovisionedDependencyDoesNotFailPreflight reproduces the reported
+// TestExecuteTerraformAll_DependencyBootstrapPreflight reproduces the reported
 // regression: on a fresh environment, `atmos terraform apply --all` failed during the
 // describe-stacks preflight because a dependent component's `!terraform.state` reference to a
 // not-yet-applied component (e.g. `kms`) was resolved strictly, before the scheduler ever got a
@@ -20,22 +21,20 @@ import (
 // from resolved vars, so the preflight only needs to tolerate — not correctly resolve — this
 // kind of reference. DryRun keeps the test hermetic: no Terraform binary is invoked, and no
 // state file exists for either component, matching a genuinely fresh environment.
-func TestExecuteTerraformAll_UnprovisionedDependencyDoesNotFailPreflight(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "stacks"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "components", "terraform", "kms"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "components", "terraform", "audit-trail"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "atmos.yaml"), []byte(`
-base_path: "."
-components:
-  terraform:
-    base_path: components/terraform
-stacks:
-  base_path: stacks
-  included_paths:
-    - "**/*"
-`), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "stacks", "dev.yaml"), []byte(`
+//
+// The table also covers the non-recoverable branch (a missing `!secret`) so a change that
+// blanket-degrades every YAML function error, instead of only the intentionally-lenient
+// `!terraform.state` case, would fail this regression guard.
+func TestExecuteTerraformAll_DependencyBootstrapPreflight(t *testing.T) {
+	tests := []struct {
+		name       string
+		stackYAML  string
+		components []string
+		wantErr    error
+	}{
+		{
+			name: "unprovisioned terraform.state dependency does not fail preflight",
+			stackYAML: `
 components:
   terraform:
     kms:
@@ -46,21 +45,68 @@ components:
           - name: kms
       vars:
         kms_key_arn: !terraform.state kms dev key_arn
+`,
+			components: []string{"kms", "audit-trail"},
+			wantErr:    nil,
+		},
+		{
+			name: "missing secret is non-recoverable and still fails preflight",
+			stackYAML: `
+components:
+  terraform:
+    app:
+      secrets:
+        vars:
+          API_KEY:
+            store: missing-secrets-store
+            required: true
+      vars:
+        api_key: !secret API_KEY
+`,
+			components: []string{"app"},
+			wantErr:    secrets.ErrStoreNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(root, "stacks"), 0o755))
+			for _, component := range tt.components {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "components", "terraform", component), 0o755))
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(root, "atmos.yaml"), []byte(`
+base_path: "."
+components:
+  terraform:
+    base_path: components/terraform
+stacks:
+  base_path: stacks
+  included_paths:
+    - "**/*"
 `), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(root, "stacks", "dev.yaml"), []byte(tt.stackYAML), 0o600))
 
-	t.Setenv("ATMOS_BASE_PATH", "")
-	t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
-	os.Unsetenv("ATMOS_BASE_PATH")
-	os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
-	t.Chdir(root)
+			t.Setenv("ATMOS_BASE_PATH", "")
+			t.Setenv("ATMOS_CLI_CONFIG_PATH", "")
+			os.Unsetenv("ATMOS_BASE_PATH")
+			os.Unsetenv("ATMOS_CLI_CONFIG_PATH")
+			t.Chdir(root)
 
-	err := ExecuteTerraformAll(&schema.ConfigAndStacksInfo{
-		Stack:            "dev",
-		ComponentType:    "terraform",
-		SubCommand:       "apply",
-		DryRun:           true,
-		ProcessTemplates: true,
-		ProcessFunctions: true,
-	})
-	assert.NoError(t, err)
+			err := ExecuteTerraformAll(&schema.ConfigAndStacksInfo{
+				Stack:            "dev",
+				ComponentType:    "terraform",
+				SubCommand:       "apply",
+				DryRun:           true,
+				ProcessTemplates: true,
+				ProcessFunctions: true,
+			})
+
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }

--- a/internal/exec/terraform_execute_helpers.go
+++ b/internal/exec/terraform_execute_helpers.go
@@ -1000,22 +1000,24 @@ func executeTerraformInitCommand(atmosConfig *schema.AtmosConfiguration, info *s
 // providers-lock hook) once init has succeeded. It hands them a TerraformExecContext whose
 // runner reuses the same binary, env (incl. TF_CLI_CONFIG_FILE pointing at the live proxy),
 // and working directory as init, so a `providers lock` runs against the already-warm cache.
-// Lock completion is best-effort: a failure is logged, not propagated, so it never fails the
-// user's plan/apply.
+// The runner goes through executeStreamingOrShell (not a raw ExecuteShellCommand) so that,
+// under --ui, `providers lock`'s own provider-fetch/checksum output (e.g. when a registry
+// cache/mirror forces a cross-platform lock) is captured by the same init spinner instead of
+// leaking raw terraform/opentofu output between the "Init … completed" and
+// "Selected … workspace" lines. Lock completion is best-effort: a failure is logged, not
+// propagated, so it never fails the user's plan/apply.
 func dispatchAfterInit(atmosConfig *schema.AtmosConfiguration, info *schema.ConfigAndStacksInfo, componentPath string, opts ...ShellCommandOption) {
 	execCtx := &provisioner.TerraformExecContext{
 		WorkingDir: componentPath,
 		Run: func(args []string) error {
-			return ExecuteShellCommand(
-				*atmosConfig,
-				info.Command,
-				args,
-				componentPath,
-				info.ComponentEnvList,
-				info.DryRun,
-				info.RedirectStdErr,
-				opts...,
-			)
+			return executeStreamingOrShell(atmosConfig, info, &streamingExecRequest{
+				componentPath:  componentPath,
+				args:           args,
+				gatePhase:      subcommandInit,
+				subCommand:     subcommandProvidersLock,
+				redirectStdErr: info.RedirectStdErr,
+				shellOpts:      opts,
+			})
 		},
 	}
 

--- a/internal/exec/terraform_generate_backends.go
+++ b/internal/exec/terraform_generate_backends.go
@@ -302,7 +302,7 @@ func ExecuteTerraformGenerateBackends(
 				// unresolved function string (or a placeholder) would silently lose the function's
 				// contribution here, the same #2888 data-loss bug the main describe/plan path fixes
 				// via this same call (see internal/exec/utils.go).
-				if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, nil); err != nil {
+				if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, nil, nil); err != nil {
 					return err
 				}
 				componentSection = configAndStacksInfo.ComponentSection

--- a/internal/exec/terraform_generate_varfiles.go
+++ b/internal/exec/terraform_generate_varfiles.go
@@ -268,7 +268,7 @@ func ExecuteTerraformGenerateVarfiles(
 				// unresolved function string (or a placeholder) would silently lose the function's
 				// contribution here, the same #2888 data-loss bug the main describe/plan path fixes
 				// via this same call (see internal/exec/utils.go).
-				if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, nil); err != nil {
+				if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, nil, nil); err != nil {
 					return err
 				}
 				componentSection = configAndStacksInfo.ComponentSection

--- a/internal/exec/terraform_streaming_ui.go
+++ b/internal/exec/terraform_streaming_ui.go
@@ -93,24 +93,43 @@ func executeStreamingOrShell(atmosConfig *schema.AtmosConfiguration, info *schem
 	return err
 }
 
-// dispatchStreamingExecutor routes to the tfui.Execute* variant matching subCommand.
-// Workspace select/new and the after-init providers-lock hook share the init spinner
-// (ExecuteInit) since neither has a dedicated TUI phase of its own. Dry runs always use the
-// plain Execute path, which short-circuits without touching the terminal. The caller's
-// cancellation (e.g. a shell-option deadline) flows through ctx, so a cancelled/timed-out
-// caller can stop a running streaming Terraform process instead of leaving it orphaned.
-func dispatchStreamingExecutor(ctx context.Context, subCommand string, dryRun bool, execOpts *tfui.ExecuteOptions) error {
+// streamingExecutorFunc is the shared signature of tfui.Execute and every
+// tfui.Execute<Phase> variant, letting selectStreamingExecutor hand one back
+// without invoking it.
+type streamingExecutorFunc func(context.Context, *tfui.ExecuteOptions) error
+
+// selectStreamingExecutor resolves the tfui.Execute* variant matching
+// subCommand without invoking it. Both dispatchStreamingExecutor and its
+// tests go through this single routing table, so a test can assert on the
+// returned function's identity (e.g. that "providers-lock" resolves to
+// tfui.ExecuteInit specifically) instead of only observing an error both
+// ExecuteInit and the plain Execute fallback would produce identically
+// outside a supported interactive environment.
+//
+// Workspace select/new and the after-init providers-lock hook share the init
+// spinner (ExecuteInit) since neither has a dedicated TUI phase of its own. Dry
+// runs always use the plain Execute path, which short-circuits without touching
+// the terminal.
+func selectStreamingExecutor(subCommand string, dryRun bool) streamingExecutorFunc {
 	if !dryRun {
 		switch subCommand {
 		case subcommandApply:
-			return tfui.ExecuteApply(ctx, execOpts)
+			return tfui.ExecuteApply
 		case "destroy":
-			return tfui.ExecuteDestroy(ctx, execOpts)
+			return tfui.ExecuteDestroy
 		case "plan":
-			return tfui.ExecutePlan(ctx, execOpts)
+			return tfui.ExecutePlan
 		case subcommandInit, subcommandWorkspace, subcommandProvidersLock:
-			return tfui.ExecuteInit(ctx, execOpts)
+			return tfui.ExecuteInit
 		}
 	}
-	return tfui.Execute(ctx, execOpts)
+	return tfui.Execute
+}
+
+// dispatchStreamingExecutor routes to the tfui.Execute* variant matching subCommand.
+// The caller's cancellation (e.g. a shell-option deadline) flows through ctx, so a
+// cancelled/timed-out caller can stop a running streaming Terraform process instead
+// of leaving it orphaned.
+func dispatchStreamingExecutor(ctx context.Context, subCommand string, dryRun bool, execOpts *tfui.ExecuteOptions) error {
+	return selectStreamingExecutor(subCommand, dryRun)(ctx, execOpts)
 }

--- a/internal/exec/terraform_streaming_ui.go
+++ b/internal/exec/terraform_streaming_ui.go
@@ -94,11 +94,11 @@ func executeStreamingOrShell(atmosConfig *schema.AtmosConfiguration, info *schem
 }
 
 // dispatchStreamingExecutor routes to the tfui.Execute* variant matching subCommand.
-// Workspace select/new share the init spinner (ExecuteInit) since they have no
-// dedicated TUI phase of their own. Dry runs always use the plain Execute path, which
-// short-circuits without touching the terminal. The caller's cancellation (e.g. a
-// shell-option deadline) flows through ctx, so a cancelled/timed-out caller can stop a
-// running streaming Terraform process instead of leaving it orphaned.
+// Workspace select/new and the after-init providers-lock hook share the init spinner
+// (ExecuteInit) since neither has a dedicated TUI phase of its own. Dry runs always use the
+// plain Execute path, which short-circuits without touching the terminal. The caller's
+// cancellation (e.g. a shell-option deadline) flows through ctx, so a cancelled/timed-out
+// caller can stop a running streaming Terraform process instead of leaving it orphaned.
 func dispatchStreamingExecutor(ctx context.Context, subCommand string, dryRun bool, execOpts *tfui.ExecuteOptions) error {
 	if !dryRun {
 		switch subCommand {
@@ -108,7 +108,7 @@ func dispatchStreamingExecutor(ctx context.Context, subCommand string, dryRun bo
 			return tfui.ExecuteDestroy(ctx, execOpts)
 		case "plan":
 			return tfui.ExecutePlan(ctx, execOpts)
-		case subcommandInit, subcommandWorkspace:
+		case subcommandInit, subcommandWorkspace, subcommandProvidersLock:
 			return tfui.ExecuteInit(ctx, execOpts)
 		}
 	}

--- a/internal/exec/terraform_streaming_ui_test.go
+++ b/internal/exec/terraform_streaming_ui_test.go
@@ -5,7 +5,8 @@ package exec
 //   - executeStreamingOrShell: retry-gated shell fallback, the "streaming not
 //     requested" silent fallback, and the "streaming requested but unsupported"
 //     warn-then-fallback path.
-//   - dispatchStreamingExecutor: the subCommand -> tfui.Execute* routing table.
+//   - selectStreamingExecutor/dispatchStreamingExecutor: the subCommand ->
+//     tfui.Execute* routing table.
 //
 // The actual "streaming succeeded" branch inside executeStreamingOrShell (where
 // tfui.ShouldUseStreamingUI returns true and dispatchStreamingExecutor is invoked
@@ -15,18 +16,27 @@ package exec
 // implementation. That branch is intentionally left uncovered by this package's
 // tests (see the coverage report for this file).
 //
-// The switch cases inside dispatchStreamingExecutor ARE covered directly: each test pins
-// CI=true so telemetry.IsCI() deterministically forces every tfui.Execute* variant's own
-// precondition check (stdout/stdin TTY, CI) to return errUtils.ErrStreamingNotSupported
-// before doing any real work, regardless of whether the runner's stdout happens to be a
-// real TTY. That's a genuine safety property worth asserting: no matter which subcommand
-// is dispatched, the streaming path never attempts to spawn a real terraform process
-// outside a supported interactive environment.
+// The switch cases inside dispatchStreamingExecutor ARE covered two ways:
+//   - TestSelectStreamingExecutor_RoutesBySubcommand asserts the *identity* of
+//     the resolved tfui.Execute* variant directly (via selectStreamingExecutor),
+//     which is the only way to tell apart "routed to ExecuteInit and it
+//     refused" from "fell through to the plain Execute and it refused" - both
+//     return the identical error below.
+//   - TestDispatchStreamingExecutor_RoutesSafely pins CI=true so
+//     telemetry.IsCI() deterministically forces every tfui.Execute* variant's
+//     own precondition check (stdout/stdin TTY, CI) to return
+//     errUtils.ErrStreamingNotSupported before doing any real work, regardless
+//     of whether the runner's stdout happens to be a real TTY. That's a
+//     genuine safety property worth asserting: no matter which subcommand is
+//     dispatched, the streaming path never attempts to spawn a real terraform
+//     process outside a supported interactive environment.
 
 import (
 	"context"
 	"errors"
 	"os"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -200,6 +210,47 @@ func TestDispatchStreamingExecutor_RoutesSafely(t *testing.T) {
 			require.Error(t, err, "must refuse to run outside a supported interactive environment")
 			assert.True(t, errors.Is(err, errUtils.ErrStreamingNotSupported),
 				"expected ErrStreamingNotSupported, got: %v", err)
+		})
+	}
+}
+
+// funcName returns the fully-qualified name of the function fn points to, e.g.
+// "github.com/cloudposse/atmos/pkg/terraform/ui.ExecuteInit". Used below to
+// assert selectStreamingExecutor picked a *specific* tfui.Execute* variant,
+// since every variant returns the identical errUtils.ErrStreamingNotSupported
+// outside a real TTY and so can't be told apart by their error alone.
+func funcName(fn streamingExecutorFunc) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+// TestSelectStreamingExecutor_RoutesBySubcommand asserts the *identity* of the
+// tfui.Execute* variant selectStreamingExecutor resolves for each subCommand,
+// rather than only the error it eventually returns. Without this, a
+// providers-lock/workspace case that silently regressed to falling through to
+// the plain tfui.Execute path (the "unrecognized subcommand" fallback) would
+// still pass a test that only checks for errUtils.ErrStreamingNotSupported,
+// since that fallback returns the exact same sentinel error outside a real TTY.
+func TestSelectStreamingExecutor_RoutesBySubcommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		subCommand string
+		dryRun     bool
+		want       streamingExecutorFunc
+	}{
+		{name: "dry run always uses the plain Execute path", subCommand: subcommandApply, dryRun: true, want: tfui.Execute},
+		{name: "apply routes to ExecuteApply", subCommand: subcommandApply, dryRun: false, want: tfui.ExecuteApply},
+		{name: "destroy routes to ExecuteDestroy", subCommand: "destroy", dryRun: false, want: tfui.ExecuteDestroy},
+		{name: "plan routes to ExecutePlan", subCommand: "plan", dryRun: false, want: tfui.ExecutePlan},
+		{name: "init routes to ExecuteInit", subCommand: subcommandInit, dryRun: false, want: tfui.ExecuteInit},
+		{name: "workspace routes to ExecuteInit, not the plain Execute fallback", subCommand: subcommandWorkspace, dryRun: false, want: tfui.ExecuteInit},
+		{name: "providers-lock routes to ExecuteInit, not the plain Execute fallback", subCommand: subcommandProvidersLock, dryRun: false, want: tfui.ExecuteInit},
+		{name: "unrecognized subcommand falls through to the plain Execute path", subCommand: "unknown-subcommand", dryRun: false, want: tfui.Execute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectStreamingExecutor(tt.subCommand, tt.dryRun)
+			assert.Equal(t, funcName(tt.want), funcName(got))
 		})
 	}
 }

--- a/internal/exec/terraform_streaming_ui_test.go
+++ b/internal/exec/terraform_streaming_ui_test.go
@@ -172,6 +172,11 @@ func TestDispatchStreamingExecutor_RoutesSafely(t *testing.T) {
 			dryRun:     false,
 		},
 		{
+			name:       "providers-lock shares the init phase's ExecuteInit dispatch",
+			subCommand: subcommandProvidersLock,
+			dryRun:     false,
+		},
+		{
 			name:       "unrecognized subcommand falls through to the plain Execute path",
 			subCommand: "unknown-subcommand",
 			dryRun:     false,

--- a/internal/exec/terraform_utils_test.go
+++ b/internal/exec/terraform_utils_test.go
@@ -224,6 +224,7 @@ func TestExecuteTerraformQueryRoutesThroughSchedulerAdapter(t *testing.T) {
 		useMocks bool,
 		tagsFilter []string,
 		labelsFilter map[string]string,
+		errOptions DescribeStacksErrorOptions,
 	) (map[string]any, error) {
 		described = true
 		require.NotNil(t, atmosConfig)
@@ -453,6 +454,7 @@ func TestExecuteTerraformQueryPropagatesSetupErrors(t *testing.T) {
 			bool,
 			[]string,
 			map[string]string,
+			DescribeStacksErrorOptions,
 		) (map[string]any, error) {
 			return nil, expectedErr
 		})
@@ -492,6 +494,7 @@ func TestExecuteTerraformQueryPropagatesSetupErrors(t *testing.T) {
 			bool,
 			[]string,
 			map[string]string,
+			DescribeStacksErrorOptions,
 		) (map[string]any, error) {
 			return map[string]any{}, nil
 		})

--- a/internal/exec/utils.go
+++ b/internal/exec/utils.go
@@ -1081,7 +1081,10 @@ func processStacks(
 	// is a freshly-built tree (never aliasing the shared FindStacksMap cache) once ProcessCustomYamlTags
 	// has returned, so mutating it in place here is safe under concurrent bulk commands.
 	if processYamlFunctions {
-		if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, skip); err != nil {
+		// evalSections is nil (full eager evaluation): processStacks backs terraform/helmfile/
+		// describe-component and every other non-list caller, none of which opt into the
+		// evaluation-scope filter -- see isSectionRequired.
+		if err := resolveDeferredYamlFunctions(atmosConfig, &configAndStacksInfo, &settingsSectionStruct, componentTemplateContext, skip, nil); err != nil {
 			return configAndStacksInfo, err
 		}
 	}

--- a/pkg/generator/ui/template_picker_test.go
+++ b/pkg/generator/ui/template_picker_test.go
@@ -1,0 +1,211 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudposse/atmos/pkg/generator/templates"
+)
+
+// realAWSLandingZoneDescription reproduces the exact description from
+// pkg/generator/templates/catalog.yaml that triggered the reported bug: on a
+// normal-width terminal it was cut off mid-word ("...provisioned end to end
+// on t") and wrapped onto a stray partial second line ("local emulator.").
+const realAWSLandingZoneDescription = "AWS landing zone — dev/staging/prod environments with a conventional " +
+	"baseline (audit trail, KMS, SSM, monitoring, IAM), provisioned end to end on the local emulator."
+
+// TestTruncateAtWordBoundary verifies descriptions are shortened at a word
+// boundary (never mid-word) and always fit within the requested width.
+func TestTruncateAtWordBoundary(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxWidth int
+		expected string
+	}{
+		{
+			name:     "shorter than max is unchanged",
+			input:    "hello",
+			maxWidth: 10,
+			expected: "hello",
+		},
+		{
+			name:     "equal to max is unchanged",
+			input:    "hello",
+			maxWidth: 5,
+			expected: "hello",
+		},
+		{
+			name:     "breaks on word boundary, not mid-word",
+			input:    "hello world",
+			maxWidth: 8,
+			expected: "hello…",
+		},
+		{
+			name:     "long description truncates cleanly",
+			input:    realAWSLandingZoneDescription,
+			maxWidth: 40,
+			expected: "AWS landing zone — dev/staging/prod…",
+		},
+		{
+			name:     "zero width yields empty string",
+			input:    "hello",
+			maxWidth: 0,
+			expected: "",
+		},
+		{
+			name:     "negative width yields empty string",
+			input:    "hello",
+			maxWidth: -5,
+			expected: "",
+		},
+		{
+			name:     "single word longer than budget still terminates",
+			input:    "supercalifragilisticexpialidocious",
+			maxWidth: 5,
+			expected: "supe…",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			maxWidth: 10,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateAtWordBoundary(tt.input, tt.maxWidth)
+			assert.Equal(t, tt.expected, result)
+			if tt.maxWidth > 0 {
+				assert.LessOrEqualf(t, lipgloss.Width(result), tt.maxWidth,
+					"result %q must fit within maxWidth %d", result, tt.maxWidth)
+			}
+			// The one behavior this bug report is about: never split a word
+			// mid-character onto what looks like a stray fragment. A clean
+			// truncation either returns the original string untouched, is
+			// emptied entirely (non-positive width budget), or ends with
+			// the ellipsis.
+			if result != tt.input && result != "" {
+				assert.True(t, strings.HasSuffix(result, "…"), "truncated result must end with an ellipsis, got %q", result)
+			}
+		})
+	}
+}
+
+// TestEmbedsColumnWidths verifies the description column shrinks and grows
+// with the real terminal width instead of staying fixed, while never
+// dropping below the legibility floor, and that the key/name columns are
+// sized from actual content (bounded) rather than an assumed constant.
+func TestEmbedsColumnWidths(t *testing.T) {
+	configs := map[string]templates.Configuration{
+		// "azure/landing-zone" (19 chars) is longer than the old hard-coded
+		// 15-char key column assumption; the computed column widths must
+		// account for it so the description budget stays accurate.
+		"azure/landing-zone": {Name: "azure/landing-zone", Description: "Azure landing zone"},
+		"atmos":              {Name: "atmos", Description: "Complete atmos.yaml configuration only"},
+	}
+
+	tests := []struct {
+		name          string
+		terminalWidth int
+		wantAtLeast   int
+		wantAtMost    int
+	}{
+		{name: "narrow terminal floors at minimum", terminalWidth: 40, wantAtLeast: minDescriptionWidth, wantAtMost: minDescriptionWidth},
+		{name: "normal 80-column terminal", terminalWidth: 80, wantAtLeast: minDescriptionWidth},
+		{name: "wide terminal grows the column", terminalWidth: 160, wantAtLeast: 80},
+	}
+
+	widths := map[int]int{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyWidth, nameWidth, descWidth := embedsColumnWidths(configs, tt.terminalWidth)
+			// The key/name columns must be sized to fit "azure/landing-zone"
+			// (19 chars) without truncation, not the old fixed constant.
+			assert.GreaterOrEqual(t, keyWidth, lipgloss.Width("azure/landing-zone"))
+			assert.GreaterOrEqual(t, nameWidth, lipgloss.Width("azure/landing-zone"))
+			assert.GreaterOrEqual(t, descWidth, tt.wantAtLeast)
+			if tt.wantAtMost > 0 {
+				assert.LessOrEqual(t, descWidth, tt.wantAtMost)
+			}
+			widths[tt.terminalWidth] = descWidth
+		})
+	}
+
+	// Width must be monotonically non-decreasing as the terminal grows --
+	// this is the core regression check: it must not be a hard-coded
+	// constant that ignores the real terminal width.
+	require.LessOrEqual(t, widths[40], widths[80])
+	require.Less(t, widths[80], widths[160])
+}
+
+// TestBuildEmbedsTemplateOptions_FitsTerminalWidth verifies the rendered
+// option line for a long, real-world description fits within the terminal
+// width at a couple of representative widths, and never splits a word
+// mid-character.
+func TestBuildEmbedsTemplateOptions_FitsTerminalWidth(t *testing.T) {
+	configs := map[string]templates.Configuration{
+		"aws/landing-zone": {
+			Name:        "aws/landing-zone",
+			Description: realAWSLandingZoneDescription,
+		},
+	}
+
+	var widest string
+	const wideEnoughForFullDescription = 400
+	for _, width := range []int{40, 80, 120, 200, wideEnoughForFullDescription} {
+		t.Run("width_"+strconv.Itoa(width), func(t *testing.T) {
+			options := buildEmbedsTemplateOptions(configs, width)
+			require.Len(t, options, 1)
+
+			displayText := options[0].Key
+			if lipgloss.Width(displayText) > width {
+				// It's acceptable for the fixed-width key/name columns
+				// alone to exceed a very narrow terminal (huh still wraps
+				// the full line at a real word boundary via its own Select
+				// rendering), but the description we appended must be the
+				// part responsible for shrinking, and it must end cleanly
+				// rather than splitting a word mid-character.
+				assert.True(t, strings.HasSuffix(displayText, "…"),
+					"long option text %q must end with an ellipsis instead of an arbitrary cut", displayText)
+			}
+			if width == wideEnoughForFullDescription {
+				widest = displayText
+			}
+		})
+	}
+	// At a wide-enough terminal, the description should render in full
+	// rather than being truncated unnecessarily.
+	assert.Contains(t, widest, realAWSLandingZoneDescription)
+}
+
+// TestBuildScaffoldDisplayText_TruncatesDescription verifies the scaffold
+// picker (atmos scaffold) applies the same terminal-width-aware truncation
+// as the embeds picker, including when a source suffix is present.
+func TestBuildScaffoldDisplayText_TruncatesDescription(t *testing.T) {
+	templateConfig := map[string]interface{}{
+		"description": realAWSLandingZoneDescription,
+		"source":      "github.com/cloudposse/atmos.git//examples/scaffolds/aws/landing-zone",
+	}
+
+	for _, width := range []int{60, 80, 120} {
+		t.Run("width_"+strconv.Itoa(width), func(t *testing.T) {
+			displayText, valid := buildScaffoldDisplayText("aws/landing-zone", templateConfig, width)
+			require.True(t, valid)
+			require.Contains(t, displayText, "(from github.com/cloudposse/atmos.git//examples/scaffolds/aws/landing-zone)")
+			if !strings.Contains(displayText, realAWSLandingZoneDescription) {
+				// Truncated: the description portion must end cleanly with
+				// an ellipsis, never mid-word.
+				descPortion := strings.SplitN(displayText, " (from ", 2)[0]
+				assert.True(t, strings.HasSuffix(strings.TrimRight(descPortion, " "), "…"),
+					"truncated description %q must end with an ellipsis", descPortion)
+			}
+		})
+	}
+}

--- a/pkg/generator/ui/template_picker_test.go
+++ b/pkg/generator/ui/template_picker_test.go
@@ -185,6 +185,36 @@ func TestBuildEmbedsTemplateOptions_FitsTerminalWidth(t *testing.T) {
 	assert.Contains(t, widest, realAWSLandingZoneDescription)
 }
 
+// TestBuildScaffoldTemplateOptions_TruncatesLongNameButKeepsFullValue covers a
+// source-free scaffold key longer than scaffoldNameColumnWidth: the displayed
+// name column must be truncated (previously "%-20s" only padded, never
+// truncated, letting a long key push the line past the terminal-width budget
+// descWidth already assumed), while the option's underlying value -- used for
+// lookup after selection -- must remain the full, untruncated key.
+func TestBuildScaffoldTemplateOptions_TruncatesLongNameButKeepsFullValue(t *testing.T) {
+	longName := "an-unusually-long-scaffold-template-key-name"
+	require.Greater(t, lipgloss.Width(longName), scaffoldNameColumnWidth)
+
+	templatesMap := map[string]interface{}{
+		longName: map[string]interface{}{
+			"description": "short description, no source",
+		},
+	}
+
+	const terminalWidth = 80
+	options, templateNames := buildScaffoldTemplateOptions(templatesMap, terminalWidth)
+	require.Len(t, options, 1)
+	require.Equal(t, []string{longName}, templateNames)
+
+	displayText := options[0].Key
+	assert.LessOrEqual(t, lipgloss.Width(displayText), terminalWidth,
+		"display text %q must fit within the terminal width budget", displayText)
+	assert.NotContains(t, displayText, longName,
+		"the untruncated name must not appear verbatim once it exceeds the name column budget")
+	assert.Equal(t, longName, options[0].Value,
+		"the option's underlying value must stay the full, untruncated template name for post-selection lookup")
+}
+
 // TestBuildScaffoldDisplayText_TruncatesDescription verifies the scaffold
 // picker (atmos scaffold) applies the same terminal-width-aware truncation
 // as the embeds picker, including when a source suffix is present.

--- a/pkg/generator/ui/ui.go
+++ b/pkg/generator/ui/ui.go
@@ -327,7 +327,14 @@ func buildScaffoldDisplayText(templateName string, templateConfig interface{}, t
 	}
 	description = truncateAtWordBoundary(description, descWidth)
 
-	displayText := fmt.Sprintf("%-20s   %s", templateName, description) + sourceSuffix
+	// Truncate the displayed name too (a no-op when already within budget):
+	// "%-*s" only pads -- it never truncates -- so a scaffold key longer than
+	// scaffoldNameColumnWidth would otherwise silently push the whole line
+	// past the terminal-width budget descWidth above already assumed. The
+	// option's underlying value (set by the caller via huh.NewOption) stays
+	// the untruncated templateName, so selecting it still resolves correctly.
+	displayName := truncateAtWordBoundary(templateName, scaffoldNameColumnWidth)
+	displayText := fmt.Sprintf("%-*s   %s", scaffoldNameColumnWidth, displayName, description) + sourceSuffix
 
 	return displayText, true
 }

--- a/pkg/generator/ui/ui.go
+++ b/pkg/generator/ui/ui.go
@@ -51,6 +51,29 @@ const (
 	versionColumnMinWidth = 15
 	descColumnMinWidth    = 40
 
+	// Column layout for the interactive "Select a template" picker
+	// (huh.Select, see PromptForTemplate/buildEmbedsTemplateOptions/
+	// buildScaffoldDisplayText). Unlike the bubbles-table columns above,
+	// these options render as a single line of plain text, so the
+	// description column width is computed from the real terminal width
+	// (GetTerminalWidth) rather than hard-coded, and the description text
+	// itself is truncated at a word boundary to fit -- otherwise huh wraps
+	// the whole line as one blob and can split a word mid-character onto a
+	// stray partial second line.
+	embedsKeyColumnWidth    = 24
+	embedsNameColumnWidth   = 35
+	scaffoldNameColumnWidth = 20
+	// Literal separator between padded columns in the fmt.Sprintf format
+	// strings below ("   ", 3 spaces).
+	selectColumnGap = 3
+	// Reserves room for huh's cursor ("> ") and Select field padding (see
+	// huh.Select.renderOption/View in the huh library) so the computed
+	// description width doesn't overrun the real line width.
+	selectOverhead = 4
+	// Floors the description column so text (and its truncation ellipsis)
+	// stay legible even on very narrow terminals.
+	minDescriptionWidth = 20
+
 	// File permissions.
 	dirPermissions = 0o755
 
@@ -183,8 +206,41 @@ func calculateMaxColumnWidths(rows [][]string, nameWidth, sourceWidth, versionWi
 	return nameWidth, sourceWidth, versionWidth, descWidth
 }
 
-// buildEmbedsTemplateOptions builds huh options from embedded configuration map.
-func buildEmbedsTemplateOptions(configs map[string]tmpl.Configuration) []huh.Option[string] {
+// embedsColumnWidths computes the key/name/description column widths for the
+// "Select a template" picker from real content, bounded by embedsKeyColumnWidth
+// /embedsNameColumnWidth so a single unusually long key or name can't blow out
+// the whole row. The description column absorbs whatever's left of
+// terminalWidth after the key/name columns, their separators, and huh's own
+// rendering overhead (selectOverhead), always at least minDescriptionWidth so
+// descriptions stay legible on narrow terminals. Key/name widths are computed
+// the same way (rather than assumed constants) so the description budget
+// matches what buildEmbedsTemplateOptions actually renders; otherwise a
+// key/name longer than the assumed constant silently pushes the line past
+// terminalWidth and huh has to wrap it after all.
+func embedsColumnWidths(configs map[string]tmpl.Configuration, terminalWidth int) (keyWidth, nameWidth, descWidth int) {
+	for key := range configs {
+		if w := lipgloss.Width(key); w > keyWidth {
+			keyWidth = w
+		}
+		if w := lipgloss.Width(configs[key].Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+	keyWidth = min(max(keyWidth, 1), embedsKeyColumnWidth)
+	nameWidth = min(max(nameWidth, 1), embedsNameColumnWidth)
+
+	descWidth = terminalWidth - keyWidth - nameWidth - (selectColumnGap * 2) - selectOverhead
+	if descWidth < minDescriptionWidth {
+		descWidth = minDescriptionWidth
+	}
+	return keyWidth, nameWidth, descWidth
+}
+
+// buildEmbedsTemplateOptions builds huh options from embedded configuration
+// map, using terminalWidth (from InitUI.GetTerminalWidth) to size the
+// description column dynamically instead of letting huh wrap an oversized
+// line mid-word.
+func buildEmbedsTemplateOptions(configs map[string]tmpl.Configuration, terminalWidth int) []huh.Option[string] {
 	// Build config keys for consistent ordering.
 	var templateNames []string
 	for key := range configs {
@@ -192,17 +248,33 @@ func buildEmbedsTemplateOptions(configs map[string]tmpl.Configuration) []huh.Opt
 	}
 	sort.Strings(templateNames)
 
+	keyWidth, nameWidth, descWidth := embedsColumnWidths(configs, terminalWidth)
+
 	var options []huh.Option[string]
 	for _, key := range templateNames {
 		config := configs[key]
-		displayText := fmt.Sprintf("%-15s   %-35s   %s", key, config.Name, config.Description)
+		// Truncate the displayed key/name too (a no-op when already within
+		// budget): keyWidth/nameWidth are capped by embedsKeyColumnWidth/
+		// embedsNameColumnWidth, but fmt's "%-*s" only pads -- it never
+		// truncates -- so an entry whose key/name exceeds the cap would
+		// otherwise silently push the whole line past terminalWidth and
+		// force huh to wrap it despite the description budget below
+		// already accounting for that cap. The option's underlying value
+		// stays the untruncated key so template lookup after selection
+		// (configs[selectedName]) still works.
+		displayKey := truncateAtWordBoundary(key, keyWidth)
+		displayName := truncateAtWordBoundary(config.Name, nameWidth)
+		desc := truncateAtWordBoundary(config.Description, descWidth)
+		displayText := fmt.Sprintf("%-*s   %-*s   %s", keyWidth, displayKey, nameWidth, displayName, desc)
 		options = append(options, huh.NewOption(displayText, key))
 	}
 	return options
 }
 
-// buildScaffoldTemplateOptions builds huh options from scaffold templates in atmos.yaml.
-func buildScaffoldTemplateOptions(templates interface{}) ([]huh.Option[string], []string) {
+// buildScaffoldTemplateOptions builds huh options from scaffold templates in
+// atmos.yaml, using terminalWidth to size the description column the same
+// way buildEmbedsTemplateOptions does.
+func buildScaffoldTemplateOptions(templates interface{}, terminalWidth int) ([]huh.Option[string], []string) {
 	templatesMap, ok := templates.(map[string]interface{})
 	if !ok {
 		return nil, nil
@@ -219,7 +291,7 @@ func buildScaffoldTemplateOptions(templates interface{}) ([]huh.Option[string], 
 	var templateNames []string
 
 	for _, templateName := range sortedNames {
-		displayText, valid := buildScaffoldDisplayText(templateName, templatesMap[templateName])
+		displayText, valid := buildScaffoldDisplayText(templateName, templatesMap[templateName], terminalWidth)
 		if !valid {
 			continue
 		}
@@ -231,7 +303,11 @@ func buildScaffoldTemplateOptions(templates interface{}) ([]huh.Option[string], 
 }
 
 // buildScaffoldDisplayText constructs display text for a scaffold template.
-func buildScaffoldDisplayText(templateName string, templateConfig interface{}) (string, bool) {
+// The description is truncated at a word boundary to fit within
+// terminalWidth alongside the name column, gap, and (when present) the
+// " (from <source>)" suffix -- otherwise a long description plus a long
+// source URL can overrun the line and wrap mid-word.
+func buildScaffoldDisplayText(templateName string, templateConfig interface{}, terminalWidth int) (string, bool) {
 	templateMap, ok := templateConfig.(map[string]interface{})
 	if !ok {
 		return "", false
@@ -240,12 +316,63 @@ func buildScaffoldDisplayText(templateName string, templateConfig interface{}) (
 	description := getStringFromMap(templateMap, "description")
 	source := getStringFromMap(templateMap, "source")
 
-	displayText := fmt.Sprintf("%-20s   %s", templateName, description)
+	sourceSuffix := ""
 	if source != "" {
-		displayText += fmt.Sprintf(" (from %s)", source)
+		sourceSuffix = fmt.Sprintf(" (from %s)", source)
 	}
 
+	descWidth := terminalWidth - scaffoldNameColumnWidth - selectColumnGap - selectOverhead - lipgloss.Width(sourceSuffix)
+	if descWidth < minDescriptionWidth {
+		descWidth = minDescriptionWidth
+	}
+	description = truncateAtWordBoundary(description, descWidth)
+
+	displayText := fmt.Sprintf("%-20s   %s", templateName, description) + sourceSuffix
+
 	return displayText, true
+}
+
+// truncateAtWordBoundary shortens s to fit within maxWidth display columns,
+// breaking on the last whole word rather than splitting a word mid-character,
+// and appends an ellipsis to signal truncation. Unlike truncateString (a
+// byte-length-based helper used for short debug/error previews elsewhere in
+// this file), this is display-width aware via lipgloss.Width so multi-byte
+// characters (e.g. the "—" em dash used in template descriptions) are
+// measured correctly.
+func truncateAtWordBoundary(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+
+	const ellipsis = "…"
+	budget := maxWidth - lipgloss.Width(ellipsis)
+	if budget <= 0 {
+		return ellipsis
+	}
+
+	runes := []rune(s)
+	width := 0
+	cut := 0
+	for i, r := range runes {
+		w := lipgloss.Width(string(r))
+		if width+w > budget {
+			break
+		}
+		width += w
+		cut = i + 1
+	}
+
+	truncated := string(runes[:cut])
+	// Prefer breaking on the last whole word so a long description doesn't
+	// get sliced mid-word (e.g. "...end to end on t" continuing onto a
+	// stray partial line).
+	if idx := strings.LastIndexAny(truncated, " \t"); idx > 0 {
+		truncated = truncated[:idx]
+	}
+	return strings.TrimRight(truncated, " \t") + ellipsis
 }
 
 // getStringFromMap safely extracts a string value from a map.
@@ -1629,16 +1756,21 @@ func (ui *InitUI) DisplayTemplateTable(header []string, rows [][]string) {
 func (ui *InitUI) PromptForTemplate(templateType string, templates interface{}) (string, error) {
 	var options []huh.Option[string]
 
+	// Size the description column from the real terminal width instead of a
+	// hard-coded constant, so long descriptions truncate cleanly rather than
+	// wrapping mid-word (see buildEmbedsTemplateOptions/buildScaffoldDisplayText).
+	terminalWidth := ui.GetTerminalWidth()
+
 	switch templateType {
 	case "embeds":
 		// Handle tmpl.Configuration map.
 		if configs, ok := templates.(map[string]tmpl.Configuration); ok {
-			options = buildEmbedsTemplateOptions(configs)
+			options = buildEmbedsTemplateOptions(configs, terminalWidth)
 		}
 
 	case templateTypeScaffold:
 		// Handle scaffold templates from atmos.yaml.
-		scaffoldOptions, _ := buildScaffoldTemplateOptions(templates)
+		scaffoldOptions, _ := buildScaffoldTemplateOptions(templates, terminalWidth)
 		options = append(options, scaffoldOptions...)
 	}
 

--- a/pkg/list/column/required_sections.go
+++ b/pkg/list/column/required_sections.go
@@ -1,0 +1,128 @@
+package column
+
+import (
+	"sort"
+
+	"github.com/cloudposse/atmos/pkg/perf"
+	atmostemplate "github.com/cloudposse/atmos/pkg/template"
+)
+
+// sectionBackedFields maps a column-template top-level field name to the identically named
+// top-level Atmos component section it is a verbatim passthrough of. Every list command's row
+// extraction (pkg/list/extract) copies these sections onto the row map under the same key it
+// uses in the raw ComponentSection (e.g. extract/stacks.go's `stack["vars"] = vars`,
+// extract/metadata.go's `"settings": instance.Settings`), so a column referencing one of these
+// fields requires that section to be fully evaluated (Go templates + YAML functions) rather than
+// left as raw/merged text.
+var sectionBackedFields = map[string]string{
+	"vars":     "vars",
+	"settings": "settings",
+	"metadata": "metadata",
+	"env":      "env",
+	"backend":  "backend",
+}
+
+// derivedFields lists top-level column-template fields that pkg/list/extract computes from
+// already-cheap identifiers (stack/component names) or from `metadata` (enabled, locked, tags,
+// labels, status, type, ...). Referencing one of these does not, by itself, require any
+// additional section: callers that need `metadata` for filtering/status derivation (list
+// components, list instances) fold it into the required set independently of column selection —
+// see cmd/list/components.go and pkg/list/list_instances.go.
+var derivedFields = map[string]struct{}{
+	"stack": {}, "component": {}, "atmos_component": {}, "atmos_stack": {},
+	"atmos_component_type": {}, "enabled": {}, "locked": {}, "abstract": {},
+	"file": {}, "name": {}, "workflow": {}, "description": {}, "steps": {},
+	"components": {}, "atmos_vendor_type": {}, "atmos_vendor_file": {}, "atmos_vendor_target": {},
+	"status": {}, "status_text": {}, "component_type": {}, "component_folder": {},
+	"component_base": {}, "inherits": {}, "type": {}, "tags": {}, "labels": {}, "stack_count": {},
+}
+
+// RequiredSections statically determines which top-level Atmos component sections (vars,
+// settings, metadata, env, backend) the given column templates actually reference, by walking
+// each column's parsed Go-template AST for field references (see pkg/template.ExtractFieldRefs)
+// whose first path segment names a section.
+//
+// Returns ok=false whenever any column can't be statically resolved this way: a catch-all `.raw`
+// reference (which exposes the entire row, including every section), a `range`/`with` block
+// (which rebinds "." — see pkg/template.HasDynamicScope), an unparseable template, or any
+// top-level field this function does not recognize as either section-backed or derived. Callers
+// MUST treat ok=false as "pass nil / evaluate everything": under-computing the required set is
+// far worse than over-computing it, since a displayed column would then show raw, unevaluated
+// text instead of falling back cleanly to full evaluation.
+//
+// A true result with an empty (non-nil) `sections` slice is a real, meaningful answer — "no
+// section is required" — and is distinct from a nil slice. Callers MUST preserve that
+// distinction (e.g. by passing the returned slice through unchanged, never coalescing an empty
+// result to nil) since downstream evaluation-gating treats nil as "no filter" (see
+// internal/exec's isSectionRequired).
+func RequiredSections(columns []Config) (sections []string, ok bool) {
+	defer perf.Track(nil, "list.column.RequiredSections")()
+
+	required := make(map[string]struct{})
+
+	for _, col := range columns {
+		dynamic, err := atmostemplate.HasDynamicScope(col.Value)
+		if err != nil || dynamic {
+			return nil, false
+		}
+
+		refs, err := atmostemplate.ExtractFieldRefs(col.Value)
+		if err != nil {
+			return nil, false
+		}
+
+		if !collectRequiredSections(refs, required) {
+			return nil, false
+		}
+	}
+
+	result := make([]string, 0, len(required))
+	for s := range required {
+		result = append(result, s)
+	}
+	sort.Strings(result)
+
+	return result, true
+}
+
+// EnsureSection returns sections with name added if not already present, preserving a non-nil
+// result: an empty (but non-nil) input slice stays non-nil, matching isSectionRequired's contract
+// that a non-nil filter -- even an empty one -- means "gating is active," never "no filter".
+//
+// Callers use this to fold in a section their row-extraction pipeline always needs regardless of
+// column selection (e.g. `metadata`, which list components/instances always read for
+// enabled/locked/tags/labels/status derivation -- see cmd/list/components.go and
+// pkg/list/list_instances.go) into the result of RequiredSections.
+func EnsureSection(sections []string, name string) []string {
+	for _, s := range sections {
+		if s == name {
+			return sections
+		}
+	}
+	return append(sections, name)
+}
+
+// collectRequiredSections folds the section references from refs into required, returning false
+// the moment it encounters a reference RequiredSections cannot safely resolve.
+func collectRequiredSections(refs []atmostemplate.FieldRef, required map[string]struct{}) bool {
+	for _, ref := range refs {
+		if len(ref.Path) == 0 {
+			continue
+		}
+		top := ref.Path[0]
+
+		if top == "raw" {
+			return false
+		}
+		if section, known := sectionBackedFields[top]; known {
+			required[section] = struct{}{}
+			continue
+		}
+		if _, known := derivedFields[top]; known {
+			continue
+		}
+		// Unrecognized top-level field: cannot prove it is section-free. Fall back to full eval.
+		return false
+	}
+	return true
+}

--- a/pkg/list/column/required_sections.go
+++ b/pkg/list/column/required_sections.go
@@ -43,12 +43,13 @@ var derivedFields = map[string]struct{}{
 // whose first path segment names a section.
 //
 // Returns ok=false whenever any column can't be statically resolved this way: a catch-all `.raw`
-// reference (which exposes the entire row, including every section), a `range`/`with` block
-// (which rebinds "." — see pkg/template.HasDynamicScope), an unparseable template, or any
-// top-level field this function does not recognize as either section-backed or derived. Callers
-// MUST treat ok=false as "pass nil / evaluate everything": under-computing the required set is
-// far worse than over-computing it, since a displayed column would then show raw, unevaluated
-// text instead of falling back cleanly to full evaluation.
+// reference (which exposes the entire row, including every section), a bare root reference like
+// `{{ . }}` (which likewise exposes the entire row — see pkg/template.HasRootReference), a
+// `range`/`with` block (which rebinds "." — see pkg/template.HasDynamicScope), an unparseable
+// template, or any top-level field this function does not recognize as either section-backed or
+// derived. Callers MUST treat ok=false as "pass nil / evaluate everything": under-computing the
+// required set is far worse than over-computing it, since a displayed column would then show raw,
+// unevaluated text instead of falling back cleanly to full evaluation.
 //
 // A true result with an empty (non-nil) `sections` slice is a real, meaningful answer — "no
 // section is required" — and is distinct from a nil slice. Callers MUST preserve that
@@ -63,6 +64,11 @@ func RequiredSections(columns []Config) (sections []string, ok bool) {
 	for _, col := range columns {
 		dynamic, err := atmostemplate.HasDynamicScope(col.Value)
 		if err != nil || dynamic {
+			return nil, false
+		}
+
+		rootRef, err := atmostemplate.HasRootReference(col.Value)
+		if err != nil || rootRef {
 			return nil, false
 		}
 

--- a/pkg/list/column/required_sections_test.go
+++ b/pkg/list/column/required_sections_test.go
@@ -82,6 +82,16 @@ func TestRequiredSections(t *testing.T) {
 			wantOK:  false,
 		},
 		{
+			name:    "root value triggers fallback",
+			columns: []Config{{Name: "Raw", Value: "{{ . }}"}},
+			wantOK:  false,
+		},
+		{
+			name:    "root value as function argument triggers fallback",
+			columns: []Config{{Name: "Raw", Value: `{{ printf "%v" . }}`}},
+			wantOK:  false,
+		},
+		{
 			name:    "range over dynamic scope triggers fallback",
 			columns: []Config{{Name: "List", Value: "{{ range .vars.list }}{{ .name }}{{ end }}"}},
 			wantOK:  false,

--- a/pkg/list/column/required_sections_test.go
+++ b/pkg/list/column/required_sections_test.go
@@ -1,0 +1,154 @@
+package column
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiredSections(t *testing.T) {
+	tests := []struct {
+		name        string
+		columns     []Config
+		wantOK      bool
+		wantOrdered []string // nil means "don't check contents", used only when wantOK.
+	}{
+		{
+			name:        "stack only needs no section",
+			columns:     []Config{{Name: "Stack", Value: "{{ .stack }}"}},
+			wantOK:      true,
+			wantOrdered: []string{},
+		},
+		{
+			name: "stack and component need no section",
+			columns: []Config{
+				{Name: "Stack", Value: "{{ .stack }}"},
+				{Name: "Component", Value: "{{ .component }}"},
+			},
+			wantOK:      true,
+			wantOrdered: []string{},
+		},
+		{
+			name:        "single vars reference",
+			columns:     []Config{{Name: "Region", Value: "{{ .vars.region }}"}},
+			wantOK:      true,
+			wantOrdered: []string{"vars"},
+		},
+		{
+			name: "multiple columns union sections",
+			columns: []Config{
+				{Name: "Region", Value: "{{ .vars.region }}"},
+				{Name: "Owner", Value: "{{ .settings.owner }}"},
+				{Name: "Stack", Value: "{{ .stack }}"},
+			},
+			wantOK:      true,
+			wantOrdered: []string{"settings", "vars"},
+		},
+		{
+			name:        "duplicate section refs dedup",
+			columns:     []Config{{Name: "Both", Value: "{{ .vars.a }}{{ .vars.b }}"}},
+			wantOK:      true,
+			wantOrdered: []string{"vars"},
+		},
+		{
+			name:        "metadata backed field",
+			columns:     []Config{{Name: "Owner", Value: "{{ .metadata.owner }}"}},
+			wantOK:      true,
+			wantOrdered: []string{"metadata"},
+		},
+		{
+			name:        "env backed field",
+			columns:     []Config{{Name: "Region", Value: "{{ .env.AWS_REGION }}"}},
+			wantOK:      true,
+			wantOrdered: []string{"env"},
+		},
+		{
+			name:        "backend backed field",
+			columns:     []Config{{Name: "Bucket", Value: "{{ .backend.bucket }}"}},
+			wantOK:      true,
+			wantOrdered: []string{"backend"},
+		},
+		{
+			name:        "derived metadata-sourced fields need no section",
+			columns:     []Config{{Name: "Status", Value: "{{ .enabled }}{{ .locked }}{{ .tags }}{{ .labels }}{{ .status }}{{ .type }}"}},
+			wantOK:      true,
+			wantOrdered: []string{},
+		},
+		{
+			name:    "catch-all raw triggers fallback",
+			columns: []Config{{Name: "Raw", Value: "{{ .raw.anything }}"}},
+			wantOK:  false,
+		},
+		{
+			name:    "range over dynamic scope triggers fallback",
+			columns: []Config{{Name: "List", Value: "{{ range .vars.list }}{{ .name }}{{ end }}"}},
+			wantOK:  false,
+		},
+		{
+			name:    "with block triggers fallback",
+			columns: []Config{{Name: "With", Value: "{{ with .vars }}{{ .region }}{{ end }}"}},
+			wantOK:  false,
+		},
+		{
+			name:    "unrecognized top-level field triggers fallback",
+			columns: []Config{{Name: "Mystery", Value: "{{ .some_unknown_field }}"}},
+			wantOK:  false,
+		},
+		{
+			name:    "invalid template triggers fallback",
+			columns: []Config{{Name: "Bad", Value: "{{ .vars."}},
+			wantOK:  false,
+		},
+		{
+			name:        "no columns yields empty required set",
+			columns:     []Config{},
+			wantOK:      true,
+			wantOrdered: []string{},
+		},
+		{
+			name: "one resolvable and one unresolvable column both required to bail",
+			columns: []Config{
+				{Name: "Region", Value: "{{ .vars.region }}"},
+				{Name: "Raw", Value: "{{ .raw }}"},
+			},
+			wantOK: false,
+		},
+		{
+			// pkg/template.ExtractFieldRefs/HasDynamicScope parse with no FuncMap, so any
+			// column.BuildColumnFuncMap() custom function (get, truncate, ternary, ...) fails to
+			// parse there and falls back to ok=false -- the conservative behavior called out in
+			// RequiredSections' doc comment ("a custom func ... that could touch anything").
+			name:    "custom func from BuildColumnFuncMap triggers fallback",
+			columns: []Config{{Name: "Region", Value: "{{ get .vars \"region\" }}"}},
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sections, ok := RequiredSections(tt.columns)
+			require.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				assert.Nil(t, sections)
+				return
+			}
+			require.NotNil(t, sections, "a true result must return a non-nil slice (even when empty) -- nil is reserved for ok=false")
+			sort.Strings(sections)
+			assert.Equal(t, tt.wantOrdered, sections)
+		})
+	}
+}
+
+// TestRequiredSections_EmptyNotNil pins the nil-vs-empty contract explicitly: when ok is true and
+// no section is required, the returned slice must be non-nil so downstream evaluation-gating
+// (which distinguishes nil "no filter" from empty-but-non-nil "nothing required") behaves
+// correctly. A regression here (e.g. returning a bare `var result []string`) would silently
+// disable gating for exactly the case that matters most: default `list stacks` columns.
+func TestRequiredSections_EmptyNotNil(t *testing.T) {
+	sections, ok := RequiredSections([]Config{{Name: "Stack", Value: "{{ .stack }}"}})
+	require.True(t, ok)
+	require.NotNil(t, sections)
+	assert.Empty(t, sections)
+}

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -440,13 +440,17 @@ func sortInstances(instances []schema.Instance) []schema.Instance {
 // `metadata` is unconditionally folded in: extract.Metadata always reads it (enabled/locked/tags/
 // labels/status/type derive from it), and createInstance filters abstract components on
 // metadata.type before any row is ever built — both independent of which columns are displayed.
+// `settings` is folded in whenever this invocation may upload instances (opts.Upload, or Atmos
+// Pro's GateOpen firing implicitly): buildUploadInstances reads instance.Settings for
+// extractProSettings's "settings.pro" payload regardless of which columns are on screen, so
+// skipping settings evaluation would silently upload unresolved template/YAML-tag text.
 //
 // Returns nil (full eager evaluation, the historical behavior) whenever RequiredSections can't
 // statically prove which sections are safe to skip, OR when --filter/--query is set: both are YQ
 // expressions (a different, unparsed-here expression language), so which fields they touch cannot
 // be statically determined the way column.Value Go-template refs can — see
 // column.RequiredSections' doc comment on under-computing being unsafe.
-func resolveInstancesEvalSections(columns []column.Config, opts *InstancesCommandOptions) []string {
+func resolveInstancesEvalSections(atmosConfig *schema.AtmosConfiguration, columns []column.Config, opts *InstancesCommandOptions) []string {
 	defer perf.Track(nil, "list.resolveInstancesEvalSections")()
 
 	if opts.FilterSpec != "" || opts.Query != "" {
@@ -457,7 +461,11 @@ func resolveInstancesEvalSections(columns []column.Config, opts *InstancesComman
 	if !ok {
 		return nil
 	}
-	return column.EnsureSection(sections, "metadata")
+	sections = column.EnsureSection(sections, "metadata")
+	if opts.Upload || proexec.GateOpen(atmosConfig) {
+		sections = column.EnsureSection(sections, "settings")
+	}
+	return sections
 }
 
 // getInstanceColumns returns column configuration from CLI flag, atmos.yaml, or defaults.
@@ -1021,7 +1029,7 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 		// evalSections narrows evaluation to the sections the resolved columns (plus `metadata`,
 		// which extract.Metadata and buildInstanceFilters's tags/labels filters always need) and
 		// the --filter/--query row transforms actually read — see resolveInstancesEvalSections.
-		evalSections := resolveInstancesEvalSections(columns, opts)
+		evalSections := resolveInstancesEvalSections(&atmosConfig, columns, opts)
 		instances, _, err = processInstances(
 			&atmosConfig,
 			opts.AuthManager,

--- a/pkg/list/list_instances.go
+++ b/pkg/list/list_instances.go
@@ -435,6 +435,31 @@ func sortInstances(instances []schema.Instance) []schema.Instance {
 	return instances
 }
 
+// ResolveInstancesEvalSections computes the evaluation-scope filter (see
+// column.RequiredSections/e.ExecuteDescribeStacksWithEvalSections) for the resolved column set.
+// `metadata` is unconditionally folded in: extract.Metadata always reads it (enabled/locked/tags/
+// labels/status/type derive from it), and createInstance filters abstract components on
+// metadata.type before any row is ever built — both independent of which columns are displayed.
+//
+// Returns nil (full eager evaluation, the historical behavior) whenever RequiredSections can't
+// statically prove which sections are safe to skip, OR when --filter/--query is set: both are YQ
+// expressions (a different, unparsed-here expression language), so which fields they touch cannot
+// be statically determined the way column.Value Go-template refs can — see
+// column.RequiredSections' doc comment on under-computing being unsafe.
+func resolveInstancesEvalSections(columns []column.Config, opts *InstancesCommandOptions) []string {
+	defer perf.Track(nil, "list.resolveInstancesEvalSections")()
+
+	if opts.FilterSpec != "" || opts.Query != "" {
+		return nil
+	}
+
+	sections, ok := column.RequiredSections(columns)
+	if !ok {
+		return nil
+	}
+	return column.EnsureSection(sections, "metadata")
+}
+
 // getInstanceColumns returns column configuration from CLI flag, atmos.yaml, or defaults.
 // Returns error if CLI flag parsing fails.
 // Precedence: CLI flag > list.instances.columns > components.list.columns (deprecated) > defaults.
@@ -607,6 +632,7 @@ func processInstancesWithDeps(
 	authDisabled bool,
 	tagsFilter []string,
 	labelsFilter map[string]string,
+	evalSections []string,
 ) ([]schema.Instance, map[string]any, error) {
 	stacksMap, err := executeDescribeStacksForInstances(
 		atmosConfig,
@@ -618,6 +644,7 @@ func processInstancesWithDeps(
 		authDisabled,
 		tagsFilter,
 		labelsFilter,
+		evalSections,
 	)
 	if err != nil {
 		log.Error(errUtils.ErrExecuteDescribeStacks.Error(), "error", err)
@@ -675,13 +702,42 @@ type scopedStacksProcessor interface {
 	) (map[string]any, error)
 }
 
+// evalSectionsStacksProcessor is the optional interface for processors supporting the
+// evaluation-sections gate (see column.RequiredSections / e.ExecuteDescribeStacksWithEvalSections)
+// on top of the auth-disabled + tags/labels-scoped behavior. Kept separate from
+// scopedStacksProcessor and authDisabledStacksProcessor so existing test doubles that only
+// implement those narrower interfaces keep compiling and behaving exactly as before — evalSections
+// gating is purely an additional, optional optimization, never a correctness requirement.
+type evalSectionsStacksProcessor interface {
+	ExecuteDescribeStacksWithEvalSections(
+		atmosConfig *schema.AtmosConfiguration,
+		filterByStack string,
+		components []string,
+		componentTypes []string,
+		sections []string,
+		ignoreMissingFiles bool,
+		processTemplates bool,
+		processYamlFunctions bool,
+		includeEmptyStacks bool,
+		skip []string,
+		authManager auth.AuthManager,
+		authDisabled bool,
+		tagsFilter []string,
+		labelsFilter map[string]string,
+		evalSections []string,
+	) (map[string]any, error)
+}
+
 // executeDescribeStacksForInstances dispatches to the most capable describe
-// variant the processor implements: the scoped variant when a tags/labels
-// early-skip filter is requested, the auth-disabled variant when authDisabled
-// is set, and the standard ExecuteDescribeStacks call otherwise. The `skip`
-// list is forwarded to every path so --skip continues to bypass the named
-// YAML functions. A processor without the optional scoped interface simply
-// describes unscoped — the row filters remain the authoritative final pass.
+// variant the processor implements: the eval-sections variant when a non-nil
+// evalSections filter is requested (a strict superset of the scoped/auth-disabled
+// behavior below), the scoped variant when a tags/labels early-skip filter is
+// requested, the auth-disabled variant when authDisabled is set, and the standard
+// ExecuteDescribeStacks call otherwise. The `skip` list is forwarded to every path
+// so --skip continues to bypass the named YAML functions. A processor without the
+// relevant optional interface simply describes without that capability — the row
+// filters remain the authoritative final pass, and eval-sections gating is purely
+// a performance/warning optimization, never required for correctness.
 //
 //nolint:revive // Helper mirrors the StacksProcessor call shape with skip + authDisabled passthrough.
 func executeDescribeStacksForInstances(
@@ -693,7 +749,26 @@ func executeDescribeStacksForInstances(
 	authDisabled bool,
 	tagsFilter []string,
 	labelsFilter map[string]string,
+	evalSections []string,
 ) (map[string]any, error) {
+	if evalSections != nil {
+		if processor, ok := stacksProcessor.(evalSectionsStacksProcessor); ok {
+			return processor.ExecuteDescribeStacksWithEvalSections(
+				atmosConfig, "", nil, nil, nil,
+				false, // ignoreMissingFiles
+				processTemplates,
+				processYamlFunctions,
+				false, // includeEmptyStacks
+				skip,
+				authManager,
+				authDisabled,
+				tagsFilter,
+				labelsFilter,
+				evalSections,
+			)
+		}
+	}
+
 	if len(tagsFilter) > 0 || len(labelsFilter) > 0 {
 		if processor, ok := stacksProcessor.(scopedStacksProcessor); ok {
 			return processor.ExecuteDescribeStacksScoped(
@@ -755,6 +830,7 @@ func processInstances(
 	authDisabled bool,
 	tagsFilter []string,
 	labelsFilter map[string]string,
+	evalSections []string,
 ) ([]schema.Instance, map[string]any, error) {
 	return processInstancesWithDeps(
 		atmosConfig,
@@ -767,6 +843,7 @@ func processInstances(
 		authDisabled,
 		tagsFilter,
 		labelsFilter,
+		evalSections,
 	)
 }
 
@@ -927,11 +1004,24 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 	// With closure flags, the whole flow goes through the shared scoped closure
 	// engine instead: only the closure's stacks and components are evaluated,
 	// and the membership filter below owns row selection.
+	//
+	// Resolve columns before describing so the evaluation-scope filter (below) always matches
+	// the columns that actually end up on screen.
+	columns, err := getInstanceColumns(&atmosConfig, opts.ColumnsFlag)
+	if err != nil {
+		log.Error("failed to get columns", "error", err)
+		return errors.Join(errUtils.ErrInvalidConfig, err)
+	}
+
 	var instances []schema.Instance
 	var closureMembers map[string]struct{}
 	if opts.closureRequested() {
 		instances, closureMembers, err = processInstancesScopedClosure(&atmosConfig, opts, labels)
 	} else {
+		// evalSections narrows evaluation to the sections the resolved columns (plus `metadata`,
+		// which extract.Metadata and buildInstanceFilters's tags/labels filters always need) and
+		// the --filter/--query row transforms actually read — see resolveInstancesEvalSections.
+		evalSections := resolveInstancesEvalSections(columns, opts)
 		instances, _, err = processInstances(
 			&atmosConfig,
 			opts.AuthManager,
@@ -942,6 +1032,7 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 			opts.AuthDisabled,
 			opts.Tags,
 			labels,
+			evalSections,
 		)
 	}
 	if err != nil {
@@ -951,13 +1042,6 @@ func ExecuteListInstancesCmd(opts *InstancesCommandOptions) error {
 
 	// Extract instances into renderer-compatible format with metadata fields.
 	data := extract.Metadata(instances)
-
-	// Get column configuration.
-	columns, err := getInstanceColumns(&atmosConfig, opts.ColumnsFlag)
-	if err != nil {
-		log.Error("failed to get columns", "error", err)
-		return errors.Join(errUtils.ErrInvalidConfig, err)
-	}
 
 	// Create column selector.
 	selector, err := column.NewSelector(columns, column.BuildColumnFuncMap())

--- a/pkg/list/list_instances_authdisabled_test.go
+++ b/pkg/list/list_instances_authdisabled_test.go
@@ -118,6 +118,7 @@ func TestExecuteDescribeStacksForInstances_AuthDisabledDispatchesToAuthDisabledM
 		true, // authDisabled — the bit under test.
 		nil,  // tagsFilter
 		nil,  // labelsFilter
+		nil,  // evalSections
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -149,6 +150,7 @@ func TestExecuteDescribeStacksForInstances_AuthDisabledFalseUsesRegularPath(t *t
 		false, // authDisabled=false — regular path expected.
 		nil,   // tagsFilter
 		nil,   // labelsFilter
+		nil,   // evalSections
 	)
 	require.NoError(t, err)
 	assert.True(t, fake.executeDescribeStacksCalled,
@@ -175,6 +177,7 @@ func TestExecuteDescribeStacksForInstances_FallsBackWhenInterfaceNotImplemented(
 		true,  // authDisabled=true but processor doesn't implement the optional interface.
 		nil,   // tagsFilter
 		nil,   // labelsFilter
+		nil,   // evalSections
 	)
 	require.NoError(t, err)
 	assert.True(t, fake.called,
@@ -200,6 +203,7 @@ func TestExecuteDescribeStacksForInstances_ScopedFiltersFallBackWhenUnsupported(
 		true,                             // authDisabled
 		[]string{"production"},           // tagsFilter
 		map[string]string{"env": "prod"}, // labelsFilter
+		nil,                              // evalSections
 	)
 	require.NoError(t, err)
 	assert.True(t, fake.executeDescribeStacksAuthDisabled,
@@ -241,6 +245,7 @@ func TestProcessInstancesWithDeps_AuthDisabledPropagatesAuthDisabledFlag(t *test
 		true,  // authDisabled
 		nil,   // tagsFilter
 		nil,   // labelsFilter
+		nil,   // evalSections
 	)
 	require.NoError(t, err)
 	require.Len(t, instances, 1)
@@ -286,6 +291,7 @@ func TestProcessInstances_AuthDisabledConstructsDefaultProcessor(t *testing.T) {
 		true,  // authDisabled
 		nil,   // tagsFilter
 		nil,   // labelsFilter
+		nil,   // evalSections
 	)
 	// With no stacks configured, ExecuteDescribeStacksWithAuthDisabled returns
 	// an empty map; the upstream collector then returns an empty slice. The

--- a/pkg/list/list_instances_closure_test.go
+++ b/pkg/list/list_instances_closure_test.go
@@ -196,7 +196,7 @@ func TestExecuteDescribeStacksForInstances_ScopedDispatch(t *testing.T) {
 		fake := &scopedFakeProcessor{}
 		_, err := executeDescribeStacksForInstances(
 			&schema.AtmosConfiguration{}, fake, nil, true, true, nil, false,
-			[]string{"app"}, nil,
+			[]string{"app"}, nil, nil,
 		)
 		require.NoError(t, err)
 		assert.True(t, fake.scopedCalled, "a tags filter must dispatch to ExecuteDescribeStacksScoped")
@@ -210,7 +210,7 @@ func TestExecuteDescribeStacksForInstances_ScopedDispatch(t *testing.T) {
 		labels := map[string]string{"env": "dev"}
 		_, err := executeDescribeStacksForInstances(
 			&schema.AtmosConfiguration{}, fake, nil, true, true, nil, false,
-			nil, labels,
+			nil, labels, nil,
 		)
 		require.NoError(t, err)
 		assert.True(t, fake.scopedCalled, "a labels filter must dispatch to ExecuteDescribeStacksScoped")
@@ -223,7 +223,7 @@ func TestExecuteDescribeStacksForInstances_ScopedDispatch(t *testing.T) {
 		fake := &scopedFakeProcessor{}
 		_, err := executeDescribeStacksForInstances(
 			&schema.AtmosConfiguration{}, fake, nil, true, true, nil, false,
-			nil, nil,
+			nil, nil, nil,
 		)
 		require.NoError(t, err)
 		assert.False(t, fake.scopedCalled)

--- a/pkg/list/list_instances_coverage_test.go
+++ b/pkg/list/list_instances_coverage_test.go
@@ -612,6 +612,64 @@ func TestGetInstanceColumns(t *testing.T) {
 	}
 }
 
+// TestResolveInstancesEvalSections verifies the evaluation-scope filter derived from the resolved
+// column set: `metadata` is always folded in (extract.Metadata and createInstance's abstract-type
+// filtering always read it, regardless of which columns are shown), and --filter/--query force a
+// nil (full eager evaluation) fallback since their YQ expressions cannot be statically analyzed
+// the way column.Value Go-template refs can.
+func TestResolveInstancesEvalSections(t *testing.T) {
+	tests := []struct {
+		name        string
+		columns     []column.Config
+		opts        *InstancesCommandOptions
+		expectNil   bool
+		expectExact []string
+	}{
+		{
+			name:        "default columns require only metadata",
+			columns:     defaultInstanceColumns,
+			opts:        &InstancesCommandOptions{},
+			expectExact: []string{"metadata"},
+		},
+		{
+			name:        "columns referencing vars require vars and metadata",
+			columns:     []column.Config{{Name: "Component", Value: "{{ .component }}"}, {Name: "Region", Value: "{{ .vars.region }}"}},
+			opts:        &InstancesCommandOptions{},
+			expectExact: []string{"metadata", "vars"},
+		},
+		{
+			name:      "unresolvable column (raw) falls back to nil",
+			columns:   []column.Config{{Name: "Raw", Value: "{{ .raw }}"}},
+			opts:      &InstancesCommandOptions{},
+			expectNil: true,
+		},
+		{
+			name:      "--filter set forces nil (YQ expression, not statically analyzable)",
+			columns:   defaultInstanceColumns,
+			opts:      &InstancesCommandOptions{FilterSpec: ".enabled == true"},
+			expectNil: true,
+		},
+		{
+			name:      "--query set forces nil (YQ expression, not statically analyzable)",
+			columns:   defaultInstanceColumns,
+			opts:      &InstancesCommandOptions{Query: ".component"},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveInstancesEvalSections(tt.columns, tt.opts)
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			assert.ElementsMatch(t, tt.expectExact, result)
+		})
+	}
+}
+
 // TestBuildInstanceSorters tests sorter configuration.
 func TestBuildInstanceSorters(t *testing.T) {
 	tests := []struct {

--- a/pkg/list/list_instances_coverage_test.go
+++ b/pkg/list/list_instances_coverage_test.go
@@ -614,52 +614,85 @@ func TestGetInstanceColumns(t *testing.T) {
 
 // TestResolveInstancesEvalSections verifies the evaluation-scope filter derived from the resolved
 // column set: `metadata` is always folded in (extract.Metadata and createInstance's abstract-type
-// filtering always read it, regardless of which columns are shown), and --filter/--query force a
-// nil (full eager evaluation) fallback since their YQ expressions cannot be statically analyzed
-// the way column.Value Go-template refs can.
+// filtering always read it, regardless of which columns are shown), `settings` is folded in
+// whenever this invocation may upload instances (opts.Upload or Atmos Pro's GateOpen), and
+// --filter/--query force a nil (full eager evaluation) fallback since their YQ expressions cannot
+// be statically analyzed the way column.Value Go-template refs can.
 func TestResolveInstancesEvalSections(t *testing.T) {
+	proConfigured := &schema.AtmosConfiguration{Settings: schema.AtmosSettings{Pro: schema.ProSettings{Token: "test-token"}}}
+
 	tests := []struct {
 		name        string
+		atmosConfig *schema.AtmosConfiguration
 		columns     []column.Config
 		opts        *InstancesCommandOptions
+		forceCI     bool
 		expectNil   bool
 		expectExact []string
 	}{
 		{
 			name:        "default columns require only metadata",
+			atmosConfig: &schema.AtmosConfiguration{},
 			columns:     defaultInstanceColumns,
 			opts:        &InstancesCommandOptions{},
 			expectExact: []string{"metadata"},
 		},
 		{
 			name:        "columns referencing vars require vars and metadata",
+			atmosConfig: &schema.AtmosConfiguration{},
 			columns:     []column.Config{{Name: "Component", Value: "{{ .component }}"}, {Name: "Region", Value: "{{ .vars.region }}"}},
 			opts:        &InstancesCommandOptions{},
 			expectExact: []string{"metadata", "vars"},
 		},
 		{
-			name:      "unresolvable column (raw) falls back to nil",
-			columns:   []column.Config{{Name: "Raw", Value: "{{ .raw }}"}},
-			opts:      &InstancesCommandOptions{},
-			expectNil: true,
+			name:        "unresolvable column (raw) falls back to nil",
+			atmosConfig: &schema.AtmosConfiguration{},
+			columns:     []column.Config{{Name: "Raw", Value: "{{ .raw }}"}},
+			opts:        &InstancesCommandOptions{},
+			expectNil:   true,
 		},
 		{
-			name:      "--filter set forces nil (YQ expression, not statically analyzable)",
-			columns:   defaultInstanceColumns,
-			opts:      &InstancesCommandOptions{FilterSpec: ".enabled == true"},
-			expectNil: true,
+			name:        "--filter set forces nil (YQ expression, not statically analyzable)",
+			atmosConfig: &schema.AtmosConfiguration{},
+			columns:     defaultInstanceColumns,
+			opts:        &InstancesCommandOptions{FilterSpec: ".enabled == true"},
+			expectNil:   true,
 		},
 		{
-			name:      "--query set forces nil (YQ expression, not statically analyzable)",
-			columns:   defaultInstanceColumns,
-			opts:      &InstancesCommandOptions{Query: ".component"},
-			expectNil: true,
+			name:        "--query set forces nil (YQ expression, not statically analyzable)",
+			atmosConfig: &schema.AtmosConfiguration{},
+			columns:     defaultInstanceColumns,
+			opts:        &InstancesCommandOptions{Query: ".component"},
+			expectNil:   true,
+		},
+		{
+			name:        "--upload folds settings in alongside metadata",
+			atmosConfig: &schema.AtmosConfiguration{},
+			columns:     defaultInstanceColumns,
+			opts:        &InstancesCommandOptions{Upload: true},
+			expectExact: []string{"metadata", "settings"},
+		},
+		{
+			name:        "Atmos Pro GateOpen folds settings in even without --upload",
+			atmosConfig: proConfigured,
+			columns:     defaultInstanceColumns,
+			opts:        &InstancesCommandOptions{},
+			forceCI:     true,
+			expectExact: []string{"metadata", "settings"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resolveInstancesEvalSections(tt.columns, tt.opts)
+			if tt.forceCI {
+				// GateOpen requires telemetry.IsCI() in addition to Pro credentials; force it
+				// deterministically rather than depending on whether this test happens to run
+				// inside real CI.
+				preserved := telemetry.PreserveCIEnvVars()
+				t.Cleanup(func() { telemetry.RestoreCIEnvVars(preserved) })
+				t.Setenv("CI", "true")
+			}
+			result := resolveInstancesEvalSections(tt.atmosConfig, tt.columns, tt.opts)
 			if tt.expectNil {
 				assert.Nil(t, result)
 				return

--- a/pkg/list/list_instances_process_test.go
+++ b/pkg/list/list_instances_process_test.go
@@ -42,7 +42,7 @@ func TestProcessInstancesWithDeps_Success(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, instances, 2)
@@ -66,7 +66,7 @@ func TestProcessInstancesWithDeps_ExecuteDescribeStacksError(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(nil, expectedErr)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, instances)
@@ -87,7 +87,7 @@ func TestProcessInstancesWithDeps_EmptyStacksMap(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Empty(t, instances)
@@ -122,7 +122,7 @@ func TestProcessInstancesWithDeps_InvalidStackPattern(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, stacksMapResult, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "[", false, nil, nil)
+	instances, stacksMapResult, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "[", false, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, instances)
@@ -173,7 +173,7 @@ func TestProcessInstancesWithDeps_MultipleStacks(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, instances, 3)
@@ -214,7 +214,7 @@ func TestProcessInstancesWithDeps_AbstractComponentsFiltered(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, instances, 1)
@@ -250,7 +250,7 @@ func TestProcessInstancesWithDeps_InvalidStackStructure(t *testing.T) {
 		ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, true, false, false, nil, nil).
 		Return(stacksMap, nil)
 
-	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil)
+	instances, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, nil, "", false, nil, nil, nil)
 
 	assert.NoError(t, err)
 	// Only prod stack should be processed successfully.
@@ -305,7 +305,7 @@ func TestProcessInstancesWithDeps_PropagatesTemplateAndFunctionFlags(t *testing.
 				).
 				Return(map[string]interface{}{}, nil)
 
-			_, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, tc.processTemplates, tc.processYamlFunctions, nil, "", false, nil, nil)
+			_, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, tc.processTemplates, tc.processYamlFunctions, nil, "", false, nil, nil, nil)
 			assert.NoError(t, err)
 		})
 	}
@@ -349,7 +349,7 @@ func TestProcessInstancesWithDeps_PropagatesSkipFlag(t *testing.T) {
 				).
 				Return(map[string]interface{}{}, nil)
 
-			_, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, tc.skip, "", false, nil, nil)
+			_, _, err := processInstancesWithDeps(atmosConfig, mockStacksProcessor, nil, true, false, tc.skip, "", false, nil, nil, nil)
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/list/list_metadata.go
+++ b/pkg/list/list_metadata.go
@@ -129,7 +129,10 @@ func ExecuteListMetadataCmd(info *schema.ConfigAndStacksInfo, cmd *cobra.Command
 	// Process instances (same as list instances, but we'll extract metadata).
 	// authDisabled is false here because `list metadata` doesn't expose
 	// --identity=false yet; parity with `list instances` (#2412) is a follow-up.
-	instances, _, err := processInstances(&atmosConfig, opts.AuthManager, opts.ProcessTemplates, opts.ProcessFunctions, opts.Skip, opts.Stack, false, nil, nil)
+	// evalSections stays nil: `list metadata` isn't wired into the evaluation-scope gate (see
+	// column.RequiredSections) yet -- unaffected by this change, exactly like every other
+	// non-`list stacks`/`list components`/`list instances` caller.
+	instances, _, err := processInstances(&atmosConfig, opts.AuthManager, opts.ProcessTemplates, opts.ProcessFunctions, opts.Skip, opts.Stack, false, nil, nil, nil)
 	if err != nil {
 		return errors.Join(errUtils.ErrProcessInstances, err)
 	}

--- a/pkg/template/ast.go
+++ b/pkg/template/ast.go
@@ -328,6 +328,41 @@ func HasDynamicScope(templateStr string) (bool, error) {
 	return dynamic, nil
 }
 
+// HasRootReference reports whether a template contains a bare "." action (*parse.DotNode) --
+// e.g. "{{ . }}" or "{{ printf "%v" . }}" -- which accesses the entire root data value rather
+// than a specific named field. ExtractFieldRefs only records *parse.FieldNode matches, so a
+// template consisting solely of "{{ . }}" yields zero field references even though it exposes
+// every field of the root, including ones no FieldNode ever names. Callers like
+// pkg/list/column.RequiredSections that statically enumerate which root-level fields a template
+// touches must treat any such reference as unresolvable rather than silently recording it as
+// touching nothing.
+func HasRootReference(templateStr string) (bool, error) {
+	defer perf.Track(nil, "template.HasRootReference")()
+
+	if !strings.Contains(templateStr, templateOpenDelim) {
+		return false, nil
+	}
+
+	tmpl, err := template.New("").Parse(templateStr)
+	if err != nil {
+		return false, err
+	}
+
+	tree := tmpl.Tree
+	if tree == nil || tree.Root == nil {
+		return false, nil
+	}
+
+	root := false
+	walkAST(tree.Root, func(node parse.Node) {
+		if _, ok := node.(*parse.DotNode); ok {
+			root = true
+		}
+	})
+
+	return root, nil
+}
+
 // LookupFieldPath resolves a field path against map-like data.
 func LookupFieldPath(data any, path []string) (any, bool) {
 	defer perf.Track(nil, "template.LookupFieldPath")()

--- a/pkg/template/ast.go
+++ b/pkg/template/ast.go
@@ -12,6 +12,10 @@ import (
 	"github.com/cloudposse/atmos/pkg/perf"
 )
 
+// templateOpenDelim is the default Go-template opening delimiter, used as a cheap pre-check
+// before parsing: a string containing none of it cannot possibly hold a template action.
+const templateOpenDelim = "{{"
+
 // FieldRef represents a reference to a field in a template (e.g., .locals.foo).
 type FieldRef struct {
 	Path []string // e.g., ["locals", "foo"] for .locals.foo
@@ -31,7 +35,7 @@ func ExtractFieldRefs(templateStr string) ([]FieldRef, error) {
 	defer perf.Track(nil, "template.ExtractFieldRefs")()
 
 	// Quick check - if no template delimiters, no refs possible.
-	if !strings.Contains(templateStr, "{{") {
+	if !strings.Contains(templateStr, templateOpenDelim) {
 		return nil, nil
 	}
 
@@ -174,7 +178,7 @@ func HasTemplateActions(str string) (bool, error) {
 	defer perf.Track(nil, "template.HasTemplateActions")()
 
 	// Quick check - if no template delimiters, no actions possible.
-	if !strings.Contains(str, "{{") {
+	if !strings.Contains(str, templateOpenDelim) {
 		return false, nil
 	}
 
@@ -231,7 +235,7 @@ func ExtractAllFieldRefsByPrefix(templateStr string, prefix string) ([]string, e
 func ExtractPlainFieldRef(templateStr string) (FieldRef, bool, error) {
 	defer perf.Track(nil, "template.ExtractPlainFieldRef")()
 
-	if !strings.Contains(templateStr, "{{") {
+	if !strings.Contains(templateStr, templateOpenDelim) {
 		return FieldRef{}, false, nil
 	}
 
@@ -287,6 +291,41 @@ func fieldRefFromAction(action *parse.ActionNode) (FieldRef, bool) {
 	}
 
 	return FieldRef{Path: field.Ident}, true
+}
+
+// HasDynamicScope reports whether a template contains a `range` or `with` action, either of
+// which rebinds "." to something other than the template's root data for the body it encloses.
+// Field references found inside such a body (e.g. `.name` inside
+// `{{ range .vars.list }}{{ .name }}{{ end }}`) are NOT relative to the template's root, so a
+// caller using ExtractFieldRefs to statically determine which root-level fields a template
+// touches (see pkg/list/column.RequiredSections) must treat any template containing dynamic
+// scope as unresolvable rather than misattributing those inner references to the root.
+func HasDynamicScope(templateStr string) (bool, error) {
+	defer perf.Track(nil, "template.HasDynamicScope")()
+
+	if !strings.Contains(templateStr, templateOpenDelim) {
+		return false, nil
+	}
+
+	tmpl, err := template.New("").Parse(templateStr)
+	if err != nil {
+		return false, err
+	}
+
+	tree := tmpl.Tree
+	if tree == nil || tree.Root == nil {
+		return false, nil
+	}
+
+	dynamic := false
+	walkAST(tree.Root, func(node parse.Node) {
+		switch node.(type) {
+		case *parse.RangeNode, *parse.WithNode:
+			dynamic = true
+		}
+	})
+
+	return dynamic, nil
 }
 
 // LookupFieldPath resolves a field path against map-like data.

--- a/pkg/template/ast_test.go
+++ b/pkg/template/ast_test.go
@@ -343,6 +343,35 @@ func TestHasTemplateActions(t *testing.T) {
 	}
 }
 
+func TestHasDynamicScope(t *testing.T) {
+	tests := []struct {
+		template string
+		expected bool
+	}{
+		{"{{ .foo }}", false},
+		{"{{ if .x }}y{{ end }}", false},
+		{"{{ .vars.region }}", false},
+		{"plain text", false},
+		{"", false},
+		{"{{ range .items }}{{ . }}{{ end }}", true},
+		{"{{ with .config }}{{ .value }}{{ end }}", true},
+		{"{{ if .x }}{{ range .items }}{{ . }}{{ end }}{{ end }}", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.template, func(t *testing.T) {
+			result, err := HasDynamicScope(tt.template)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasDynamicScope_InvalidTemplate(t *testing.T) {
+	_, err := HasDynamicScope("{{ .foo }")
+	assert.Error(t, err)
+}
+
 func TestFieldRefString(t *testing.T) {
 	tests := []struct {
 		path     []string

--- a/pkg/template/ast_test.go
+++ b/pkg/template/ast_test.go
@@ -372,6 +372,34 @@ func TestHasDynamicScope_InvalidTemplate(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestHasRootReference(t *testing.T) {
+	tests := []struct {
+		template string
+		expected bool
+	}{
+		{"{{ .foo }}", false},
+		{"{{ .vars.region }}", false},
+		{"plain text", false},
+		{"", false},
+		{"{{ . }}", true},
+		{`{{ printf "%v" . }}`, true},
+		{"{{ if .x }}{{ . }}{{ end }}", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.template, func(t *testing.T) {
+			result, err := HasRootReference(tt.template)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasRootReference_InvalidTemplate(t *testing.T) {
+	_, err := HasRootReference("{{ . }")
+	assert.Error(t, err)
+}
+
 func TestFieldRefString(t *testing.T) {
 	tests := []struct {
 		path     []string

--- a/pkg/terraform/ui/init_model.go
+++ b/pkg/terraform/ui/init_model.go
@@ -297,6 +297,8 @@ func (m *InitModel) formatAction() string {
 	switch m.subCommand {
 	case "init":
 		return "Init"
+	case "providers-lock":
+		return "Provider lock"
 	case "workspace":
 		if m.workspace != "" {
 			return fmt.Sprintf("Selected `%s` workspace for", m.workspace)

--- a/pkg/terraform/ui/init_model_test.go
+++ b/pkg/terraform/ui/init_model_test.go
@@ -320,6 +320,24 @@ func TestInitModel_View_Done_Error(t *testing.T) {
 	assert.Contains(t, view, "2.0s")
 }
 
+func TestInitModel_View_Done_ProvidersLock(t *testing.T) {
+	t.Parallel()
+
+	clock := newTestClock()
+	reader := strings.NewReader("")
+	m := NewInitModel("myapp", "dev", "providers-lock", reader, WithInitClock(clock))
+	m.done = true
+
+	clock.advance(2 * time.Second)
+
+	view := m.View()
+
+	assert.Contains(t, view, "Provider lock")
+	assert.Contains(t, view, "dev/myapp")
+	assert.Contains(t, view, "completed")
+	assert.Contains(t, view, "2.0s")
+}
+
 func TestInitModel_View_Done_Workspace(t *testing.T) {
 	t.Parallel()
 
@@ -350,6 +368,7 @@ func TestInitModel_FormatAction(t *testing.T) {
 		expected   string
 	}{
 		{"init command", "init", "", "Init"},
+		{"providers-lock command", "providers-lock", "", "Provider lock"},
 		{"workspace with name", "workspace", "dev", "Selected `dev` workspace for"},
 		{"workspace without name", "workspace", "", "Selected workspace for"},
 		{"custom command", "custom", "", "Custom"},

--- a/pkg/ui/formatter.go
+++ b/pkg/ui/formatter.go
@@ -1205,6 +1205,11 @@ func (f *formatter) renderMarkdown(content string, preserveNewlines, noWrap bool
 		return content, err
 	}
 
+	// Fix glamour's missing hanging indent on wrapped list continuation
+	// lines (see markdown.FixListHangingIndent for why this is a
+	// post-process rather than a renderer/style option).
+	rendered = markdown.FixListHangingIndent(rendered)
+
 	// Remove trailing whitespace that glamour adds for padding.
 	return atmosansi.TrimLinesRight(rendered), nil
 }

--- a/pkg/ui/markdown/custom_renderer.go
+++ b/pkg/ui/markdown/custom_renderer.go
@@ -240,7 +240,11 @@ func getGlamourGoldmark(renderer *glamour.TermRenderer) goldmark.Markdown {
 // TestCustomRendererWritesNothingToStdout, which guards this reasoning
 // against a future glamour upgrade.
 func (r *CustomRenderer) Render(content string) (string, error) {
-	return r.glamour.Render(content)
+	rendered, err := r.glamour.Render(content)
+	if err != nil {
+		return rendered, err
+	}
+	return FixListHangingIndent(rendered), nil
 }
 
 // Close is a no-op for compatibility with glamour.TermRenderer interface.

--- a/pkg/ui/markdown/list_indent.go
+++ b/pkg/ui/markdown/list_indent.go
@@ -24,6 +24,14 @@ var bulletPrefixPattern = regexp.MustCompile(`^• `)
 // Enumeration.BlockPrefix ". ", see the same two style sources above).
 var orderedPrefixPattern = regexp.MustCompile(`^\d+\. `)
 
+// listLevel tracks one active nesting level's hanging-indent state: the
+// visible indent of that level's own bullet/number line (baseIndent) and how
+// many extra spaces its continuation lines need (hangIndent).
+type listLevel struct {
+	baseIndent int
+	hangIndent int
+}
+
 // FixListHangingIndent re-indents wrapped continuation lines of bullet and
 // ordered markdown list items so they align under the item's own text
 // instead of falling flush with the bullet/number.
@@ -65,12 +73,14 @@ func FixListHangingIndent(rendered string) string {
 
 	lines := strings.Split(rendered, "\n")
 
-	// hangIndent is the number of extra spaces continuation lines of the
-	// current item need; -1 means "not currently inside a list item".
-	hangIndent := -1
-	// baseIndent is the visible indent width of the item's own bullet/number
-	// line; continuation lines of that item share this same indent.
-	baseIndent := -1
+	// stack holds one listLevel per active nesting depth, outermost first.
+	// Tracking a stack (rather than a single flat baseIndent/hangIndent
+	// pair) is required so that a nested list's own bullet doesn't clobber
+	// its enclosing item's state: once the nested list ends and a wrapped
+	// continuation line of the *outer* item resumes at the outer indent,
+	// the outer level is still on the stack (just no longer on top) and its
+	// hangIndent can be recovered instead of falling flush with the marker.
+	var stack []listLevel
 
 	for i, line := range lines {
 		plain := ansi.Strip(line)
@@ -78,32 +88,59 @@ func FixListHangingIndent(rendered string) string {
 		indent := len(plain) - len(trimmed)
 
 		if trimmed == "" {
-			hangIndent = -1
+			stack = stack[:0]
 			continue
 		}
 
 		if prefix := listItemPrefix(trimmed); prefix != "" {
-			baseIndent = indent
-			// Rune count, not byte length: the bullet "•" (U+2022) is a
-			// single terminal column but three UTF-8 bytes.
-			hangIndent = utf8.RuneCountInString(prefix)
+			stack = pushListLevel(stack, indent, prefix)
 			continue
 		}
 
-		if hangIndent >= 0 && indent == baseIndent {
-			// Plain leading spaces are visually identical to any styled
-			// spaces already on the line -- a space glyph has no visible
-			// foreground color -- so prepending them unstyled is safe and
-			// avoids needing to parse past embedded ANSI codes to find an
-			// "insertion point".
-			lines[i] = strings.Repeat(" ", hangIndent) + line
-			continue
-		}
-
-		hangIndent = -1
+		stack, lines[i] = applyHangingIndent(stack, indent, line)
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// pushListLevel records a new bullet/number line's own indent and hanging
+// indent onto stack. A new bullet/number at this indent either starts a
+// deeper nested list (indent greater than every tracked level) or is a new
+// sibling item replacing the level(s) at or below its own indent (indent <=
+// some tracked level's baseIndent) -- those are popped first so a sibling
+// never merges with its predecessor's state.
+func pushListLevel(stack []listLevel, indent int, prefix string) []listLevel {
+	for len(stack) > 0 && stack[len(stack)-1].baseIndent >= indent {
+		stack = stack[:len(stack)-1]
+	}
+	return append(stack, listLevel{
+		baseIndent: indent,
+		// Rune count, not byte length: the bullet "•" (U+2022) is a single
+		// terminal column but three UTF-8 bytes.
+		hangIndent: utf8.RuneCountInString(prefix),
+	})
+}
+
+// applyHangingIndent handles one non-bullet/number line: it pops any levels
+// deeper than indent (those inner list items ended, this line dedented past
+// them), then, if the now-top level's baseIndent matches indent, prepends
+// its hangIndent onto line as a continuation of that level. Otherwise indent
+// doesn't match any tracked level, so line isn't a continuation of anything
+// currently active and tracking stops entirely.
+func applyHangingIndent(stack []listLevel, indent int, line string) ([]listLevel, string) {
+	for len(stack) > 0 && stack[len(stack)-1].baseIndent > indent {
+		stack = stack[:len(stack)-1]
+	}
+
+	if len(stack) > 0 && stack[len(stack)-1].baseIndent == indent {
+		// Plain leading spaces are visually identical to any styled spaces
+		// already on the line -- a space glyph has no visible foreground
+		// color -- so prepending them unstyled is safe and avoids needing
+		// to parse past embedded ANSI codes to find an "insertion point".
+		return stack, strings.Repeat(" ", stack[len(stack)-1].hangIndent) + line
+	}
+
+	return stack[:0], line
 }
 
 // listItemPrefix returns the bullet/number prefix (e.g. "• " or "12. ") at

--- a/pkg/ui/markdown/list_indent.go
+++ b/pkg/ui/markdown/list_indent.go
@@ -1,0 +1,116 @@
+package markdown
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/cloudposse/atmos/pkg/perf"
+)
+
+// bulletPrefixPattern matches the literal bullet glamour renders for unordered
+// list items. Atmos always configures Item.BlockPrefix as "• " -- both the
+// builtin default style (styles.go getBuiltinDefaultStyle) and every
+// theme-derived style (theme/converter.go createGlamourStyleFromTheme) use
+// this exact literal, so matching it directly (rather than reading it back
+// out of a StyleConfig) is safe and avoids threading style state through
+// every render call site.
+var bulletPrefixPattern = regexp.MustCompile(`^• `)
+
+// orderedPrefixPattern matches the "<number>. " prefix glamour renders for
+// ordered list items (the item's own number followed by the literal
+// Enumeration.BlockPrefix ". ", see the same two style sources above).
+var orderedPrefixPattern = regexp.MustCompile(`^\d+\. `)
+
+// FixListHangingIndent re-indents wrapped continuation lines of bullet and
+// ordered markdown list items so they align under the item's own text
+// instead of falling flush with the bullet/number.
+//
+// Why this exists (glamour v1.0.0, ansi/blockelement.go BlockElement.Finish):
+// a whole list -- every item's bullet/number and text -- is rendered into one
+// shared buffer, then word-wrapped as a single blob and given one uniform
+// block-level left margin. Glamour has no concept of a hanging indent, so
+// every wrapped line, including continuation lines, gets the same left
+// margin as the bullet/number line itself. The words placed on each line are
+// already correct; only the per-line left padding is wrong, which is why
+// this is a line-based post-process rather than a re-wrap.
+//
+// Overriding glamour's list rendering via a higher-priority goldmark
+// NodeRenderer (the pattern extensions/linkify.go uses for ast.KindString)
+// was evaluated and rejected for this bug. Glamour funnels an entire list's
+// content (bullets, numbers, and every inline node inside each item) through
+// a single unexported blockStack owned by the ansi.ANSIRenderer it builds
+// internally, and that blockStack is never exposed to goldmark's
+// NodeRendererFunc signature. Overriding ast.KindList/ast.KindListItem
+// without also reimplementing every inline node kind (text, emphasis, links,
+// code spans, and so on) would write list content to the wrong buffer
+// entirely. Doing it correctly would require a second, deeper layer of
+// unsafe reflection on top of getGlamourGoldmark's (into glamour's
+// ANSIRenderer, then into its private RenderContext.blockStack) for what is
+// ultimately a missing-padding bug, not a wrong-content bug. Transforming
+// glamour's own, otherwise-correct, rendered output is the narrower and more
+// robust fix.
+//
+// This is applied to every markdown render path in pkg/ui (both
+// CustomRenderer.Render and formatter.renderMarkdown's raw glamour path),
+// since both can render lists.
+func FixListHangingIndent(rendered string) string {
+	defer perf.Track(nil, "markdown.FixListHangingIndent")()
+
+	if rendered == "" || !strings.Contains(rendered, "\n") {
+		return rendered
+	}
+
+	lines := strings.Split(rendered, "\n")
+
+	// hangIndent is the number of extra spaces continuation lines of the
+	// current item need; -1 means "not currently inside a list item".
+	hangIndent := -1
+	// baseIndent is the visible indent width of the item's own bullet/number
+	// line; continuation lines of that item share this same indent.
+	baseIndent := -1
+
+	for i, line := range lines {
+		plain := ansi.Strip(line)
+		trimmed := strings.TrimLeft(plain, " ")
+		indent := len(plain) - len(trimmed)
+
+		if trimmed == "" {
+			hangIndent = -1
+			continue
+		}
+
+		if prefix := listItemPrefix(trimmed); prefix != "" {
+			baseIndent = indent
+			// Rune count, not byte length: the bullet "•" (U+2022) is a
+			// single terminal column but three UTF-8 bytes.
+			hangIndent = utf8.RuneCountInString(prefix)
+			continue
+		}
+
+		if hangIndent >= 0 && indent == baseIndent {
+			// Plain leading spaces are visually identical to any styled
+			// spaces already on the line -- a space glyph has no visible
+			// foreground color -- so prepending them unstyled is safe and
+			// avoids needing to parse past embedded ANSI codes to find an
+			// "insertion point".
+			lines[i] = strings.Repeat(" ", hangIndent) + line
+			continue
+		}
+
+		hangIndent = -1
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// listItemPrefix returns the bullet/number prefix (e.g. "• " or "12. ") at
+// the start of trimmed, or "" if trimmed doesn't start with one.
+func listItemPrefix(trimmed string) string {
+	if m := bulletPrefixPattern.FindString(trimmed); m != "" {
+		return m
+	}
+	return orderedPrefixPattern.FindString(trimmed)
+}

--- a/pkg/ui/markdown/list_indent_test.go
+++ b/pkg/ui/markdown/list_indent_test.go
@@ -82,6 +82,15 @@ func TestFixListHangingIndent(t *testing.T) {
 				"  • Second item short",
 		},
 		{
+			name: "outer item's wrapped text resumes correctly after a nested list ends",
+			in: "  • Outer item wraps across\n" +
+				"    1. Inner item\n" +
+				"  outer continuation resumes here",
+			want: "  • Outer item wraps across\n" +
+				"    1. Inner item\n" +
+				"    outer continuation resumes here",
+		},
+		{
 			name: "no list content is left untouched",
 			in:   "Just a paragraph\nwith two lines.",
 			want: "Just a paragraph\nwith two lines.",

--- a/pkg/ui/markdown/list_indent_test.go
+++ b/pkg/ui/markdown/list_indent_test.go
@@ -1,0 +1,174 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFixListHangingIndent covers the pure line-transform in isolation, using
+// already-"glamour-shaped" plain text (no ANSI) so expectations are exact and
+// independent of the actual glamour renderer's word-wrap decisions.
+func TestFixListHangingIndent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bullet continuation aligns under item text",
+			in: "  • Add your first workload component\n" +
+				"  under components/terraform/ and wire it\n" +
+				"  into the stage stacks.",
+			want: "  • Add your first workload component\n" +
+				"    under components/terraform/ and wire it\n" +
+				"    into the stage stacks.",
+		},
+		{
+			name: "two-digit ordinal continuation aligns under item text",
+			in: "  12. In stacks/_defaults.yaml, delete the\n" +
+				"  emulator component and everything",
+			want: "  12. In stacks/_defaults.yaml, delete the\n" +
+				"      emulator component and everything",
+		},
+		{
+			name: "single-digit ordinal continuation aligns under item text",
+			in: "  1. In stacks/_defaults.yaml, delete the\n" +
+				"  emulator component and everything",
+			want: "  1. In stacks/_defaults.yaml, delete the\n" +
+				"     emulator component and everything",
+		},
+		{
+			name: "blank line ends continuation tracking",
+			in: "  • Item one wraps here\n" +
+				"  continuation of item one\n" +
+				"\n" +
+				"  not part of any list",
+			want: "  • Item one wraps here\n" +
+				"    continuation of item one\n" +
+				"\n" +
+				"  not part of any list",
+		},
+		{
+			name: "dedent ends continuation tracking",
+			in: "    • Nested item wraps\n" +
+				"    continuation nested\n" +
+				"  outer text after dedent",
+			want: "    • Nested item wraps\n" +
+				"      continuation nested\n" +
+				"  outer text after dedent",
+		},
+		{
+			name: "nested ordered list tracked independently of its parent bullet",
+			in: "  • Outer item\n" +
+				"    1. Inner ordered item wraps here\n" +
+				"    inner continuation",
+			want: "  • Outer item\n" +
+				"    1. Inner ordered item wraps here\n" +
+				"       inner continuation",
+		},
+		{
+			name: "second item's bullet line is not treated as a continuation",
+			in: "  • First item wraps\n" +
+				"  first continuation\n" +
+				"  • Second item short",
+			want: "  • First item wraps\n" +
+				"    first continuation\n" +
+				"  • Second item short",
+		},
+		{
+			name: "no list content is left untouched",
+			in:   "Just a paragraph\nwith two lines.",
+			want: "Just a paragraph\nwith two lines.",
+		},
+		{
+			name: "empty string is returned unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "single line without a newline is returned unchanged",
+			in:   "• single line, nothing to wrap",
+			want: "• single line, nothing to wrap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FixListHangingIndent(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestFixListHangingIndent_Integration renders real markdown through the full
+// CustomRenderer pipeline at a narrow width that forces a wrap, then verifies
+// -- after stripping ANSI codes -- that each continuation line's leading
+// whitespace is exactly the bullet/number line's indent plus the width of its
+// own prefix ("• " or "<n>. ").
+func TestFixListHangingIndent_Integration(t *testing.T) {
+	tests := []struct {
+		name       string
+		markdown   string
+		prefixWant string // Expected literal prefix on the first content line (after indent).
+	}{
+		{
+			name:       "bullet list wraps with hanging indent",
+			markdown:   "- Add your first workload component under components/terraform/ and wire it into the stage stacks.",
+			prefixWant: "• ",
+		},
+		{
+			name: "ordered list wraps with hanging indent",
+			markdown: "1. In stacks/_defaults.yaml, delete the emulator component and everything from " +
+				"access_key down in the backend block; pick a globally unique state bucket name.",
+			prefixWant: "1. ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer, err := NewCustomRenderer(WithWordWrap(40), WithColorProfile(termenv.TrueColor))
+			require.NoError(t, err)
+
+			out, err := renderer.Render(tt.markdown)
+			require.NoError(t, err)
+
+			lines := nonBlankLines(ansi.Strip(out))
+			require.GreaterOrEqual(t, len(lines), 2, "expected the text to wrap onto at least two lines, got: %q", lines)
+
+			firstIndent := leadingSpaces(lines[0])
+			require.True(t, strings.HasPrefix(lines[0][firstIndent:], tt.prefixWant),
+				"first line %q should start (after indent) with %q", lines[0], tt.prefixWant)
+
+			wantContinuationIndent := firstIndent + utf8.RuneCountInString(tt.prefixWant)
+			for _, line := range lines[1:] {
+				assert.Equal(t, wantContinuationIndent, leadingSpaces(line),
+					"continuation line %q should be indented under the item's own text", line)
+			}
+		})
+	}
+}
+
+// nonBlankLines splits s into lines, dropping any that are empty once
+// trimmed (glamour surrounds documents/lists with blank margin lines that
+// aren't relevant to indent alignment).
+func nonBlankLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// leadingSpaces returns the number of leading space characters in s.
+func leadingSpaces(s string) int {
+	return len(s) - len(strings.TrimLeft(s, " "))
+}


### PR DESCRIPTION
## what

- `atmos terraform apply --all` no longer aborts before the scheduler runs anything, on a fresh environment where a dependent component's `!terraform.state`/`!terraform.output` reference points at a component that hasn't been applied yet (e.g. `audit-trail` reading `kms`'s `key_arn` before `kms` has run). This does not skip or fake the value: the preflight's unresolved placeholder is discarded and never reaches Terraform. Each component still independently re-describes and re-resolves its own vars from scratch immediately before its own plan/apply — by which point, in a correctly-ordered dependency graph, `kms` has already applied and `!terraform.state` reads the real value.
- `atmos list stacks`/`list components`/`list instances` now skip evaluating Go templates (`atmos.Component`, `atmos.GomplateDatasource`) and YAML functions (`!terraform.state`, `!terraform.output`, `!store`) for stack/component sections that no displayed column actually reads. Previously every value was resolved eagerly regardless of the requested columns, which produced a spurious "N value(s) could not be determined and are shown as `(computed)`" warning for values that were never shown, and could take 30s–6+ minutes on stacks that use `!terraform.output`/`atmos.Component` in `vars` — even though `list stacks` only ever displays stack names by default. Closes #3068.
- The `atmos init` "Select a template" picker now sizes its columns to the real terminal width instead of hard-coded widths, so long descriptions truncate cleanly at a word boundary instead of splitting mid-word onto a stray line.
- Under `--ui`, the after-init `providers lock` step (triggered by an active registry/plugin cache) now streams through the same init spinner as `terraform init`/`plan`/`apply`, instead of dumping raw provider-fetch/checksum output into the middle of the fancy UI.
- Wrapped continuation lines of bullet and ordered markdown lists (rendered in the terminal, e.g. a scaffold README shown by `atmos init`) are now indented to align under the item's own text instead of falling flush with the bullet/number.

## why

- The `--all` preflight only exists to build the dependency graph and validate config before the scheduler starts — it's built purely from static `dependencies`/`settings.depends_on`, never from resolved vars. But it previously resolved `!terraform.state`/`!terraform.output` for every component strictly, so an unprovisioned dependency (normal and expected on a fresh AWS landing-zone environment: `kms` → `audit-trail`/`baseline`/`monitoring`) aborted the entire run before a single component was applied. Since the preflight's resolved value for this one recoverable error class is never used for anything but graph construction — and every node re-resolves its own vars fresh, for real, immediately before its own apply — degrading (not failing on) this specific error class during preflight (reusing the existing `--error-mode=warn` machinery) is safe and unblocks the documented `apply --all` bootstrap flow. Other error classes (e.g. a missing `!secret`) are unaffected and still fail the preflight as before.
- The describe-stacks pipeline behind `list stacks`/`list components`/`list instances` resolved **every** section of **every** component before column projection ever happened, regardless of whether any column would display the result. A new opt-in evaluation-scope filter (`evalSections`, deliberately separate from the existing output-only `sections` filter used by `describe stacks --sections=X`, so that command's behavior is untouched) is derived from the resolved column set and threaded through both the Go-template render pass and YAML-function resolution, falling back to full eager evaluation whenever the column templates can't be statically proven safe to skip.
- The template picker's fixed column widths didn't account for actual terminal width or content length, producing broken wrapping on normal-size terminals.
- The `providers lock` hook ran through a raw shell call that bypassed the streaming TUI entirely, so its output leaked raw into an otherwise fully-`--ui`-rendered run.
- Glamour renders an entire markdown list into one shared buffer, word-wraps it as a single blob, and applies one uniform block-level margin to every resulting line, with no concept of a hanging indent for wrapped continuation lines.

## references

- Closes #3068
