### PR TITLE
fix(ci): invalidate CloudFront cache on website deploys

### DIFF
--- a/.github/actions/s3-deploy/action.yml
+++ b/.github/actions/s3-deploy/action.yml
@@ -13,6 +13,19 @@ inputs:
   s3-uri:
     description: 'Destination S3 URI, with or without a trailing slash (e.g. s3://my-bucket/pr-123/)'
     required: true
+  cloudfront-distribution-id:
+    description: >
+      CloudFront distribution ID to invalidate after the sync (e.g. E2WVYUGW40ZPA8).
+      `sync --delete` can remove hashed bundles that an edge location's cached
+      `index.html` from the previous deploy still references, causing chunk-load
+      404s until the cache naturally expires. Leave empty to skip invalidation
+      (e.g. when the caller has no CloudFront-invalidation permission).
+    required: false
+    default: ''
+  cloudfront-invalidation-paths:
+    description: 'Space-separated invalidation paths, only used when cloudfront-distribution-id is set.'
+    required: false
+    default: '/*'
 
 runs:
   using: composite
@@ -24,3 +37,17 @@ runs:
         LOCAL_DIR: ${{ inputs.local-dir }}
         S3_URI: ${{ inputs.s3-uri }}
       run: '"$DEPLOY_SCRIPT" "$LOCAL_DIR" "$S3_URI"'
+
+    # Fire-and-forget: invalidation typically completes in under a minute and
+    # there's no need to block the job on it.
+    - name: Invalidate CloudFront Cache
+      if: inputs.cloudfront-distribution-id != ''
+      shell: bash
+      env:
+        DISTRIBUTION_ID: ${{ inputs.cloudfront-distribution-id }}
+        INVALIDATION_PATHS: ${{ inputs.cloudfront-invalidation-paths }}
+      run: |
+        # shellcheck disable=SC2086 # INVALIDATION_PATHS is an intentionally unquoted, space-separated path list.
+        aws cloudfront create-invalidation \
+          --distribution-id "${DISTRIBUTION_ID}" \
+          --paths ${INVALIDATION_PATHS}

--- a/.github/workflows/website-deploy-prod.yml
+++ b/.github/workflows/website-deploy-prod.yml
@@ -26,6 +26,8 @@ env:
   IAM_ROLE_SESSION_NAME: cloudposse-atmos-ci-deploy-release
   S3_BUCKET_NAME: cplive-plat-ue2-prod-atmos-docs-origin
   DEPLOYMENT_HOST: atmos.tools
+  # atmos-docs-site-spa (plat-ue2-prod) in cloudposse/infra-live.
+  CLOUDFRONT_DISTRIBUTION_ID: E2WVYUGW40ZPA8
 
 # These permissions are needed to interact with the GitHub's OIDC Token endpoint
 permissions:
@@ -57,6 +59,7 @@ jobs:
             storage.googleapis.com:443
             us.i.posthog.com:443
             cplive-plat-ue2-prod-atmos-docs-origin.s3.us-east-2.amazonaws.com:443
+            cloudfront.amazonaws.com:443
             api.scorecard.dev:443
             www.bestpractices.dev:443
 
@@ -128,11 +131,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # `s3 sync --delete` can remove hashed JS/CSS bundles that an edge location's
+      # cached `index.html` from the previous deploy still references (the
+      # distribution's default cache behavior floors caching at
+      # cloudfront_min_ttl=60s regardless of origin Cache-Control headers), so this
+      # also invalidates the distribution -- see s3-deploy/action.yml. The deploy
+      # role already has cloudfront:CreateInvalidation on this distribution
+      # (infra-live github-actions-iam-policy.tf).
       - name: Copy Website to S3 Bucket
         uses: ./.github/actions/s3-deploy
         with:
           local-dir: website/build
           s3-uri: s3://${{ env.S3_BUCKET_NAME }}/
+          cloudfront-distribution-id: ${{ env.CLOUDFRONT_DISTRIBUTION_ID }}
 
       - name: Trigger ReIndexing of atmos.tools and docs.cloudposse.com Docs
         run: |

--- a/.github/workflows/website-preview-deploy.yml
+++ b/.github/workflows/website-preview-deploy.yml
@@ -21,6 +21,8 @@ env:
   IAM_ROLE_ARN: arn:aws:iam::068007702576:role/cplive-plat-ue2-dev-atmos-docs-gha
   IAM_ROLE_SESSION_NAME: cloudposse-atmos-ci-deploy-pr-${{ github.event.workflow_run.pull_requests[0].number }}
   S3_BUCKET_NAME: cplive-plat-ue2-dev-atmos-docs-origin
+  # atmos-docs-site-spa (plat-ue2-dev) in cloudposse/infra-live.
+  CLOUDFRONT_DISTRIBUTION_ID: E1U29O8X09M5UR
   PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
   DEPLOYMENT_HOST: pr-${{ github.event.workflow_run.pull_requests[0].number }}.atmos-docs.ue2.dev.plat.cloudposse.org
 
@@ -58,6 +60,7 @@ jobs:
             sts.us-east-2.amazonaws.com:443
             *.actions.githubusercontent.com:443
             cplive-plat-ue2-dev-atmos-docs-origin.s3.us-east-2.amazonaws.com:443
+            cloudfront.amazonaws.com:443
 
       - name: Start deployment
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
@@ -97,11 +100,16 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ steps.github-app.outputs.token }}
 
+      # Invalidation is scoped to this PR's own prefix so one preview deploy never
+      # invalidates every other open PR's cached preview -- see the matching
+      # comment in website-deploy-prod.yml for why an invalidation is needed at all.
       - name: Copy Website to S3 Bucket PR Folder
         uses: ./.github/actions/s3-deploy
         with:
           local-dir: website/build
           s3-uri: s3://${{ env.S3_BUCKET_NAME }}/pr-${{ env.PR_NUMBER }}/
+          cloudfront-distribution-id: ${{ env.CLOUDFRONT_DISTRIBUTION_ID }}
+          cloudfront-invalidation-paths: /pr-${{ env.PR_NUMBER }}/*
 
       - name: Update deployment status
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1

--- a/docs/fixes/2026-09-09-website-cloudfront-stale-chunk-invalidation.md
+++ b/docs/fixes/2026-09-09-website-cloudfront-stale-chunk-invalidation.md
@@ -1,0 +1,84 @@
+# Fix: website deploys now invalidate CloudFront so stale `index.html` can't 404 on deleted chunks
+
+**Date:** 2026-09-09
+
+## Summary
+
+atmos.tools threw a browser `ChunkLoadError` (404 on a hashed `assets/js/*.js`
+bundle referenced by the already-loaded runtime). This looked like a repeat of
+the 2026-09-08 concurrent-deploy race
+(`docs/fixes/2026-09-08-website-deploy-race-serialize.md`), but that fix is
+working correctly — GitHub Actions run history shows the second of two
+`Website Deploy Prod` runs queued behind the first via the `concurrency` group
+and only started its job after the first completed. The real gap:
+`website-deploy-prod.yml` runs `aws s3 sync --delete` against the S3 origin but
+never invalidates the CloudFront distribution in front of it, so an edge
+location caching the prior deploy's `index.html` can keep serving it (and its
+now-deleted chunk references) for up to `cloudfront_min_ttl` after a newer
+deploy's `--delete` pass removes those chunks.
+
+## Context
+
+The `atmos-docs-site-spa` distributions (`cloudposse/infra-live`,
+`stacks/catalog/spa-s3-cloudfront/{defaults,atmos-docs/defaults}.yaml`) use the
+legacy per-behavior TTL fields, not a modern cache policy: `cloudfront_min_ttl:
+60`, `cloudfront_default_ttl: 60`. CloudFront's legacy TTL model uses `min_ttl`
+as an absolute floor regardless of the origin's `Cache-Control` header, so even
+adding explicit no-cache headers to `index.html` in `deploy.sh` would not have
+closed the gap — the fix has to be an invalidation, not a header change.
+
+Confirmed (read-only, via `gh api`/`gh pr view` against `cloudposse/infra-live`)
+that this floor is unrelated to `cloudposse/infra-live#1706`, a same-day PR the
+reporter suspected — that PR only added a CORS viewer-response CloudFront
+Function scoped to the `/img/*` behavior and explicitly keeps "Production ...
+existing TTLs" on the default behavior unchanged.
+
+The fix is fully containable in `cloudposse/atmos`: `infra-live`'s
+`components/terraform/spa-s3-cloudfront/github-actions-iam-policy.tf` already
+grants both deploy roles (`cplive-plat-ue2-prod-atmos-docs-gha` and
+`cplive-plat-ue2-dev-atmos-docs-gha`) `cloudfront:CreateInvalidation` /
+`cloudfront:GetInvalidation` scoped to their own distribution ARN. That
+permission was simply unused. No `infra-live` change was needed.
+
+## Changes
+
+- `.github/actions/s3-deploy/action.yml`: added optional
+  `cloudfront-distribution-id` / `cloudfront-invalidation-paths` inputs and a
+  composite step that runs `aws cloudfront create-invalidation` when a
+  distribution ID is supplied. Fire-and-forget (no `wait
+  invalidation-completed`) — invalidation typically completes in well under a
+  minute and blocking would only slow the deploy job.
+- `.github/workflows/website-deploy-prod.yml`: added `CLOUDFRONT_DISTRIBUTION_ID:
+  E2WVYUGW40ZPA8` (prod `atmos-docs-site-spa`) and passed it to the `Copy
+  Website to S3 Bucket` step with the default `/*` invalidation path. Added
+  `cloudfront.amazonaws.com:443` to the Harden Runner allowlist (CloudFront's
+  control-plane API is a single global endpoint, not regional).
+- `.github/workflows/website-preview-deploy.yml`: same pattern for the dev
+  distribution (`E1U29O8X09M5UR`), scoped to `/pr-<N>/*` instead of `/*` so one
+  PR's deploy never invalidates every other open PR's cached preview.
+
+## Validation
+
+- `actionlint` on both modified workflow files: clean.
+- `python3 -c "import yaml; yaml.safe_load(open(...))"` on the modified
+  `s3-deploy/action.yml`: parses. (`actionlint` itself doesn't understand
+  composite `action.yml` files — confirmed pre-existing across every action in
+  `.github/actions/`, not specific to this change.)
+- Confirmed the exact `aws cloudfront create-invalidation --distribution-id
+  E2WVYUGW40ZPA8 --paths '/*'` command the new step runs actually succeeds under
+  the deploy role's permissions: ran it manually via `atmos auth exec` against
+  `cloudposse/infra-live` (`--profile managers --identity plat-prod/terraform`)
+  as an immediate remediation for the live incident. Invalidation
+  `IB9LFMBACSW7CEWQ9MRS7ZOPRZ` reached `Completed` within about a minute.
+- Confirmed via `aws iam get-role-policy` (not just the Terraform source) that
+  the *deployed* `cplive-plat-ue2-prod-atmos-docs-gha` role policy already
+  contains the `CloudfrontActions` statement (`cloudfront:CreateInvalidation`,
+  `cloudfront:GetInvalidation` on `arn:aws:cloudfront::557075604627:distribution/E2WVYUGW40ZPA8`),
+  so the new CI step will work under the real OIDC-assumed role with no
+  `infra-live` change required.
+- Still pending: watching an actual `Website Deploy Prod` run (post-merge)
+  execute the new `Invalidate CloudFront Cache` step end-to-end in CI.
+
+## Follow-ups
+
+None.


### PR DESCRIPTION
## what

- Add a `cloudfront-distribution-id` / `cloudfront-invalidation-paths` input and invalidation step to the shared `.github/actions/s3-deploy` composite action.
- Wire it into `website-deploy-prod.yml` (invalidates `/*` on the prod `atmos-docs-site-spa` distribution `E2WVYUGW40ZPA8`) and `website-preview-deploy.yml` (invalidates only `/pr-<N>/*` on the dev distribution `E1U29O8X09M5UR`, so one PR's deploy never busts every other open PR's preview cache).
- Add `cloudfront.amazonaws.com:443` to both workflows' Harden Runner allowlist.
- Add a fix-log entry documenting the root cause and validation.

## why

- atmos.tools threw a browser `ChunkLoadError` (404 on a hashed JS bundle). Root cause: `website-deploy-prod.yml` runs `aws s3 sync --delete` but never invalidated CloudFront, and the distribution's legacy per-behavior TTL (`min_ttl: 60`) floors edge caching regardless of origin `Cache-Control`. A client hitting a stale edge-cached `index.html` within that window got 404s on chunks a newer deploy had already deleted.
- This is a different bug than the 2026-09-08 concurrent-deploy race (`docs/fixes/2026-09-08-website-deploy-race-serialize.md`) — confirmed via GitHub Actions run history that the existing `concurrency:` guard is working correctly.
- The deploy IAM roles already grant `cloudfront:CreateInvalidation`/`cloudfront:GetInvalidation` scoped to their own distribution (confirmed live via `aws iam get-role-policy`, not just the `infra-live` Terraform source) — it was simply unused, so this fix is fully contained in `cloudposse/atmos` with no `infra-live` change needed.
- Manually ran the invalidation against prod as immediate remediation for the live incident; confirmed it reached `Completed`.

## references

- `docs/fixes/2026-09-09-website-cloudfront-stale-chunk-invalidation.md`
- `docs/fixes/2026-09-08-website-deploy-race-serialize.md` (related prior incident, confirmed not the same root cause)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CloudFront caches are now invalidated after production website deployments, helping prevent users from receiving stale pages or broken asset references.
  * Preview deployments invalidate only their corresponding preview path, reducing unintended cache refreshes.

* **Documentation**
  * Added documentation describing the stale-cache issue, its resolution, and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->