### PR TITLE
fix: describe/error/prompt DX bugs found while field-testing aws/cloudformation

### DIFF
--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -205,6 +205,10 @@ func getRunnableDescribeComponentCmd(
 			return fmt.Errorf("%w: the command requires one argument `component`", errUtils.ErrInvalidArguments)
 		}
 
+		if err := resolveDescribeComponentStack(cmd, args); err != nil {
+			return err
+		}
+
 		f, err := parseDescribeComponentFlags(cmd)
 		if err != nil {
 			return err
@@ -233,6 +237,15 @@ func getRunnableDescribeComponentCmd(
 		f.errorMode = e.ResolveErrorMode(f.errorMode, atmosConfig.Describe.ErrorMode)
 		if f.errorMode != "strict" && f.errorMode != "warn" && f.errorMode != "silent" {
 			return fmt.Errorf("%w: %q", e.ErrInvalidErrorMode, f.errorMode)
+		}
+
+		// Validated here (after resolveDescribeComponentStack's interactive prompt has
+		// had a chance to fill it in, and after the flag-shape validations above) rather
+		// than via cmd.MarkPersistentFlagRequired("stack"): that Cobra-native mechanism
+		// runs BEFORE RunE and would bypass the prompt entirely. See
+		// resolveDescribeComponentStack's doc comment for the full rationale.
+		if f.stack == "" {
+			return errUtils.ErrMissingStack
 		}
 
 		component, err = resolveComponentFromPathIfNeeded(&g, &atmosConfig, component, f.stack, needsPathResolution)
@@ -271,6 +284,49 @@ func getRunnableDescribeComponentCmd(
 			AuthManager:          authManager,
 		})
 	}
+}
+
+// describeComponentStackCompletion is the completion function used to prompt for a
+// missing --stack flag. A package-level var (rather than calling StackFlagCompletion
+// directly) so tests can substitute a fake completion function without needing a
+// real Atmos config/stacks setup -- mirroring the existing seam pattern used for
+// initCliConfig/executeDescribeStacks in cmd/terraform/shared/prompt.go.
+var describeComponentStackCompletion flags.CompletionFunc = StackFlagCompletion
+
+// resolveDescribeComponentStack fills in a missing `--stack` flag interactively when
+// possible, writing the selection back onto cmd's own "stack" flag so the caller's
+// subsequent cmd.Flags().GetString("stack") read (via parseDescribeComponentFlags)
+// observes it.
+//
+// `describe component` used to enforce --stack via
+// cmd.MarkPersistentFlagRequired("stack"), which is Cobra's own required-flag
+// validation and runs BEFORE RunE -- so it always produced Cobra's generic
+// "required flag(s) \"stack\" not set" error and never gave this interactive
+// prompt a chance to run, even in a real terminal. Registering the flag as
+// not-required and validating it here (after attempting the prompt) restores the
+// documented `$ atmos describe component vpc` -> `? Choose a stack` behavior.
+//
+// Args is the command's positional args (already validated to be exactly the
+// component name by cobra.ExactArgs(1)), passed through so StackFlagCompletion can
+// filter the stack list down to stacks that actually define that component.
+func resolveDescribeComponentStack(cmd *cobra.Command, args []string) error {
+	stackFlag := cmd.Flags().Lookup("stack")
+	if stackFlag == nil || stackFlag.Value.String() != "" || stackFlag.Changed {
+		// Either there's no stack flag, a value is already present, or the user
+		// explicitly set it (even to empty) -- nothing to prompt for.
+		return nil
+	}
+
+	selected, err := flags.PromptForMissingRequired("stack", "Choose a stack", describeComponentStackCompletion, cmd, args)
+	if err != nil {
+		return err
+	}
+	if selected == "" {
+		// Not interactive, or no matching stacks -- let the caller's own
+		// ErrMissingStack check report the missing flag.
+		return nil
+	}
+	return stackFlag.Value.Set(selected)
 }
 
 // resolveComponentFromPathIfNeeded resolves a filesystem path to a component name when needed.
@@ -312,10 +368,11 @@ func init() {
 		errUtils.CheckErrorPrintAndExit(err, "", "")
 	}
 
-	err := describeComponentCmd.MarkPersistentFlagRequired("stack")
-	if err != nil {
-		errUtils.CheckErrorPrintAndExit(err, "", "")
-	}
-
+	// --stack is intentionally NOT marked required here (contrast with
+	// MarkPersistentFlagRequired used elsewhere): that Cobra-native mechanism
+	// validates before RunE ever runs, which would bypass
+	// resolveDescribeComponentStack's interactive prompt entirely. Missing --stack
+	// is instead validated in getRunnableDescribeComponentCmd after the prompt has
+	// had a chance to fill it in.
 	describeCmd.AddCommand(describeComponentCmd)
 }

--- a/cmd/describe_component.go
+++ b/cmd/describe_component.go
@@ -319,7 +319,7 @@ func resolveDescribeComponentStack(cmd *cobra.Command, args []string) error {
 
 	selected, err := flags.PromptForMissingRequired("stack", "Choose a stack", describeComponentStackCompletion, cmd, args)
 	if err != nil {
-		return err
+		return fmt.Errorf("prompt for --stack: %w", err)
 	}
 	if selected == "" {
 		// Not interactive, or no matching stacks -- let the caller's own

--- a/cmd/describe_component_test.go
+++ b/cmd/describe_component_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +17,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/internal/exec"
+	"github.com/cloudposse/atmos/pkg/flags"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/store"
 	"github.com/cloudposse/atmos/pkg/telemetry"
@@ -114,6 +119,143 @@ func TestGetRunnableDescribeComponentCmd_MissingStackTriggersPrompt(t *testing.T
 	assert.Equal(tk, []string{"vpc"}, capturedArgs, "the completion function must receive the component positional arg for filtering")
 	require.ErrorIs(tk, err, errUtils.ErrMissingStack,
 		"a still-missing stack after the prompt attempt must fail with the standard ErrMissingStack, not a Cobra required-flag error or a silent empty-stack execution")
+}
+
+// TestResolveDescribeComponentStack_PromptSelectsStack drives resolveDescribeComponentStack's
+// real success path: PromptForMissingRequired -> flags.PromptForValue -> the actual Huh form
+// body (title, options), run in accessible mode via flags.SetFormRunnerForTest so it doesn't
+// need a live TTY. This covers the `return stackFlag.Value.Set(selected)` line -- proving a
+// selection made through the real prompt is written back onto the command's own "stack" flag.
+func TestResolveDescribeComponentStack_PromptSelectsStack(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, flags.IsInteractive(), "test setup must actually reach the interactive branch")
+
+	restoreRunner := flags.SetFormRunnerForTest(func(f *huh.Form) error {
+		// "1\n" selects the first listed option ("dev") via Huh's accessible-mode
+		// numbered prompt -- this exercises the real title/options rendering and
+		// selection logic, not a stub.
+		return f.WithAccessible(true).WithInput(strings.NewReader("1\n")).WithOutput(io.Discard).Run()
+	})
+	defer restoreRunner()
+
+	originalCompletion := describeComponentStackCompletion
+	var capturedArgs []string
+	describeComponentStackCompletion = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		capturedArgs = append([]string{}, args...)
+		return []string{"dev", "staging"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { describeComponentStackCompletion = originalCompletion }()
+
+	cmd := &cobra.Command{Use: "component"}
+	cmd.Flags().String("stack", "", "")
+
+	err := resolveDescribeComponentStack(cmd, []string{"vpc"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vpc"}, capturedArgs, "completion function must receive the component positional arg")
+	assert.Equal(t, "dev", cmd.Flags().Lookup("stack").Value.String(),
+		"the selection made through the real prompt must be written back onto the stack flag")
+}
+
+// TestResolveDescribeComponentStack_PromptFormError covers resolveDescribeComponentStack's
+// error-wrapping branch: when the underlying prompt fails (e.g. the Huh form itself errors),
+// resolveDescribeComponentStack must wrap it with "prompt for --stack" context rather than
+// silently discarding it or panicking.
+func TestResolveDescribeComponentStack_PromptFormError(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, flags.IsInteractive(), "test setup must actually reach the interactive branch")
+
+	boom := errors.New("form boom")
+	restoreRunner := flags.SetFormRunnerForTest(func(*huh.Form) error { return boom })
+	defer restoreRunner()
+
+	originalCompletion := describeComponentStackCompletion
+	describeComponentStackCompletion = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"dev", "staging"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { describeComponentStackCompletion = originalCompletion }()
+
+	cmd := &cobra.Command{Use: "component"}
+	cmd.Flags().String("stack", "", "")
+
+	err := resolveDescribeComponentStack(cmd, []string{"vpc"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), "prompt for --stack", "error must be wrapped with the --stack prompt context")
+}
+
+// TestGetRunnableDescribeComponentCmd_StackPromptErrorPropagates covers the early-return
+// branch in getRunnableDescribeComponentCmd's RunE closure: when resolveDescribeComponentStack
+// itself fails (as opposed to yielding no selection), the command must return that error
+// immediately rather than continuing on to parse flags or execute the describe.
+func TestGetRunnableDescribeComponentCmd_StackPromptErrorPropagates(t *testing.T) {
+	tk := NewTestKit(t)
+	viper.Reset()
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	tk.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+
+	testCmd := &cobra.Command{Use: "component"}
+	testCmd.Flags().String("stack", "", "")
+	testCmd.Flags().String("format", "yaml", "")
+	testCmd.Flags().String("file", "", "")
+	testCmd.Flags().Bool("process-templates", true, "")
+	testCmd.Flags().Bool("process-functions", true, "")
+	testCmd.Flags().Bool("use-mocks", false, "")
+	testCmd.Flags().String("query", "", "")
+	testCmd.Flags().StringSlice("skip", nil, "")
+	testCmd.Flags().Bool("provenance", false, "")
+
+	boom := errors.New("form boom")
+	restoreRunner := flags.SetFormRunnerForTest(func(*huh.Form) error { return boom })
+	defer restoreRunner()
+
+	originalCompletion := describeComponentStackCompletion
+	describeComponentStackCompletion = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"dev", "staging"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { describeComponentStackCompletion = originalCompletion }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := exec.NewMockDescribeComponentCmdExec(ctrl)
+	mockExec.EXPECT().ExecuteDescribeComponentCmd(gomock.Any()).Times(0)
+
+	run := getRunnableDescribeComponentCmd(getRunnableDescribeComponentCmdProps{
+		checkAtmosConfigE: func(opts ...AtmosValidateOption) error { return nil },
+		initCliConfig: func(info schema.ConfigAndStacksInfo, processStacks bool) (schema.AtmosConfiguration, error) {
+			return schema.AtmosConfiguration{}, nil
+		},
+		isExplicitComponentPath: func(component string) bool { return false },
+		resolveComponentFromPath: func(atmosConfig *schema.AtmosConfiguration, component, stack string) (string, error) {
+			return component, nil
+		},
+		executeDescribeComponent: func(params *exec.ExecuteDescribeComponentParams) (map[string]any, error) {
+			return nil, nil
+		},
+		newDescribeComponentExec: mockExec,
+	})
+
+	err := run(testCmd, []string{"vpc"})
+
+	require.Error(tk, err)
+	assert.ErrorIs(tk, err, boom, "the underlying form error must propagate unwrapped through errors.Is")
+	assert.Contains(tk, err.Error(), "prompt for --stack",
+		"a failing stack prompt must short-circuit RunE with the prompt's own wrapped error, "+
+			"not continue on to flag parsing or execution")
 }
 
 func TestDescribeComponentCmd_ProvenanceFlag(t *testing.T) {

--- a/cmd/describe_component_test.go
+++ b/cmd/describe_component_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	errUtils "github.com/cloudposse/atmos/errors"
 	"github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/store"
+	"github.com/cloudposse/atmos/pkg/telemetry"
 )
 
 func TestDescribeComponentCmd_Error(t *testing.T) {
@@ -23,6 +25,95 @@ func TestDescribeComponentCmd_Error(t *testing.T) {
 	// The command requires exactly one argument (the component name).
 	err := describeComponentCmd.RunE(describeComponentCmd, []string{})
 	assert.Error(tk, err, "describe component command should return an error when called with no parameters")
+}
+
+// TestDescribeComponentCmd_StackNotCobraRequired is a regression test for the
+// missing-stack interactive prompt never firing: describe_component.go used to call
+// describeComponentCmd.MarkPersistentFlagRequired("stack"), which is Cobra's own
+// required-flag validation and runs BEFORE RunE -- unconditionally producing
+// Cobra's generic "required flag(s) \"stack\" not set" error and never giving
+// resolveDescribeComponentStack's interactive prompt a chance to run, even in a
+// real terminal. This asserts the "stack" flag no longer carries Cobra's
+// required-flag annotation.
+func TestDescribeComponentCmd_StackNotCobraRequired(t *testing.T) {
+	stackFlag := describeComponentCmd.PersistentFlags().Lookup("stack")
+	require.NotNil(t, stackFlag, "stack flag should be registered")
+
+	required, ok := stackFlag.Annotations[cobra.BashCompOneRequiredFlag]
+	if ok {
+		assert.NotEqual(t, []string{"true"}, required,
+			"stack flag must not be marked Cobra-required, or the interactive "+
+				"missing-stack prompt never gets a chance to run before Cobra's own "+
+				"required-flag validation rejects the command")
+	}
+}
+
+// TestGetRunnableDescribeComponentCmd_MissingStackTriggersPrompt is a regression
+// test proving `atmos describe component <name>` with no --stack, in a
+// mocked-interactive context, attempts the interactive "Choose a stack" prompt
+// path (resolveDescribeComponentStack -> flags.PromptForMissingRequired ->
+// describeComponentStackCompletion) instead of failing before ever reaching RunE.
+// It also proves that when the prompt yields no selection (e.g. no matching
+// stacks), the command still fails clearly via errUtils.ErrMissingStack rather
+// than silently proceeding with an empty stack.
+func TestGetRunnableDescribeComponentCmd_MissingStackTriggersPrompt(t *testing.T) {
+	tk := NewTestKit(t)
+	viper.Reset()
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	tk.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+
+	testCmd := &cobra.Command{Use: "component"}
+	testCmd.Flags().String("stack", "", "")
+	testCmd.Flags().String("format", "yaml", "")
+	testCmd.Flags().String("file", "", "")
+	testCmd.Flags().Bool("process-templates", true, "")
+	testCmd.Flags().Bool("process-functions", true, "")
+	testCmd.Flags().Bool("use-mocks", false, "")
+	testCmd.Flags().String("query", "", "")
+	testCmd.Flags().StringSlice("skip", nil, "")
+	testCmd.Flags().Bool("provenance", false, "")
+
+	var capturedFlagName string
+	var capturedArgs []string
+	originalCompletion := describeComponentStackCompletion
+	describeComponentStackCompletion = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		capturedFlagName = "stack"
+		capturedArgs = append([]string{}, args...)
+		// No matching stacks -- forces the graceful "let the caller validate"
+		// fallback instead of needing a real TTY form to complete a selection.
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { describeComponentStackCompletion = originalCompletion }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := exec.NewMockDescribeComponentCmdExec(ctrl)
+	mockExec.EXPECT().ExecuteDescribeComponentCmd(gomock.Any()).Times(0)
+
+	run := getRunnableDescribeComponentCmd(getRunnableDescribeComponentCmdProps{
+		checkAtmosConfigE: func(opts ...AtmosValidateOption) error { return nil },
+		initCliConfig: func(info schema.ConfigAndStacksInfo, processStacks bool) (schema.AtmosConfiguration, error) {
+			return schema.AtmosConfiguration{}, nil
+		},
+		isExplicitComponentPath: func(component string) bool { return false },
+		resolveComponentFromPath: func(atmosConfig *schema.AtmosConfiguration, component, stack string) (string, error) {
+			return component, nil
+		},
+		executeDescribeComponent: func(params *exec.ExecuteDescribeComponentParams) (map[string]any, error) {
+			return nil, nil
+		},
+		newDescribeComponentExec: mockExec,
+	})
+
+	err := run(testCmd, []string{"vpc"})
+
+	assert.Equal(tk, "stack", capturedFlagName, "the missing-stack prompt path must be attempted (completion function invoked)")
+	assert.Equal(tk, []string{"vpc"}, capturedArgs, "the completion function must receive the component positional arg for filtering")
+	require.ErrorIs(tk, err, errUtils.ErrMissingStack,
+		"a still-missing stack after the prompt attempt must fail with the standard ErrMissingStack, not a Cobra required-flag error or a silent empty-stack execution")
 }
 
 func TestDescribeComponentCmd_ProvenanceFlag(t *testing.T) {

--- a/cmd/terraform/shared/prompt.go
+++ b/cmd/terraform/shared/prompt.go
@@ -401,7 +401,14 @@ func listStacksForComponent(cmd *cobra.Command, component string) ([]string, err
 	return stacks, nil
 }
 
-// stackContainsComponent checks if a stack contains the specified terraform component.
+// stackContainsComponent checks if a stack contains the specified component, under
+// any component type section (terraform, aws/cloudformation, helmfile, packer,
+// container, kubernetes, helm, etc). This function is reused by StackFlagCompletion
+// for commands whose components aren't terraform (e.g. `atmos aws cloudformation`),
+// so it must not assume a single component type -- checking only "terraform" would
+// silently find zero matches for every other component type, which empties out
+// StackFlagCompletion's filtered branch instead of returning the stacks that
+// actually contain the component.
 func stackContainsComponent(stackData any, component string) bool {
 	stackMap, ok := stackData.(map[string]any)
 	if !ok {
@@ -411,12 +418,16 @@ func stackContainsComponent(stackData any, component string) bool {
 	if !ok {
 		return false
 	}
-	terraform, ok := components["terraform"].(map[string]any)
-	if !ok {
-		return false
+	for _, typeSection := range components {
+		typeMap, ok := typeSection.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasComponent := typeMap[component]; hasComponent {
+			return true
+		}
 	}
-	_, hasComponent := terraform[component]
-	return hasComponent
+	return false
 }
 
 // listAllStacks returns all stacks.

--- a/cmd/terraform/shared/prompt_test.go
+++ b/cmd/terraform/shared/prompt_test.go
@@ -249,6 +249,44 @@ func TestStackContainsComponent(t *testing.T) {
 			component: "vpc",
 			expected:  true,
 		},
+		{
+			// Regression test: stackContainsComponent must not assume terraform is
+			// the only component type. StackFlagCompletion is reused by non-terraform
+			// callers (e.g. `atmos aws cloudformation`), whose components live under
+			// "aws/cloudformation", not "terraform". Before this fix, a
+			// aws/cloudformation component would never match here, so
+			// listStacksForComponent always returned zero stacks for it and the
+			// missing-stack interactive prompt silently fell through to a hard
+			// "stack is required" error instead of showing a filtered picker.
+			name: "component found under a non-terraform component type",
+			stackData: map[string]any{
+				"components": map[string]any{
+					"aws/cloudformation": map[string]any{
+						"vpc": map[string]any{"stack_name": "test-vpc"},
+					},
+				},
+			},
+			component: "vpc",
+			expected:  true,
+		},
+		{
+			name: "component found under a non-terraform type among several types",
+			stackData: map[string]any{
+				"components": map[string]any{
+					"terraform": map[string]any{
+						"eks": map[string]any{},
+					},
+					"helmfile": map[string]any{
+						"nginx": map[string]any{},
+					},
+					"aws/cloudformation": map[string]any{
+						"vpc": map[string]any{},
+					},
+				},
+			},
+			component: "vpc",
+			expected:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -995,6 +1033,35 @@ func TestListStacksForComponent(t *testing.T) {
 			mockStacksMap:   map[string]any{},
 			expectedStacks:  nil,
 			expectedError:   false,
+		},
+		{
+			// Regression test for the missing-stack interactive prompt showing every
+			// stack in the org unfiltered for a non-terraform component (e.g.
+			// `atmos aws cloudformation apply <component>`): listStacksForComponent
+			// (via StackFlagCompletion) must find stacks whose component lives under
+			// a non-"terraform" component type section.
+			name:            "success with non-terraform component type (aws/cloudformation)",
+			component:       "vpc",
+			mockConfigError: nil,
+			mockStacksError: nil,
+			mockStacksMap: map[string]any{
+				"prod": map[string]any{
+					"components": map[string]any{
+						"aws/cloudformation": map[string]any{
+							"vpc": map[string]any{"stack_name": "prod-vpc"},
+						},
+					},
+				},
+				"unrelated": map[string]any{
+					"components": map[string]any{
+						"aws/cloudformation": map[string]any{
+							"rds": map[string]any{},
+						},
+					},
+				},
+			},
+			expectedStacks: []string{"prod"},
+			expectedError:  false,
 		},
 		{
 			name:            "results are sorted alphabetically",

--- a/docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md
+++ b/docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md
@@ -118,8 +118,11 @@ task's original hypothesis about a missing CFN whitelist entry there was disprov
 - Manual CLI check: `atmos build` from repo root, then from `examples/cloudformation`:
   `atmos describe component demo -s local` (no flags — the actual default path, since
   `--provenance` defaults to enabled) now prints `path: template.yaml`, `stack_name:
-  atmos-cfn-demo-local`, `parameters:`, `hooks:`, `settings:`, `provision:`, `metadata:`, and
-  `component:` — all previously silently dropped from this exact invocation.
+  atmos-cfn-demo-local`, `parameters:`, `hooks:`, `settings:`, `provision:`, and `metadata:` — all
+  previously silently dropped from this exact invocation. (A later fix on this branch excludes the
+  synthetic, always-injected `component` key from this same resurrection logic, so `component:`
+  does *not* appear here unless the stack YAML explicitly sets it — see the `git log` history on
+  `pkg/provenance/data_transform.go` for that follow-up.)
 - `GOTOOLCHAIN=go1.26.6 ./custom-gcl run --config=.golangci.yml --allow-serial-runners
   --new-from-rev=origin/main` — reports findings only in files owned by other concurrent fixes on
   this branch (`pkg/component/aws/cloudformation/*`, `pkg/utils/component_path_utils.go`,

--- a/docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md
+++ b/docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md
@@ -1,0 +1,140 @@
+# Fix: `describe component --provenance` no longer drops populated aws/cloudformation sections
+
+**Date:** 2026-09-09
+
+## Summary
+
+`atmos describe component <name> -s <stack>` for an `aws/cloudformation` component never showed
+`path`, `stack_name`, `parameters`, `template`, `termination_protection`, `capabilities`, `tags`,
+`stack_policy`, `role_arn`, `notification_arns`, `disable_rollback`, or `timeout_in_minutes` — even
+though these are real, documented top-level fields and the same values were correctly read and used
+at real `apply`/`delete` execution time. The bug was in the provenance-rendering pipeline
+(`pkg/provenance/data_transform.go`), not in component-type population or in
+`FilterComputedFields`'s allowlist, both of which were already correct.
+
+## Context
+
+The task hypothesis was that CFN-specific top-level sections never made it into
+`configAndStacksInfo.ComponentSection` in the first place — i.e. that `tryProcessWithComponentType`
+(`internal/exec/describe_component.go`) or the stack-processing pipeline it delegates to had a
+missing per-component-type whitelist entry for CFN, mirroring the known "new component TYPE
+describe/list whitelist" pattern in this codebase (see `.claude/skills/atmos-core-component-development`).
+
+That hypothesis did not hold up under direct investigation:
+
+- `internal/exec/stack_processor_process_stacks_helpers_extraction.go:420-445` already defines
+  `cloudFormationComponentSectionKeys` and `extractCloudFormationComponentSection`, populated
+  whenever `opts.ComponentType == cfg.CloudFormationComponentType`
+  (`stack_processor_process_stacks_helpers_extraction.go:328-330`).
+- `internal/exec/stack_processor_merge.go:719-733` deep-merges `result.BaseComponentCloudFormation`
+  and `result.ComponentCloudFormation` into the final component map (`comp`) for CFN components,
+  mirroring the equivalent Helm block immediately above it.
+- A direct call to `ExecuteDescribeComponentWithContext` for the `examples/cloudformation` `demo`
+  component (writing a throwaway test to dump `result.ComponentSection` keys, then
+  `FilterComputedFields(result.ComponentSection)` keys) showed **all** of `path`, `stack_name`,
+  `parameters`, `hooks`, `metadata`, `provision`, `settings`, and `component` present and correct,
+  identically whether `atmosConfig.TrackProvenance` was `true` or `false`.
+- Running the CLI directly with `--provenance=false` also showed every field correctly. Running the
+  exact same command with **no flag** (i.e. the actual default, since `--provenance` defaults to "on"
+  per `describe.provenance` in `atmosConfig`) reproduced the bug — and dropped not just the CFN
+  fields but *every* top-level section except `vars`/`import`/`flags`, even for a `terraform`
+  component with a `settings`/`hooks` block. That proved the drop was generic to the provenance
+  render path, not CFN-specific, and not a population-side gap at all.
+
+The actual root cause: `pkg/provenance/data_transform.go`'s `filterEmptySections` (called from
+`prepareYAMLForProvenance`, `pkg/provenance/tree_renderer.go:187`, on the way to
+`RenderInlineProvenanceWithStackFile`) kept a top-level section **only if `hasSectionProvenance`
+found a recorded provenance entry for it** (`data_transform.go:82-86`, pre-fix). Its own doc comment
+said the intent was narrower — "removes top-level sections that have no provenance... prevents
+displaying sections like `backend: {}` or `overrides: {}`" (i.e. hide *empty*, auto-generated
+placeholder sections) — but the implementation conflated "no provenance was ever recorded for this
+key" with "this key is empty," and dropped the section outright in both cases.
+
+Most nested sections *do* get per-key provenance recorded, because their final value comes from
+`pkg/merge.MergeWithOptionsAndContext` (`pkg/merge/merge.go:634-701`), which calls
+`MergeWithProvenance` → `recordProvenanceRecursive` whenever provenance tracking is enabled. But
+`aws/cloudformation`'s `path`/`stack_name`/`parameters`/`hooks`/`settings`/`provision`/etc. are
+copied into the final component map as **plain values** via `extractCloudFormationComponentSection`
+and the direct-assignment loop in `stack_processor_merge.go:730-732`
+(`for key, value := range finalComponentCloudFormation { comp[key] = value }`) — never merged
+key-by-key through the provenance-tracked path — so no entry is ever recorded for them, and
+`filterEmptySections` treated "never recorded" as "must be empty" and silently dropped real,
+non-empty data. (The renderer itself, `RenderInlineProvenanceWithStackFile`/
+`processYAMLLineWithProvenance` in `pkg/provenance/tree_renderer.go:288-314`, was confirmed
+*not* to drop unannotated lines — it just omits the inline `# ● [1] file:line` comment for them —
+ruling out the render loop as the culprit and pointing squarely at the upstream filter.)
+
+`FilterComputedFields`'s allowlist (`internal/exec/describe_component.go:637-705`) was already
+correct and complete for CFN, as the task's own investigation found — it was simply unreachable
+because `filterEmptySections` ran afterward, deeper in the `--provenance` render path, and removed
+the sections before they ever reached the terminal.
+
+## Changes
+
+- `pkg/provenance/data_transform.go:68-123` — `filterEmptySections` now keeps a section if it has
+  recorded provenance **or** its value is genuinely non-empty (`isEmptyValue`: `nil`, an empty map,
+  or an empty slice). Only sections that are *both* unprovenanced *and* empty are dropped now,
+  matching the function's original stated intent instead of its previous, broader implementation.
+  Scalars (including the empty string) are never treated as empty, since a deliberately-set empty
+  string is real configured data, not a generated placeholder.
+- `pkg/provenance/provenance_helpers_test.go` — updated
+  `TestRenderInlineProvenance_YAMLMarshallingError`. That test previously asserted the render
+  produced `{}` for a map of `func`/`chan` values; it worked only because the old, over-broad filter
+  happened to remove those unprovenanced keys before they ever reached the YAML encoder. With the
+  filter now preserving non-empty values, the encoder legitimately reports a marshal error for the
+  unmarshalable types, which `RenderInlineProvenanceWithStackFile` already surfaces as a graceful
+  error string (no panic) — the test now asserts that message instead.
+- `pkg/provenance/data_transform_test.go` — added
+  `TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections`, reproducing the exact CFN shape
+  (`path`, `stack_name`, `parameters`, `termination_protection`, `capabilities`, `settings`, `hooks`
+  all unprovenanced but non-empty, alongside genuinely empty/unprovenanced `backend`/`overrides`
+  placeholders) and asserting the former survive while the latter are still dropped.
+- `internal/exec/describe_component_provenance_test.go` — added
+  `TestDescribeComponent_CloudFormationProvenanceKeepsUnprovenancedFields`, an end-to-end regression
+  test against `examples/cloudformation`'s `demo` component: calls
+  `ExecuteDescribeComponentWithContext` with `TrackProvenance = true`, applies
+  `FilterComputedFields` (the CLI's default schema filter), and renders through
+  `p.RenderInlineProvenanceWithStackFile` exactly as `ExecuteDescribeComponentCmd` does — then
+  asserts `path`, `stack_name`, `parameters`, `hooks`, `settings`, `provision`, and `metadata` all
+  appear in the rendered output. Verified this test fails against the pre-fix
+  `data_transform.go` (via `git stash` of just that file) and passes with the fix restored.
+  **This specific test lives in the `aws/cloudformation` PR stack (not yet merged to `main`), since
+  it depends on `examples/cloudformation` and `cfg.CloudFormationComponentType`; the actual bug fix
+  below (`pkg/provenance/data_transform.go`) is general and applies to every component type — it
+  ships here, on `main`, backed by the general-purpose
+  `TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections` unit test instead.**
+
+No changes were made to `internal/exec/describe_component.go`'s `FilterComputedFields`,
+`detectComponentType`, or `tryProcessWithComponentType` — all three were already correct, and the
+task's original hypothesis about a missing CFN whitelist entry there was disproven by direct testing.
+
+## Validation
+
+- `go build ./...` — passes.
+- `go test ./pkg/provenance/...` — passes, including the new and updated tests.
+- `go test ./internal/exec/...` (and targeted `-run` subsets covering `Describe|Provenance|CloudFormation`)
+  — passes.
+- `go test ./pkg/merge/...` — passes (unaffected).
+- Manual CLI check: `atmos build` from repo root, then from `examples/cloudformation`:
+  `atmos describe component demo -s local` (no flags — the actual default path, since
+  `--provenance` defaults to enabled) now prints `path: template.yaml`, `stack_name:
+  atmos-cfn-demo-local`, `parameters:`, `hooks:`, `settings:`, `provision:`, `metadata:`, and
+  `component:` — all previously silently dropped from this exact invocation.
+- `GOTOOLCHAIN=go1.26.6 ./custom-gcl run --config=.golangci.yml --allow-serial-runners
+  --new-from-rev=origin/main` — reports findings only in files owned by other concurrent fixes on
+  this branch (`pkg/component/aws/cloudformation/*`, `pkg/utils/component_path_utils.go`,
+  `internal/exec/describe_affected_components_test.go`, `internal/exec/yaml_func_terraform_output.go`);
+  zero findings on any file this fix touched.
+- `atmos test` (full suite) was run once; `github.com/cloudposse/atmos/tests` failed with an HTTP2
+  transport read timeout inside `go test`'s own goroutine dump (a real-network dependency stalling
+  in this sandboxed environment), unrelated to `pkg/provenance` or `internal/exec` — those two
+  packages' own suites passed cleanly on their own, and the stalled package's failure carries no
+  stack frame anywhere near this change.
+
+## Follow-ups
+
+None. The fix is scoped to the render-time filter and does not require plumbing per-key provenance
+recording into the CFN (or Helm) "single bag" extraction path — doing so would be a larger,
+separate enhancement (recording provenance for `path`/`stack_name`/etc. individually) with no
+functional bug attached; today's fix already restores correct, complete `describe component` output
+for these fields, only without a per-key `# ● [1] file:line` annotation on them specifically.

--- a/docs/fixes/2026-09-09-error-callout-gradient-two-tone.md
+++ b/docs/fixes/2026-09-09-error-callout-gradient-two-tone.md
@@ -1,0 +1,82 @@
+# Fix: Explanation callout gradient no longer collapses to a two-tone jump on short callouts
+
+**Date:** 2026-09-09
+
+## Summary
+
+`errors/formatter.go`'s `renderExplanationCallout` applies a background color gradient across the wrapped
+lines of an error's "explanation"/"hint" callout. For short callouts (2-3 lines, the common case for real
+error messages), `gradientRatio(i, total)` sampled only the gradient's two pure endpoint colors with zero
+interpolation in between, producing a jarring two-tone box instead of a smooth gradient. `gradientRatio` now
+floors its step count at `explanationGradientMinSteps` (3), so short callouts sample a narrow, blended slice
+near the gradient's start instead of jumping straight to both extremes. Callouts with 4+ lines already
+exceeded this floor and render byte-for-byte identically to before.
+
+## Context
+
+Found via a real-AWS field-test session: a live error was raised on a real AWS account and its rendered
+explanation callout was visually inspected in a real terminal, showing an abrupt color seam between the
+callout's two lines. The raw ANSI escape codes were captured from the actual terminal output and confirmed
+the two lines used the gradient's pure endpoint backgrounds directly, with no blending: line 1
+`rgb(51,32,79)` (`#33204f`, the configured `explanationGradientStart`) and line 2 `rgb(18,60,92)` (`#123c5c`,
+the configured `explanationGradientEnd`).
+
+Reading `gradientRatio` confirmed the root cause: `gradientRatio(index, total) = index / (total-1)`. For
+`total == 2` this returns exactly `0.0` and `1.0` -- the two pure endpoints -- and for `total == 3` it returns
+`0.0, 0.5, 1.0`, still touching both pure endpoints. Only callouts with 4 or more lines avoided sampling both
+extremes. Most real error explanations and hints wrap to 2-3 lines, making the broken case the common case,
+not an edge case.
+
+## Changes
+
+- `errors/formatter.go`: added the `ExplanationGradientMinSteps` constant (value `3`) and updated
+  `gradientRatio` to use `max(total-1, ExplanationGradientMinSteps)` as its step denominator instead of
+  `total-1` directly. This only changes behavior for `total < 4` (2 and 3 line callouts); for `total >= 4` the
+  denominator is unchanged from before, so long callouts render identically to before the fix.
+- `errors/formatter_test.go`:
+  - Updated `TestRenderExplanationCallout_ColorAddsGradientBackground` to stop asserting the old two-tone
+    behavior (it previously asserted a 2-line callout contained both the pure start *and* pure end colors,
+    which was the bug baked into the test suite).
+  - Added `TestRenderExplanationCallout_ShortCalloutIsSubtleGradient`, which renders a 2-line callout and
+    asserts its second line is not the gradient's pure end color, and that the two lines' background colors
+    are within half the full gradient's color distance of each other (i.e. close shades, not maximally
+    distant extremes).
+  - Added `TestRenderExplanationCallout_LongCalloutKeepsFullGradient`, which renders a 6-line callout and
+    asserts the first/last lines still hit the pure start/end colors exactly (proving the long-callout case is
+    unregressed) while every consecutive pair of lines still differs (proving visible progression, not a flat
+    fill).
+  - `restoreCalloutColorsAfterReset`/`calloutColorPrefix` (the Glamour full-reset handling) were not touched;
+    `TestRenderExplanationCallout_RestoresColorsAfterNestedReset` remains green unchanged.
+
+## Validation
+
+Before/after RGB values captured directly from `renderExplanationCallout` output (TrueColor profile forced):
+
+| Callout | Line | Before (RGB) | After (RGB) |
+|---|---|---|---|
+| 2-line | 1 | `(51,32,79)` | `(51,32,79)` (unchanged) |
+| 2-line | 2 | `(18,60,92)` (pure end -- the bug) | `(40,40,83)` (close shade, not the pure end) |
+| 6-line | 1 | `(51,32,79)` | `(51,32,79)` (unchanged) |
+| 6-line | 2..5 | `(44,38,81) .. (25,54,89)` | `(44,38,81) .. (25,54,89)` (unchanged) |
+| 6-line | 6 | `(18,60,92)` | `(18,60,92)` (unchanged) |
+
+Commands run:
+
+```bash
+go build ./...
+go test ./errors/...
+GOTOOLCHAIN=go1.26.6 ./custom-gcl run --config=.golangci.yml --allow-serial-runners --new-from-rev=origin/main
+```
+
+- `go build ./...` -- passed.
+- `go test ./errors/...` -- passed, including the three new/updated gradient tests and the pre-existing
+  Glamour-reset test.
+- `custom-gcl run --new-from-rev=origin/main` -- passed for `errors/formatter.go` and
+  `errors/formatter_test.go` (one `godot` finding on the new constant's doc comment was fixed by capitalizing
+  its first word, matching the file's existing convention for unexported-constant doc comments, e.g.
+  `explanationForeground`). Unrelated findings reported by the same lint run in `internal/exec/` and
+  `pkg/utils/` belong to other in-progress work on this branch and were left untouched.
+
+## Follow-ups
+
+None.

--- a/docs/fixes/2026-09-09-missing-stack-prompt-not-firing.md
+++ b/docs/fixes/2026-09-09-missing-stack-prompt-not-firing.md
@@ -1,0 +1,183 @@
+# Fix: Missing-flag/positional-arg interactive prompts didn't actually fire for `describe component` or `aws cloudformation`
+
+**Date:** 2026-09-09
+
+## Summary
+
+Three related reports about the "prompt for missing `--stack`/component" feature
+(`pkg/flags/interactive.go`, `pkg/flags/standard.go`) were investigated:
+
+1. **Reported:** the prompt is gated behind an undiscoverable `--interactive` opt-in that
+  defaults to `false`. **Finding: not reproducible.** `global.NewFlags().Interactive` is
+  already `true` (set in `pkg/flags/global/flags.go`, committed well before this
+  investigation), and `isInteractive()` already returns `true` by default in a real TTY,
+  non-CI context with no `--interactive` flag passed. No code change was needed for this
+  part, but regression tests were added to lock the behavior in (see Validation).
+2. **Reported:** `describe component` bypasses the prompt via
+  `cmd.MarkPersistentFlagRequired("stack")`. **Confirmed and fixed.**
+3. **Reported:** when the prompt does fire, it can show every stack in the org unfiltered,
+  suspected to be a positional-arg-vs-flag prompt ordering bug. **Partially confirmed, and a
+  second, more direct root cause was found and fixed too**, see Changes.
+
+## Context
+
+Live testing found that `atmos aws cloudformation apply <component>` and
+`atmos describe component <component>`, run with no `--stack`, hard-failed with `stack is
+required...` instead of showing the documented `? Choose a stack` interactive picker
+(see `pkg/flags/interactive.go`'s `PromptForMissingRequired` doc example). Reproducing this
+against the actual code (not just theory) required building the CLI and running it under
+`ATMOS_FORCE_TTY=true` against `tests/fixtures/scenarios/aws-cloudformation-outputs`, plus
+temporary debug instrumentation to observe `isInteractive()`'s inputs and the stack
+completion function's return values at each step. That reproduction is what distinguished
+the real root causes from the reported hypotheses below.
+
+## Changes
+
+### Bug 1 -- `--interactive` default (no code change; hypothesis corrected)
+
+Investigated `pkg/flags/global/flags.go`'s `NewFlags()` (`Interactive: true`, line ~104),
+`pkg/flags/global_builder.go`'s flag registration (`WithBoolFlag("interactive", "",
+defaults.Interactive, ...)`), and `cmd/root.go`'s `init()` wiring
+(`globalParser.RegisterPersistentFlags(RootCmd)` + `BindToViper`). Built the CLI and ran it
+with debug prints inside `isInteractive()`: with no `--interactive` flag passed, in a forced
+TTY, non-CI shell, `viper.GetBool("interactive")` was already `true`. Grepped every other
+consumer of `viper.GetBool("interactive")`/`defaults.Interactive`
+(`cmd/init/init.go`, `cmd/scaffold/scaffold.go`, `cmd/devcontainer/exec.go`,
+`pkg/auth/manager.go`) -- each defines its own independent `interactive` flag or reads the
+same global one consistently; nothing shadows or overrides the default to `false`. No fix
+needed. Regression tests added in `pkg/flags/global/flags_test.go`,
+`pkg/flags/global_builder_test.go`, and `pkg/flags/interactive_test.go` to catch a future
+regression of this default.
+
+### Bug 2 -- `describe component` bypassed the prompt via Cobra's native required-flag check
+
+`cmd/describe_component.go`'s `init()` called
+`describeComponentCmd.MarkPersistentFlagRequired("stack")`, which is Cobra's own
+required-flag validation and runs **before** `RunE` -- so a missing `--stack` always
+produced Cobra's generic `Error: required flag(s) "stack" not set` and never gave the
+interactive-prompt code a chance to run, regardless of TTY/interactive state.
+
+- Removed the `MarkPersistentFlagRequired("stack")` call (`cmd/describe_component.go`,
+  `init()`).
+- Added `resolveDescribeComponentStack(cmd, args)`, called at the top of
+  `getRunnableDescribeComponentCmd`'s returned closure (before `parseDescribeComponentFlags`
+  reads `--stack`). It calls `flags.PromptForMissingRequired("stack", "Choose a stack",
+  describeComponentStackCompletion, cmd, args)` and, if a value was selected, writes it back
+  onto `cmd`'s own `"stack"` flag (`stackFlag.Value.Set(selected)`), mirroring the
+  write-back pattern in `pkg/flags/standard.go`'s `promptForSingleMissingFlag`.
+- Introduced a package-level var `describeComponentStackCompletion =
+  StackFlagCompletion` (the existing `cmd/cmd_utils.go` completion function, already used
+  for `--stack` shell completion via `AddStackCompletion`) so tests can substitute a fake
+  completion function.
+- Moved the "is stack still missing?" check (`if f.stack == "" { return
+  errUtils.ErrMissingStack }`) to run after the prompt attempt and after the existing
+  flag-shape/error-mode validations, but before any real work (path resolution, auth
+  manager creation, executing the describe). This replaces Cobra's generic error message
+  with the same `errUtils.ErrMissingStack` used by every other stack-consuming command
+  (`cmd/terraform/shell.go`, `internal/exec/terraform.go`, etc).
+- Did **not** touch the `component` positional arg's `cobra.ExactArgs(1)` requirement --
+  out of scope for this fix, which targeted `--stack` specifically per the reported example
+  (`$ atmos describe component vpc` -> `? Choose a stack`).
+
+### Bug 3 -- unfiltered stack list, two distinct confirmed causes
+
+**3a. `StackFlagCompletion`'s component filter only recognized `terraform` components.**
+This is the actual, directly reproduced cause of the exact scenario in the report
+(`atmos aws cloudformation apply <component>` with the component given, `--stack` missing):
+`cmd/terraform/shared/prompt.go`'s `stackContainsComponent` (used by
+`listStacksForComponent`, used by `StackFlagCompletion`, reused as-is by
+`cmd/aws/cloudformation/cloudformation.go` and `cmd/terraform/backend/*.go` /
+`cmd/aws/cloudformation/backend/*.go`) hardcoded `components["terraform"]` as the only
+component-type section it checked. For an `aws/cloudformation` component (or any
+non-terraform component reusing this shared completion function), the filter always found
+zero matches -- **not** "every stack", but an empty option list -- which silently skipped
+the prompt entirely (`PromptForMissingRequired`'s `len(options) == 0` branch) and fell
+through to the hard `stack is required` error. Confirmed via a debug build against
+`tests/fixtures/scenarios/aws-cloudformation-outputs`: before the fix,
+`aws cfn apply vpc` (no `--stack`) logged `options: []`; after the fix, it logged
+`options: [test]` (the one stack that actually defines the `vpc` cloudformation
+component) and proceeded to the interactive picker.
+
+  - Fixed `stackContainsComponent` (`cmd/terraform/shared/prompt.go`) to check the
+    component name across **all** component-type sections under `"components"`, not just
+    `"terraform"`.
+  - The identical bug existed in `pkg/list/list_stacks.go`'s `FilterAndListStacks` (used by
+    `cmd/cmd_utils.go`'s `StackFlagCompletion` -- the one `describe_component.go` uses via
+    `AddStackCompletion`/`describeComponentStackCompletion` -- and by
+    `cmd/container/completions.go` and `cmd/ansible/completions.go`, whose components are
+    never `"terraform"`). Fixed the same way, extracted into a small
+    `stackContainsAnyTypeComponent` helper.
+
+**3b. Required-flag prompts ran before positional-arg prompts.** Confirmed via a unit test
+against the real `pkg/flags` pipeline: when both a required flag (e.g. `--stack`) and a
+required positional arg (e.g. the component) are missing, `handleInteractivePrompts` used to
+run Use Case 1 (missing required flags) before Use Case 3 (missing positional args), so the
+flag's completion function always received an **empty** `args` slice -- the positional arg
+hadn't been resolved yet -- causing `StackFlagCompletion` to fall back to listing every
+stack in the org, unfiltered. (When the component **was** already supplied on the command
+line, this ordering bug did not apply: `result.PositionalArgs` is populated during flag
+parsing, step 1 of `Parse()`, well before any prompting -- confirmed by a passing unit test
+with pre-supplied positional args, see Validation.)
+
+  - Swapped the order in `pkg/flags/standard.go`'s `handleInteractivePrompts`: positional-arg
+    prompts (Use Case 3) now run before required-flag prompts (Use Case 1), so a flag's
+    completion function benefits from an already-resolved positional arg the majority of the
+    time a command combines both.
+
+## Validation
+
+- `go build ./...` -- succeeds.
+- `go test ./pkg/flags/... ./pkg/list/... ./cmd/terraform/... ./cmd/...` -- all pass
+  (including the full `./cmd/...` suite, since this is a cross-cutting flag-handling
+  change).
+- `GOTOOLCHAIN=go1.26.6 ./custom-gcl run --new-from-rev=origin/main ./cmd/... ./pkg/flags/...
+  ./pkg/list/...` -- 0 issues (two `godot` findings on new comments were fixed during the
+  pass).
+- Manual end-to-end verification with a debug build against
+  `tests/fixtures/scenarios/aws-cloudformation-outputs`:
+  - `ATMOS_FORCE_TTY=true atmos aws cloudformation apply vpc` (no `--stack`): before the fix,
+    hard-failed immediately with `stack is required...`; after the fix, correctly reaches
+    the interactive picker with a filtered one-stack option list (fails only on
+    `huh: could not open a new TTY`, expected in this headless sandbox).
+  - `ATMOS_FORCE_TTY=true atmos describe component vpc` (no `--stack`): before the fix,
+    Cobra's own `required flag(s) "stack" not set`; after the fix, reaches the same
+    filtered interactive picker.
+  - Without `ATMOS_FORCE_TTY` (non-interactive): both commands still fail cleanly with
+    `stack is required; specify it on the command line using the flag --stack <stack>
+    (shorthand -s)` -- no regression to the non-interactive fallback.
+  - `atmos describe component vpc --stack test` (explicit stack, regression check):
+    succeeds and prints the expected component config.
+- New/updated tests:
+  - `pkg/flags/global/flags_test.go` -- `TestNewFlags` now asserts `Interactive` defaults to
+    `true`.
+  - `pkg/flags/global_builder_test.go` -- asserts the registered `interactive` pflag's
+    `DefValue` is `"true"`.
+  - `pkg/flags/interactive_test.go` --
+    `TestIsInteractive_DefaultsTrueWithoutExplicitFlag` proves `isInteractive()` is `true`
+    by default in a real TTY/non-CI context using only the registered flag default (no
+    `--interactive` passed), and still `false` in CI or without a TTY.
+  - `cmd/describe_component_test.go` --
+    `TestDescribeComponentCmd_StackNotCobraRequired` asserts the `stack` flag no longer
+    carries Cobra's required-flag annotation;
+    `TestGetRunnableDescribeComponentCmd_MissingStackTriggersPrompt` asserts a missing
+    `--stack` reaches and calls the prompt's completion function (with the component arg for
+    filtering) instead of a hard Cobra error, and still fails with `errUtils.ErrMissingStack`
+    when no stack is selected.
+  - `cmd/terraform/shared/prompt_test.go` -- new cases in `TestStackContainsComponent` and
+    `TestListStacksForComponent` proving a component under a non-`"terraform"` section
+    (e.g. `"aws/cloudformation"`) is now correctly matched.
+  - `pkg/list/list_stacks_test.go` --
+    `TestFilterAndListStacks_NonTerraformComponentType` proving the same for
+    `FilterAndListStacks`.
+  - `pkg/flags/standard_test.go` --
+    `TestStandardFlagParser_HandleInteractivePrompts_PositionalArgsBeforeFlagPrompts` proves
+    the positional-arg prompt now runs before the required-flag prompt;
+    `TestStandardFlagParser_PromptForSingleMissingFlag_ReceivesPositionalArgs` proves a
+    required flag's completion function receives an already-CLI-supplied positional arg.
+
+## Follow-ups
+
+None. The `component` positional arg's `cobra.ExactArgs(1)` requirement on
+`describe component` (a similar but distinct hard-Cobra-validation pattern) was
+deliberately left untouched -- out of scope for this fix, which targeted the `--stack`
+flag specifically per the reported example.

--- a/errors/formatter.go
+++ b/errors/formatter.go
@@ -46,6 +46,18 @@ const (
 	explanationForeground = "#F7FAFC"
 	hexColorLength        = 6
 	hexColorBase          = 16
+
+	// ExplanationGradientMinSteps is a floor on the number of gradient steps used
+	// by gradientRatio. Without it, a short callout (2-3 wrapped lines, the most
+	// common case for real error explanations/hints) samples the gradient at
+	// i/(total-1), which for total<=3 always includes both pure endpoint colors
+	// with zero blending in between -- visually a jarring two-tone seam rather
+	// than a gradient. Flooring the step count treats short callouts as a narrow
+	// slice near the start of a longer virtual gradient, so adjacent lines get
+	// close, blended shades instead of the extremes. Callouts with more lines
+	// than this floor already sample the full gradient smoothly and are
+	// unaffected (their total-1 exceeds the floor, so the formula is unchanged).
+	explanationGradientMinSteps = 3
 )
 
 type markdownSections struct {
@@ -559,7 +571,14 @@ func gradientRatio(index int, total int) float64 {
 	if total <= 1 {
 		return 0
 	}
-	return float64(index) / float64(total-1)
+	// Floor the step count so short callouts sample a narrow, blended slice of
+	// the gradient near its start instead of jumping straight to the pure
+	// start/end colors. See explanationGradientMinSteps for the full rationale.
+	steps := total - 1
+	if steps < explanationGradientMinSteps {
+		steps = explanationGradientMinSteps
+	}
+	return float64(index) / float64(steps)
 }
 
 func interpolateHexColor(start string, end string, ratio float64) string {

--- a/errors/formatter_test.go
+++ b/errors/formatter_test.go
@@ -2,6 +2,9 @@ package errors
 
 import (
 	"fmt"
+	"math"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -9,6 +12,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudposse/atmos/pkg/schema"
 	"github.com/cloudposse/atmos/pkg/ui/markdown"
@@ -417,6 +421,37 @@ func TestFormat_WithExplanationNoColorIsPlaintext(t *testing.T) {
 	assert.Contains(t, result, "The selected stack prod was not found.")
 }
 
+// backgroundRGBPattern matches a truecolor background SGR sequence (e.g.
+// "48;2;51;32;79") so tests can assert on the actual gradient color a
+// rendered callout line used.
+var backgroundRGBPattern = regexp.MustCompile(`48;2;(\d+);(\d+);(\d+)`)
+
+// backgroundRGB extracts the first truecolor background sequence in a
+// rendered line.
+func backgroundRGB(t *testing.T, line string) (r, g, b int) {
+	t.Helper()
+	match := backgroundRGBPattern.FindStringSubmatch(line)
+	require.Lenf(t, match, 4, "expected a 48;2;r;g;b background sequence in line: %q", line)
+
+	r, err := strconv.Atoi(match[1])
+	require.NoError(t, err)
+	g, err = strconv.Atoi(match[2])
+	require.NoError(t, err)
+	b, err = strconv.Atoi(match[3])
+	require.NoError(t, err)
+	return r, g, b
+}
+
+// colorDistance returns the Euclidean distance between two RGB colors, used
+// to compare how close (or far) two gradient samples are relative to the
+// gradient's total start-to-end span.
+func colorDistance(r1, g1, b1, r2, g2, b2 int) float64 {
+	dr := float64(r1 - r2)
+	dg := float64(g1 - g2)
+	db := float64(b1 - b2)
+	return math.Sqrt(dr*dr + dg*dg + db*db)
+}
+
 func TestRenderExplanationCallout_ColorAddsGradientBackground(t *testing.T) {
 	previousProfile := lipgloss.DefaultRenderer().ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -429,9 +464,81 @@ func TestRenderExplanationCallout_ColorAddsGradientBackground(t *testing.T) {
 	assert.Contains(t, callout, "\x1b[")
 	assert.Contains(t, callout, "first line")
 	assert.Contains(t, callout, "second line")
+	// The first line always starts at the gradient's pure start color.
 	assert.Contains(t, callout, "48;2;51;32;79")
-	assert.Contains(t, callout, "48;2;18;60;92")
 	assert.Contains(t, callout, "38;2;247;250;252")
+}
+
+// TestRenderExplanationCallout_ShortCalloutIsSubtleGradient guards against the
+// two-tone regression: a 2-line callout (the common case for real error
+// explanations/hints, which typically wrap to 2-3 lines) must not jump
+// straight from the gradient's pure start color to its pure end color. The
+// two lines should be close, blended shades from a wider virtual gradient,
+// not the two maximally distant extremes.
+func TestRenderExplanationCallout_ShortCalloutIsSubtleGradient(t *testing.T) {
+	previousProfile := lipgloss.DefaultRenderer().ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+	})
+
+	callout := renderExplanationCallout("first line\nsecond line", 80, true)
+	lines := strings.Split(callout, newline)
+	require.Len(t, lines, 2)
+
+	r1, g1, b1 := backgroundRGB(t, lines[0])
+	r2, g2, b2 := backgroundRGB(t, lines[1])
+
+	startR, startG, startB := parseHexColor(explanationGradientStart)
+	endR, endG, endB := parseHexColor(explanationGradientEnd)
+	fullDistance := colorDistance(startR, startG, startB, endR, endG, endB)
+
+	// The second line must not be the pure end color -- that was the two-tone bug.
+	assert.False(t, r2 == endR && g2 == endG && b2 == endB,
+		"second line must not use the gradient's pure end color %d,%d,%d", endR, endG, endB)
+
+	// The two lines should be close to each other relative to the full gradient
+	// span, not maximally distant (i.e. not one pure endpoint each).
+	stepDistance := colorDistance(r1, g1, b1, r2, g2, b2)
+	assert.Lessf(t, stepDistance, fullDistance*0.5,
+		"adjacent callout lines should be close shades, got distance %.1f of a %.1f total gradient span", stepDistance, fullDistance)
+}
+
+// TestRenderExplanationCallout_LongCalloutKeepsFullGradient ensures the fix
+// for short callouts does not regress the many-line case, which already
+// renders a smooth gradient across the full start-to-end color range.
+func TestRenderExplanationCallout_LongCalloutKeepsFullGradient(t *testing.T) {
+	previousProfile := lipgloss.DefaultRenderer().ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+	})
+
+	text := strings.Join([]string{"line one", "line two", "line three", "line four", "line five", "line six"}, newline)
+	callout := renderExplanationCallout(text, 80, true)
+	lines := strings.Split(callout, newline)
+	require.Len(t, lines, 6)
+
+	startR, startG, startB := parseHexColor(explanationGradientStart)
+	endR, endG, endB := parseHexColor(explanationGradientEnd)
+
+	firstR, firstG, firstB := backgroundRGB(t, lines[0])
+	lastR, lastG, lastB := backgroundRGB(t, lines[len(lines)-1])
+	assert.Equal(t, startR, firstR)
+	assert.Equal(t, startG, firstG)
+	assert.Equal(t, startB, firstB)
+	assert.Equal(t, endR, lastR)
+	assert.Equal(t, endG, lastG)
+	assert.Equal(t, endB, lastB)
+
+	// Verify visible progression between every consecutive pair of lines
+	// (not a flat, unchanging color).
+	for i := 1; i < len(lines); i++ {
+		prevR, prevG, prevB := backgroundRGB(t, lines[i-1])
+		curR, curG, curB := backgroundRGB(t, lines[i])
+		assert.Falsef(t, prevR == curR && prevG == curG && prevB == curB,
+			"expected visible color progression between line %d and %d", i-1, i)
+	}
 }
 
 func TestRenderExplanationCallout_RestoresColorsAfterNestedReset(t *testing.T) {

--- a/pkg/flags/global/flags_test.go
+++ b/pkg/flags/global/flags_test.go
@@ -18,6 +18,13 @@ func TestNewFlags(t *testing.T) {
 	assert.Equal(t, "cpu", flags.ProfileType, "ProfileType default")
 	assert.False(t, flags.Heatmap, "Heatmap default")
 	assert.Equal(t, "bar", flags.HeatmapMode, "HeatmapMode default")
+	// Interactive must default to true: the missing-required-flag/positional-arg
+	// prompts (pkg/flags.PromptForMissingRequired et al.) are gated on this value
+	// via viper.GetBool("interactive") in isInteractive(). If this regressed to the
+	// Go zero-value false, every "Choose a stack"/"Choose a component" prompt would
+	// require the user to already know to pass --interactive first -- defeating the
+	// whole point of prompting a user who forgot a required flag.
+	assert.True(t, flags.Interactive, "Interactive default")
 
 	// Test zero values for optional fields.
 	assert.Empty(t, flags.Chdir, "Chdir should be empty")

--- a/pkg/flags/global_builder_test.go
+++ b/pkg/flags/global_builder_test.go
@@ -41,7 +41,16 @@ func TestGlobalOptionsBuilder(t *testing.T) {
 		assert.NotNil(t, cmd.PersistentFlags().Lookup("mask"), "mask flag should be registered")
 		assert.NotNil(t, cmd.PersistentFlags().Lookup("pager"), "pager flag should be registered")
 		assert.NotNil(t, cmd.PersistentFlags().Lookup("cast"), "cast flag should be registered")
-		assert.NotNil(t, cmd.PersistentFlags().Lookup("interactive"), "interactive flag should be registered")
+		interactiveFlag := cmd.PersistentFlags().Lookup("interactive")
+		assert.NotNil(t, interactiveFlag, "interactive flag should be registered")
+		// The registered pflag default must be "true": missing-required-flag/positional-arg
+		// prompts (flags.PromptForMissingRequired et al.) gate on viper.GetBool("interactive"),
+		// which reads this flag's default when the user never passes --interactive. A
+		// zero-value default here would silently make every "Choose a stack" prompt
+		// require an undiscoverable --interactive opt-in first.
+		if interactiveFlag != nil {
+			assert.Equal(t, "true", interactiveFlag.DefValue, "interactive flag should default to true")
+		}
 
 		// Authentication flags.
 		assert.NotNil(t, cmd.PersistentFlags().Lookup("identity"), "identity flag should be registered")

--- a/pkg/flags/interactive.go
+++ b/pkg/flags/interactive.go
@@ -67,6 +67,31 @@ func IsInteractive() bool {
 	return isInteractive()
 }
 
+// runForm executes a Huh form's interactive prompt. A package-level var (rather
+// than calling form.Run() directly) so tests -- including in other packages via
+// SetFormRunnerForTest -- can substitute a fake runner (e.g. accessible mode
+// reading from a string reader, or a canned error) without needing a live TTY.
+// Mirrors the per-package runForm seam pattern used by cmd/secret/prompt_test.go
+// and cmd/store/prompt_test.go; this one is exported because PromptForValue is
+// shared by callers in other packages (e.g. cmd/describe_component.go's
+// resolveDescribeComponentStack) whose own tests need to drive this exact path.
+var runForm = func(f *huh.Form) error {
+	return f.Run()
+}
+
+// SetFormRunnerForTest overrides the Huh form runner used by PromptForValue and
+// returns a restore function. Test-only seam: production code always uses the
+// default (f.Run()); tests substitute this to either drive the real prompt body
+// via Huh's accessible mode (no live TTY required) or inject a canned error to
+// exercise a caller's error-wrapping path.
+func SetFormRunnerForTest(fn func(*huh.Form) error) (restore func()) {
+	defer perf.Track(nil, "flags.SetFormRunnerForTest")()
+
+	orig := runForm
+	runForm = fn
+	return func() { runForm = orig }
+}
+
 // PromptForValue shows an interactive Huh selector with the given options.
 // Returns the selected value or an error.
 //
@@ -107,7 +132,7 @@ func PromptForValue(name, title string, options []string) (string, error) {
 	).WithKeyMap(keyMap).WithTheme(uiutils.NewAtmosHuhTheme())
 
 	// Run form.
-	if err := form.Run(); err != nil {
+	if err := runForm(form); err != nil {
 		// Check if user aborted (Ctrl+C, ESC, etc.).
 		if errors.Is(err, huh.ErrUserAborted) {
 			ui.Warning("Selection cancelled")

--- a/pkg/flags/interactive_test.go
+++ b/pkg/flags/interactive_test.go
@@ -36,6 +36,63 @@ func TestIsInteractive(t *testing.T) {
 	})
 }
 
+// TestIsInteractive_DefaultsTrueWithoutExplicitFlag is a regression test for the
+// missing-required-flag/positional-arg prompts (PromptForMissingRequired,
+// PromptForOptionalValue, PromptForPositionalArg) requiring an undiscoverable
+// --interactive opt-in before they would ever fire. It proves isInteractive()
+// returns true in a genuinely interactive context (real TTY, not CI) using ONLY
+// the --interactive flag's registered DEFAULT -- the same way a real invocation of
+// `atmos describe component vpc` (no --interactive passed) resolves it end to end
+// via GlobalOptionsBuilder -> RegisterPersistentFlags -> BindToViper -- and that it
+// still correctly returns false outside a genuine interactive context (CI, or no
+// TTY), so this isn't loosening the safety gate, only removing a redundant opt-in.
+func TestIsInteractive_DefaultsTrueWithoutExplicitFlag(t *testing.T) {
+	// Other tests in this package call viper.Set("interactive", ...), which installs
+	// a permanent override that outranks any later pflag binding in Viper's
+	// precedence order -- restoring the "original" value on cleanup isn't enough to
+	// undo that override if it was never true to begin with. Reset clears it so this
+	// test genuinely observes the registered flag DEFAULT, not another test's leaked
+	// override.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// Build and bind the real global flag set -- the same path cmd/root.go's init()
+	// uses -- onto a fresh, unparsed command so "interactive" is left at its
+	// registered default (no --interactive/ATMOS_INTERACTIVE involved at all).
+	cmd := &cobra.Command{Use: "test"}
+	parser := NewGlobalOptionsBuilder().Build()
+	parser.RegisterPersistentFlags(cmd)
+	require.NoError(t, parser.BindToViper(viper.GetViper()))
+
+	t.Run("true in a real TTY, non-CI context", func(t *testing.T) {
+		preserved := telemetry.PreserveCIEnvVars()
+		defer telemetry.RestoreCIEnvVars(preserved)
+		t.Setenv("ATMOS_FORCE_TTY", "true")
+
+		assert.True(t, viper.GetBool("interactive"),
+			"the interactive flag's registered default must be true without an explicit --interactive/ATMOS_INTERACTIVE")
+		assert.True(t, isInteractive(),
+			"isInteractive() must return true by default in a real TTY, non-CI context -- no --interactive opt-in should be required")
+	})
+
+	t.Run("still false in CI even with the default TTY-true setup", func(t *testing.T) {
+		t.Setenv("ATMOS_FORCE_TTY", "true")
+		t.Setenv("CI", "true")
+
+		assert.False(t, isInteractive(), "isInteractive() must remain false in CI regardless of the interactive default")
+	})
+
+	t.Run("still false without a TTY even with the default", func(t *testing.T) {
+		preserved := telemetry.PreserveCIEnvVars()
+		defer telemetry.RestoreCIEnvVars(preserved)
+		// Explicitly ensure ATMOS_FORCE_TTY is unset so isTTYForPromptInput() falls
+		// through to the real (non-TTY, in a test binary) stdin check.
+		t.Setenv("ATMOS_FORCE_TTY", "false")
+
+		assert.False(t, isInteractive(), "isInteractive() must remain false without a TTY regardless of the interactive default")
+	})
+}
+
 // TestPromptForValue tests the PromptForValue function.
 func TestPromptForValue(t *testing.T) {
 	// Save original viper state.

--- a/pkg/flags/standard.go
+++ b/pkg/flags/standard.go
@@ -1021,13 +1021,24 @@ func (p *StandardFlagParser) handleInteractivePrompts(result *ParsedConfig, comb
 		return err
 	}
 
-	// Use Case 1: Handle missing required flags.
-	if err := p.promptForMissingRequiredFlags(result, combinedFlags); err != nil {
+	// Use Case 3: Handle missing required positional arguments BEFORE Use Case 1's
+	// flag prompts. A missing required flag's completion function (e.g. a "Choose a
+	// stack" selector) is often filtered by an already-selected positional arg (e.g.
+	// the component the user is targeting) -- see cmd/terraform/shared.StackFlagCompletion
+	// and cmd/aws/cloudformation's stackFlagCompletion, both of which filter stacks by
+	// result.PositionalArgs[0] when present. If the required-flag prompt ran first while
+	// the positional arg was still unresolved, its completion function would always see
+	// an empty args slice and fall back to an unfiltered "list everything" result (e.g.
+	// every stack across every account/region in the org) instead of waiting for the
+	// positional arg to be resolved. Resolving positional args first lets that filtering
+	// benefit from the freshly-selected value the vast majority of the time a command
+	// combines both (a required flag + a required positional arg).
+	if err := p.promptForMissingPositionalArgs(result); err != nil {
 		return err
 	}
 
-	// Use Case 3: Handle missing required positional arguments.
-	if err := p.promptForMissingPositionalArgs(result); err != nil {
+	// Use Case 1: Handle missing required flags.
+	if err := p.promptForMissingRequiredFlags(result, combinedFlags); err != nil {
 		return err
 	}
 

--- a/pkg/flags/standard_test.go
+++ b/pkg/flags/standard_test.go
@@ -12,6 +12,7 @@ import (
 
 	errUtils "github.com/cloudposse/atmos/errors"
 	cfg "github.com/cloudposse/atmos/pkg/config"
+	"github.com/cloudposse/atmos/pkg/telemetry"
 )
 
 func TestNewStandardFlagParser(t *testing.T) {
@@ -1436,6 +1437,115 @@ func TestStandardFlagParser_HandleInteractivePrompts_AllCases(t *testing.T) {
 		err := parser.handleInteractivePrompts(result, cmd.Flags())
 		assert.NoError(t, err)
 	})
+}
+
+// TestStandardFlagParser_HandleInteractivePrompts_PositionalArgsBeforeFlagPrompts is
+// a regression test for the missing-stack prompt showing every stack in the org
+// unfiltered instead of a filtered list. Root cause: handleInteractivePrompts used
+// to run Use Case 1 (missing required flags, e.g. --stack) BEFORE Use Case 3
+// (missing required positional args, e.g. the component). When a command requires
+// both and the user supplies neither, the required flag's completion function
+// (e.g. cmd/terraform/shared.StackFlagCompletion) received an empty args slice --
+// the positional arg hadn't been resolved yet -- and fell back to listing
+// everything instead of filtering. Swapping the order lets a required flag's
+// completion benefit from an already-resolved positional arg the vast majority of
+// the time both are missing.
+func TestStandardFlagParser_HandleInteractivePrompts_PositionalArgsBeforeFlagPrompts(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, isInteractive(), "test setup must actually reach the interactive branch")
+
+	var callOrder []string
+	// Both completion functions return no options so PromptForMissingRequired /
+	// PromptForPositionalArg short-circuit before ever needing a real TTY form
+	// (huh.Form.Run requires /dev/tty, unavailable in CI/test environments) --
+	// see PromptForMissingRequired's and PromptForPositionalArg's "let Cobra
+	// handle the error" empty-options branch.
+	componentCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		callOrder = append(callOrder, "component")
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	stackCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		callOrder = append(callOrder, "stack")
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	builder := NewPositionalArgsBuilder()
+	builder.AddArg(&PositionalArgSpec{
+		Name:           "component",
+		Required:       true,
+		CompletionFunc: componentCompletion,
+		PromptTitle:    "Choose a component",
+	})
+	specs, validator, usage := builder.Build()
+
+	parser := NewStandardFlagParser(
+		WithStringFlag("stack", "s", "", "Stack name"),
+		WithCompletionPrompt("stack", "Choose a stack", stackCompletion),
+		WithPositionalArgPrompt("component", "Choose a component", componentCompletion),
+	)
+	parser.SetPositionalArgs(specs, validator, usage)
+
+	cmd := &cobra.Command{Use: "apply"}
+	parser.RegisterFlags(cmd)
+
+	result := &ParsedConfig{
+		Flags:          map[string]interface{}{"stack": ""},
+		PositionalArgs: []string{},
+	}
+
+	err := parser.handleInteractivePrompts(result, cmd.Flags())
+	require.NoError(t, err)
+	require.Equal(t, []string{"component", "stack"}, callOrder,
+		"the positional-arg prompt must run before the required-flag prompt so the "+
+			"flag's completion function can filter by an already-resolved positional arg")
+}
+
+// TestStandardFlagParser_PromptForSingleMissingFlag_ReceivesPositionalArgs proves
+// (case (c) of the missing-stack prompt fix) that when a positional arg was
+// already supplied on the command line -- not prompted for -- a required flag's
+// completion function receives it via result.PositionalArgs, and can therefore
+// filter its options (e.g. cmd/terraform/shared.StackFlagCompletion filtering
+// stacks down to ones containing the given component) instead of falling back to
+// an unfiltered list.
+func TestStandardFlagParser_PromptForSingleMissingFlag_ReceivesPositionalArgs(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, isInteractive(), "test setup must actually reach the interactive branch")
+
+	var capturedArgs []string
+	stackCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		capturedArgs = append([]string{}, args...)
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	parser := NewStandardFlagParser(
+		WithStringFlag("stack", "s", "", "Stack name"),
+		WithCompletionPrompt("stack", "Choose a stack", stackCompletion),
+	)
+	cmd := &cobra.Command{Use: "apply"}
+	parser.RegisterFlags(cmd)
+
+	result := &ParsedConfig{
+		Flags:          map[string]interface{}{"stack": ""},
+		PositionalArgs: []string{"fixdemo"},
+	}
+
+	err := parser.promptForSingleMissingFlag("stack", result, cmd.Flags())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fixdemo"}, capturedArgs,
+		"the required flag's completion function must see the already-provided "+
+			"positional arg so it can filter its options by it")
 }
 
 // TestStandardFlagParser_BindFlagsToViper_EdgeCases tests edge cases in binding.

--- a/pkg/flags/standard_test.go
+++ b/pkg/flags/standard_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -1546,6 +1547,112 @@ func TestStandardFlagParser_PromptForSingleMissingFlag_ReceivesPositionalArgs(t 
 	assert.Equal(t, []string{"fixdemo"}, capturedArgs,
 		"the required flag's completion function must see the already-provided "+
 			"positional arg so it can filter its options by it")
+}
+
+// TestStandardFlagParser_HandleInteractivePrompts_PositionalArgPromptErrorPropagates
+// covers handleInteractivePrompts' Use Case 3 error-return branch: when
+// promptForMissingPositionalArgs itself fails (the underlying prompt errors, not
+// merely "no options available"), handleInteractivePrompts must return that error
+// immediately rather than continuing on to Use Case 1's required-flag prompts.
+// Forces the failure via the runForm seam (see interactive.go) so the real
+// PromptForPositionalArg -> PromptForValue call chain is exercised up to the
+// point the form would run, without needing a live TTY.
+func TestStandardFlagParser_HandleInteractivePrompts_PositionalArgPromptErrorPropagates(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, isInteractive(), "test setup must actually reach the interactive branch")
+
+	boom := errors.New("form boom")
+	origRunForm := runForm
+	runForm = func(*huh.Form) error { return boom }
+	defer func() { runForm = origRunForm }()
+
+	var stackCompletionCalled bool
+	componentCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"vpc", "eks"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	stackCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		stackCompletionCalled = true
+		return []string{"dev"}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	builder := NewPositionalArgsBuilder()
+	builder.AddArg(&PositionalArgSpec{
+		Name:           "component",
+		Required:       true,
+		CompletionFunc: componentCompletion,
+		PromptTitle:    "Choose a component",
+	})
+	specs, validator, usage := builder.Build()
+
+	parser := NewStandardFlagParser(
+		WithStringFlag("stack", "s", "", "Stack name"),
+		WithCompletionPrompt("stack", "Choose a stack", stackCompletion),
+		WithPositionalArgPrompt("component", "Choose a component", componentCompletion),
+	)
+	parser.SetPositionalArgs(specs, validator, usage)
+
+	cmd := &cobra.Command{Use: "apply"}
+	parser.RegisterFlags(cmd)
+
+	result := &ParsedConfig{
+		Flags:          map[string]interface{}{"stack": ""},
+		PositionalArgs: []string{},
+	}
+
+	err := parser.handleInteractivePrompts(result, cmd.Flags())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.False(t, stackCompletionCalled,
+		"a failing positional-arg prompt must short-circuit before Use Case 1's required-flag prompt ever runs")
+}
+
+// TestStandardFlagParser_HandleInteractivePrompts_RequiredFlagPromptErrorPropagates
+// covers handleInteractivePrompts' Use Case 1 error-return branch: when
+// promptForMissingRequiredFlags itself fails, handleInteractivePrompts must
+// return that error rather than swallowing it. The positional arg is already
+// supplied so Use Case 3 short-circuits without prompting, isolating the
+// failure to the required-flag prompt path.
+func TestStandardFlagParser_HandleInteractivePrompts_RequiredFlagPromptErrorPropagates(t *testing.T) {
+	originalInteractive := viper.GetBool("interactive")
+	defer viper.Set("interactive", originalInteractive)
+
+	preserved := telemetry.PreserveCIEnvVars()
+	defer telemetry.RestoreCIEnvVars(preserved)
+	t.Setenv("ATMOS_FORCE_TTY", "true")
+	viper.Set("interactive", true)
+	require.True(t, isInteractive(), "test setup must actually reach the interactive branch")
+
+	boom := errors.New("form boom")
+	origRunForm := runForm
+	runForm = func(*huh.Form) error { return boom }
+	defer func() { runForm = origRunForm }()
+
+	stackCompletion := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"dev", "staging"}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	parser := NewStandardFlagParser(
+		WithStringFlag("stack", "s", "", "Stack name"),
+		WithCompletionPrompt("stack", "Choose a stack", stackCompletion),
+	)
+
+	cmd := &cobra.Command{Use: "apply"}
+	parser.RegisterFlags(cmd)
+
+	result := &ParsedConfig{
+		Flags:          map[string]interface{}{"stack": ""},
+		PositionalArgs: []string{"already-provided"},
+	}
+
+	err := parser.handleInteractivePrompts(result, cmd.Flags())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
 }
 
 // TestStandardFlagParser_BindFlagsToViper_EdgeCases tests edge cases in binding.

--- a/pkg/list/list_stacks.go
+++ b/pkg/list/list_stacks.go
@@ -6,25 +6,19 @@ import (
 	"github.com/samber/lo"
 )
 
-// FilterAndListStacks filters stacks by the given component
+// FilterAndListStacks filters stacks by the given component. The component is
+// matched under any component type section (terraform, aws/cloudformation,
+// helmfile, packer, container, ansible, kubernetes, helm, etc) -- this function is
+// shared by completion/prompt callers across component types (e.g.
+// cmd/container/completions.go, cmd/ansible/completions.go), so it must not assume
+// terraform is the only component type or it silently returns zero matches for
+// every other type.
 func FilterAndListStacks(stacksMap map[string]any, component string) ([]string, error) {
 	if component != "" {
 		// Filter stacks by component
 		filteredStacks := []string{}
 		for stackName, stackData := range stacksMap {
-			v2, ok := stackData.(map[string]any)
-			if !ok {
-				continue
-			}
-			components, ok := v2["components"].(map[string]any)
-			if !ok {
-				continue
-			}
-			terraform, ok := components["terraform"].(map[string]any)
-			if !ok {
-				continue
-			}
-			if _, exists := terraform[component]; exists {
+			if stackContainsAnyTypeComponent(stackData, component) {
 				filteredStacks = append(filteredStacks, stackName)
 			}
 		}
@@ -40,4 +34,27 @@ func FilterAndListStacks(stacksMap map[string]any, component string) ([]string, 
 	stacks := lo.Keys(stacksMap)
 	sort.Strings(stacks)
 	return stacks, nil
+}
+
+// stackContainsAnyTypeComponent reports whether stackData defines component under
+// any component type section.
+func stackContainsAnyTypeComponent(stackData any, component string) bool {
+	v2, ok := stackData.(map[string]any)
+	if !ok {
+		return false
+	}
+	components, ok := v2["components"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, typeSection := range components {
+		typeMap, ok := typeSection.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, exists := typeMap[component]; exists {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/list/list_stacks_test.go
+++ b/pkg/list/list_stacks_test.go
@@ -64,3 +64,43 @@ func TestFilterAndListStacks_NoMatchingComponent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, output)
 }
+
+// TestFilterAndListStacks_NonTerraformComponentType is a regression test: this
+// function is shared by non-terraform completion/prompt callers (e.g.
+// cmd/container/completions.go, cmd/ansible/completions.go, cmd/cmd_utils.go's
+// describe-stack completion), so it must find a component defined under any
+// component type section, not only "terraform" -- otherwise it always returns
+// zero matches for every other component type.
+func TestFilterAndListStacks_NonTerraformComponentType(t *testing.T) {
+	stacksMap := map[string]any{
+		"prod": map[string]any{
+			"components": map[string]any{
+				"aws/cloudformation": map[string]any{
+					"vpc": map[string]any{"stack_name": "prod-vpc"},
+				},
+			},
+		},
+		"dev": map[string]any{
+			"components": map[string]any{
+				"container": map[string]any{
+					"api": map[string]any{},
+				},
+			},
+		},
+		"unrelated": map[string]any{
+			"components": map[string]any{
+				"aws/cloudformation": map[string]any{
+					"rds": map[string]any{},
+				},
+			},
+		},
+	}
+
+	output, err := FilterAndListStacks(stacksMap, "vpc")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"prod"}, output)
+
+	output, err = FilterAndListStacks(stacksMap, "api")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"dev"}, output)
+}

--- a/pkg/list/list_stacks_test.go
+++ b/pkg/list/list_stacks_test.go
@@ -104,3 +104,70 @@ func TestFilterAndListStacks_NonTerraformComponentType(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"dev"}, output)
 }
+
+// TestStackContainsAnyTypeComponent covers the malformed-data guard clauses in
+// stackContainsAnyTypeComponent: a stack value that isn't a map, a stack map
+// missing (or with a malformed) "components" section, and a component-type
+// section whose value isn't a map (which must be skipped, not treated as a
+// match or an error), alongside the successful match path.
+func TestStackContainsAnyTypeComponent(t *testing.T) {
+	tests := []struct {
+		name      string
+		stackData any
+		component string
+		want      bool
+	}{
+		{
+			name:      "stack data is not a map",
+			stackData: "not-a-map",
+			component: "vpc",
+			want:      false,
+		},
+		{
+			name: "components key missing",
+			stackData: map[string]any{
+				"vars": map[string]any{"foo": "bar"},
+			},
+			component: "vpc",
+			want:      false,
+		},
+		{
+			name: "components value is not a map",
+			stackData: map[string]any{
+				"components": "not-a-map",
+			},
+			component: "vpc",
+			want:      false,
+		},
+		{
+			name: "type section value is not a map is skipped, later valid section still matches",
+			stackData: map[string]any{
+				"components": map[string]any{
+					"terraform": "not-a-map",
+					"container": map[string]any{
+						"vpc": map[string]any{},
+					},
+				},
+			},
+			component: "vpc",
+			want:      true,
+		},
+		{
+			name: "type section value is not a map and no other section matches",
+			stackData: map[string]any{
+				"components": map[string]any{
+					"terraform": "not-a-map",
+				},
+			},
+			component: "vpc",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stackContainsAnyTypeComponent(tt.stackData, tt.component)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/provenance/data_transform.go
+++ b/pkg/provenance/data_transform.go
@@ -65,9 +65,20 @@ func renameImportsToImport(data any, ctx *m.MergeContext) any {
 	return newMap
 }
 
-// filterEmptySections removes top-level sections that have no provenance.
-// This prevents displaying sections like "backend: {}" or "overrides: {}" when they
-// weren't explicitly defined in any file and are just generated placeholders.
+// filterEmptySections removes top-level sections that are both empty and have
+// no recorded provenance. This prevents displaying sections like "backend: {}"
+// or "overrides: {}" when they weren't explicitly defined in any file and are
+// just generated placeholders.
+//
+// A section is kept if it has recorded provenance OR its value is genuinely
+// non-empty. The "OR non-empty" half matters because many component sections
+// (e.g. aws/cloudformation's path/stack_name/parameters/hooks/settings, which
+// are copied into the final component map as plain values rather than merged
+// key-by-key through the provenance-tracked merge path) never get a per-key
+// provenance entry recorded at all, even though they carry real, non-empty
+// data. Treating "no provenance" as "must be empty" silently dropped those
+// populated sections from `describe component --provenance` output — see
+// docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md.
 func filterEmptySections(data any, ctx *m.MergeContext) any {
 	defer perf.Track(nil, "provenance.filterEmptySections")()
 
@@ -80,12 +91,31 @@ func filterEmptySections(data any, ctx *m.MergeContext) any {
 	filtered := make(map[string]any)
 
 	for key, value := range dataMap {
-		if hasSectionProvenance(ctx, key) {
+		if hasSectionProvenance(ctx, key) || !isEmptyValue(value) {
 			filtered[key] = value
 		}
 	}
 
 	return filtered
+}
+
+// isEmptyValue reports whether value is a shape Atmos uses for generated
+// placeholder sections that were never configured: nil, an empty map, or an
+// empty slice. Scalars (including the empty string) are never considered
+// empty here, since a deliberately-set empty string is real data, not a
+// placeholder.
+func isEmptyValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		return len(v) == 0
+	case []any:
+		return len(v) == 0
+	default:
+		return false
+	}
 }
 
 // hasSectionProvenance reports whether any recorded provenance path belongs to

--- a/pkg/provenance/data_transform.go
+++ b/pkg/provenance/data_transform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	cfg "github.com/cloudposse/atmos/pkg/config"
 	m "github.com/cloudposse/atmos/pkg/merge"
 	"github.com/cloudposse/atmos/pkg/perf"
 )
@@ -79,6 +80,14 @@ func renameImportsToImport(data any, ctx *m.MergeContext) any {
 // data. Treating "no provenance" as "must be empty" silently dropped those
 // populated sections from `describe component --provenance` output — see
 // docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md.
+//
+// The cfg.ComponentSectionName key ("component") is excluded from the "OR
+// non-empty" escape hatch: stack_processor_process_stacks.go unconditionally
+// sets it to the component's own name on every component, purely for the
+// template system's consumption, regardless of whether the user ever wrote a
+// `component:` attribute. It is therefore always non-empty but never
+// meaningfully "configured" unless it actually has recorded provenance (i.e.
+// a user explicitly set it), so it must stay gated on provenance alone.
 func filterEmptySections(data any, ctx *m.MergeContext) any {
 	defer perf.Track(nil, "provenance.filterEmptySections")()
 
@@ -91,7 +100,8 @@ func filterEmptySections(data any, ctx *m.MergeContext) any {
 	filtered := make(map[string]any)
 
 	for key, value := range dataMap {
-		if hasSectionProvenance(ctx, key) || !isEmptyValue(value) {
+		revivableByNonEmpty := key != cfg.ComponentSectionName && !isEmptyValue(value)
+		if hasSectionProvenance(ctx, key) || revivableByNonEmpty {
 			filtered[key] = value
 		}
 	}

--- a/pkg/provenance/data_transform.go
+++ b/pkg/provenance/data_transform.go
@@ -2,6 +2,7 @@ package provenance
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	cfg "github.com/cloudposse/atmos/pkg/config"
@@ -110,19 +111,26 @@ func filterEmptySections(data any, ctx *m.MergeContext) any {
 }
 
 // isEmptyValue reports whether value is a shape Atmos uses for generated
-// placeholder sections that were never configured: nil, an empty map, or an
-// empty slice. Scalars (including the empty string) are never considered
-// empty here, since a deliberately-set empty string is real data, not a
-// placeholder.
+// placeholder sections that were never configured: nil, an empty or nil map,
+// or an empty or nil slice of any element type. Scalars (including the empty
+// string) are never considered empty here, since a deliberately-set empty
+// string is real data, not a placeholder.
+//
+// Kind-based reflection (rather than a type switch on map[string]any/[]any)
+// is required because some sections -- e.g. ComponentImportsSection, always
+// assigned into the component map as []string -- carry a typed nil or empty
+// slice of a concrete element type. A type switch would fall through to the
+// default case and treat that placeholder as non-empty, resurrecting an
+// unprovenanced, genuinely-empty "import: []" section.
 func isEmptyValue(value any) bool {
 	if value == nil {
 		return true
 	}
-	switch v := value.(type) {
-	case map[string]any:
-		return len(v) == 0
-	case []any:
-		return len(v) == 0
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Slice:
+		return rv.IsNil() || rv.Len() == 0
 	default:
 		return false
 	}

--- a/pkg/provenance/data_transform_test.go
+++ b/pkg/provenance/data_transform_test.go
@@ -1,6 +1,7 @@
 package provenance
 
 import (
+	"reflect"
 	"testing"
 
 	m "github.com/cloudposse/atmos/pkg/merge"
@@ -151,5 +152,64 @@ func TestFilterEmptySectionsNilContextKeepsEverything(t *testing.T) {
 
 	if len(filteredMap) != len(data) {
 		t.Errorf("expected all %d keys to survive with a nil context, got %d: %v", len(data), len(filteredMap), filteredMap)
+	}
+}
+
+// TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections is a regression
+// test for the bug where `describe component --provenance` (the default
+// output mode) silently dropped real, non-empty top-level sections that never
+// got a per-key provenance entry recorded -- notably aws/cloudformation's
+// path/stack_name/parameters/hooks/settings/provision, which are populated as
+// plain copied values rather than merged key-by-key through the
+// provenance-tracked merge path. See
+// docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md.
+//
+// A section must survive filtering if it has recorded provenance OR its
+// value is genuinely non-empty; only sections that are both unprovenanced
+// AND empty (Atmos-generated placeholders like "backend: {}") should be
+// dropped.
+func TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections(t *testing.T) {
+	ctx := m.NewMergeContext()
+	ctx.EnableProvenance()
+	// Only "vars" has recorded provenance; everything else below is real,
+	// non-empty aws/cloudformation component data with no provenance at all.
+	ctx.RecordProvenance("components.aws/cloudformation.demo.vars.stage", m.ProvenanceEntry{
+		File: "deploy/local.yaml", Line: 8, Type: m.ProvenanceTypeInline, Depth: 1,
+	})
+
+	data := map[string]any{
+		"vars":                   map[string]any{"stage": "local"},
+		"path":                   "template.yaml",
+		"stack_name":             "atmos-cfn-demo-local",
+		"parameters":             map[string]any{"Stage": "local"},
+		"termination_protection": true,
+		"capabilities":           []any{"CAPABILITY_NAMED_IAM"},
+		"settings":               map[string]any{"aws_cloudformation": map[string]any{"region": "us-east-1"}},
+		"hooks":                  map[string]any{"mark-after-apply": map[string]any{"kind": "command"}},
+		"backend":                map[string]any{}, // genuinely empty placeholder, no provenance.
+		"overrides":              map[string]any{}, // genuinely empty placeholder, no provenance.
+	}
+
+	filtered := filterEmptySections(data, ctx)
+	filteredMap, ok := filtered.(map[string]any)
+	if !ok {
+		t.Fatalf("expected filterEmptySections to return a map, got %T", filtered)
+	}
+
+	for _, key := range []string{"vars", "path", "stack_name", "parameters", "termination_protection", "capabilities", "settings", "hooks"} {
+		value, ok := filteredMap[key]
+		if !ok {
+			t.Errorf("expected non-empty section %q to survive filtering even without provenance, but it was dropped: %v", key, filteredMap)
+			continue
+		}
+		if !reflect.DeepEqual(value, data[key]) {
+			t.Errorf("expected section %q to keep its original value %v, got %v", key, data[key], value)
+		}
+	}
+
+	for _, key := range []string{"backend", "overrides"} {
+		if _, ok := filteredMap[key]; ok {
+			t.Errorf("expected empty, unprovenanced section %q to be filtered out, but it survived: %v", key, filteredMap)
+		}
 	}
 }

--- a/pkg/provenance/data_transform_test.go
+++ b/pkg/provenance/data_transform_test.go
@@ -213,3 +213,64 @@ func TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections(t *testing.T) {
 		}
 	}
 }
+
+// TestFilterEmptySectionsDropsSyntheticComponentKey is a regression test for
+// the "component" key leaking into every `describe component` output.
+// The stack_processor_process_stacks.go file unconditionally sets
+// componentMap["component"] = componentName on every component for the
+// template system's own consumption, regardless of whether the user ever
+// wrote a `component:` attribute. Unlike aws/cloudformation's plain-value
+// sections, it must stay gated on provenance alone -- otherwise the "OR
+// non-empty" escape hatch (TestFilterEmptySectionsKeepsNonEmptyUnprovenancedSections)
+// resurrects it for every component, since it is a non-empty string with no
+// provenance by construction.
+func TestFilterEmptySectionsDropsSyntheticComponentKey(t *testing.T) {
+	ctx := m.NewMergeContext()
+	ctx.EnableProvenance()
+	// No provenance recorded for "component" -- this mirrors the synthetic,
+	// Go-injected value that was never written by a user.
+
+	data := map[string]any{
+		"component": "test-component",
+		"path":      "template.yaml", // unrelated plain-value section, no provenance.
+	}
+
+	filtered := filterEmptySections(data, ctx)
+	filteredMap, ok := filtered.(map[string]any)
+	if !ok {
+		t.Fatalf("expected filterEmptySections to return a map, got %T", filtered)
+	}
+
+	if _, ok := filteredMap["component"]; ok {
+		t.Errorf("expected synthetic, unprovenanced 'component' key to be filtered out, but it survived: %v", filteredMap)
+	}
+	if _, ok := filteredMap["path"]; !ok {
+		t.Errorf("expected unrelated non-empty unprovenanced section 'path' to still survive via the non-empty escape hatch, but it was dropped: %v", filteredMap)
+	}
+}
+
+// TestFilterEmptySectionsKeepsUserSetComponentKey verifies that a
+// user-authored `component:` attribute (real provenance recorded) still
+// survives filtering, distinguishing it from the synthetic, Go-injected
+// default value covered by TestFilterEmptySectionsDropsSyntheticComponentKey.
+func TestFilterEmptySectionsKeepsUserSetComponentKey(t *testing.T) {
+	ctx := m.NewMergeContext()
+	ctx.EnableProvenance()
+	ctx.RecordProvenance("components.terraform.app.component", m.ProvenanceEntry{
+		File: "dev.yaml", Line: 3, Type: m.ProvenanceTypeInline, Depth: 1,
+	})
+
+	data := map[string]any{
+		"component": "base-component",
+	}
+
+	filtered := filterEmptySections(data, ctx)
+	filteredMap, ok := filtered.(map[string]any)
+	if !ok {
+		t.Fatalf("expected filterEmptySections to return a map, got %T", filtered)
+	}
+
+	if value, ok := filteredMap["component"]; !ok || value != "base-component" {
+		t.Errorf("expected user-set 'component' key (has recorded provenance) to survive filtering, got %v", filteredMap)
+	}
+}

--- a/pkg/provenance/data_transform_test.go
+++ b/pkg/provenance/data_transform_test.go
@@ -274,3 +274,67 @@ func TestFilterEmptySectionsKeepsUserSetComponentKey(t *testing.T) {
 		t.Errorf("expected user-set 'component' key (has recorded provenance) to survive filtering, got %v", filteredMap)
 	}
 }
+
+// TestFilterEmptySectionsDropsTypedEmptySlice is a regression test for a typed
+// nil/empty slice (e.g. ComponentImportsSection, always assigned into the
+// component map as []string) being treated as non-empty by isEmptyValue's
+// former type switch on map[string]any/[]any, which fell through to the
+// default case for any other concrete slice type. That resurrected an
+// unprovenanced, genuinely-empty "import: []" section for components with no
+// stack imports at all.
+func TestFilterEmptySectionsDropsTypedEmptySlice(t *testing.T) {
+	ctx := m.NewMergeContext()
+	ctx.EnableProvenance()
+	// No provenance recorded for "import" -- mirrors a component with no
+	// stack imports, where ComponentImportsSection is a nil or empty []string.
+
+	data := map[string]any{
+		"import":       []string(nil),
+		"dependencies": []string{},
+	}
+
+	filtered := filterEmptySections(data, ctx)
+	filteredMap, ok := filtered.(map[string]any)
+	if !ok {
+		t.Fatalf("expected filterEmptySections to return a map, got %T", filtered)
+	}
+
+	for _, key := range []string{"import", "dependencies"} {
+		if _, ok := filteredMap[key]; ok {
+			t.Errorf("expected typed nil/empty slice section %q (no provenance) to be filtered out, but it survived: %v", key, filteredMap)
+		}
+	}
+}
+
+// TestIsEmptyValue exercises isEmptyValue directly across the shapes it must
+// distinguish: nil, empty/nil maps and slices of any concrete type, non-empty
+// maps/slices, and scalars (including the empty string, which is real data).
+func TestIsEmptyValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{"nil", nil, true},
+		{"nil []any", []any(nil), true},
+		{"empty []any", []any{}, true},
+		{"nil []string", []string(nil), true},
+		{"empty []string", []string{}, true},
+		{"non-empty []string", []string{"a"}, false},
+		{"nil map[string]any", map[string]any(nil), true},
+		{"empty map[string]any", map[string]any{}, true},
+		{"non-empty map[string]any", map[string]any{"a": 1}, false},
+		{"empty string", "", false},
+		{"non-empty string", "x", false},
+		{"zero int", 0, false},
+		{"bool false", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyValue(tc.value); got != tc.want {
+				t.Errorf("isEmptyValue(%#v) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/provenance/provenance_helpers_test.go
+++ b/pkg/provenance/provenance_helpers_test.go
@@ -428,16 +428,18 @@ func TestRenderInlineProvenance_DifferentProvenanceTypes(t *testing.T) {
 }
 
 func TestRenderInlineProvenance_YAMLMarshallingError(t *testing.T) {
-	// Test that non-serializable values are handled gracefully.
-	// Note: gopkg.in/yaml.v3 has internal panic recovery that converts
-	// unmarshallable types (like functions, channels) to `{}` instead of
-	// propagating the panic. This test documents the behavior and ensures
-	// panic recovery is in place for any future YAML library changes.
+	// Test that non-serializable values are handled gracefully (no panic).
 	//
-	// The panic recovery in RenderInlineProvenanceWithStackFile exists as
-	// defensive programming to handle edge cases, but current yaml.v3 behavior
-	// makes it difficult to trigger via test data without directly invoking
-	// the low-level encoder.
+	// filterEmptySections only drops a section when it is BOTH unprovenanced
+	// AND empty (nil, an empty map, or an empty slice) -- see
+	// docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md for why:
+	// dropping any unprovenanced section, empty or not, silently hid real,
+	// non-empty component data (e.g. aws/cloudformation's path/stack_name/
+	// hooks/settings) that never gets per-key provenance recorded. A `func`/
+	// `chan` value is neither empty nor provenanced, so it now survives
+	// filtering and reaches the YAML encoder, which reports a marshal error
+	// instead of silently producing `{}`. RenderInlineProvenanceWithStackFile
+	// surfaces that error as plain text rather than panicking.
 	data := map[string]any{
 		"func": func() {},
 		"chan": make(chan int),
@@ -449,11 +451,7 @@ func TestRenderInlineProvenance_YAMLMarshallingError(t *testing.T) {
 	atmosConfig := &schema.AtmosConfiguration{}
 	result := RenderInlineProvenanceWithStackFile(data, ctx, atmosConfig, "broken.yaml")
 
-	// yaml.v3 marshals these as `{}` instead of panicking.
-	// Since the values have no provenance, they're filtered out by filterEmptySections,
-	// resulting in an empty top-level map `{}`.
-	// Verify the function doesn't panic and returns valid output.
+	// Verify the function doesn't panic and returns a graceful error message.
 	assert.NotEmpty(t, result)
-	assert.Contains(t, result, "Provenance Legend")
-	assert.Contains(t, result, "{}")
+	assert.Contains(t, result, "Error rendering YAML")
 }


### PR DESCRIPTION
## What

Four general, cross-cutting bug fixes:

1. **errors/formatter.go** — short (2-line) error callouts rendered with a jarring two-tone background instead of a smooth gradient (pure gradient-endpoint colors with no interpolation).
2. **cmd/describe_component.go** — `describe component` couldn't prompt for a missing `--stack`; it used Cobra's native `MarkPersistentFlagRequired`, which hard-fails before the interactive-prompt code ever runs.
3. **cmd/terraform/shared/prompt.go** / **pkg/flags/standard.go** — the missing-stack prompt's component-filter was hardcoded to `components["terraform"]` (so any non-terraform component always matched zero stacks and fell back to an unfiltered, org-wide list), and the flag prompt ran before the positional-arg prompt, so the filter never saw the component name even when one had already been typed.
4. **pkg/provenance/data_transform.go** — `filterEmptySections` treated "no per-key provenance recorded" as "this section is empty," silently dropping any top-level section populated as a plain value rather than merged key-by-key (reproduces for any component type, e.g. a terraform component's `settings`/`hooks`).

## Why

Found via a real-AWS field-test pass on the (currently unmerged) `aws/cloudformation` feature stack. All four bugs are general Atmos behavior unrelated to CloudFormation itself, so they ship here independently rather than waiting on that stack to merge.

## References

- `docs/fixes/2026-09-09-error-callout-gradient-two-tone.md`
- `docs/fixes/2026-09-09-missing-stack-prompt-not-firing.md`
- `docs/fixes/2026-09-09-cfn-describe-component-missing-fields.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive prompts now help resolve missing stack values when running `describe component`.
  - Stack suggestions now include components from all supported component types, not only Terraform.
  - Interactive prompts resolve required positional arguments before dependent flag suggestions.

- **Bug Fixes**
  - Provenance output now preserves non-empty CloudFormation component fields.
  - Short error callouts now use smoother gradients, while longer callouts retain full gradient coloring.
  - Interactive mode is enabled by default in eligible terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->