### PR TITLE
fix(ci): stop Mergify updating bot PRs once approved

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -32,6 +32,8 @@ pull_request_rules:
       - and: *is_dependency_bot
       - "-conflict"
       - "#commits-behind>0"
+      # Approval is required to enter the merge queue, and queued branches can't be updated.
+      - "#approved-reviews-by=0"
     actions:
       update:
 


### PR DESCRIPTION
## what

- Add `#approved-reviews-by=0` to the Mergify rule **Keep Dependabot/Renovate PRs up to date with main**, so Mergify stops running `update` on a bot PR once it has an approval.

## why

Since `main` moved to GitHub's native merge queue (ruleset "Merge Queue", 2026-08-06), this rule fails on essentially every bot PR that gets enqueued — 6 of the last 12 (#3066, #3067, #3071, #3086, #3091, #3098):

> Base branch update has failed
> protected branch '<pr head branch>' check failed: A pull request for this branch has been added to a merge queue. Branches that are queued for merging cannot be updated.

Mechanism:

- Mergify's `update` action merges `main` into the PR's head branch. GitHub locks that branch while the PR sits in the native queue.
- Mergify's built-in "skip if queued" guard is `queue-position = -1`, which only reflects Mergify's own queue. There is no Mergify condition for GitHub's native queue, and nothing lands on the head SHA either (no check-run or commit status is created on enqueue), so there is nothing else to condition on.
- The rule wakes on PR webhooks, not promptly on pushes to `main`. On the failing PRs the branch had been behind for 50–70 min unnoticed; Mergify re-evaluated ~2 min after the approval/enqueue events, when the branch was already locked:

  | PR | approved | enqueued | update failed | merged |
  |----|----------|----------|---------------|--------|
  | #3091 | 02:20:02Z | 02:20:09Z | 02:21:44Z | 02:40Z |
  | #3098 | 02:22:21Z | 02:22:28Z | 02:24:37Z | 02:43Z |
  | #3067 | 20:35:15Z | 20:35:32Z | 20:37:46Z | 21:25Z |
  | #3066 | 20:35:30Z | 20:35:35Z | 20:38:05Z | 21:25Z |

Why approval is the right gate: the "Required Pull Request Reviews" ruleset requires 1 approval with no bypass actors, so GitHub cannot enqueue a PR without a current approval. Approval is therefore a strictly earlier signal than enqueue, with no timing dependency (an Actions workflow on `pull_request: enqueued` toggling a label would be racing that same ~2 min window). After approval the merge queue owns freshness by re-testing against current `main`.

Side benefit: the ruleset has `dismiss_stale_reviews_on_push: true`, so today a Mergify update landing after approval dismisses the approval and forces a re-review. That stops.

Context: this rule was added in #2752 because `main` then had `strict: true` (require branches up to date). That protection is gone with the merge queue, so the alternative of deleting the rule outright is also valid; this keeps pre-review freshness for bot PRs.

The failures were cosmetic (Mergify is not a required status check; the PRs merged via the queue), but they show up as a red check on every bot PR.

## references

- #2752 (introduced the rule)
- Mergify `update` action docs: "You do not need to use this action if you use the merge queue."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency pull request handling so branches are refreshed only after receiving at least one approval.
  * Added guidance explaining the approval requirement before entering the merge queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->