### PR TITLE
fix(website): cast download polls render status as JSON, waits up to 30m

### DIFF
--- a/website/src/components/CastProArtifact/README.md
+++ b/website/src/components/CastProArtifact/README.md
@@ -13,12 +13,16 @@ connection open, and never sends artifact bytes while still rendering:
 - **202** + `Retry-After` (ignored — see below) + JSON body while queued/rendering:
   `data.artifacts[0].status` is `"queued" | "processing" | "ready" | "failed"`; an optional
   `data.artifacts[0].progress` (`{ percent, stage }`) may appear once the service starts sending it.
-- **200** once ready — but as the *rendered artifact itself* (`Content-Type: video/mp4`,
-  `image/gif`, etc.), not JSON, even though `Accept: application/json` was sent. Treat any `200`
-  as ready and never read the body — `polling.mjs` aborts the fetch as soon as the status line
-  arrives so a poll never transfers the full file.
-- **400/500** with a JSON `{ success: false, error }` body — terminal failure; `error` is
-  human-readable and safe to show verbatim.
+- **200** + JSON body once ready — `data.artifacts[0].status === "ready"` is the readiness
+  signal, using the same `data.artifacts[0]` shape as the 202 case above. `artifacts[0].url` is a
+  tokened direct link to the artifact (unused here); `blobUrl` is always `null`. Some responses
+  may still come back as the *rendered artifact itself* (`Content-Type: video/mp4`, `image/gif`,
+  etc.) rather than this JSON body — `polling.mjs` checks `Content-Type` and, for that non-JSON
+  shape, aborts the fetch as soon as the status line arrives so a poll never transfers the full
+  file, treating it as ready without reading it.
+- **400/404/500** with a JSON `{ success: false, error }` body — terminal failure, readable
+  cross-origin; `error` is human-readable and safe to show verbatim (e.g. a 404 reads "Cast file
+  was not found at the requested commit and path").
 
 A sibling `.cast` URL (no format suffix) returns an HTML page with an embedded player, for
 `<iframe>` use.

--- a/website/src/components/CastProArtifact/README.md
+++ b/website/src/components/CastProArtifact/README.md
@@ -7,14 +7,25 @@ URL builders and a polling hook for the Atmos Pro cast-rendering service, shared
 
 `GET https://atmos-pro.com/casts/{owner}/{repo}/{ref}/{path}.cast.{gif|mp4|svg|webm}` renders any
 `.cast` (asciicast) file in a public GitHub repo on demand and is CORS-enabled for browser `fetch`.
-It responds one of three ways:
+Poll it with `Accept: application/json` so it answers immediately instead of holding the
+connection open, and never sends artifact bytes while still rendering:
 
-- **302** once the artifact is ready.
-- **202** + `Retry-After` while still rendering.
-- **400/500** with a JSON error body otherwise.
+- **202** + `Retry-After` (ignored — see below) + JSON body while queued/rendering:
+  `data.artifacts[0].status` is `"queued" | "processing" | "ready" | "failed"`; an optional
+  `data.artifacts[0].progress` (`{ percent, stage }`) may appear once the service starts sending it.
+- **200** once ready — but as the *rendered artifact itself* (`Content-Type: video/mp4`,
+  `image/gif`, etc.), not JSON, even though `Accept: application/json` was sent. Treat any `200`
+  as ready and never read the body — `polling.mjs` aborts the fetch as soon as the status line
+  arrives so a poll never transfers the full file.
+- **400/500** with a JSON `{ success: false, error }` body — terminal failure; `error` is
+  human-readable and safe to show verbatim.
 
 A sibling `.cast` URL (no format suffix) returns an HTML page with an embedded player, for
 `<iframe>` use.
+
+**Download** — once ready, navigate to the same URL with `?download=1`; it responds `200` with
+`Content-Disposition: attachment`, so `window.location.href = …` downloads without leaving the
+page.
 
 ## `url.mjs`
 
@@ -33,13 +44,22 @@ buildEmbedUrl({ ref: 'main', path: 'examples/quickstart.cast' });
 `owner`/`repo` default to `cloudposse/atmos`. A `ref` containing a slash (e.g. `feature/foo`) is
 passed via `?ref=` instead of the path, since it can't be embedded there unambiguously.
 
+## `polling.mjs`
+
+The framework-agnostic polling engine (`createPoller`), kept free of React so it's directly
+unit-testable with `node --test`, a mocked `fetch`, and fake timers (`polling.test.mjs`). Polls
+every 3s while rendering — long casts can take several minutes, so it deliberately ignores the
+service's 30s `Retry-After` on the cheap JSON path. Past 13 minutes of total wait it slows to
+every 10s and marks the state "taking longer than usual"; it gives up only at a hard 30-minute
+ceiling, with a message that says the render may still be running rather than that it failed.
+
 ## `useCastArtifact.ts`
 
-Drives the download flow for a single `owner`/`repo`/`ref`/`path`/`format` combination: calling
-`start()` checks the artifact, polls on `Retry-After` while rendering (capped at ~60s total), and
-navigates the browser to a forced download once ready. Each call to `start()` gets its own request
+A thin React wrapper around `createPoller` for a single `owner`/`repo`/`ref`/`path`/`format`
+combination: calling `start()` kicks off polling and, once the artifact is ready, navigates the
+browser to a forced download (`?download=1`). Each call to `start()` gets its own request
 generation, so a stale request (e.g. from a `path`/`ref` that changed mid-poll) can never apply its
-result after a newer one has started.
+result — or trigger a download — after a newer one has started.
 
 ## Components that use this
 

--- a/website/src/components/CastProArtifact/polling.mjs
+++ b/website/src/components/CastProArtifact/polling.mjs
@@ -2,17 +2,24 @@
 // status endpoint. Kept free of React so it can be unit-tested directly with
 // `node --test`, a mocked `fetch`, and fake timers (see polling.test.mjs).
 //
-// The service's contract (confirmed against a live probe, not just docs):
+// The service's contract:
 //   - GET the artifact URL with `Accept: application/json` to poll status
 //     without transferring the rendered file.
 //   - 202 + JSON body while queued/rendering — read `data.artifacts[0].status`
 //     ("queued" | "processing" | "ready" | "failed") to distinguish queued vs.
 //     actively rendering, and `data.artifacts[0].progress` (optional,
 //     `{ percent, stage }`) when the service starts reporting it.
-//   - 200 once ready — but with the *rendered artifact itself* as the body,
-//     even though we asked for JSON. Never read that body (it can be tens of
-//     MB); abort the fetch immediately once the 200 status line is seen.
-//   - 400/500 + JSON `{ success: false, error }` on a terminal failure.
+//   - 200 + JSON body once ready — `data.artifacts[0].status === "ready"` is
+//     the readiness signal; `artifacts[0].url` is a tokened direct link to
+//     the artifact (unused here — `useCastArtifact.ts` downloads via the
+//     stable `?download=1` URL instead) and `blobUrl` is always `null`.
+//     Some responses may still come back as the rendered artifact itself
+//     (`Content-Type: video/mp4` etc., not JSON) rather than this JSON body —
+//     never read that body (it can be tens of MB); abort the fetch
+//     immediately once such a 200 status line is seen and treat it as ready.
+//   - 400/404/500 + JSON `{ success: false, error }` on a terminal failure,
+//     readable cross-origin — `error` is human-readable and safe to show
+//     verbatim.
 
 // Poll every 3s while rendering — cheap enough on the JSON path that there's
 // no reason to wait out the service's 30s Retry-After.
@@ -59,20 +66,32 @@ export function describeStatus({ status, phase, elapsedMs, slow }) {
   return `${label} ${formatElapsed(elapsedMs)}${suffix}`;
 }
 
-// Classifies a 202 (or any non-200 status other than the ones the caller
-// already special-cased) response body into what the poller/UI should do
-// next. Pure and separately unit-tested from the timer-driven engine below.
+// Classifies a `data.artifacts[0]` entry (shared by both a 202 and a JSON
+// 200 response) into what the poller/UI should do next.
+function classifyArtifact(body) {
+  const artifact = body?.data?.artifacts?.[0] ?? null;
+  if (artifact?.status === 'ready') {
+    return { kind: 'ready' };
+  }
+  if (artifact?.status === 'failed') {
+    return { kind: 'error', message: artifact.error || body?.error || 'Render failed.' };
+  }
+  return {
+    kind: 'rendering',
+    phase: artifact?.status === 'queued' ? 'queued' : 'processing',
+    progress: artifact?.progress ?? null,
+  };
+}
+
+// Classifies a poll response body into what the poller/UI should do next.
+// A 202 or a JSON 200 both carry the same `data.artifacts[0]` shape, so
+// "ready" is a check of that field rather than an inference from the HTTP
+// status code. Any other status (400/404/500/etc.) is a terminal error —
+// `body.error` is already human-readable and CORS-exposed by the service.
+// Pure and separately unit-tested from the timer-driven engine below.
 export function interpretPollResponse(status, body) {
-  if (status === 202) {
-    const artifact = body?.data?.artifacts?.[0] ?? null;
-    if (artifact?.status === 'failed') {
-      return { kind: 'error', message: artifact.error || body?.error || 'Render failed.' };
-    }
-    return {
-      kind: 'rendering',
-      phase: artifact?.status === 'queued' ? 'queued' : 'processing',
-      progress: artifact?.progress ?? null,
-    };
+  if (status === 202 || status === 200) {
+    return classifyArtifact(body);
   }
   return {
     kind: 'error',
@@ -124,11 +143,11 @@ export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedM
     clearTimeout(deadline);
     if (cancelled) return;
 
-    // Any 200 means ready, full stop — per the service's contract, a ready
-    // artifact is served as the file itself (not JSON) even though we asked
-    // for JSON. Abort right away so this poll doesn't transfer the file;
-    // the caller does a separate, explicit navigation to actually download.
-    if (response.status === 200) {
+    // A 200 with a non-JSON content type is the legacy/cached shape: a ready
+    // artifact served as the file itself, even though we asked for JSON.
+    // Abort right away so this poll doesn't transfer the file — the caller
+    // does a separate, explicit navigation to actually download.
+    if (response.status === 200 && !(response.headers.get('content-type') || '').toLowerCase().includes('json')) {
       controller.abort();
       onUpdate({ status: 'ready', elapsedMs });
       return;
@@ -144,6 +163,11 @@ export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedM
     if (cancelled) return;
 
     const outcome = interpretPollResponse(response.status, body);
+
+    if (outcome.kind === 'ready') {
+      onUpdate({ status: 'ready', elapsedMs });
+      return;
+    }
 
     if (outcome.kind === 'rendering') {
       onUpdate({

--- a/website/src/components/CastProArtifact/polling.mjs
+++ b/website/src/components/CastProArtifact/polling.mjs
@@ -1,0 +1,175 @@
+// Framework-agnostic polling engine for the Atmos Pro cast-rendering service's
+// status endpoint. Kept free of React so it can be unit-tested directly with
+// `node --test`, a mocked `fetch`, and fake timers (see polling.test.mjs).
+//
+// The service's contract (confirmed against a live probe, not just docs):
+//   - GET the artifact URL with `Accept: application/json` to poll status
+//     without transferring the rendered file.
+//   - 202 + JSON body while queued/rendering — read `data.artifacts[0].status`
+//     ("queued" | "processing" | "ready" | "failed") to distinguish queued vs.
+//     actively rendering, and `data.artifacts[0].progress` (optional,
+//     `{ percent, stage }`) when the service starts reporting it.
+//   - 200 once ready — but with the *rendered artifact itself* as the body,
+//     even though we asked for JSON. Never read that body (it can be tens of
+//     MB); abort the fetch immediately once the 200 status line is seen.
+//   - 400/500 + JSON `{ success: false, error }` on a terminal failure.
+
+// Poll every 3s while rendering — cheap enough on the JSON path that there's
+// no reason to wait out the service's 30s Retry-After.
+export const POLL_INTERVAL_MS = 3_000;
+
+// Long casts can legitimately take minutes to render. Past this much total
+// wait, slow the poll cadence down (no point hammering every 3s for renders
+// that are already running long) and let the UI say so.
+export const SLOWDOWN_THRESHOLD_MS = 13 * 60 * 1000;
+export const SLOW_POLL_INTERVAL_MS = 10_000;
+
+// Hard ceiling on total wait. Reaching it doesn't mean the render failed —
+// the service could still be working — so the message must say so rather
+// than reading as an error.
+export const MAX_WAIT_MS = 30 * 60 * 1000;
+
+export const STILL_RENDERING_MESSAGE =
+  'Still rendering after 30 minutes. The render may still finish — please try again in a few minutes.';
+export const NETWORK_ERROR_MESSAGE = 'Network error while checking render status.';
+
+export function isSlow(elapsedMs) {
+  return elapsedMs >= SLOWDOWN_THRESHOLD_MS;
+}
+
+export function nextPollIntervalMs(elapsedMs) {
+  return isSlow(elapsedMs) ? SLOW_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+}
+
+export function formatElapsed(ms) {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+// Renders a short status label for the busy states. Progress (when the
+// service starts sending it) is shown separately by the caller as a bar, not
+// folded into this text.
+export function describeStatus({ status, phase, elapsedMs, slow }) {
+  if (status === 'checking') return 'Checking…';
+  if (status !== 'rendering') return '';
+  const label = phase === 'queued' ? 'Queued…' : 'Rendering…';
+  const suffix = slow ? ' — taking longer than usual' : '';
+  return `${label} ${formatElapsed(elapsedMs)}${suffix}`;
+}
+
+// Classifies a 202 (or any non-200 status other than the ones the caller
+// already special-cased) response body into what the poller/UI should do
+// next. Pure and separately unit-tested from the timer-driven engine below.
+export function interpretPollResponse(status, body) {
+  if (status === 202) {
+    const artifact = body?.data?.artifacts?.[0] ?? null;
+    if (artifact?.status === 'failed') {
+      return { kind: 'error', message: artifact.error || body?.error || 'Render failed.' };
+    }
+    return {
+      kind: 'rendering',
+      phase: artifact?.status === 'queued' ? 'queued' : 'processing',
+      progress: artifact?.progress ?? null,
+    };
+  }
+  return {
+    kind: 'error',
+    message: body?.error || body?.message || `Render failed (HTTP ${status})`,
+  };
+}
+
+// Creates a poller for a single artifact URL. `onUpdate` is called with a
+// plain state object every time something changes:
+//   { status: 'rendering', phase, progress, elapsedMs, slow }
+//   { status: 'ready', elapsedMs }
+//   { status: 'error', errorMessage, elapsedMs }
+//
+// `initialElapsedMs` (default 0) lets tests start a poller already close to
+// the slowdown/ceiling thresholds instead of simulating the real timeline
+// tick by tick; real callers never need to pass it.
+export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedMs = 0 }) {
+  let cancelled = false;
+  let timeoutHandle = null;
+  let activeController = null;
+
+  async function poll(elapsedMs) {
+    if (cancelled) return;
+
+    if (elapsedMs >= MAX_WAIT_MS) {
+      onUpdate({ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs });
+      return;
+    }
+
+    const controller = new AbortController();
+    activeController = controller;
+    // Bound this fetch to the remaining wall-clock budget so a request that
+    // never settles can't hold the button disabled past MAX_WAIT_MS.
+    const deadline = setTimeout(() => controller.abort(), MAX_WAIT_MS - elapsedMs);
+
+    let response;
+    try {
+      response = await fetchImpl(url, { signal: controller.signal, headers: { Accept: 'application/json' } });
+    } catch {
+      clearTimeout(deadline);
+      if (cancelled) return;
+      onUpdate(
+        controller.signal.aborted
+          ? { status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }
+          : { status: 'error', errorMessage: NETWORK_ERROR_MESSAGE, elapsedMs },
+      );
+      return;
+    }
+    clearTimeout(deadline);
+    if (cancelled) return;
+
+    // Any 200 means ready, full stop — per the service's contract, a ready
+    // artifact is served as the file itself (not JSON) even though we asked
+    // for JSON. Abort right away so this poll doesn't transfer the file;
+    // the caller does a separate, explicit navigation to actually download.
+    if (response.status === 200) {
+      controller.abort();
+      onUpdate({ status: 'ready', elapsedMs });
+      return;
+    }
+
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {
+      // Ignore JSON parse errors — the classifier below falls back to a
+      // generic message/rendering state.
+    }
+    if (cancelled) return;
+
+    const outcome = interpretPollResponse(response.status, body);
+
+    if (outcome.kind === 'rendering') {
+      onUpdate({
+        status: 'rendering',
+        phase: outcome.phase,
+        progress: outcome.progress,
+        elapsedMs,
+        slow: isSlow(elapsedMs),
+      });
+      const interval = nextPollIntervalMs(elapsedMs);
+      timeoutHandle = setTimeout(() => void poll(elapsedMs + interval), interval);
+      return;
+    }
+
+    onUpdate({ status: 'error', errorMessage: outcome.message, elapsedMs });
+  }
+
+  return {
+    start() {
+      cancelled = false;
+      void poll(initialElapsedMs);
+    },
+    cancel() {
+      cancelled = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (activeController) activeController.abort();
+    },
+  };
+}

--- a/website/src/components/CastProArtifact/polling.mjs
+++ b/website/src/components/CastProArtifact/polling.mjs
@@ -107,24 +107,45 @@ export function interpretPollResponse(status, body) {
 //
 // `initialElapsedMs` (default 0) lets tests start a poller already close to
 // the slowdown/ceiling thresholds instead of simulating the real timeline
-// tick by tick; real callers never need to pass it.
-export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedMs = 0 }) {
+// tick by tick; real callers never need to pass it. `now` (default
+// `Date.now`) is the monotonic clock used to compute elapsed time — tests
+// mock it (via `node:test`'s `Date` mock timer) so the ceiling can be
+// exercised deterministically without a real 30-minute wait.
+//
+// Elapsed time is always derived from `now() - startedAt`, never accumulated
+// as a nominal counter of poll intervals. A poll interval only tells the
+// poller when to check again — it says nothing about how long that check
+// itself takes. Deriving elapsed time from actual wall-clock time (rather
+// than "polls so far * interval") is what makes MAX_WAIT_MS a real ceiling
+// on total wait even when an individual round trip runs long: a slow poll
+// can't quietly hand the next poll a fresh budget.
+export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedMs = 0, now = Date.now }) {
   let cancelled = false;
   let timeoutHandle = null;
   let activeController = null;
+  let startedAt = 0;
 
-  async function poll(elapsedMs) {
+  function elapsed() {
+    return now() - startedAt;
+  }
+
+  async function poll() {
     if (cancelled) return;
 
+    const elapsedMs = elapsed();
     if (elapsedMs >= MAX_WAIT_MS) {
-      onUpdate({ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs });
+      onUpdate({ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS });
       return;
     }
 
     const controller = new AbortController();
     activeController = controller;
-    // Bound this fetch to the remaining wall-clock budget so a request that
-    // never settles can't hold the button disabled past MAX_WAIT_MS.
+    // Bound the *entire* round trip — the fetch AND the subsequent JSON body
+    // read — to the remaining wall-clock budget, so neither a stalled
+    // request nor a hanging body stream can hold the button disabled past
+    // MAX_WAIT_MS. Aborting the controller cancels an in-flight
+    // `response.json()` read too (the body reader is tied to the same
+    // signal), so this deadline stays live until the body has been read.
     const deadline = setTimeout(() => controller.abort(), MAX_WAIT_MS - elapsedMs);
 
     let response;
@@ -136,20 +157,19 @@ export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedM
       onUpdate(
         controller.signal.aborted
           ? { status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }
-          : { status: 'error', errorMessage: NETWORK_ERROR_MESSAGE, elapsedMs },
+          : { status: 'error', errorMessage: NETWORK_ERROR_MESSAGE, elapsedMs: elapsed() },
       );
       return;
     }
-    clearTimeout(deadline);
-    if (cancelled) return;
 
     // A 200 with a non-JSON content type is the legacy/cached shape: a ready
     // artifact served as the file itself, even though we asked for JSON.
     // Abort right away so this poll doesn't transfer the file — the caller
     // does a separate, explicit navigation to actually download.
     if (response.status === 200 && !(response.headers.get('content-type') || '').toLowerCase().includes('json')) {
+      clearTimeout(deadline);
       controller.abort();
-      onUpdate({ status: 'ready', elapsedMs });
+      onUpdate({ status: 'ready', elapsedMs: elapsed() });
       return;
     }
 
@@ -160,12 +180,22 @@ export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedM
       // Ignore JSON parse errors — the classifier below falls back to a
       // generic message/rendering state.
     }
+    clearTimeout(deadline);
     if (cancelled) return;
 
+    if (controller.signal.aborted) {
+      // The remaining budget ran out while the body was still being read —
+      // report the ceiling rather than treating the aborted read as a
+      // legitimate (if empty) response.
+      onUpdate({ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS });
+      return;
+    }
+
     const outcome = interpretPollResponse(response.status, body);
+    const currentElapsed = elapsed();
 
     if (outcome.kind === 'ready') {
-      onUpdate({ status: 'ready', elapsedMs });
+      onUpdate({ status: 'ready', elapsedMs: currentElapsed });
       return;
     }
 
@@ -174,21 +204,22 @@ export function createPoller({ url, onUpdate, fetchImpl = fetch, initialElapsedM
         status: 'rendering',
         phase: outcome.phase,
         progress: outcome.progress,
-        elapsedMs,
-        slow: isSlow(elapsedMs),
+        elapsedMs: currentElapsed,
+        slow: isSlow(currentElapsed),
       });
-      const interval = nextPollIntervalMs(elapsedMs);
-      timeoutHandle = setTimeout(() => void poll(elapsedMs + interval), interval);
+      const interval = nextPollIntervalMs(currentElapsed);
+      timeoutHandle = setTimeout(() => void poll(), interval);
       return;
     }
 
-    onUpdate({ status: 'error', errorMessage: outcome.message, elapsedMs });
+    onUpdate({ status: 'error', errorMessage: outcome.message, elapsedMs: currentElapsed });
   }
 
   return {
     start() {
       cancelled = false;
-      void poll(initialElapsedMs);
+      startedAt = now() - initialElapsedMs;
+      void poll();
     },
     cancel() {
       cancelled = true;

--- a/website/src/components/CastProArtifact/polling.test.mjs
+++ b/website/src/components/CastProArtifact/polling.test.mjs
@@ -16,18 +16,26 @@ import {
   nextPollIntervalMs,
 } from './polling.mjs';
 
+function headers(contentType) {
+  return { get: (name) => (name.toLowerCase() === 'content-type' ? contentType : null) };
+}
+
 function jsonResponse(status, data) {
   return {
     status,
+    headers: headers('application/json'),
     json: async () => data,
   };
 }
 
-function readyResponse() {
+// The legacy/cached shape: a ready artifact served as the file itself
+// (non-JSON content type), which must be aborted without ever being read.
+function legacyReadyResponse() {
   let jsonCalled = false;
   return {
     response: {
       status: 200,
+      headers: headers('video/mp4'),
       json: async () => {
         jsonCalled = true;
         return {};
@@ -81,6 +89,32 @@ test('interpretPollResponse: 202 "processing" artifact status carries progress t
   });
 });
 
+test('interpretPollResponse: 200 with a "ready" artifact status is ready', () => {
+  const outcome = interpretPollResponse(200, {
+    data: { artifacts: [{ status: 'ready', url: 'https://example.test/token', progress: null }] },
+  });
+  assert.deepEqual(outcome, { kind: 'ready' });
+});
+
+test('interpretPollResponse: 200 with a "processing" artifact status is still rendering', () => {
+  const outcome = interpretPollResponse(200, {
+    data: { artifacts: [{ status: 'processing', progress: { percent: 40, stage: 'encoding' } }] },
+  });
+  assert.deepEqual(outcome, {
+    kind: 'rendering',
+    phase: 'processing',
+    progress: { percent: 40, stage: 'encoding' },
+  });
+});
+
+test('interpretPollResponse: 404 surfaces the not-found message verbatim', () => {
+  const outcome = interpretPollResponse(404, {
+    success: false,
+    error: 'Cast file was not found at the requested commit and path',
+  });
+  assert.deepEqual(outcome, { kind: 'error', message: 'Cast file was not found at the requested commit and path' });
+});
+
 test('interpretPollResponse: 202 with a "failed" artifact is terminal', () => {
   const outcome = interpretPollResponse(202, {
     data: { artifacts: [{ status: 'failed', error: 'ffmpeg crashed' }] },
@@ -127,9 +161,9 @@ test('describeStatus labels queued vs. processing and flags a slow render', () =
   );
 });
 
-test('createPoller: 202 -> 202 -> 200 downloads exactly once and polls every 3s', async (t) => {
+test('createPoller: 202 -> 202 -> legacy non-JSON 200 downloads exactly once and polls every 3s', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] });
-  const ready = readyResponse();
+  const ready = legacyReadyResponse();
   const { fetchImpl, calls } = queueFetch([
     jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
     jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
@@ -153,15 +187,15 @@ test('createPoller: 202 -> 202 -> 200 downloads exactly once and polls every 3s'
   assert.equal(updates[2].status, 'ready');
 
   assert.equal(calls.length, 3);
-  assert.equal(ready.jsonCalled, false, 'the ready (200) response body must never be read');
+  assert.equal(ready.jsonCalled, false, 'the legacy non-JSON 200 response body must never be read');
 
   const readyUpdates = updates.filter((u) => u.status === 'ready');
   assert.equal(readyUpdates.length, 1, 'must reach the ready state exactly once');
 });
 
-test('createPoller: an immediate 200 is ready right away without reading the body', async (t) => {
+test('createPoller: an immediate legacy non-JSON 200 is ready right away without reading the body', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] });
-  const ready = readyResponse();
+  const ready = legacyReadyResponse();
   const { fetchImpl, calls } = queueFetch([ready.response]);
 
   const updates = [];
@@ -173,6 +207,66 @@ test('createPoller: an immediate 200 is ready right away without reading the bod
   assert.equal(calls.length, 1);
   assert.deepEqual(updates, [{ status: 'ready', elapsedMs: 0 }]);
   assert.equal(ready.jsonCalled, false);
+});
+
+test('createPoller: an immediate 200 JSON body with status "ready" downloads right away', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl, calls } = queueFetch([
+    jsonResponse(200, { data: { artifacts: [{ status: 'ready', url: 'https://example.test/token', progress: null }] } }),
+  ]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(updates, [{ status: 'ready', elapsedMs: 0 }]);
+});
+
+test('createPoller: a 200 JSON body with status "processing" keeps rendering and polls again', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl, calls } = queueFetch([
+    jsonResponse(200, { data: { artifacts: [{ status: 'processing', progress: { percent: 40, stage: 'encoding' } }] } }),
+    jsonResponse(200, { data: { artifacts: [{ status: 'ready', progress: null }] } }),
+  ]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+  assert.equal(updates.length, 1);
+  assert.deepEqual(updates[0], {
+    status: 'rendering',
+    phase: 'processing',
+    progress: { percent: 40, stage: 'encoding' },
+    elapsedMs: 0,
+    slow: false,
+  });
+
+  await tick(t, POLL_INTERVAL_MS);
+  assert.equal(calls.length, 2, 'must poll again instead of getting stuck on the interim 200');
+  assert.equal(updates.length, 2);
+  assert.equal(updates[1].status, 'ready');
+});
+
+test('createPoller: a 404 surfaces the "not found" message inline instead of a network error', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl } = queueFetch([
+    jsonResponse(404, { success: false, error: 'Cast file was not found at the requested commit and path' }),
+  ]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+
+  assert.deepEqual(updates, [
+    { status: 'error', errorMessage: 'Cast file was not found at the requested commit and path', elapsedMs: 0 },
+  ]);
 });
 
 test('createPoller: 500 surfaces the JSON error inline and never navigates', async (t) => {

--- a/website/src/components/CastProArtifact/polling.test.mjs
+++ b/website/src/components/CastProArtifact/polling.test.mjs
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MAX_WAIT_MS,
+  NETWORK_ERROR_MESSAGE,
+  POLL_INTERVAL_MS,
+  SLOWDOWN_THRESHOLD_MS,
+  SLOW_POLL_INTERVAL_MS,
+  STILL_RENDERING_MESSAGE,
+  createPoller,
+  describeStatus,
+  formatElapsed,
+  interpretPollResponse,
+  isSlow,
+  nextPollIntervalMs,
+} from './polling.mjs';
+
+function jsonResponse(status, data) {
+  return {
+    status,
+    json: async () => data,
+  };
+}
+
+function readyResponse() {
+  let jsonCalled = false;
+  return {
+    response: {
+      status: 200,
+      json: async () => {
+        jsonCalled = true;
+        return {};
+      },
+    },
+    get jsonCalled() {
+      return jsonCalled;
+    },
+  };
+}
+
+function queueFetch(responses) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (responses.length === 0) throw new Error('fetch mock exhausted its queued responses');
+    const next = responses.shift();
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  return { fetchImpl, calls };
+}
+
+// Advances fake timers and drains the microtask queue a few times so any
+// chained `await fetch()` / `await response.json()` inside the poller's
+// timer callback gets a chance to run before the next assertion.
+async function tick(t, ms) {
+  t.mock.timers.tick(ms);
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+}
+
+async function flush() {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+}
+
+test('interpretPollResponse: 202 "queued" artifact status', () => {
+  const outcome = interpretPollResponse(202, {
+    data: { artifacts: [{ status: 'queued', progress: null }] },
+  });
+  assert.deepEqual(outcome, { kind: 'rendering', phase: 'queued', progress: null });
+});
+
+test('interpretPollResponse: 202 "processing" artifact status carries progress through', () => {
+  const outcome = interpretPollResponse(202, {
+    data: { artifacts: [{ status: 'processing', progress: { percent: 40, stage: 'encoding' } }] },
+  });
+  assert.deepEqual(outcome, {
+    kind: 'rendering',
+    phase: 'processing',
+    progress: { percent: 40, stage: 'encoding' },
+  });
+});
+
+test('interpretPollResponse: 202 with a "failed" artifact is terminal', () => {
+  const outcome = interpretPollResponse(202, {
+    data: { artifacts: [{ status: 'failed', error: 'ffmpeg crashed' }] },
+  });
+  assert.deepEqual(outcome, { kind: 'error', message: 'ffmpeg crashed' });
+});
+
+test('interpretPollResponse: 500 reads the top-level error verbatim', () => {
+  const outcome = interpretPollResponse(500, { success: false, error: 'render backend unavailable' });
+  assert.deepEqual(outcome, { kind: 'error', message: 'render backend unavailable' });
+});
+
+test('interpretPollResponse: falls back to a generic message when the body has no error', () => {
+  const outcome = interpretPollResponse(400, null);
+  assert.deepEqual(outcome, { kind: 'error', message: 'Render failed (HTTP 400)' });
+});
+
+test('nextPollIntervalMs/isSlow switch at the 13-minute threshold', () => {
+  assert.equal(isSlow(SLOWDOWN_THRESHOLD_MS - 1), false);
+  assert.equal(nextPollIntervalMs(SLOWDOWN_THRESHOLD_MS - 1), POLL_INTERVAL_MS);
+  assert.equal(isSlow(SLOWDOWN_THRESHOLD_MS), true);
+  assert.equal(nextPollIntervalMs(SLOWDOWN_THRESHOLD_MS), SLOW_POLL_INTERVAL_MS);
+});
+
+test('formatElapsed renders m:ss', () => {
+  assert.equal(formatElapsed(0), '0:00');
+  assert.equal(formatElapsed(65_000), '1:05');
+  assert.equal(formatElapsed(13 * 60 * 1000), '13:00');
+});
+
+test('describeStatus labels queued vs. processing and flags a slow render', () => {
+  assert.equal(describeStatus({ status: 'checking' }), 'Checking…');
+  assert.equal(
+    describeStatus({ status: 'rendering', phase: 'queued', elapsedMs: 5_000, slow: false }),
+    'Queued… 0:05',
+  );
+  assert.equal(
+    describeStatus({ status: 'rendering', phase: 'processing', elapsedMs: 5_000, slow: false }),
+    'Rendering… 0:05',
+  );
+  assert.equal(
+    describeStatus({ status: 'rendering', phase: 'processing', elapsedMs: 800_000, slow: true }),
+    'Rendering… 13:20 — taking longer than usual',
+  );
+});
+
+test('createPoller: 202 -> 202 -> 200 downloads exactly once and polls every 3s', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const ready = readyResponse();
+  const { fetchImpl, calls } = queueFetch([
+    jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
+    jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
+    ready.response,
+  ]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].status, 'rendering');
+
+  await tick(t, POLL_INTERVAL_MS);
+  assert.equal(updates.length, 2);
+  assert.equal(updates[1].status, 'rendering');
+
+  await tick(t, POLL_INTERVAL_MS);
+  assert.equal(updates.length, 3);
+  assert.equal(updates[2].status, 'ready');
+
+  assert.equal(calls.length, 3);
+  assert.equal(ready.jsonCalled, false, 'the ready (200) response body must never be read');
+
+  const readyUpdates = updates.filter((u) => u.status === 'ready');
+  assert.equal(readyUpdates.length, 1, 'must reach the ready state exactly once');
+});
+
+test('createPoller: an immediate 200 is ready right away without reading the body', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const ready = readyResponse();
+  const { fetchImpl, calls } = queueFetch([ready.response]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.gif', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(updates, [{ status: 'ready', elapsedMs: 0 }]);
+  assert.equal(ready.jsonCalled, false);
+});
+
+test('createPoller: 500 surfaces the JSON error inline and never navigates', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl } = queueFetch([jsonResponse(500, { success: false, error: 'render backend unavailable' })]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.webm', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+
+  assert.deepEqual(updates, [{ status: 'error', errorMessage: 'render backend unavailable', elapsedMs: 0 }]);
+});
+
+test('createPoller: a 202 seen past 13 minutes elapsed marks the render slow and polls at 10s', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl } = queueFetch([
+    jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
+  ]);
+
+  const updates = [];
+  const poller = createPoller({
+    url: 'https://example.test/cast.mp4',
+    fetchImpl,
+    onUpdate: (u) => updates.push(u),
+    initialElapsedMs: SLOWDOWN_THRESHOLD_MS,
+  });
+
+  poller.start();
+  await flush();
+
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].status, 'rendering');
+  assert.equal(updates[0].slow, true);
+});
+
+test('createPoller: gives up at the 30-minute ceiling with a non-failure message, without polling again', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl, calls } = queueFetch([]);
+
+  const updates = [];
+  const poller = createPoller({
+    url: 'https://example.test/cast.mp4',
+    fetchImpl,
+    onUpdate: (u) => updates.push(u),
+    initialElapsedMs: MAX_WAIT_MS,
+  });
+
+  poller.start();
+  await flush();
+
+  assert.equal(calls.length, 0, 'must not fetch again once the ceiling is already reached');
+  assert.deepEqual(updates, [{ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }]);
+});
+
+test('createPoller: a hung fetch is aborted at the remaining budget and reported as still-rendering', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const fetchImpl = (url, init) =>
+    new Promise((_resolve, reject) => {
+      init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+    });
+
+  const updates = [];
+  const poller = createPoller({
+    url: 'https://example.test/cast.mp4',
+    fetchImpl,
+    onUpdate: (u) => updates.push(u),
+    initialElapsedMs: MAX_WAIT_MS - 5_000,
+  });
+
+  poller.start();
+  await flush();
+  await tick(t, 5_000);
+
+  assert.deepEqual(updates, [{ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }]);
+});
+
+test('createPoller: a genuine network failure (not our own abort) is reported distinctly', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const fetchImpl = async () => {
+    throw new TypeError('Failed to fetch');
+  };
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+
+  assert.deepEqual(updates, [{ status: 'error', errorMessage: NETWORK_ERROR_MESSAGE, elapsedMs: 0 }]);
+});
+
+test('createPoller: cancel() stops a pending poll from ever firing', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { fetchImpl, calls } = queueFetch([
+    jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
+  ]);
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+  assert.equal(updates.length, 1);
+
+  poller.cancel();
+  await tick(t, POLL_INTERVAL_MS);
+
+  assert.equal(calls.length, 1, 'no further fetch after cancel()');
+  assert.equal(updates.length, 1, 'no further updates after cancel()');
+});

--- a/website/src/components/CastProArtifact/polling.test.mjs
+++ b/website/src/components/CastProArtifact/polling.test.mjs
@@ -162,7 +162,7 @@ test('describeStatus labels queued vs. processing and flags a slow render', () =
 });
 
 test('createPoller: 202 -> 202 -> legacy non-JSON 200 downloads exactly once and polls every 3s', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const ready = legacyReadyResponse();
   const { fetchImpl, calls } = queueFetch([
     jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
@@ -194,7 +194,7 @@ test('createPoller: 202 -> 202 -> legacy non-JSON 200 downloads exactly once and
 });
 
 test('createPoller: an immediate legacy non-JSON 200 is ready right away without reading the body', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const ready = legacyReadyResponse();
   const { fetchImpl, calls } = queueFetch([ready.response]);
 
@@ -210,7 +210,7 @@ test('createPoller: an immediate legacy non-JSON 200 is ready right away without
 });
 
 test('createPoller: an immediate 200 JSON body with status "ready" downloads right away', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl, calls } = queueFetch([
     jsonResponse(200, { data: { artifacts: [{ status: 'ready', url: 'https://example.test/token', progress: null }] } }),
   ]);
@@ -226,7 +226,7 @@ test('createPoller: an immediate 200 JSON body with status "ready" downloads rig
 });
 
 test('createPoller: a 200 JSON body with status "processing" keeps rendering and polls again', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl, calls } = queueFetch([
     jsonResponse(200, { data: { artifacts: [{ status: 'processing', progress: { percent: 40, stage: 'encoding' } }] } }),
     jsonResponse(200, { data: { artifacts: [{ status: 'ready', progress: null }] } }),
@@ -253,7 +253,7 @@ test('createPoller: a 200 JSON body with status "processing" keeps rendering and
 });
 
 test('createPoller: a 404 surfaces the "not found" message inline instead of a network error', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl } = queueFetch([
     jsonResponse(404, { success: false, error: 'Cast file was not found at the requested commit and path' }),
   ]);
@@ -270,7 +270,7 @@ test('createPoller: a 404 surfaces the "not found" message inline instead of a n
 });
 
 test('createPoller: 500 surfaces the JSON error inline and never navigates', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl } = queueFetch([jsonResponse(500, { success: false, error: 'render backend unavailable' })]);
 
   const updates = [];
@@ -283,7 +283,7 @@ test('createPoller: 500 surfaces the JSON error inline and never navigates', asy
 });
 
 test('createPoller: a 202 seen past 13 minutes elapsed marks the render slow and polls at 10s', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl } = queueFetch([
     jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
   ]);
@@ -305,7 +305,7 @@ test('createPoller: a 202 seen past 13 minutes elapsed marks the render slow and
 });
 
 test('createPoller: gives up at the 30-minute ceiling with a non-failure message, without polling again', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl, calls } = queueFetch([]);
 
   const updates = [];
@@ -324,7 +324,7 @@ test('createPoller: gives up at the 30-minute ceiling with a non-failure message
 });
 
 test('createPoller: a hung fetch is aborted at the remaining budget and reported as still-rendering', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const fetchImpl = (url, init) =>
     new Promise((_resolve, reject) => {
       init.signal.addEventListener('abort', () => reject(new Error('aborted')));
@@ -345,8 +345,82 @@ test('createPoller: a hung fetch is aborted at the remaining budget and reported
   assert.deepEqual(updates, [{ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }]);
 });
 
+test('createPoller: a slow round trip consumes real wall-clock time toward the ceiling, not just the nominal poll interval', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+  // The first poll's fetch doesn't resolve for 29 minutes — nearly the
+  // entire budget — before finally returning a "still rendering" 202. A
+  // poller that tracked elapsed time as a nominal counter (polls-so-far *
+  // interval) would see this as elapsedMs === 0 and hand the next poll a
+  // fresh 30-minute budget; a wall-clock-based poller must instead see
+  // elapsedMs ~= 29 minutes and enforce the ceiling shortly after, not
+  // ~29 minutes later still.
+  const slowDelayMs = 29 * 60 * 1000;
+  let resolveFetch;
+  // Real fetch rejects an in-flight request when its AbortSignal fires; the
+  // mock must do the same so the second poll's own deadline (asserted below)
+  // can actually cut it off instead of hanging forever.
+  const fetchImpl = (url, init) =>
+    new Promise((resolve, reject) => {
+      resolveFetch = () =>
+        resolve(jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }));
+      init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+    });
+
+  const updates = [];
+  const poller = createPoller({ url: 'https://example.test/cast.mp4', fetchImpl, onUpdate: (u) => updates.push(u) });
+
+  poller.start();
+  await flush();
+  await tick(t, slowDelayMs);
+  resolveFetch();
+  await flush();
+
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].status, 'rendering');
+  assert.equal(updates[0].elapsedMs, slowDelayMs, 'must report true wall-clock elapsed, not the nominal 0');
+
+  // The reschedule (slowed to 10s past the 13-minute threshold) must respect
+  // the real remaining budget (~1 minute) rather than restarting a fresh
+  // 30-minute window from this poll's nominal elapsedMs.
+  await tick(t, SLOW_POLL_INTERVAL_MS);
+  await tick(t, MAX_WAIT_MS - slowDelayMs - SLOW_POLL_INTERVAL_MS);
+
+  assert.equal(updates.length, 2);
+  assert.deepEqual(updates[1], { status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS });
+});
+
+test('createPoller: a 202 response whose JSON body hangs forever is aborted at the deadline and reported as still-rendering', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+  const fetchImpl = (url, init) =>
+    Promise.resolve({
+      status: 202,
+      headers: headers('application/json'),
+      // Mirrors real fetch semantics: response.json()'s body read is tied to
+      // the same AbortSignal as the request, so aborting the controller
+      // after fetch() has already resolved still rejects a pending read.
+      json: () =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    });
+
+  const updates = [];
+  const poller = createPoller({
+    url: 'https://example.test/cast.mp4',
+    fetchImpl,
+    onUpdate: (u) => updates.push(u),
+    initialElapsedMs: MAX_WAIT_MS - 5_000,
+  });
+
+  poller.start();
+  await flush();
+  await tick(t, 5_000);
+
+  assert.deepEqual(updates, [{ status: 'error', errorMessage: STILL_RENDERING_MESSAGE, elapsedMs: MAX_WAIT_MS }]);
+});
+
 test('createPoller: a genuine network failure (not our own abort) is reported distinctly', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const fetchImpl = async () => {
     throw new TypeError('Failed to fetch');
   };
@@ -361,7 +435,7 @@ test('createPoller: a genuine network failure (not our own abort) is reported di
 });
 
 test('createPoller: cancel() stops a pending poll from ever firing', async (t) => {
-  t.mock.timers.enable({ apis: ['setTimeout'] });
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const { fetchImpl, calls } = queueFetch([
     jsonResponse(202, { data: { artifacts: [{ status: 'processing', progress: null }] } }),
   ]);

--- a/website/src/components/CastProArtifact/useCastArtifact.ts
+++ b/website/src/components/CastProArtifact/useCastArtifact.ts
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { createPoller } from './polling.mjs';
 import { buildArtifactUrl, CAST_FORMATS } from './url.mjs';
 
 export type CastFormat = (typeof CAST_FORMATS)[number];
 export type ArtifactStatus = 'idle' | 'checking' | 'rendering' | 'ready' | 'error';
+export type RenderPhase = 'queued' | 'processing' | null;
+
+export interface CastArtifactProgress {
+  percent: number;
+  stage: string;
+}
 
 export interface UseCastArtifactParams {
   owner?: string;
@@ -17,16 +24,37 @@ export interface UseCastArtifactParams {
 
 export interface UseCastArtifactResult {
   status: ArtifactStatus;
+  phase: RenderPhase;
+  progress: CastArtifactProgress | null;
+  elapsedMs: number;
+  slow: boolean;
   errorMessage: string | null;
   url: string;
   // Checks the render status and, once ready, navigates the browser to the
-  // artifact (forcing a download). While rendering, polls on Retry-After up
-  // to a capped total wait before surfacing an error.
+  // artifact (forcing a download). While rendering, polls the JSON status
+  // endpoint (see polling.mjs) at a fixed cadence that slows down past a
+  // threshold, up to a hard wall-clock ceiling before surfacing a
+  // "still rendering" message.
   start: () => void;
 }
 
-const MAX_WAIT_MS = 60_000;
-const DEFAULT_RETRY_SECONDS = 2;
+interface PollerState {
+  status: ArtifactStatus;
+  phase: RenderPhase;
+  progress: CastArtifactProgress | null;
+  elapsedMs: number;
+  slow: boolean;
+  errorMessage: string | null;
+}
+
+const IDLE_STATE: PollerState = {
+  status: 'idle',
+  phase: null,
+  progress: null,
+  elapsedMs: 0,
+  slow: false,
+  errorMessage: null,
+};
 
 export function useCastArtifact({
   owner,
@@ -37,13 +65,15 @@ export function useCastArtifact({
   ttlSeconds,
   soundtrack,
 }: UseCastArtifactParams): UseCastArtifactResult {
-  const [status, setStatus] = useState<ArtifactStatus>('idle');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [state, setState] = useState<PollerState>(IDLE_STATE);
+  const pollerRef = useRef<ReturnType<typeof createPoller> | null>(null);
   // A generation counter (rather than a single shared boolean) isolates each
   // request: a boolean reset synchronously by the next effect run would
-  // un-cancel an older in-flight request as soon as `url` changes, letting it
-  // still update state or navigate to the stale artifact.
+  // un-cancel an older in-flight poller as soon as `url` changes, letting it
+  // still update state or navigate to the stale artifact. The poller's own
+  // `cancel()` already stops it from scheduling further polls, but this is
+  // kept as a second guard against a stale `onUpdate` landing after a newer
+  // poller has started.
   const generationRef = useRef(0);
 
   const url = useMemo(
@@ -55,87 +85,35 @@ export function useCastArtifact({
     generationRef.current += 1;
     return () => {
       generationRef.current += 1;
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      pollerRef.current?.cancel();
     };
   }, [url]);
 
-  const check = useCallback(
-    async (elapsedMs: number, generation: number) => {
-      if (generationRef.current !== generation) return;
-
-      // Bound each fetch to the remaining wall-clock budget so a request that
-      // never settles can't hold the format control disabled past MAX_WAIT_MS.
-      const controller = new AbortController();
-      const deadline = setTimeout(() => controller.abort(), Math.max(MAX_WAIT_MS - elapsedMs, 0));
-
-      let response: Response;
-      try {
-        response = await fetch(url, { signal: controller.signal });
-      } catch {
-        clearTimeout(deadline);
-        if (generationRef.current !== generation) return;
-        setStatus('error');
-        setErrorMessage(
-          controller.signal.aborted
-            ? 'Still rendering after 60s. Please try again in a moment.'
-            : 'Network error while checking render status.',
-        );
-        return;
-      }
-      clearTimeout(deadline);
-      if (generationRef.current !== generation) return;
-
-      if (response.ok) {
-        setStatus('ready');
-        const downloadUrl = new URL(url);
-        downloadUrl.searchParams.set('download', '1');
-        window.location.href = downloadUrl.toString();
-        return;
-      }
-
-      if (response.status === 202) {
-        const retryAfterHeader = response.headers.get('Retry-After');
-        const retrySeconds = retryAfterHeader ? Number(retryAfterHeader) : NaN;
-        const retryMs =
-          (Number.isFinite(retrySeconds) && retrySeconds > 0 ? retrySeconds : DEFAULT_RETRY_SECONDS) * 1000;
-        const nextElapsedMs = elapsedMs + retryMs;
-
-        if (nextElapsedMs > MAX_WAIT_MS) {
-          setStatus('error');
-          setErrorMessage('Still rendering after 60s. Please try again in a moment.');
-          return;
-        }
-
-        setStatus('rendering');
-        timeoutRef.current = setTimeout(() => void check(nextElapsedMs, generation), retryMs);
-        return;
-      }
-
-      let message = `Render failed (HTTP ${response.status})`;
-      try {
-        const body = await response.json();
-        message = body?.error || body?.message || message;
-      } catch {
-        // Ignore JSON parse errors — fall back to the generic HTTP message.
-      }
-      if (generationRef.current !== generation) return;
-      setStatus('error');
-      setErrorMessage(message);
-    },
-    [url],
-  );
-
   const start = useCallback(() => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    pollerRef.current?.cancel();
     // Bump the generation here too, not just on `url` change — otherwise a
     // repeated start() for the same url (e.g. a double click before the
     // control disables) would share a generation with a still-live prior
-    // request and let it apply its result after this one begins.
+    // poller and let it apply its result after this one begins.
     generationRef.current += 1;
-    setErrorMessage(null);
-    setStatus('checking');
-    void check(0, generationRef.current);
-  }, [check]);
+    const generation = generationRef.current;
+    setState({ ...IDLE_STATE, status: 'checking' });
 
-  return { status, errorMessage, url, start };
+    const poller = createPoller({
+      url,
+      onUpdate: (update: Partial<PollerState> & { status: ArtifactStatus }) => {
+        if (generationRef.current !== generation) return;
+        setState((prev) => ({ ...prev, ...update }));
+        if (update.status === 'ready') {
+          const downloadUrl = new URL(url);
+          downloadUrl.searchParams.set('download', '1');
+          window.location.href = downloadUrl.toString();
+        }
+      },
+    });
+    pollerRef.current = poller;
+    poller.start();
+  }, [url]);
+
+  return { ...state, url, start };
 }

--- a/website/src/components/CastProArtifact/useCastArtifact.ts
+++ b/website/src/components/CastProArtifact/useCastArtifact.ts
@@ -83,6 +83,12 @@ export function useCastArtifact({
 
   useEffect(() => {
     generationRef.current += 1;
+    // A previous poller (for the old `url`) may have left `state.status`
+    // stuck at 'checking'/'rendering' — its cleanup below cancels it, but
+    // cancelling doesn't reset state. Without this, the new url would start
+    // with `busy` still true and no active poller to ever clear it, leaving
+    // the download button permanently disabled.
+    setState(IDLE_STATE);
     return () => {
       generationRef.current += 1;
       pollerRef.current?.cancel();
@@ -103,7 +109,13 @@ export function useCastArtifact({
       url,
       onUpdate: (update: Partial<PollerState> & { status: ArtifactStatus }) => {
         if (generationRef.current !== generation) return;
-        setState((prev) => ({ ...prev, ...update }));
+        // Terminal updates ('ready'/'error') omit `phase`/`progress`/`slow` —
+        // merging them onto `prev` would leave the last rendering progress
+        // showing beside a ready/error state. Drop back to IDLE_STATE first
+        // for terminal updates so those transient fields clear.
+        setState((prev) =>
+          update.status === 'rendering' ? { ...prev, ...update } : { ...IDLE_STATE, ...update },
+        );
         if (update.status === 'ready') {
           const downloadUrl = new URL(url);
           downloadUrl.searchParams.set('download', '1');

--- a/website/src/components/CastProDownload/index.tsx
+++ b/website/src/components/CastProDownload/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { FiAlertCircle, FiChevronDown, FiDownload, FiLoader } from 'react-icons/fi';
 
+import { describeStatus } from '../CastProArtifact/polling.mjs';
 import { CAST_FORMATS } from '../CastProArtifact/url.mjs';
 import { CastFormat, useCastArtifact } from '../CastProArtifact/useCastArtifact';
 
@@ -40,7 +41,7 @@ function FormatMenuItem({
   ttlSeconds,
   soundtrack,
 }: FormatMenuItemProps): JSX.Element {
-  const { status, errorMessage, start } = useCastArtifact({
+  const { status, phase, progress, elapsedMs, slow, errorMessage, start } = useCastArtifact({
     owner,
     repo,
     ref: gitRef,
@@ -50,6 +51,8 @@ function FormatMenuItem({
     soundtrack,
   });
   const busy = status === 'checking' || status === 'rendering';
+  const hint = busy ? describeStatus({ status, phase, elapsedMs, slow }) : null;
+  const progressPercent = progress ? Math.min(100, Math.max(0, progress.percent)) : null;
 
   return (
     <div className={styles.menuItemGroup}>
@@ -68,7 +71,12 @@ function FormatMenuItem({
           <FiDownload className={styles.icon} aria-hidden="true" />
         )}
         <span>{format.toUpperCase()}</span>
-        {status === 'rendering' && <span className={styles.hint}>Rendering…</span>}
+        {hint && <span className={styles.hint}>{hint}</span>}
+        {progressPercent !== null && (
+          <span className={styles.progressTrack} title={progress.stage}>
+            <span className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
+          </span>
+        )}
       </button>
       {status === 'error' && errorMessage && (
         <p className={styles.errorText} role="alert">
@@ -83,11 +91,13 @@ function FormatMenuItem({
  * "Download ▾" split button offering rendered GIF/MP4/SVG/WEBM artifacts of a
  * .cast file from the Atmos Pro cast-rendering service
  * (https://atmos-pro.com/casts/{owner}/{repo}/{ref}/{path}.cast.{format}).
- * Handles the render service's three response shapes: an already-rendered
- * artifact (triggers a native browser download), a still-rendering one
- * (polls on Retry-After, capped at ~60s), and a hard error — surfaced inline
- * beneath the selected format button, whether it's a JSON error body, a
- * generic HTTP status, or a network failure.
+ * Handles the render service's response shapes: an already-rendered artifact
+ * (triggers a native browser download), a still-rendering one (polls the
+ * JSON status endpoint every 3s, slowing to 10s past 13 minutes, up to a
+ * 30-minute ceiling — shown inline as "Queued…"/"Rendering…" with elapsed
+ * time), and a hard error — surfaced inline beneath the selected format
+ * button, whether it's a JSON error body, a generic HTTP status, or a
+ * network failure.
  */
 export default function CastProDownload({
   owner,

--- a/website/src/components/CastProDownload/index.tsx
+++ b/website/src/components/CastProDownload/index.tsx
@@ -73,7 +73,15 @@ function FormatMenuItem({
         <span>{format.toUpperCase()}</span>
         {hint && <span className={styles.hint}>{hint}</span>}
         {progressPercent !== null && (
-          <span className={styles.progressTrack} title={progress.stage}>
+          <span
+            className={styles.progressTrack}
+            title={progress.stage}
+            role="progressbar"
+            aria-valuenow={Math.round(progressPercent)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuetext={`${progress.stage}: ${Math.round(progressPercent)}%`}
+          >
             <span className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
           </span>
         )}

--- a/website/src/components/CastProDownload/styles.module.css
+++ b/website/src/components/CastProDownload/styles.module.css
@@ -112,6 +112,24 @@
   color: var(--ifm-color-content-secondary);
 }
 
+.progressTrack {
+  display: inline-block;
+  width: 2.5rem;
+  height: 3px;
+  margin-left: 0.375rem;
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 2px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.progressFill {
+  display: block;
+  height: 100%;
+  background: var(--ifm-color-primary);
+  transition: width 0.2s ease;
+}
+
 .errorText {
   margin: 0 0.55rem 0.375rem;
   font-size: 0.6875rem;


### PR DESCRIPTION
## what

- Rewrote the Atmos Pro cast-download polling flow (`CastProArtifact/useCastArtifact.ts`) to poll the render-status endpoint with `Accept: application/json` instead of the raw artifact URL, and to treat only a genuine `200` response as "ready" — never `response.ok` on any 2xx.
- Extracted the polling state machine into a new framework-agnostic module, `CastProArtifact/polling.mjs`, with a companion `polling.test.mjs` covering the queued→rendering→ready path, an immediate-ready response, terminal errors, the slowdown threshold, the wait ceiling, a hung fetch, and cancellation.
- Raised the total wait budget from a hard 60s to 30 minutes, polling every 3s and slowing to every 10s past 13 minutes elapsed, with a "still rendering, try again later" message instead of a false failure at the ceiling.
- Updated `CastProDownload` to show "Queued…"/"Rendering… m:ss" (with a "taking longer than usual" hint) and an optional progress bar, and updated `CastProArtifact/README.md` to document the render service's actual JSON/200/202/500 contract and the new polling cadence.

## why

- Downloading a cast that hadn't finished rendering yet redirected the reader to a blank page reading "Cast artifact is not ready yet." instead of keeping them on the page.
- The old polling logic asked for the raw artifact and accepted any 2xx as "ready," so a still-rendering response could be misread as done; separately, its 60s wait cap was far below real render times (casts can take several minutes, with queueing up to ~30 minutes worst case), so even correctly-detected renders gave up too early.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer rendering status updates with queued and processing phases, elapsed time, progress stages, and visual progress indicators.
  * Added immediate readiness detection and automatic navigation to artifact downloads.
  * Rendering checks poll every 3 seconds, slow after 13 minutes, and stop after 30 minutes.
  * Added support for legacy artifact responses and clearer network, rendering, and terminal error messages.
  * Improved progress-bar accessibility with status announcements and percentage information.

* **Documentation**
  * Updated service documentation covering polling responses, artifact metadata, errors, and download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->