### PR TITLE
fix(ci): cap concurrent subprocess launches in acceptance test orchestration

### DIFF
--- a/docs/fixes/2026-09-11-windows-acceptance-subprocess-race.md
+++ b/docs/fixes/2026-09-11-windows-acceptance-subprocess-race.md
@@ -47,6 +47,19 @@ own file with `//go:build windows` / `//go:build !windows` instead of a runtime 
 - New `internal/ci/acceptance/subprocess_cap_other.go` (`//go:build !windows`): a single no-op
   `acquireSubprocessSlot` returning an empty release func and `nil` error, matching the minimal-stub pattern
   used by `trust_install_other.go`.
+- `internal/ci/acceptance/command.go`: added an `acquireSubprocessSlotFunc` package var (defaulting to
+  `acquireSubprocessSlot`) and routed `run`/`output` through it instead of calling `acquireSubprocessSlot`
+  directly. This is a test seam, not a behavior change — Codecov flagged the PR's patch coverage at 69.23%
+  because `run`/`output`'s `if slotErr != nil`/`if err != nil` branches around the subprocess-slot call are
+  only reachable when `acquireSubprocessSlot` returns an error, which the real implementation only does on
+  Windows (ctx done before a slot frees up); on every other platform `subprocess_cap_other.go`'s no-op always
+  returns `nil`, so those branches were structurally unreachable in a non-Windows test run. The seam lets a
+  test substitute a fake that returns an error on any platform, to assert the real
+  `run`/`output` error-wrapping behavior on that path.
+- `internal/ci/acceptance/command_test.go`: new `TestRunPropagatesSubprocessSlotError` and
+  `TestOutputPropagatesSubprocessSlotError`, each overriding `acquireSubprocessSlotFunc` (restored via
+  `t.Cleanup`) to return a sentinel error and asserting `run`/`output` propagate it (via `errors.Is`) without
+  ever invoking the underlying command.
 
 (Prior rounds of this fix, unchanged by this doc: `66e50d45f5` added the semaphore and cap; `72319350ae`
 scoped it to Windows via the runtime check this doc's changes now replace with build tags.)
@@ -58,10 +71,18 @@ scoped it to Windows via the runtime check this doc's changes now replace with b
   this sandbox can't run a Windows binary, so this is a cross-compile check only, not an execution check).
 - `go vet ./internal/ci/acceptance/...` — clean.
 - `gofumpt -l internal/ci/acceptance/*.go` — no output.
-- `go test ./internal/ci/acceptance/...` — `ok`, 62.8s.
-- `./custom-gcl run --new-from-rev=origin/main` — skipped: no prebuilt `custom-gcl` binary exists in this
-  worktree (per this repo's own convention, pre-commit hooks run a prebuilt binary rather than building it
-  in-hook, and none was available here to run standalone either).
+- `go test ./internal/ci/acceptance/...` — `ok`, 13.5s (re-run after adding the coverage-gap tests below;
+  62.8s the first time, before local build caches were warm).
+- `go test ./internal/ci/acceptance/... -run 'TestRunPropagatesSubprocessSlotError|TestOutputPropagatesSubprocessSlotError' -v`
+  — both pass.
+- `atmos fix coverage` (`.claude/skills/test-coverage/scripts/patch-test-coverage.sh` vs `origin/main`) — the
+  two previously-uncovered patch lines Codecov flagged (`run`'s and `output`'s `acquireSubprocessSlot` error
+  branches) now show a nonzero hit count in the coverage profile; the file's only remaining zero-count lines
+  (`writeStatus`'s `Fprintf` error branch, two spots in the retry loop) are pre-existing, outside this patch's
+  diff, and unchanged by this fix.
+- `./custom-gcl run --new-from-rev=origin/main` — 0 issues (built the missing binary first via
+  `go tool mage lint:customGCL`, run standalone rather than through the pre-commit hook, per this repo's
+  convention of never building it from inside the hook).
 - Not independently re-confirmed here: the `66e50d45f5`/`72319350ae` commit messages' own stated local
   Windows-crash reproduction and the ~15s→~11.7s macOS timing comparison — those are prior, already-landed
   validation, not re-run for this file-split refactor since it doesn't change runtime behavior on any

--- a/docs/fixes/2026-09-11-windows-acceptance-subprocess-race.md
+++ b/docs/fixes/2026-09-11-windows-acceptance-subprocess-race.md
@@ -1,0 +1,75 @@
+# Fix: Windows GC/allocator crash from concurrent subprocess launches in acceptance-test orchestration
+
+**Date:** 2026-09-11
+
+## Summary
+
+`internal/ci/acceptance`'s own acceptance-test suite runs ~90 `t.Parallel()` subtests that each shell out to
+`go build`/`go test -c`/`go test`/precompiled `*.test.exe` binaries. On a wide Windows CI runner, letting that
+many real `go` toolchain subprocesses launch fully concurrently triggered a Windows-only Go runtime
+GC/allocator crash. Fixed by capping concurrent subprocess launches to 4 on Windows, then moving that
+Windows-only logic into a build-tagged file (`//go:build windows` / `//go:build !windows`) to match this
+codebase's established platform-split convention instead of a runtime `GOOS` check in shared code.
+
+## Context
+
+This package's acceptance tests each independently allocate and syscall heavily when they shell out. On a
+wide/many-core CI runner with no cap, that produced a runtime-fatal GC/allocator crash ("fatal error: found
+pointer to free object" / "marked free object in span") in `mcache`/`mgcsweep` during a concurrent `os/exec`
+process launch — a long-standing, still-recurring class of Go runtime race under heavy concurrent
+allocation+syscall pressure on Windows (golang/go#44900, #45364, #47415, #54247; every report is
+Windows-only), not anything specific to the command being run. Seen bouncing PR #3115 from the merge queue
+twice for unrelated reasons; this specific crash was on the first attempt (windows, shard 3/10, run
+34558935380).
+
+The first fix (commit `66e50d45f5`) added the cap for every platform. A quick follow-up (commit
+`72319350ae`) scoped it to Windows only, since the race has never been reported on Linux/macOS and capping
+them too just serializes work for no benefit — confirmed locally: this package's test suite dropped from
+~15s to ~11.7s on macOS once the cap was scoped out. That follow-up implemented the scoping as an inline
+`if runtime.GOOS != "windows" { return no-op }` check inside `command.go`, which left Windows-only semaphore
+machinery (a const, a package var, and most of a function body) compiled into every platform's build, gated
+only by a runtime branch. This codebase has an established convention for exactly this shape of
+platform-specific code — grepped and found 13+ existing `*_windows.go` / `*_other.go` (or `*_unix.go`)
+build-tag file pairs (e.g. `pkg/terraform/cache/trust_install_windows.go` +
+`pkg/terraform/cache/trust_install_other.go`), each splitting the platform-specific implementation into its
+own file with `//go:build windows` / `//go:build !windows` instead of a runtime check. This fix brings
+`internal/ci/acceptance` in line with that convention.
+
+## Changes
+
+- `internal/ci/acceptance/command.go`: removed the `maxConcurrentSubprocesses` const, the `subprocessSlots`
+  package var, and the `acquireSubprocessSlot` function (previously gated by a `runtime.GOOS != "windows"`
+  check); dropped the now-unused `runtime` import. The `run`/`output` call sites that invoke
+  `acquireSubprocessSlot` are unchanged.
+- New `internal/ci/acceptance/subprocess_cap_windows.go` (`//go:build windows`): the real
+  `maxConcurrentSubprocesses`/`subprocessSlots`/`acquireSubprocessSlot` implementation, moved verbatim (minus
+  the now-unnecessary `runtime.GOOS` check, since the build tag handles that).
+- New `internal/ci/acceptance/subprocess_cap_other.go` (`//go:build !windows`): a single no-op
+  `acquireSubprocessSlot` returning an empty release func and `nil` error, matching the minimal-stub pattern
+  used by `trust_install_other.go`.
+
+(Prior rounds of this fix, unchanged by this doc: `66e50d45f5` added the semaphore and cap; `72319350ae`
+scoped it to Windows via the runtime check this doc's changes now replace with build tags.)
+
+## Validation
+
+- `go build ./...` — clean.
+- `GOOS=windows go build ./internal/ci/acceptance/...` — clean (confirms the windows-tagged file compiles;
+  this sandbox can't run a Windows binary, so this is a cross-compile check only, not an execution check).
+- `go vet ./internal/ci/acceptance/...` — clean.
+- `gofumpt -l internal/ci/acceptance/*.go` — no output.
+- `go test ./internal/ci/acceptance/...` — `ok`, 62.8s.
+- `./custom-gcl run --new-from-rev=origin/main` — skipped: no prebuilt `custom-gcl` binary exists in this
+  worktree (per this repo's own convention, pre-commit hooks run a prebuilt binary rather than building it
+  in-hook, and none was available here to run standalone either).
+- Not independently re-confirmed here: the `66e50d45f5`/`72319350ae` commit messages' own stated local
+  Windows-crash reproduction and the ~15s→~11.7s macOS timing comparison — those are prior, already-landed
+  validation, not re-run for this file-split refactor since it doesn't change runtime behavior on any
+  platform (same semaphore, same cap, same no-op condition, only the compilation boundary moved).
+- The actual Windows-crash fix (as opposed to this refactor's compile/test correctness) can only be confirmed
+  by the next real Windows CI run, same caveat as other Windows-only race fixes in this directory (e.g.
+  `2026-08-19-terraform-registry-cache-windows-ci-timeout.md`).
+
+## Follow-ups
+
+None.

--- a/internal/ci/acceptance/command.go
+++ b/internal/ci/acceptance/command.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -35,48 +34,7 @@ const (
 	// can't grow that buffer without limit. The real diagnostic is one short line
 	// (well under this), so bounding it doesn't affect detection.
 	maxTransientMatchWindow = 4096
-
-	// Caps how many subprocesses (go build/go test/go tool covdata, plus each
-	// precompiled *.test.exe) this package launches at once, on Windows hosts
-	// only (see acquireSubprocessSlot). This package's own acceptance tests run
-	// dozens of t.Parallel() subtests that each shell out, so without a cap, a
-	// wide/many-core Windows CI runner lets that many real `go` toolchain
-	// invocations (each independently allocating and syscalling heavily) run
-	// fully concurrently. That has produced a runtime-fatal GC/allocator crash
-	// ("fatal error: found pointer to free object" / "marked free object in
-	// span") in mcache/mgcsweep during a concurrent os/exec process launch -- a
-	// long-standing, still-recurring class of Go runtime race under heavy
-	// concurrent allocation+syscall pressure specifically on Windows (see e.g.
-	// golang/go#44900, #45364, #47415, #54247; the reports are Windows-only),
-	// not anything specific to the command being run. Serializing actual
-	// subprocess launches (while still letting the surrounding Go test logic
-	// run in parallel) avoids the trigger condition without giving up test
-	// parallelism where it doesn't involve a real subprocess -- and without
-	// slowing down Linux/macOS, which haven't exhibited this crash.
-	maxConcurrentSubprocesses = 4
 )
-
-// subprocessSlots limits how many commandRunner.run/output calls -- across every
-// commandRunner instance, since each caller constructs its own -- may have a real
-// `cmd.Run()` in flight at once, on Windows. See maxConcurrentSubprocesses.
-var subprocessSlots = make(chan struct{}, maxConcurrentSubprocesses)
-
-// acquireSubprocessSlot blocks until a subprocess slot is free or ctx is done,
-// returning a release func to call (typically deferred) once the subprocess
-// exits. It's a no-op on every host OS but Windows -- the GC/allocator race
-// this guards against (see maxConcurrentSubprocesses) has only been observed
-// there, so Linux/macOS runs keep their full, uncapped concurrency.
-func acquireSubprocessSlot(ctx context.Context) (func(), error) {
-	if runtime.GOOS != "windows" {
-		return func() {}, nil
-	}
-	select {
-	case subprocessSlots <- struct{}{}:
-		return func() { <-subprocessSlots }, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
 
 var (
 	errInvalidConfiguration = errors.New("invalid acceptance configuration")

--- a/internal/ci/acceptance/command.go
+++ b/internal/ci/acceptance/command.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -36,31 +37,39 @@ const (
 	maxTransientMatchWindow = 4096
 
 	// Caps how many subprocesses (go build/go test/go tool covdata, plus each
-	// precompiled *.test.exe) this package launches at once. This package's own
-	// acceptance tests run dozens of t.Parallel() subtests that each shell out,
-	// so without a cap, a wide/many-core CI runner lets that many real `go`
-	// toolchain invocations (each independently allocating and syscalling
-	// heavily) run fully concurrently. On Windows that has produced a
-	// runtime-fatal GC/allocator crash ("fatal error: found pointer to free
-	// object" / "marked free object in span") in mcache/mgcsweep during a
-	// concurrent os/exec process launch -- a long-standing, still-recurring
-	// class of Go runtime race under heavy concurrent allocation+syscall
-	// pressure on Windows (see e.g. golang/go#44900, #45364, #47415, #54247),
+	// precompiled *.test.exe) this package launches at once, on Windows hosts
+	// only (see acquireSubprocessSlot). This package's own acceptance tests run
+	// dozens of t.Parallel() subtests that each shell out, so without a cap, a
+	// wide/many-core Windows CI runner lets that many real `go` toolchain
+	// invocations (each independently allocating and syscalling heavily) run
+	// fully concurrently. That has produced a runtime-fatal GC/allocator crash
+	// ("fatal error: found pointer to free object" / "marked free object in
+	// span") in mcache/mgcsweep during a concurrent os/exec process launch -- a
+	// long-standing, still-recurring class of Go runtime race under heavy
+	// concurrent allocation+syscall pressure specifically on Windows (see e.g.
+	// golang/go#44900, #45364, #47415, #54247; the reports are Windows-only),
 	// not anything specific to the command being run. Serializing actual
 	// subprocess launches (while still letting the surrounding Go test logic
 	// run in parallel) avoids the trigger condition without giving up test
-	// parallelism where it doesn't involve a real subprocess.
+	// parallelism where it doesn't involve a real subprocess -- and without
+	// slowing down Linux/macOS, which haven't exhibited this crash.
 	maxConcurrentSubprocesses = 4
 )
 
 // subprocessSlots limits how many commandRunner.run/output calls -- across every
 // commandRunner instance, since each caller constructs its own -- may have a real
-// `cmd.Run()` in flight at once. See maxConcurrentSubprocesses.
+// `cmd.Run()` in flight at once, on Windows. See maxConcurrentSubprocesses.
 var subprocessSlots = make(chan struct{}, maxConcurrentSubprocesses)
 
 // acquireSubprocessSlot blocks until a subprocess slot is free or ctx is done,
-// returning a release func to call (typically deferred) once the subprocess exits.
+// returning a release func to call (typically deferred) once the subprocess
+// exits. It's a no-op on every host OS but Windows -- the GC/allocator race
+// this guards against (see maxConcurrentSubprocesses) has only been observed
+// there, so Linux/macOS runs keep their full, uncapped concurrency.
 func acquireSubprocessSlot(ctx context.Context) (func(), error) {
+	if runtime.GOOS != "windows" {
+		return func() {}, nil
+	}
 	select {
 	case subprocessSlots <- struct{}{}:
 		return func() { <-subprocessSlots }, nil

--- a/internal/ci/acceptance/command.go
+++ b/internal/ci/acceptance/command.go
@@ -44,6 +44,11 @@ var (
 	errCommandFailed        = errors.New("command failed")
 )
 
+// acquireSubprocessSlotFunc is a seam over acquireSubprocessSlot so tests can simulate
+// its error path (real only on Windows, when ctx is done before a slot frees up) on any
+// platform, without depending on the Windows-only semaphore actually blocking.
+var acquireSubprocessSlotFunc = acquireSubprocessSlot
+
 type commandRunner struct {
 	stdout     io.Writer
 	stderr     io.Writer
@@ -115,7 +120,7 @@ func (r commandRunner) run(ctx context.Context, opts runOptions, name string, ar
 			cmd.Stderr = io.MultiWriter(r.stderr, detector)
 		}
 
-		release, slotErr := acquireSubprocessSlot(ctx)
+		release, slotErr := acquireSubprocessSlotFunc(ctx)
 		if slotErr != nil {
 			return fmt.Errorf("%w: run %s: %w", errCommandFailed, commandString(name, args), slotErr)
 		}
@@ -190,7 +195,7 @@ func (r commandRunner) output(ctx context.Context, dir string, env []string, nam
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	release, err := acquireSubprocessSlot(ctx)
+	release, err := acquireSubprocessSlotFunc(ctx)
 	if err != nil {
 		return "", fmt.Errorf("run %s: %w", commandString(name, args), err)
 	}

--- a/internal/ci/acceptance/command.go
+++ b/internal/ci/acceptance/command.go
@@ -34,7 +34,40 @@ const (
 	// can't grow that buffer without limit. The real diagnostic is one short line
 	// (well under this), so bounding it doesn't affect detection.
 	maxTransientMatchWindow = 4096
+
+	// Caps how many subprocesses (go build/go test/go tool covdata, plus each
+	// precompiled *.test.exe) this package launches at once. This package's own
+	// acceptance tests run dozens of t.Parallel() subtests that each shell out,
+	// so without a cap, a wide/many-core CI runner lets that many real `go`
+	// toolchain invocations (each independently allocating and syscalling
+	// heavily) run fully concurrently. On Windows that has produced a
+	// runtime-fatal GC/allocator crash ("fatal error: found pointer to free
+	// object" / "marked free object in span") in mcache/mgcsweep during a
+	// concurrent os/exec process launch -- a long-standing, still-recurring
+	// class of Go runtime race under heavy concurrent allocation+syscall
+	// pressure on Windows (see e.g. golang/go#44900, #45364, #47415, #54247),
+	// not anything specific to the command being run. Serializing actual
+	// subprocess launches (while still letting the surrounding Go test logic
+	// run in parallel) avoids the trigger condition without giving up test
+	// parallelism where it doesn't involve a real subprocess.
+	maxConcurrentSubprocesses = 4
 )
+
+// subprocessSlots limits how many commandRunner.run/output calls -- across every
+// commandRunner instance, since each caller constructs its own -- may have a real
+// `cmd.Run()` in flight at once. See maxConcurrentSubprocesses.
+var subprocessSlots = make(chan struct{}, maxConcurrentSubprocesses)
+
+// acquireSubprocessSlot blocks until a subprocess slot is free or ctx is done,
+// returning a release func to call (typically deferred) once the subprocess exits.
+func acquireSubprocessSlot(ctx context.Context) (func(), error) {
+	select {
+	case subprocessSlots <- struct{}{}:
+		return func() { <-subprocessSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
 
 var (
 	errInvalidConfiguration = errors.New("invalid acceptance configuration")
@@ -115,7 +148,12 @@ func (r commandRunner) run(ctx context.Context, opts runOptions, name string, ar
 			cmd.Stderr = io.MultiWriter(r.stderr, detector)
 		}
 
+		release, slotErr := acquireSubprocessSlot(ctx)
+		if slotErr != nil {
+			return fmt.Errorf("%w: run %s: %w", errCommandFailed, commandString(name, args), slotErr)
+		}
 		err := cmd.Run()
+		release()
 		if err == nil {
 			return nil
 		}
@@ -185,8 +223,14 @@ func (r commandRunner) output(ctx context.Context, dir string, env []string, nam
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("run %s: %w: %s", commandString(name, args), err, strings.TrimSpace(stderr.String()))
+	release, err := acquireSubprocessSlot(ctx)
+	if err != nil {
+		return "", fmt.Errorf("run %s: %w", commandString(name, args), err)
+	}
+	runErr := cmd.Run()
+	release()
+	if runErr != nil {
+		return "", fmt.Errorf("run %s: %w: %s", commandString(name, args), runErr, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.String(), nil
 }

--- a/internal/ci/acceptance/command_test.go
+++ b/internal/ci/acceptance/command_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -351,5 +352,55 @@ func TestRunDoesNotRetryWhenNotRetryTransient(t *testing.T) {
 	}
 	if string(remaining) != "0" {
 		t.Fatalf("fail count = %q, want %q (run() must invoke the command exactly once)", remaining, "0")
+	}
+}
+
+// errStubSubprocessSlot is a sentinel injected via acquireSubprocessSlotFunc to
+// simulate the real (Windows-only) semaphore's error path -- ctx done before a slot
+// frees up -- on any platform.
+var errStubSubprocessSlot = errors.New("stub subprocess slot error")
+
+// stubAcquireSubprocessSlotError overrides acquireSubprocessSlotFunc for the duration
+// of the test to always fail, restoring the real acquireSubprocessSlot afterward.
+func stubAcquireSubprocessSlotError(t *testing.T) {
+	t.Helper()
+	acquireSubprocessSlotFunc = func(context.Context) (func(), error) { return nil, errStubSubprocessSlot }
+	t.Cleanup(func() { acquireSubprocessSlotFunc = acquireSubprocessSlot })
+}
+
+// TestRunPropagatesSubprocessSlotError covers run's acquireSubprocessSlotFunc error
+// path (command.go), which the real acquireSubprocessSlot can only take on Windows --
+// see subprocess_cap_windows.go/subprocess_cap_other.go.
+func TestRunPropagatesSubprocessSlotError(t *testing.T) {
+	stubAcquireSubprocessSlotError(t)
+
+	runner := newHelperRunner(t)
+	err := runner.run(context.Background(), runOptions{dir: t.TempDir()}, "go", "version")
+	if err == nil {
+		t.Fatal("expected run() to fail when acquireSubprocessSlotFunc fails")
+	}
+	if !errors.Is(err, errCommandFailed) {
+		t.Fatalf("run() error = %v, want it to wrap errCommandFailed", err)
+	}
+	if !errors.Is(err, errStubSubprocessSlot) {
+		t.Fatalf("run() error = %v, want it to wrap the subprocess slot error", err)
+	}
+}
+
+// TestOutputPropagatesSubprocessSlotError is output's counterpart to
+// TestRunPropagatesSubprocessSlotError.
+func TestOutputPropagatesSubprocessSlotError(t *testing.T) {
+	stubAcquireSubprocessSlotError(t)
+
+	runner := newHelperRunner(t)
+	out, err := runner.output(context.Background(), t.TempDir(), nil, "go", "version")
+	if err == nil {
+		t.Fatal("expected output() to fail when acquireSubprocessSlotFunc fails")
+	}
+	if !errors.Is(err, errStubSubprocessSlot) {
+		t.Fatalf("output() error = %v, want it to wrap the subprocess slot error", err)
+	}
+	if out != "" {
+		t.Fatalf("output() = %q, want empty output on a subprocess-slot failure", out)
 	}
 }

--- a/internal/ci/acceptance/subprocess_cap_other.go
+++ b/internal/ci/acceptance/subprocess_cap_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package acceptance
+
+import "context"
+
+// acquireSubprocessSlot is a no-op on every platform but Windows -- the GC/allocator
+// race the real cap guards against (see subprocess_cap_windows.go) has only been
+// observed there, so Linux/macOS runs keep their full, uncapped concurrency.
+func acquireSubprocessSlot(_ context.Context) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/ci/acceptance/subprocess_cap_windows.go
+++ b/internal/ci/acceptance/subprocess_cap_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package acceptance
+
+import "context"
+
+// maxConcurrentSubprocesses caps how many subprocesses (go build/go test/go tool
+// covdata, plus each precompiled *.test.exe) this package launches at once. This
+// package's own acceptance tests run dozens of t.Parallel() subtests that each shell
+// out, so without a cap, a wide/many-core Windows CI runner lets that many real `go`
+// toolchain invocations (each independently allocating and syscalling heavily) run
+// fully concurrently. That has produced a runtime-fatal GC/allocator crash ("fatal
+// error: found pointer to free object" / "marked free object in span") in
+// mcache/mgcsweep during a concurrent os/exec process launch -- a long-standing,
+// still-recurring class of Go runtime race under heavy concurrent allocation+syscall
+// pressure specifically on Windows (see e.g. golang/go#44900, #45364, #47415, #54247;
+// the reports are Windows-only), not anything specific to the command being run.
+// Serializing actual subprocess launches (while still letting the surrounding Go test
+// logic run in parallel) avoids the trigger condition without giving up test
+// parallelism where it doesn't involve a real subprocess. See subprocess_cap_other.go
+// for why this cap doesn't exist on other platforms.
+const maxConcurrentSubprocesses = 4
+
+// subprocessSlots limits how many commandRunner.run/output calls -- across every
+// commandRunner instance, since each caller constructs its own -- may have a real
+// `cmd.Run()` in flight at once. See maxConcurrentSubprocesses.
+var subprocessSlots = make(chan struct{}, maxConcurrentSubprocesses)
+
+// acquireSubprocessSlot blocks until a subprocess slot is free or ctx is done,
+// returning a release func to call (typically deferred) once the subprocess exits.
+func acquireSubprocessSlot(ctx context.Context) (func(), error) {
+	select {
+	case subprocessSlots <- struct{}{}:
+		return func() { <-subprocessSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/ci/acceptance/testfixture_test.go
+++ b/internal/ci/acceptance/testfixture_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -61,9 +60,10 @@ func buildFixtureTestBinary(t *testing.T, testNames []string) string {
 	}
 
 	binary := filepath.Join(t.TempDir(), "fixture.test")
-	cmd := exec.Command("go", "test", "-c", "-covermode=atomic", "-o", binary, ".")
-	cmd.Dir = src
-	if output, err := cmd.CombinedOutput(); err != nil {
+	// Routed through commandRunner.output (rather than a bare exec.Command) so this
+	// shares its subprocessSlots cap with every other subprocess this package's tests
+	// launch -- see maxConcurrentSubprocesses.
+	if output, err := newCommandRunner().output(t.Context(), src, nil, "go", "test", "-c", "-covermode=atomic", "-o", binary, "."); err != nil {
 		t.Fatalf("build fixture test binary: %v\n%s", err, output)
 	}
 	return binary


### PR DESCRIPTION
## what

- Adds a small package-level semaphore (`maxConcurrentSubprocesses = 4`) in `internal/ci/acceptance/command.go` that caps how many real subprocesses (`go build`/`go test -c`/`go test`/precompiled `*.test.exe`) `commandRunner.run`/`.output` may have in flight at once, across every `commandRunner` instance.
- Refactors `testfixture_test.go`'s `buildFixtureTestBinary` to route its `go test -c` compile through `commandRunner.output` instead of a bare `exec.Command`, so it shares the same cap.

## why

- PR #3115 was added to the merge queue twice and bounced both times for reasons unrelated to its own diff. The first bounce (windows, shard 3/10) failed with a Go runtime `fatal error: found pointer to free object` (`runtime: marked free object in span`) during a concurrent `os/exec` process launch triggered from this package's own acceptance-test suite.
- This package's test suite runs ~90 `t.Parallel()` subtests, many of which shell out to the real `go` toolchain. On a wide CI runner that lets dozens of real `go build`/`go test` subprocesses launch fully concurrently — each independently allocating and syscalling heavily — which is the kind of condition known to trigger a long-standing, still-recurring class of Go runtime GC/allocator race on Windows (see golang/go#44900, #45364, #47415, #54247). It's a documented class of upstream Go runtime flakiness under heavy concurrent allocation+syscall pressure, not a bug in the specific command being run.
- Capping actual subprocess launches (while leaving the surrounding Go test logic free to run in parallel) removes the trigger condition without giving up test parallelism where it doesn't involve a real subprocess. Verified locally: `go test ./internal/ci/acceptance/... -v` still passes in full (~15s, no deadlocks) with the cap in place.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of Windows acceptance tests by limiting concurrent subprocess launches.
  - Applied the same concurrency control when building test fixtures.
  - Improved error handling when subprocess capacity cannot be acquired.

- **Tests**
  - Added coverage for subprocess slot-acquisition failures across supported platforms.

- **Documentation**
  - Documented the Windows acceptance-test concurrency fix, validation results, and follow-up status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->