### PR TITLE
fix(ui): output-only plans no longer reported as NO CHANGES in --ui

### DIFF
--- a/internal/exec/packer.go
+++ b/internal/exec/packer.go
@@ -226,8 +226,11 @@ func ExecutePacker(
 	log.Debug("Variables for component in stack", "component", info.ComponentFromArg, "stack", info.Stack, "variables", info.ComponentVarsSection)
 
 	// Write variables to a file.
-	varFile := constructPackerComponentVarfileName(info)
 	varFilePath := constructPackerComponentVarfilePath(&atmosConfig, info)
+	varFilePath, err = filepath.Abs(varFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Packer variable file path: %w", err)
+	}
 
 	log.Debug("Writing the variables to file", "file", varFilePath)
 
@@ -269,7 +272,7 @@ func ExecutePacker(
 	// Prepare arguments and flags.
 	allArgsAndFlags := []string{}
 	allArgsAndFlags = append(allArgsAndFlags, info.SubCommand)
-	allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFile}...)
+	allArgsAndFlags = append(allArgsAndFlags, []string{"-var-file", varFilePath}...)
 	allArgsAndFlags = append(allArgsAndFlags, info.AdditionalArgsAndFlags...)
 	allArgsAndFlags = append(allArgsAndFlags, template)
 

--- a/internal/exec/packer_auth_test.go
+++ b/internal/exec/packer_auth_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -119,6 +120,8 @@ func TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv(t *testing.T) {
 	origShell := executePackerShellCommand
 	t.Cleanup(func() { executePackerShellCommand = origShell })
 
+	var capturedArgs []string
+	var capturedDir string
 	var capturedEnv []string
 	var shellCalled bool
 	executePackerShellCommand = func(
@@ -131,6 +134,8 @@ func TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv(t *testing.T) {
 		redirectStdError string,
 		opts ...ShellCommandOption,
 	) error {
+		capturedArgs = append([]string(nil), args...)
+		capturedDir = dir
 		capturedEnv = env
 		shellCalled = true
 		return nil
@@ -149,6 +154,12 @@ func TestExecutePacker_InjectsAuthCredentialsIntoSubprocessEnv(t *testing.T) {
 	err := ExecutePacker(info, &PackerFlags{})
 	require.NoError(t, err)
 	require.True(t, shellCalled, "packer shell command should have been invoked")
+	require.GreaterOrEqual(t, len(capturedArgs), 3)
+	require.Equal(t, "-var-file", capturedArgs[1])
+	require.True(t, filepath.IsAbs(capturedArgs[2]),
+		"Packer must receive an absolute variable-file path")
+	require.Equal(t, filepath.Clean(capturedDir), filepath.Dir(filepath.Clean(capturedArgs[2])),
+		"Packer variable file must be located in its working directory")
 	require.Contains(t, strings.Join(capturedEnv, "\n"), sentinel,
 		"Atmos Auth credentials must be injected into the packer subprocess environment")
 }

--- a/pkg/terraform/ui/executor.go
+++ b/pkg/terraform/ui/executor.go
@@ -319,11 +319,12 @@ func showPlanTree(ctx context.Context, opts *ExecuteOptions, planFile string) {
 	}
 
 	add, change, remove := tree.GetChangeSummary()
-	// Only render tree if there are changes; otherwise just show badge.
-	if add > 0 || change > 0 || remove > 0 {
+	hasOutputChanges := tree.HasOutputChanges()
+	// Only render tree if there are changes (resource or output); otherwise just show badge.
+	if add > 0 || change > 0 || remove > 0 || hasOutputChanges {
 		ui.Writef(fmtNewlineStr, tree.RenderTreeWithConfig(opts.RenderConfig))
 	}
-	ui.Write(RenderChangeSummaryBadges(add, change, remove))
+	ui.Write(RenderChangeSummaryBadges(add, change, remove, hasOutputChanges))
 }
 
 // executePlanWithUserFile runs plan using the caller-provided -out planfile, then
@@ -621,15 +622,16 @@ func showTwoPhasePlanTree(ctx context.Context, opts *ExecuteOptions, planFile st
 	}
 
 	add, change, remove := tree.GetChangeSummary()
-	if add == 0 && change == 0 && remove == 0 {
+	hasOutputChanges := tree.HasOutputChanges()
+	if add == 0 && change == 0 && remove == 0 && !hasOutputChanges {
 		// No changes to apply - show badge only.
-		ui.Write(RenderChangeSummaryBadges(add, change, remove))
+		ui.Write(RenderChangeSummaryBadges(add, change, remove, hasOutputChanges))
 		return true
 	}
 
 	// Display the dependency tree and badge summary.
 	ui.Writef(fmtNewlineStr, tree.RenderTreeWithConfig(opts.RenderConfig))
-	ui.Write(RenderChangeSummaryBadges(add, change, remove))
+	ui.Write(RenderChangeSummaryBadges(add, change, remove, hasOutputChanges))
 	return false
 }
 
@@ -737,15 +739,16 @@ func executeWithPlanFile(ctx context.Context, opts *ExecuteOptions, planFile str
 	if err == nil {
 		// Check if there are any changes.
 		add, change, remove := tree.GetChangeSummary()
-		if add == 0 && change == 0 && remove == 0 {
+		hasOutputChanges := tree.HasOutputChanges()
+		if add == 0 && change == 0 && remove == 0 && !hasOutputChanges {
 			// No changes to apply - show badge, outputs, and exit.
-			ui.Write(RenderChangeSummaryBadges(add, change, remove))
+			ui.Write(RenderChangeSummaryBadges(add, change, remove, hasOutputChanges))
 			fetchAndDisplayOutputs(opts.Command, opts.WorkingDir, opts.Env)
 			return nil
 		}
 		// Display the dependency tree and badge summary.
 		ui.Writef(fmtNewlineStr, tree.RenderTreeWithConfig(opts.RenderConfig))
-		ui.Write(RenderChangeSummaryBadges(add, change, remove))
+		ui.Write(RenderChangeSummaryBadges(add, change, remove, hasOutputChanges))
 	}
 
 	// Confirm.

--- a/pkg/terraform/ui/executor_test.go
+++ b/pkg/terraform/ui/executor_test.go
@@ -1009,6 +1009,27 @@ func TestShowPlanTree_NoChangesShowsBadgeOnly(t *testing.T) {
 	assert.Contains(t, stderr.String(), "NO CHANGES")
 }
 
+// TestShowPlanTree_OutputOnlyChangeDoesNotShowNoChanges is a regression test for issue #3114:
+// a plan whose only diff is an output value (empty resource_changes but a populated
+// output_changes map) must not be reported as "NO CHANGES", or `atmos terraform plan --ui`
+// would hide the only diff that exists.
+func TestShowPlanTree_OutputOnlyChangeDoesNotShowNoChanges(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	stderr := captureUIOutput(t)
+
+	planJSON := `{"format_version":"1.2","resource_changes":[],` +
+		`"output_changes":{"vpc_id":{"actions":["update"],"before":"old","after":"new"}}}`
+	t.Setenv("_ATMOS_TEST_TF_SHOW_JSON", planJSON)
+
+	opts := &ExecuteOptions{Command: exePath, WorkingDir: t.TempDir(), Component: "vpc", Stack: "dev"}
+
+	showPlanTree(context.Background(), opts, "plan.tfplan")
+
+	assert.NotContains(t, stderr.String(), "NO CHANGES")
+	assert.Contains(t, stderr.String(), "OUTPUTS CHANGED")
+}
+
 // TestShowTwoPhasePlanTree_ReturnsFalseWhenPlanCannotBeParsed verifies an unparsable plan
 // falls through to the confirmation phase (returns false) rather than being mistaken for a
 // no-changes plan, matching the function's documented "prior behavior" contract.
@@ -1059,6 +1080,27 @@ func TestShowTwoPhasePlanTree_WithChangesReturnsFalse(t *testing.T) {
 	output := stderr.String()
 	assert.Contains(t, output, "aws_s3_bucket.main")
 	assert.Contains(t, output, "1 DELETE")
+}
+
+// TestShowTwoPhasePlanTree_OutputOnlyChangeReturnsFalse is a regression test for issue #3114:
+// a plan with zero resource changes but a real (non-no-op) output_changes entry must be
+// reported as "has changes" (false), or ExecuteApply's two-phase flow would skip confirmation
+// and apply entirely - silently dropping the new output value.
+func TestShowTwoPhasePlanTree_OutputOnlyChangeReturnsFalse(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	stderr := captureUIOutput(t)
+
+	planJSON := `{"format_version":"1.2","resource_changes":[],` +
+		`"output_changes":{"vpc_id":{"actions":["update"],"before":"old","after":"new"}}}`
+	t.Setenv("_ATMOS_TEST_TF_SHOW_JSON", planJSON)
+
+	opts := &ExecuteOptions{Command: exePath, WorkingDir: t.TempDir()}
+
+	noChanges := showTwoPhasePlanTree(context.Background(), opts, "plan.tfplan")
+
+	assert.False(t, noChanges, "an output-only diff must not be treated as no changes")
+	assert.NotContains(t, stderr.String(), "NO CHANGES")
 }
 
 // TestConfirmTwoPhaseOperation_PropagatesConfirmError verifies both the apply and destroy
@@ -1226,6 +1268,29 @@ func TestExecuteWithPlanFile_NoChangesDisplaysOutputsAndReturnsNil(t *testing.T)
 
 	require.NoError(t, runErr)
 	assert.Contains(t, stderr.String(), "NO CHANGES")
+}
+
+// TestExecuteWithPlanFile_OutputOnlyChangePropagatesConfirmError is a regression test for issue
+// #3114 (the `--planfile` apply path): a planfile whose only diff is an output value must not
+// be treated as "no changes" - it must proceed to confirmation (and here, since stdin isn't a
+// TTY in `go test`, propagate the confirmation error) rather than short-circuiting to
+// fetchAndDisplayOutputs + a nil return, which would silently skip the apply entirely.
+func TestExecuteWithPlanFile_OutputOnlyChangePropagatesConfirmError(t *testing.T) {
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	stderr := captureUIOutput(t)
+
+	planJSON := `{"format_version":"1.2","resource_changes":[],` +
+		`"output_changes":{"vpc_id":{"actions":["update"],"before":"old","after":"new"}}}`
+	t.Setenv("_ATMOS_TEST_TF_SHOW_JSON", planJSON)
+
+	opts := &ExecuteOptions{Command: exePath, WorkingDir: t.TempDir()}
+
+	runErr := executeWithPlanFile(context.Background(), opts, "plan.tfplan")
+
+	require.Error(t, runErr, "an output-only diff must proceed to confirmation/apply, not be skipped as no changes")
+	assert.ErrorIs(t, runErr, errUtils.ErrStreamingNotSupported)
+	assert.NotContains(t, stderr.String(), "NO CHANGES")
 }
 
 // TestExecute_FailsFastWhenNotTTY verifies Execute checks streaming UI preconditions (no TTY

--- a/pkg/terraform/ui/model_render.go
+++ b/pkg/terraform/ui/model_render.go
@@ -330,7 +330,11 @@ func (m *Model) renderErrorSummary(b *strings.Builder, command string, elapsed f
 // renderSuccessSummary writes the completion summary line, noting when there were no changes.
 func (m *Model) renderSuccessSummary(b *strings.Builder, command string, summary *ChangeSummaryMessage, elapsed float64) {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.ColorGray))
-	noChanges := summary != nil && summary.Changes.Add == 0 && summary.Changes.Change == 0 && summary.Changes.Remove == 0
+	// An output-only change (no resource changes, only an output value) must not be reported as
+	// "no changes" - see issue #3114 - even though summary's counts are resource-only and all
+	// zero in that case.
+	noChanges := summary != nil && summary.Changes.Add == 0 && summary.Changes.Change == 0 &&
+		summary.Changes.Remove == 0 && !m.tracker.HasOutputChanges()
 
 	if noChanges {
 		// No changes - include in markdown for bold rendering.

--- a/pkg/terraform/ui/model_test.go
+++ b/pkg/terraform/ui/model_test.go
@@ -355,6 +355,36 @@ func TestModel_View_Done_NoChanges(t *testing.T) {
 	assert.Contains(t, view, "no changes")
 }
 
+// TestModel_View_Done_OutputOnlyChangeNotReportedAsNoChanges is a regression test for issue
+// #3114: a resource-count-only ChangeSummaryMessage of all zeros must not render "(no changes)"
+// when an output value actually changed, or `atmos terraform apply --ui` would exit claiming
+// nothing happened while silently skipping the apply that would have written the new output.
+func TestModel_View_Done_OutputOnlyChangeNotReportedAsNoChanges(t *testing.T) {
+	clock := newTestClock()
+	reader := strings.NewReader("")
+	m := NewModel("myapp", "dev", "apply", reader, WithClock(clock))
+	m.done = true
+
+	// An output value changed even though no resources changed.
+	m.tracker.HandleMessage(&OutputsMessage{
+		Outputs: map[string]OutputValue{
+			"vpc_id": {Value: "vpc-123abc", Action: "update"},
+		},
+	})
+	m.tracker.HandleMessage(&ChangeSummaryMessage{
+		Changes: Changes{
+			Add:       0,
+			Change:    0,
+			Remove:    0,
+			Operation: "apply",
+		},
+	})
+
+	view := m.View()
+
+	assert.NotContains(t, view, "no changes")
+}
+
 func TestModel_View_Done_Destroy(t *testing.T) {
 	clock := newTestClock()
 	reader := strings.NewReader("")

--- a/pkg/terraform/ui/resource.go
+++ b/pkg/terraform/ui/resource.go
@@ -344,3 +344,35 @@ func (rt *ResourceTracker) GetOutputs() *OutputsMessage {
 	defer rt.mu.RUnlock()
 	return rt.outputs
 }
+
+// HasOutputChanges reports whether any captured output value represents a real change (create,
+// update, or delete), as opposed to no-op/read/absent. Terraform's streamed `outputs` JSON
+// message carries this per-output via OutputValue.Action; it's otherwise parsed and stored (see
+// GetOutputs) but never consulted, so a plan/apply whose only diff is an output value was
+// wrongly reported as having no changes (issue #3114).
+func (rt *ResourceTracker) HasOutputChanges() bool {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	if rt.outputs == nil {
+		return false
+	}
+	for _, ov := range rt.outputs.Outputs {
+		if isOutputChangeAction(ov.Action) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOutputChangeAction reports whether action represents a real output change. Terraform emits
+// "create", "update", and "delete"; "" (older Terraform versions that omit the field), "no-op",
+// and "read" are not changes.
+func isOutputChangeAction(action string) bool {
+	switch action {
+	case actionCreate, actionUpdate, actionDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/terraform/ui/resource_test.go
+++ b/pkg/terraform/ui/resource_test.go
@@ -465,6 +465,49 @@ func TestResourceTracker_HandleOutputs(t *testing.T) {
 	assert.True(t, result.Outputs["db_password"].Sensitive)
 }
 
+// TestResourceTracker_HasOutputChanges_TrueWhenOutputChanged is a regression test for issue
+// #3114: the tracker must be able to report a real (non-no-op) output value change, since
+// OutputsMessage.Outputs[name].Action is otherwise parsed and stored but never consulted.
+func TestResourceTracker_HasOutputChanges_TrueWhenOutputChanged(t *testing.T) {
+	t.Parallel()
+
+	rt := NewResourceTracker()
+	rt.HandleMessage(&OutputsMessage{
+		Outputs: map[string]OutputValue{
+			"vpc_id": {Value: "vpc-123abc", Action: "update"},
+		},
+	})
+
+	assert.True(t, rt.HasOutputChanges())
+}
+
+// TestResourceTracker_HasOutputChanges_FalseWhenNoOpOrRead verifies no-op/read/absent output
+// actions (present on every apply, changed or not) don't spuriously report a change.
+func TestResourceTracker_HasOutputChanges_FalseWhenNoOpOrRead(t *testing.T) {
+	t.Parallel()
+
+	rt := NewResourceTracker()
+	rt.HandleMessage(&OutputsMessage{
+		Outputs: map[string]OutputValue{
+			"vpc_id": {Value: "vpc-123abc", Action: "no-op"},
+			"region": {Value: "us-east-2", Action: "read"},
+			"unset":  {Value: "x"}, // Action omitted entirely (e.g. an older Terraform version).
+		},
+	})
+
+	assert.False(t, rt.HasOutputChanges())
+}
+
+// TestResourceTracker_HasOutputChanges_FalseWhenNoOutputs verifies the zero-value/no-outputs
+// case (e.g. a plan phase, before any OutputsMessage has arrived) reports no change.
+func TestResourceTracker_HasOutputChanges_FalseWhenNoOutputs(t *testing.T) {
+	t.Parallel()
+
+	rt := NewResourceTracker()
+
+	assert.False(t, rt.HasOutputChanges())
+}
+
 func TestResourceTracker_GetCurrentActivity_NoActive(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/terraform/ui/resource_test.go
+++ b/pkg/terraform/ui/resource_test.go
@@ -468,17 +468,27 @@ func TestResourceTracker_HandleOutputs(t *testing.T) {
 // TestResourceTracker_HasOutputChanges_TrueWhenOutputChanged is a regression test for issue
 // #3114: the tracker must be able to report a real (non-no-op) output value change, since
 // OutputsMessage.Outputs[name].Action is otherwise parsed and stored but never consulted.
+// TestResourceTracker_HasOutputChanges_TrueWhenOutputChanged is table-driven across every real
+// output action so a create/delete regression in isOutputChangeAction (which would make
+// HasOutputChanges wrongly report false, and the streaming summary claim "no changes") can't
+// slip through covered only by the update case.
 func TestResourceTracker_HasOutputChanges_TrueWhenOutputChanged(t *testing.T) {
 	t.Parallel()
 
-	rt := NewResourceTracker()
-	rt.HandleMessage(&OutputsMessage{
-		Outputs: map[string]OutputValue{
-			"vpc_id": {Value: "vpc-123abc", Action: "update"},
-		},
-	})
+	for _, action := range []string{"create", "update", "delete"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
 
-	assert.True(t, rt.HasOutputChanges())
+			rt := NewResourceTracker()
+			rt.HandleMessage(&OutputsMessage{
+				Outputs: map[string]OutputValue{
+					"vpc_id": {Value: "vpc-123abc", Action: action},
+				},
+			})
+
+			assert.True(t, rt.HasOutputChanges())
+		})
+	}
 }
 
 // TestResourceTracker_HasOutputChanges_FalseWhenNoOpOrRead verifies no-op/read/absent output

--- a/pkg/terraform/ui/tree.go
+++ b/pkg/terraform/ui/tree.go
@@ -7,6 +7,11 @@ type DependencyTree struct {
 	nodes     map[string]*TreeNode
 	Stack     string // Atmos stack name (e.g., "plat-ue2-dev").
 	Component string // Atmos component name (e.g., "vpc").
+	// outputChanges is the count of plan.OutputChanges entries with a real (non-no-op, non-read)
+	// action. Kept separate from GetChangeSummary's (add, change, remove) resource-only counts,
+	// which have specific semantics used elsewhere (exit codes, Destroy labeling) - see
+	// HasOutputChanges.
+	outputChanges int
 }
 
 // TreeNode represents a resource in the dependency tree.

--- a/pkg/terraform/ui/tree_builder.go
+++ b/pkg/terraform/ui/tree_builder.go
@@ -95,6 +95,7 @@ func buildTreeFromPlan(plan *tfjson.Plan, stack, component string) *DependencyTr
 	}
 
 	populateTreeNodes(tree, plan)
+	tree.outputChanges = countOutputChanges(plan)
 
 	// Build parent-child relationships from dependencies.
 	if plan.Config != nil && plan.Config.RootModule != nil {
@@ -133,6 +134,20 @@ func populateTreeNodes(tree *DependencyTree, plan *tfjson.Plan) {
 		}
 		tree.nodes[rc.Address] = node
 	}
+}
+
+// countOutputChanges counts plan.OutputChanges entries that represent a real change (create,
+// update, or delete), skipping no-op and read actions. This is Terraform's `outputs` diff -
+// e.g. an output value change with no resource changes at all - which populateTreeNodes never
+// sees since it only iterates plan.ResourceChanges (see issue #3114).
+func countOutputChanges(plan *tfjson.Plan) int {
+	count := 0
+	for _, oc := range plan.OutputChanges {
+		if oc != nil && (oc.Actions.Create() || oc.Actions.Update() || oc.Actions.Delete()) {
+			count++
+		}
+	}
+	return count
 }
 
 // resourceChangeAction determines the action for a resource change, handling composite

--- a/pkg/terraform/ui/tree_render.go
+++ b/pkg/terraform/ui/tree_render.go
@@ -629,6 +629,19 @@ func (t *DependencyTree) GetChangeSummary() (add, change, remove int) {
 	return add, change, remove
 }
 
+// HasOutputChanges reports whether the plan contains any output-only change (create, update, or
+// delete of an output value), independent of GetChangeSummary's resource-only counts. A plan
+// whose only diff is an output value has add == change == remove == 0 but must still not be
+// treated as "no changes" (see issue #3114).
+func (t *DependencyTree) HasOutputChanges() bool {
+	return t.outputChanges > 0
+}
+
+// OutputChangeCount returns the number of output-only changes in the plan.
+func (t *DependencyTree) OutputChangeCount() int {
+	return t.outputChanges
+}
+
 func countActions(node *TreeNode, add, change, remove *int) {
 	if node == nil {
 		return
@@ -688,15 +701,33 @@ func buildChangeBadges(add, change, remove int) []string {
 	return badges
 }
 
+// outputsChangedBadge renders a badge indicating an output value changed. Reuses the "change"
+// (yellow) visual language already used for in-place resource updates, since an output-only
+// diff is the same kind of change applied to an output instead of a resource.
+func outputsChangedBadge() string {
+	return changeBadge(theme.ColorYellow, "OUTPUTS CHANGED")
+}
+
 // RenderChangeSummaryBadges renders a badge-style change summary.
-// Shows "NO CHANGES" badge if all counts are zero.
+// Shows "NO CHANGES" badge only when there are no resource changes and no output changes.
 // Format: "  1 ADD 2 CHANGE 1 DELETE" with colored badges (green/yellow/red backgrounds).
-func RenderChangeSummaryBadges(add, change, remove int) string {
+// The hasOutputChanges parameter reports a plan/apply whose only diff is an output value (see
+// DependencyTree.HasOutputChanges) - never reported as "NO CHANGES", even when add, change, and
+// remove are all zero.
+func RenderChangeSummaryBadges(add, change, remove int, hasOutputChanges bool) string {
 	defer perf.Track(nil, "terraform.ui.RenderChangeSummaryBadges")()
 
-	badges := []string{noChangesBadge()}
-	if add > 0 || change > 0 || remove > 0 {
+	var badges []string
+	switch {
+	case add > 0 || change > 0 || remove > 0:
 		badges = buildChangeBadges(add, change, remove)
+		if hasOutputChanges {
+			badges = append(badges, outputsChangedBadge())
+		}
+	case hasOutputChanges:
+		badges = []string{outputsChangedBadge()}
+	default:
+		badges = []string{noChangesBadge()}
 	}
 
 	// Join badges with a space, add blank line above and below, and indent 2 spaces.

--- a/pkg/terraform/ui/tree_test.go
+++ b/pkg/terraform/ui/tree_test.go
@@ -204,30 +204,53 @@ func TestDependencyTree_GetChangeSummary_WithReplace(t *testing.T) {
 
 // TestDependencyTree_HasOutputChanges is a regression test for issue #3114: a plan whose only
 // diff is an output value (no resource changes at all) must be detectable as "has changes" via
-// a signal separate from GetChangeSummary's resource-only counts.
+// a signal separate from GetChangeSummary's resource-only counts. Table-driven across every
+// tfjson output action so a create/delete regression in countOutputChanges (which would make
+// HasOutputChanges wrongly report false, and the executor skip an output-only plan as "no
+// changes") can't slip through covered only by the update case.
 func TestDependencyTree_HasOutputChanges(t *testing.T) {
 	t.Parallel()
 
-	plan := &tfjson.Plan{
-		ResourceChanges: []*tfjson.ResourceChange{},
-		OutputChanges: map[string]*tfjson.Change{
-			"vpc_id": {Actions: tfjson.Actions{tfjson.ActionUpdate}},
-		},
+	tests := []struct {
+		name          string
+		action        tfjson.Action
+		expectChanges bool
+		expectCount   int
+	}{
+		{name: "create", action: tfjson.ActionCreate, expectChanges: true, expectCount: 1},
+		{name: "update", action: tfjson.ActionUpdate, expectChanges: true, expectCount: 1},
+		{name: "delete", action: tfjson.ActionDelete, expectChanges: true, expectCount: 1},
+		{name: "no-op", action: tfjson.ActionNoop, expectChanges: false, expectCount: 0},
+		{name: "read", action: tfjson.ActionRead, expectChanges: false, expectCount: 0},
 	}
 
-	tree := buildTreeFromPlan(plan, "dev", "vpc")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.True(t, tree.HasOutputChanges())
-	assert.Equal(t, 1, tree.OutputChangeCount())
+			plan := &tfjson.Plan{
+				ResourceChanges: []*tfjson.ResourceChange{},
+				OutputChanges: map[string]*tfjson.Change{
+					"vpc_id": {Actions: tfjson.Actions{tt.action}},
+				},
+			}
 
-	add, change, remove := tree.GetChangeSummary()
-	assert.Equal(t, 0, add)
-	assert.Equal(t, 0, change)
-	assert.Equal(t, 0, remove)
+			tree := buildTreeFromPlan(plan, "dev", "vpc")
+
+			assert.Equal(t, tt.expectChanges, tree.HasOutputChanges())
+			assert.Equal(t, tt.expectCount, tree.OutputChangeCount())
+
+			add, change, remove := tree.GetChangeSummary()
+			assert.Equal(t, 0, add)
+			assert.Equal(t, 0, change)
+			assert.Equal(t, 0, remove)
+		})
+	}
 }
 
-// TestDependencyTree_HasOutputChanges_NoOpNotCounted verifies that no-op/read output entries
-// (present in every plan, changed or not) don't spuriously flip HasOutputChanges to true.
+// TestDependencyTree_HasOutputChanges_NoOpNotCounted verifies that multiple simultaneous
+// no-op/read output entries (present in every plan, changed or not) don't spuriously flip
+// HasOutputChanges to true.
 func TestDependencyTree_HasOutputChanges_NoOpNotCounted(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/terraform/ui/tree_test.go
+++ b/pkg/terraform/ui/tree_test.go
@@ -202,6 +202,48 @@ func TestDependencyTree_GetChangeSummary_WithReplace(t *testing.T) {
 	assert.Equal(t, 2, remove) // aws_instance.old + aws_instance.web (replace).
 }
 
+// TestDependencyTree_HasOutputChanges is a regression test for issue #3114: a plan whose only
+// diff is an output value (no resource changes at all) must be detectable as "has changes" via
+// a signal separate from GetChangeSummary's resource-only counts.
+func TestDependencyTree_HasOutputChanges(t *testing.T) {
+	t.Parallel()
+
+	plan := &tfjson.Plan{
+		ResourceChanges: []*tfjson.ResourceChange{},
+		OutputChanges: map[string]*tfjson.Change{
+			"vpc_id": {Actions: tfjson.Actions{tfjson.ActionUpdate}},
+		},
+	}
+
+	tree := buildTreeFromPlan(plan, "dev", "vpc")
+
+	assert.True(t, tree.HasOutputChanges())
+	assert.Equal(t, 1, tree.OutputChangeCount())
+
+	add, change, remove := tree.GetChangeSummary()
+	assert.Equal(t, 0, add)
+	assert.Equal(t, 0, change)
+	assert.Equal(t, 0, remove)
+}
+
+// TestDependencyTree_HasOutputChanges_NoOpNotCounted verifies that no-op/read output entries
+// (present in every plan, changed or not) don't spuriously flip HasOutputChanges to true.
+func TestDependencyTree_HasOutputChanges_NoOpNotCounted(t *testing.T) {
+	t.Parallel()
+
+	plan := &tfjson.Plan{
+		OutputChanges: map[string]*tfjson.Change{
+			"vpc_id": {Actions: tfjson.Actions{tfjson.ActionNoop}},
+			"region": {Actions: tfjson.Actions{tfjson.ActionRead}},
+		},
+	}
+
+	tree := buildTreeFromPlan(plan, "dev", "vpc")
+
+	assert.False(t, tree.HasOutputChanges())
+	assert.Equal(t, 0, tree.OutputChangeCount())
+}
+
 func TestSortChildren(t *testing.T) {
 	t.Parallel()
 
@@ -1203,7 +1245,7 @@ func TestGetContrastTextColor_InvalidInput(t *testing.T) {
 func TestRenderChangeSummaryBadges_NoChanges(t *testing.T) {
 	t.Parallel()
 
-	result := RenderChangeSummaryBadges(0, 0, 0)
+	result := RenderChangeSummaryBadges(0, 0, 0, false)
 	assert.Contains(t, result, "NO CHANGES")
 	// Use patterns with numbers to avoid matching within "NO CHANGES".
 	assert.NotRegexp(t, `\d+ ADD`, result)
@@ -1214,7 +1256,7 @@ func TestRenderChangeSummaryBadges_NoChanges(t *testing.T) {
 func TestRenderChangeSummaryBadges_OnlyAdd(t *testing.T) {
 	t.Parallel()
 
-	result := RenderChangeSummaryBadges(3, 0, 0)
+	result := RenderChangeSummaryBadges(3, 0, 0, false)
 	assert.Contains(t, result, "3 ADD")
 	assert.NotContains(t, result, "CHANGE")
 	assert.NotContains(t, result, "DELETE")
@@ -1224,7 +1266,7 @@ func TestRenderChangeSummaryBadges_OnlyAdd(t *testing.T) {
 func TestRenderChangeSummaryBadges_OnlyChange(t *testing.T) {
 	t.Parallel()
 
-	result := RenderChangeSummaryBadges(0, 2, 0)
+	result := RenderChangeSummaryBadges(0, 2, 0, false)
 	assert.Contains(t, result, "2 CHANGE")
 	assert.NotContains(t, result, "ADD")
 	assert.NotContains(t, result, "DELETE")
@@ -1234,7 +1276,7 @@ func TestRenderChangeSummaryBadges_OnlyChange(t *testing.T) {
 func TestRenderChangeSummaryBadges_OnlyRemove(t *testing.T) {
 	t.Parallel()
 
-	result := RenderChangeSummaryBadges(0, 0, 5)
+	result := RenderChangeSummaryBadges(0, 0, 5, false)
 	assert.Contains(t, result, "5 DELETE")
 	assert.NotContains(t, result, "ADD")
 	assert.NotContains(t, result, "CHANGE")
@@ -1244,10 +1286,32 @@ func TestRenderChangeSummaryBadges_OnlyRemove(t *testing.T) {
 func TestRenderChangeSummaryBadges_AllTypes(t *testing.T) {
 	t.Parallel()
 
-	result := RenderChangeSummaryBadges(1, 2, 3)
+	result := RenderChangeSummaryBadges(1, 2, 3, false)
 	assert.Contains(t, result, "1 ADD")
 	assert.Contains(t, result, "2 CHANGE")
 	assert.Contains(t, result, "3 DELETE")
+	assert.NotContains(t, result, "NO CHANGES")
+}
+
+// TestRenderChangeSummaryBadges_OutputOnlyChange is a regression test for issue #3114: when
+// resource counts are all zero but an output value changed, the badge must not read
+// "NO CHANGES" - the plan/apply is not actually a no-op.
+func TestRenderChangeSummaryBadges_OutputOnlyChange(t *testing.T) {
+	t.Parallel()
+
+	result := RenderChangeSummaryBadges(0, 0, 0, true)
+	assert.NotContains(t, result, "NO CHANGES")
+	assert.Contains(t, result, "OUTPUTS CHANGED")
+}
+
+// TestRenderChangeSummaryBadges_ResourceAndOutputChanges verifies the output-changed badge is
+// additive: it appears alongside resource-change badges rather than replacing them.
+func TestRenderChangeSummaryBadges_ResourceAndOutputChanges(t *testing.T) {
+	t.Parallel()
+
+	result := RenderChangeSummaryBadges(1, 0, 0, true)
+	assert.Contains(t, result, "1 ADD")
+	assert.Contains(t, result, "OUTPUTS CHANGED")
 	assert.NotContains(t, result, "NO CHANGES")
 }
 


### PR DESCRIPTION
## what

- The streaming terraform UI (`--ui`) now treats output-only plan diffs as real changes instead of reporting `NO CHANGES`.
- Added `DependencyTree.HasOutputChanges()`/`OutputChangeCount()` (from `plan.OutputChanges`) and `ResourceTracker.HasOutputChanges()` (from the streamed `outputs` message's per-output `action`).
- Wired both into the three "no changes" gates in `pkg/terraform/ui/executor.go` (`showPlanTree`, `showTwoPhasePlanTree`, `executeWithPlanFile`) and into the streaming completion summary in `model_render.go`.
- `RenderChangeSummaryBadges` gained an `OUTPUTS CHANGED` badge and no longer renders `NO CHANGES` when only outputs changed.

## why

- `atmos terraform apply <component> -s <stack> --ui` silently skipped the confirmation prompt and the apply entirely when the only diff in the plan was an output value, so the new output never reached state (exit code 0, no error).
- `atmos terraform plan --ui` hid the output diff completely, and `atmos terraform deploy --ui` (auto-approve) applied the change correctly but printed a misleading `... completed (no changes)` summary.
- All four call sites derived "has changes" purely from resource add/change/remove counts and never consulted `tfjson.Plan.OutputChanges` or the streamed output `action` field, even though that data was already being parsed and stored.
- Added regression tests for each of the four affected code paths (`tree_test.go`, `executor_test.go`, `model_test.go`, `resource_test.go`), written first to confirm the gap before implementing the fix, per the repo's bug-fixing workflow.

## references

- Closes #3114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terraform plans that change only output values are now correctly recognized as changes.
  * Output-only changes display an **“OUTPUTS CHANGED”** badge instead of **“NO CHANGES.”**
  * Plans with both resource and output changes now show both types in the change summary.
  * Output-only changes proceed through confirmation and apply workflows correctly.
  * Completed applies with output-only changes are no longer reported as having no changes.
  * Packer variable files now resolve correctly when executing Packer commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->