### PR TITLE
ci: shard race detector tests across hosted runners

### DIFF
--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -34,7 +34,9 @@ inputs:
     required: false
     default: go.mod
   cache:
-    description: Whether to restore GOMODCACHE + GOCACHE ("true"/"false").
+    description: >-
+      Cache to restore: "true" for the full build/module cache, "race-plan" for the
+      lightweight race-planner cache, or "false" for none.
     required: false
     default: "true"
   cache-dependency-path:
@@ -45,7 +47,7 @@ inputs:
 outputs:
   cache-hit:
     description: Whether a cache entry was restored (exact or prefix match).
-    value: ${{ steps.restore.outputs.cache-matched-key != '' }}
+    value: ${{ steps.restore.outputs.cache-matched-key != '' || steps.restore-race-plan.outputs.cache-matched-key != '' }}
   cache-primary-key:
     description: >-
       The rendered primary key (OS/arch/Go version/dependency hash, no run suffix). The warmup
@@ -103,7 +105,11 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo "GOCACHE=$HOME/.cache/go-build" >> "$GITHUB_ENV"
+        if [ "${{ inputs.cache }}" = "race-plan" ]; then
+          echo "GOCACHE=$RUNNER_TEMP/race-plan-go-build" >> "$GITHUB_ENV"
+        else
+          echo "GOCACHE=$HOME/.cache/go-build" >> "$GITHUB_ENV"
+        fi
         echo "GOMODCACHE=$HOME/go/pkg/mod" >> "$GITHUB_ENV"
 
     - name: Set up Go
@@ -135,3 +141,19 @@ runs:
         restore-keys: |
           go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles(inputs.cache-dependency-path) }}-
           go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-
+
+    # The race planner only needs to compile the Mage target and enumerate
+    # local packages. Its own cache lineage avoids downloading the full,
+    # race-instrumented GOCACHE archive before any race shard can start.
+    - name: Restore the race planner build and module caches
+      id: restore-race-plan
+      if: inputs.cache == 'race-plan'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ env.GOCACHE }}
+          ${{ env.GOMODCACHE }}
+        key: race-plan-go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          race-plan-go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles(inputs.cache-dependency-path) }}-
+          race-plan-go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-

--- a/.github/workflows/setup-go-cache-warmup.yml
+++ b/.github/workflows/setup-go-cache-warmup.yml
@@ -154,6 +154,18 @@ jobs:
       - name: Get deps
         uses: ./.github/actions/go-mod-download-retry
 
+      # Keep the race planner's small GOCACHE namespace separate from the
+      # full build/race cache below. Consumers restore this before running
+      # `test:racematrix`, avoiding both a cold Mage compile and the full
+      # multi-gigabyte race cache download on the suite's startup path.
+      - name: Warm the race planner cache
+        if: matrix.target == 'linux'
+        env:
+          GOCACHE: ${{ runner.temp }}/race-plan-go-build
+          RACE_SHARD_COUNT: "4"
+          ATMOS_TEST_RACE_SHARD_SEED: ${{ github.run_id }}
+        run: go tool mage test:racematrix
+
       # Warm the same cache namespaces the real jobs compile in. Flags must
       # match the real invocations or Go's action IDs differ and the warm
       # entries go unused: atmos builds with CGO_ENABLED=0 + GOFIPS140=latest
@@ -213,3 +225,12 @@ jobs:
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
           key: ${{ steps.go.outputs.cache-primary-key }}-${{ github.run_id }}
+
+      - name: Save the race planner build and module caches
+        if: matrix.target == 'linux'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ runner.temp }}/race-plan-go-build
+            ${{ env.GOMODCACHE }}
+          key: race-plan-go-cache-${{ runner.os }}-${{ runner.arch }}-go${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -881,10 +881,10 @@ jobs:
       - name: Set up Go
         uses: ./.github/actions/setup-go-cache
         with:
-          # Planning only runs `go list`; downloading the multi-gigabyte race
-          # build cache here costs more than it saves. The race shards below
-          # still restore the warmed cache before compiling and testing.
-          cache: false
+          # Planning only needs Mage and `go list`; restore its dedicated
+          # nightly-warmed cache instead of the multi-gigabyte race archive.
+          # The race shards below still restore the full warmed cache.
+          cache: race-plan
 
       - name: Plan race shards
         id: plan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,12 @@ env:
   # OS (see tests/cli_test.go's testShard/testCaseShard and the `test` job's
   # matrix.shard list below, which must stay in sync with this count).
   TEST_SHARD_COUNT: "10"
+  # Number of parallel shards the `race` job's package list is split into
+  # (see magefiles/race_matrix.go's Test.RaceMatrix and the `race` job's
+  # hardcoded "shard N/4" name below, which must stay in sync with this
+  # count -- the job `name:` context can't read workflow `env`, same reason
+  # TEST_SHARD_COUNT above needs its own comment).
+  RACE_SHARD_COUNT: "4"
   # No `|direct` fallback: every job here runs under harden-runner's block
   # mode, where a direct fetch fans out to ~25 vanity-import hosts (k8s.io,
   # go.uber.org, gopkg.in, helm.sh, ...) that are not allowlisted, so the
@@ -850,6 +856,37 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  # Computes the `race` job's shard matrix once, upstream of the matrix
+  # itself: `go list ./...` order is stable (sorted by import path), so a
+  # naive round-robin split-per-shard-job would pin the same cluster of
+  # packages to the same shard on every run. Doing the split in one place
+  # lets it shuffle the full list first (magefiles/race_matrix.go's
+  # Test.RaceMatrix, seeded from github.run_id so the assignment still
+  # varies run to run) and hand each shard its own package list directly,
+  # rather than trusting N independent jobs to recompute an identical split.
+  # Emits the same GitHub Actions matrix JSON convention `atmos describe
+  # affected`/`atmos list instances --format=matrix` use (see pkg/matrix).
+  race-plan:
+    name: "[race] plan shards"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-cache
+
+      - name: Plan race shards
+        id: plan
+        env:
+          ATMOS_TEST_RACE_SHARD_SEED: ${{ github.run_id }}
+        run: go tool mage test:racematrix
+
   # `-race` requires CGO_ENABLED=1 (the detector's runtime is itself a cgo
   # library), unlike every other Go build/test path in this repo (CGO_ENABLED=0).
   # Enabling cgo pulls in the cgo half of github.com/bearsh/hid (transitive, via
@@ -864,41 +901,33 @@ jobs:
   # GOFIPS140=latest (set inside the `race` command itself, .atmos.d/test.yaml)
   # is unaffected by CGO_ENABLED: Go's FIPS 140-3 module is pure Go, no cgo.
   race:
-    name: "[race] non-acceptance test suite"
-    # `go test`'s package-level concurrency scales with available cores, and
-    # this job compiles+runs ~400 race-instrumented packages -- the standard
-    # ubuntu-latest runner's ~4 cores were the bottleneck (this job became
-    # the slowest check once every other job's own timeout issues were
-    # fixed). The RunsOn "terraform" family used elsewhere in this file for
-    # Go work (the build job's linux leg) turned out to be an i4i.large: 2
-    # cores, 15.7GB RAM -- fewer cores than ubuntu-latest, a downgrade for
-    # this CPU/memory-bound workload. "large" (4 cores/~32GB) was a real
-    # upgrade, but this job stayed the workflow's longest pole at ~27 minutes
-    # of pure test execution, so it now gets "xlarge" (8+ cores/~64GB, per
-    # .github's runs-on.yml): `go test` runs packages concurrently up to
-    # GOMAXPROCS, and -race's per-test memory overhead is what the extra RAM
-    # absorbs.
-    #
-    # No extras=s3-cache: the Go cache restore (setup-go-cache below) must
-    # read the GitHub Actions cache backend, where the warmup workflow saves
-    # a race-instrumented (-race, CGO_ENABLED=1) build cache on main's scope.
-    runs-on: "runs-on=${{github.run_id}}/runner=xlarge/tag=atmos/private=false"
-    # Race-instrumented binaries run several times slower and use substantially
-    # more memory than normal test binaries; this runs the entire `./...` suite
-    # unsharded (unlike the `test` job's acceptance+unit sweep), so budget
-    # generously. `./cmd/...` alone -- one subtree out of the full package set
-    # this job actually runs -- took ~45 minutes locally in isolation (see
-    # docs/fixes/2026-09-01-race-detector-ci-job-timeouts.md); real runs on
-    # this runner have finished within a few minutes of the previous 45-minute
-    # budget, leaving too little slack for checkout/setup/apt overhead plus
-    # natural runner variance.
-    timeout-minutes: 75
+    # RACE_SHARD_COUNT (workflow env) is the source of truth for the shard
+    # count; the "/4" here is hardcoded because the job `name:` context
+    # can't read workflow `env` (same reason the acceptance job's name below
+    # hardcodes "/10").
+    name: "[race] non-acceptance test suite (shard ${{ matrix.shard }}/4)"
+    needs: [race-plan]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.race-plan.outputs.matrix) }}
+    # Plain hosted ubuntu-latest, not RunsOn: this is the same image lineage
+    # setup-go-cache-warmup.yml's linux leg writes the race-instrumented
+    # (-race, CGO_ENABLED=1) Go build cache on, and the same runner the 10
+    # hosted acceptance shards already use -- so this job reads that cache
+    # directly instead of relying on the ImageOS-excluded-from-key workaround
+    # RunsOn legs needed. Splitting the suite across RACE_SHARD_COUNT shards
+    # (above) gives more total cores across the matrix than one big runner
+    # would, without paying for oversized single instances.
+    runs-on: ubuntu-latest
+    # Each shard now runs roughly 1/4 of the package list rather than the
+    # unsharded ~27-minute-plus suite, but every shard still pays the same
+    # fixed per-job overhead (checkout, toolchain installs, apt-get, cache
+    # restore) that used to be amortized over one long-running job -- so this
+    # is generous headroom above that fraction, not a straight 75÷4 division
+    # (the acceptance shard matrix above budgets the same way).
+    timeout-minutes: 30
     steps:
-      # Harden Runner doesn't cover RunsOn self-hosted runners (see the build
-      # job's linux leg, which skips it the same way); runs-on/action sets up
-      # this job's runner metadata/labels instead.
-      - uses: runs-on/action@efac073ea2507ec18797de3a81704201ade11d9d # v2.3.1
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
@@ -928,12 +957,9 @@ jobs:
       - name: Install Linux build dependencies (libudev-dev for CGO_ENABLED=1 -- see comment above)
         run: |
           # The DEB822 /etc/apt/sources.list.d/ubuntu.sources file (and the
-          # Azure mirror it points at) is a GitHub-hosted-runner-image thing
-          # (Ubuntu 24.04+); this job now runs on the RunsOn "terraform"
-          # runner (Ubuntu 22.04, no DEB822 sources file at all -- see
-          # docs/fixes for the incident where this sed failed outright with
-          # "No such file or directory"). Only rewrite the mirror if that
-          # file actually exists, so this step works on either runner image.
+          # Azure mirror it points at) is a GitHub-hosted-runner-image thing;
+          # only rewrite the mirror if that file actually exists, so this
+          # step works across runner image variations.
           if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
             sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
           fi
@@ -949,10 +975,10 @@ jobs:
         # Unlike the `test`/`build` jobs, this job never ran this step, so
         # tests needing these binaries (e.g. cmd/terraform/migrate,
         # TestPackerValidateCmd) fell back to Atmos's own lazy/auto-install
-        # path -- unreliable here since `go test ./...` runs ~400 packages as
-        # separate concurrent processes, and nothing serializes a shared
-        # install across them. Pre-installing once, before any test process
-        # starts, removes that race entirely (see docs/fixes for the
+        # path -- unreliable here since `go test ./...` runs each shard's
+        # packages as separate concurrent processes, and nothing serializes a
+        # shared install across them. Pre-installing once, before any test
+        # process starts, removes that race entirely (see docs/fixes for the
         # incident this closes).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -972,6 +998,10 @@ jobs:
           # job's acceptance steps, which already set this for the same
           # reason (see their own "Use the GitHub token" comment).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This shard's package list, precomputed by race-plan above.
+          # racePackagesFromEnv (magefiles/test_race.go) treats a non-empty
+          # TEST the same as every other manual TEST override in this repo.
+          TEST: ${{ matrix.packages }}
         run: atmos test race
 
   # Sharding the `test` job fans it out into TEST_SHARD_COUNT x 3 per-leg checks.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -880,12 +880,19 @@ jobs:
 
       - name: Set up Go
         uses: ./.github/actions/setup-go-cache
+        with:
+          # Planning only runs `go list`; downloading the multi-gigabyte race
+          # build cache here costs more than it saves. The race shards below
+          # still restore the warmed cache before compiling and testing.
+          cache: false
 
       - name: Plan race shards
         id: plan
         env:
           ATMOS_TEST_RACE_SHARD_SEED: ${{ github.run_id }}
-        run: go tool mage test:racematrix
+        run: |
+          echo "::notice title=Race shard seed::Reproduce locally with ATMOS_TEST_RACE_SHARD_SEED=${ATMOS_TEST_RACE_SHARD_SEED} RACE_SHARD_COUNT=${RACE_SHARD_COUNT} go tool mage test:racematrix"
+          go tool mage test:racematrix
 
   # `-race` requires CGO_ENABLED=1 (the detector's runtime is itself a cgo
   # library), unlike every other Go build/test path in this repo (CGO_ENABLED=0).
@@ -909,8 +916,7 @@ jobs:
     needs: [race-plan]
     strategy:
       fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.race-plan.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.race-plan.outputs.matrix) }}
     # Plain hosted ubuntu-latest, not RunsOn: this is the same image lineage
     # setup-go-cache-warmup.yml's linux leg writes the race-instrumented
     # (-race, CGO_ENABLED=1) Go build cache on, and the same runner the 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -891,7 +891,7 @@ jobs:
         env:
           ATMOS_TEST_RACE_SHARD_SEED: ${{ github.run_id }}
         run: |
-          echo "::notice title=Race shard seed::Reproduce locally with ATMOS_TEST_RACE_SHARD_SEED=${ATMOS_TEST_RACE_SHARD_SEED} RACE_SHARD_COUNT=${RACE_SHARD_COUNT} go tool mage test:racematrix"
+          echo "::notice title=Race shard seed::Reproduce locally with GITHUB_OUTPUT=/dev/stdout ATMOS_TEST_RACE_SHARD_SEED=${ATMOS_TEST_RACE_SHARD_SEED} RACE_SHARD_COUNT=${RACE_SHARD_COUNT} go tool mage test:racematrix"
           go tool mage test:racematrix
 
   # `-race` requires CGO_ENABLED=1 (the detector's runtime is itself a cgo

--- a/cmd/custom_command_integration_test.go
+++ b/cmd/custom_command_integration_test.go
@@ -1039,11 +1039,23 @@ func TestCustomCommandIntegration_ShellStepCancelledByContext(t *testing.T) {
 		defer recoverExit()
 		customCmd.Run(customCmd, []string{})
 	}()
+	// Keep the exit stub installed until the command goroutine has stopped, even
+	// when a require below aborts the test. Windows process startup can be slow
+	// under the fully sharded CI workload; restoring the process-global stub
+	// while this goroutine is still running can make the following test panic.
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Error("custom command did not stop during test cleanup")
+		}
+	})
 
 	require.Eventually(t, func() bool {
 		_, statErr := os.Stat(startedPath)
 		return statErr == nil
-	}, 5*time.Second, 10*time.Millisecond, "helper subprocess never started")
+	}, 15*time.Second, 10*time.Millisecond, "helper subprocess never started")
 
 	cancel()
 
@@ -1103,11 +1115,22 @@ func TestCustomCommandIntegration_AtmosStepCancelledByContext(t *testing.T) {
 		defer recoverExit()
 		customCmd.Run(customCmd, []string{})
 	}()
+	// This cleanup is registered after cancellationOsExitStub's cleanup, so it
+	// runs first and prevents a late goroutine from observing another test's
+	// replacement for the process-global exit hook.
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Error("custom command did not stop during test cleanup")
+		}
+	})
 
 	require.Eventually(t, func() bool {
 		_, statErr := os.Stat(startedPath)
 		return statErr == nil
-	}, 5*time.Second, 10*time.Millisecond, "helper subprocess never started")
+	}, 15*time.Second, 10*time.Millisecond, "helper subprocess never started")
 
 	cancel()
 

--- a/magefiles/race_matrix.go
+++ b/magefiles/race_matrix.go
@@ -99,7 +99,7 @@ func shuffleRacePackages(packages []string, seedValue string) []string {
 	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(seedValue))
 	seed := hasher.Sum64()
-	rng := rand.New(rand.NewPCG(seed, seed))
+	rng := rand.New(rand.NewPCG(seed, seed)) //nolint:gosec // Deterministic test sharding; not security-sensitive.
 	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
 	return shuffled
 }

--- a/magefiles/race_matrix.go
+++ b/magefiles/race_matrix.go
@@ -1,0 +1,105 @@
+//go:build mage
+
+package main
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+
+	ghactions "github.com/cloudposse/atmos/pkg/github/actions"
+	"github.com/cloudposse/atmos/pkg/matrix"
+)
+
+// raceShardCountEnv sets how many parallel shards RaceMatrix partitions the
+// race package list into. The `race-plan` CI job (test.yml) passes
+// RACE_SHARD_COUNT, the workflow-level env that also sizes the `race` job's
+// own matrix -- kept as a single source of truth between the two.
+const raceShardCountEnv = "RACE_SHARD_COUNT"
+
+// raceShardSeedEnv seeds the shuffle RaceMatrix applies before round-robin
+// bucketing. `go list ./...` order is stable (sorted by import path), so
+// without a shuffle the same cluster of packages -- e.g. every
+// pkg/toolchain subpackage, which all make real network calls -- would land
+// in the same shard on every run. The CI workflow sets this to
+// ${{ github.run_id }}: fixed for this run (RaceMatrix computes every
+// shard's package list in one place, so there's no cross-job agreement to
+// maintain) but different from the previous run, so no single shard stays
+// permanently the slow one. Unset (e.g. local invocations) yields a fixed
+// seed.
+const raceShardSeedEnv = "ATMOS_TEST_RACE_SHARD_SEED"
+
+var errInvalidRaceShardCount = fmt.Errorf("mage: %s must be a positive integer", raceShardCountEnv)
+
+// raceShardEntry is one row of the GitHub Actions matrix RaceMatrix emits:
+// its shard index (1-based, matching the `race` job name's "(shard N/M)"
+// suffix) and its space-joined package list, fed straight into `atmos test
+// race` via the TEST env override (racePackagesFromEnv in test_race.go).
+type raceShardEntry struct {
+	Shard    int    `json:"shard"`
+	Packages string `json:"packages"`
+}
+
+// RaceMatrix emits a GitHub Actions matrix -- the same --format=matrix
+// convention `atmos describe affected`/`atmos list instances` use (see
+// pkg/matrix) -- partitioning the race package list across
+// RACE_SHARD_COUNT shards, shuffled first (raceShardSeedEnv) so package
+// order doesn't pin the same slow cluster to the same shard every run. This
+// backs the `[race] plan shards` CI job (test.yml), whose output feeds the
+// `race` job's `strategy.matrix.include`.
+func (Test) RaceMatrix() error {
+	root, err := mageRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	packages, err := racePackages(root)
+	if err != nil {
+		return err
+	}
+
+	shardCount, err := strconv.Atoi(environment(raceShardCountEnv))
+	if err != nil || shardCount < 1 {
+		return errInvalidRaceShardCount
+	}
+
+	entries := raceShardMatrix(packages, shardCount, environment(raceShardSeedEnv))
+	return matrix.WriteOutput(entries, ghactions.GetOutputPath())
+}
+
+// raceShardMatrix shuffles packages (shuffleRacePackages) and buckets them
+// round-robin into shardCount groups, returning one raceShardEntry per
+// shard in shard order.
+func raceShardMatrix(packages []string, shardCount int, seedValue string) []raceShardEntry {
+	shuffled := shuffleRacePackages(packages, seedValue)
+	buckets := make([][]string, shardCount)
+	for index, pkg := range shuffled {
+		bucket := index % shardCount
+		buckets[bucket] = append(buckets[bucket], pkg)
+	}
+
+	entries := make([]raceShardEntry, shardCount)
+	for index, bucket := range buckets {
+		entries[index] = raceShardEntry{
+			Shard:    index + 1,
+			Packages: strings.Join(bucket, " "),
+		}
+	}
+	return entries
+}
+
+// shuffleRacePackages returns a copy of packages in a deterministic
+// pseudo-random order derived from seedValue: the same seed always produces
+// the same order, while different seeds produce different orders. An empty
+// seedValue is its own fixed seed.
+func shuffleRacePackages(packages []string, seedValue string) []string {
+	shuffled := append([]string(nil), packages...)
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(seedValue))
+	seed := hasher.Sum64()
+	rng := rand.New(rand.NewPCG(seed, seed))
+	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	return shuffled
+}

--- a/magefiles/race_matrix.go
+++ b/magefiles/race_matrix.go
@@ -48,7 +48,7 @@ type raceShardEntry struct {
 // RACE_SHARD_COUNT shards, shuffled first (raceShardSeedEnv) so package
 // order doesn't pin the same slow cluster to the same shard every run. This
 // backs the `[race] plan shards` CI job (test.yml), whose output feeds the
-// `race` job's `strategy.matrix.include`.
+// `race` job's `strategy.matrix`.
 func (Test) RaceMatrix() error {
 	root, err := mageRepoRoot()
 	if err != nil {

--- a/magefiles/race_matrix_test.go
+++ b/magefiles/race_matrix_test.go
@@ -67,25 +67,34 @@ func TestTestRaceMatrix(t *testing.T) {
 		require.ErrorIs(t, err, errMageRepoRootNotFound)
 	})
 
-	t.Run("missing RACE_SHARD_COUNT is an error", func(t *testing.T) {
+	t.Run("propagates package listing failure", func(t *testing.T) {
 		root := initGitRepoFixture(t)
 		t.Chdir(root)
 		setUpFakePathBinary(t, "go")
-		t.Setenv(raceShardCountEnv, "")
+		t.Setenv("ATMOS_MAGEFILES_FAKE_BIN_EXIT", "1")
 
 		err := Test{}.RaceMatrix()
-		require.ErrorIs(t, err, errInvalidRaceShardCount)
+		require.ErrorContains(t, err, "mage: go list ./...")
 	})
 
-	t.Run("invalid RACE_SHARD_COUNT is an error", func(t *testing.T) {
-		root := initGitRepoFixture(t)
-		t.Chdir(root)
-		setUpFakePathBinary(t, "go")
-		t.Setenv(raceShardCountEnv, "0")
+	invalidShardCounts := []struct {
+		name  string
+		value string
+	}{
+		{name: "missing RACE_SHARD_COUNT is an error", value: ""},
+		{name: "invalid RACE_SHARD_COUNT is an error", value: "0"},
+	}
+	for _, testCase := range invalidShardCounts {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := initGitRepoFixture(t)
+			t.Chdir(root)
+			setUpFakePathBinary(t, "go")
+			t.Setenv(raceShardCountEnv, testCase.value)
 
-		err := Test{}.RaceMatrix()
-		require.ErrorIs(t, err, errInvalidRaceShardCount)
-	})
+			err := Test{}.RaceMatrix()
+			require.ErrorIs(t, err, errInvalidRaceShardCount)
+		})
+	}
 
 	t.Run("writes a shard/packages matrix to GITHUB_OUTPUT", func(t *testing.T) {
 		root := initGitRepoFixture(t)

--- a/magefiles/race_matrix_test.go
+++ b/magefiles/race_matrix_test.go
@@ -1,0 +1,137 @@
+//go:build mage
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShuffleRacePackages(t *testing.T) {
+	packages := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+
+	t.Run("same seed always produces the same order", func(t *testing.T) {
+		first := shuffleRacePackages(packages, "run-123")
+		second := shuffleRacePackages(packages, "run-123")
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("different seeds can produce different orders", func(t *testing.T) {
+		first := shuffleRacePackages(packages, "run-123")
+		second := shuffleRacePackages(packages, "run-456")
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("shuffle is a permutation, not a lossy transform", func(t *testing.T) {
+		got := shuffleRacePackages(packages, "run-123")
+		assert.ElementsMatch(t, packages, got)
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		original := append([]string(nil), packages...)
+		shuffleRacePackages(packages, "run-123")
+		assert.Equal(t, original, packages)
+	})
+}
+
+func TestRaceShardMatrix(t *testing.T) {
+	packages := []string{
+		"github.com/cloudposse/atmos/cmd",
+		"github.com/cloudposse/atmos/pkg/toolchain",
+		"github.com/cloudposse/atmos/pkg/store",
+		"github.com/cloudposse/atmos/internal/exec",
+		"github.com/cloudposse/atmos/pkg/schema",
+	}
+
+	entries := raceShardMatrix(packages, 3, "run-123")
+	require.Len(t, entries, 3)
+
+	var allAssigned []string
+	for index, entry := range entries {
+		assert.Equal(t, index+1, entry.Shard)
+		allAssigned = append(allAssigned, strings.Fields(entry.Packages)...)
+	}
+	assert.ElementsMatch(t, packages, allAssigned)
+}
+
+func TestTestRaceMatrix(t *testing.T) {
+	t.Run("propagates repo-root resolution failure", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		err := Test{}.RaceMatrix()
+		require.ErrorIs(t, err, errMageRepoRootNotFound)
+	})
+
+	t.Run("missing RACE_SHARD_COUNT is an error", func(t *testing.T) {
+		root := initGitRepoFixture(t)
+		t.Chdir(root)
+		setUpFakePathBinary(t, "go")
+
+		err := Test{}.RaceMatrix()
+		require.ErrorIs(t, err, errInvalidRaceShardCount)
+	})
+
+	t.Run("invalid RACE_SHARD_COUNT is an error", func(t *testing.T) {
+		root := initGitRepoFixture(t)
+		t.Chdir(root)
+		setUpFakePathBinary(t, "go")
+		t.Setenv(raceShardCountEnv, "0")
+
+		err := Test{}.RaceMatrix()
+		require.ErrorIs(t, err, errInvalidRaceShardCount)
+	})
+
+	t.Run("writes a shard/packages matrix to GITHUB_OUTPUT", func(t *testing.T) {
+		root := initGitRepoFixture(t)
+		t.Chdir(root)
+		setUpFakePathBinary(t, "go")
+		t.Setenv("ATMOS_MAGEFILES_FAKE_BIN_STDOUT",
+			"github.com/cloudposse/atmos/cmd\ngithub.com/cloudposse/atmos/pkg/toolchain\ngithub.com/cloudposse/atmos/tests\n")
+		t.Setenv(raceShardCountEnv, "2")
+		t.Setenv(raceShardSeedEnv, "run-123")
+
+		outputFile := filepath.Join(t.TempDir(), "github_output")
+		t.Setenv("GITHUB_OUTPUT", outputFile)
+
+		require.NoError(t, Test{}.RaceMatrix())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		matrixJSON := extractMatrixJSON(t, string(content))
+		var payload struct {
+			Include []raceShardEntry `json:"include"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(matrixJSON), &payload))
+		require.Len(t, payload.Include, 2)
+
+		var allAssigned []string
+		for _, entry := range payload.Include {
+			allAssigned = append(allAssigned, strings.Fields(entry.Packages)...)
+		}
+		// The tests/ package is filtered out by racePackages before RaceMatrix
+		// ever sees it (same exclusion Test.Race relies on).
+		assert.ElementsMatch(t, []string{
+			"github.com/cloudposse/atmos/cmd",
+			"github.com/cloudposse/atmos/pkg/toolchain",
+		}, allAssigned)
+	})
+}
+
+// extractMatrixJSON pulls the JSON payload out of a "matrix=<json>\n..."
+// $GITHUB_OUTPUT-formatted file (see pkg/matrix.writeToFile).
+func extractMatrixJSON(t *testing.T, content string) string {
+	t.Helper()
+	for _, line := range strings.Split(content, "\n") {
+		if rest, ok := strings.CutPrefix(line, "matrix="); ok {
+			return rest
+		}
+	}
+	t.Fatalf("no matrix= line found in %q", content)
+	return ""
+}

--- a/magefiles/race_matrix_test.go
+++ b/magefiles/race_matrix_test.go
@@ -71,6 +71,7 @@ func TestTestRaceMatrix(t *testing.T) {
 		root := initGitRepoFixture(t)
 		t.Chdir(root)
 		setUpFakePathBinary(t, "go")
+		t.Setenv(raceShardCountEnv, "")
 
 		err := Test{}.RaceMatrix()
 		require.ErrorIs(t, err, errInvalidRaceShardCount)

--- a/magefiles/test_race.go
+++ b/magefiles/test_race.go
@@ -46,16 +46,18 @@ const raceParallelEnv = "ATMOS_TEST_RACE_PARALLEL"
 // tests call t.Parallel. The cap bounds that to 4 per package binary, which
 // keeps package-level concurrency (the dominant win on this ~400-package
 // sweep) as the thing that scales with the runner. Tune with
-// ATMOS_TEST_RACE_PARALLEL; note that the RunsOn "xlarge"/"large" families
-// resolve to 4- to 8-vCPU spot instances, so compare timings only across
-// runs on the same instance type.
+// ATMOS_TEST_RACE_PARALLEL; compare timings only across runs on the same
+// runner size.
 const raceParallelDefault = "4"
 
 // Race runs the full test suite (excluding ./tests/..., the CLI acceptance
 // suite) with the race detector and shuffled test order. This is the Go
 // implementation backing the `atmos test race` custom command
-// (.atmos.d/test.yaml) and the `[race] full test suite` CI job
-// (.github/workflows/test.yml).
+// (.atmos.d/test.yaml) and the `[race] non-acceptance test suite` CI job
+// (.github/workflows/test.yml). The CI job now shards this suite across
+// several parallel jobs by pre-splitting the package list upstream (see
+// Test.RaceMatrix in race_matrix.go) and passing each shard's slice through
+// the TEST override below -- Race itself has no shard-awareness of its own.
 func (Test) Race() error {
 	root, err := mageRepoRoot()
 	if err != nil {

--- a/pkg/matrix/matrix.go
+++ b/pkg/matrix/matrix.go
@@ -16,11 +16,16 @@ import (
 const defaultFilePermissions = 0o644
 
 // Output represents the GitHub Actions matrix strategy format.
-type Output struct {
-	Include []Entry `json:"include"`
+// Generic over the entry type so any caller with its own include-row shape
+// (e.g. stack/component below, or a CI job's own shard/packages row) can
+// reuse the same JSON/$GITHUB_OUTPUT plumbing instead of reimplementing it.
+type Output[T any] struct {
+	Include []T `json:"include"`
 }
 
-// Entry represents a single entry in the matrix include array.
+// Entry represents a single entry in the matrix include array for
+// stack/component-shaped matrices (`atmos describe affected`/`atmos list
+// instances --format=matrix`).
 type Entry struct {
 	Stack         string `json:"stack"`
 	Component     string `json:"component"`
@@ -30,14 +35,14 @@ type Entry struct {
 
 // Marshal serializes matrix entries to compact JSON.
 // Nil entries are normalized to an empty slice to produce {"include":[]} instead of {"include":null}.
-func Marshal(entries []Entry) ([]byte, error) {
+func Marshal[T any](entries []T) ([]byte, error) {
 	defer perf.Track(nil, "matrix.Marshal")()
 
 	include := entries
 	if include == nil {
-		include = []Entry{}
+		include = []T{}
 	}
-	output := Output{
+	output := Output[T]{
 		Include: include,
 	}
 	return json.Marshal(output)
@@ -46,7 +51,7 @@ func Marshal(entries []Entry) ([]byte, error) {
 // WriteOutput writes the matrix output to stdout or a file.
 // If outputFile is specified (for $GITHUB_OUTPUT), writes in key=value format.
 // Otherwise, writes JSON to stdout.
-func WriteOutput(entries []Entry, outputFile string) error {
+func WriteOutput[T any](entries []T, outputFile string) error {
 	defer perf.Track(nil, "matrix.WriteOutput")()
 
 	matrixJSON, err := Marshal(entries)

--- a/pkg/matrix/matrix_test.go
+++ b/pkg/matrix/matrix_test.go
@@ -34,7 +34,7 @@ func TestMarshal(t *testing.T) {
 		result, err := Marshal(entries)
 		require.NoError(t, err)
 
-		var output Output
+		var output Output[Entry]
 		err = json.Unmarshal(result, &output)
 		require.NoError(t, err)
 		require.Len(t, output.Include, 1)
@@ -52,7 +52,7 @@ func TestMarshal(t *testing.T) {
 		result, err := Marshal(entries)
 		require.NoError(t, err)
 
-		var output Output
+		var output Output[Entry]
 		err = json.Unmarshal(result, &output)
 		require.NoError(t, err)
 		require.Len(t, output.Include, 2)
@@ -85,7 +85,7 @@ func TestWriteOutput_File(t *testing.T) {
 
 		// Verify JSON is valid.
 		matrixJSON := strings.TrimPrefix(lines[0], "matrix=")
-		var output Output
+		var output Output[Entry]
 		err = json.Unmarshal([]byte(matrixJSON), &output)
 		require.NoError(t, err)
 		require.Len(t, output.Include, 1)
@@ -127,7 +127,7 @@ func TestWriteOutput_Stdout(t *testing.T) {
 }
 
 func TestMarshal_NilEntries(t *testing.T) {
-	result, err := Marshal(nil)
+	result, err := Marshal[Entry](nil)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"include":[]}`, string(result))
 }


### PR DESCRIPTION
## what

- Split the non-acceptance race suite across four hosted-runner jobs using a seeded, precomputed package matrix.
- Generalize the matrix output helpers for typed include rows and add coverage for shard planning and deterministic shuffling.

## why

- Reduce the race check's critical-path runtime and oversized-runner usage while preserving full package coverage.
- Vary package assignments between workflow runs so consistently slow package clusters do not remain pinned to one shard.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Race tests now run across four parallel shards, reducing the CI timeout from 75 to 30 minutes.
  * Test packages are distributed deterministically for more consistent execution times.

* **Reliability**
  * Added validation for missing or invalid test-shard configuration.
  * Improved cleanup and timeout handling for cancelled integration tests.

* **Maintenance**
  * Improved test-matrix generation and validation.
  * Added dedicated caching for race-test planning to improve repeated workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->