### PR TITLE
feat(website): add download/share to blog post cast embeds

### DIFF
--- a/.claude/skills/atmos-asciicast/SKILL.md
+++ b/.claude/skills/atmos-asciicast/SKILL.md
@@ -62,9 +62,9 @@ Atmos casts are product demos, regression evidence, and documentation examples a
 4. Review the cast as plain text for secrets, local paths, unstable timestamps, noisy logs, and shell complexity that distracts from Atmos.
 5. Embed it with the website `CastPlayer` component when the corresponding docs page can show it usefully, **and in the feature's changelog blog post** (see the `pull-request` skill's Blog post section) — new commands and features should ship their blog post with a working demo, not just prose. Use `CastEmbed` (which wraps `CastPlayer` with Download/Share controls) directly in blog posts, followed by a `[View the full example](/examples/<name>)` link; don't reach for `EmbedExample` there.
 
-   ```mdx
-   <CastEmbed src="/casts/cli/describe-component.cast" title="describe component" chrome controls scrubber />
-   ```
+    ```mdx
+    <CastEmbed src="/casts/cli/describe-component.cast" title="describe component" chrome controls scrubber />
+    ```
 
 6. Commit only `.cast` files: the website renders them client-side, so no display derivatives are needed. Commit GIF/MP4/PNG/JPEG derivatives only when a publishing target cannot consume the player.
 

--- a/.claude/skills/atmos-asciicast/SKILL.md
+++ b/.claude/skills/atmos-asciicast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atmos-asciicast
-description: Create and update Atmos repository asciicast demos for internal documentation, website publishing, and CastPlayer embeds.
+description: Create and update Atmos repository asciicast demos for internal documentation, website publishing, and CastPlayer/CastEmbed embeds.
 ---
 
 # Atmos Asciicast Development Skill
@@ -60,10 +60,10 @@ Atmos casts are product demos, regression evidence, and documentation examples a
 2. Add or update the workflow/custom command that regenerates the cast.
 3. Regenerate the `.cast` into `website/static/casts`.
 4. Review the cast as plain text for secrets, local paths, unstable timestamps, noisy logs, and shell complexity that distracts from Atmos.
-5. Embed it with the website `CastPlayer` component when the corresponding docs page can show it usefully, **and in the feature's changelog blog post** (see the `pull-request` skill's Blog post section) — new commands and features should ship their blog post with a working demo, not just prose. Use `CastPlayer` directly in blog posts, followed by a `[View the full example](/examples/<name>)` link; don't reach for `EmbedExample` there.
+5. Embed it with the website `CastPlayer` component when the corresponding docs page can show it usefully, **and in the feature's changelog blog post** (see the `pull-request` skill's Blog post section) — new commands and features should ship their blog post with a working demo, not just prose. Use `CastEmbed` (which wraps `CastPlayer` with Download/Share controls) directly in blog posts, followed by a `[View the full example](/examples/<name>)` link; don't reach for `EmbedExample` there.
 
    ```mdx
-   <CastPlayer src="/casts/cli/describe-component.cast" title="describe component" chrome controls scrubber />
+   <CastEmbed src="/casts/cli/describe-component.cast" title="describe component" chrome controls scrubber />
    ```
 
 6. Commit only `.cast` files: the website renders them client-side, so no display derivatives are needed. Commit GIF/MP4/PNG/JPEG derivatives only when a publishing target cannot consume the player.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -17,7 +17,7 @@ skill all point here instead of restating these rules. Don't re-duplicate them e
 Only non-draft PRs targeting `main`, labeled `minor` or `major`, need one — see the `pull-request` skill's
 label decision tree. CI enforces this via `.github/workflows/changelog-check.yml`, which checks for a new
 `website/blog/*.md` or `*.mdx` file (draft PRs, and PRs targeting a branch other than `main`, are exempt
-entirely). Write posts as `.mdx` regardless — Rule 3 below embeds `<CastPlayer>` as real JSX, which only
+entirely). Write posts as `.mdx` regardless — Rule 3 below embeds `<CastEmbed>` as real JSX, which only
 `.mdx` renders; CI accepts `.md` but that's not this repo's convention.
 If a change is genuinely internal-only with zero user-visible effect, it doesn't get a post at all — that
 invariant belongs to the `roadmap` skill ("no changelog post for internal-only refactors"); don't work around
@@ -126,14 +126,18 @@ block a post. When a recorded demo exists (or is worth recording) under `example
 per the `atmos-asciicast` skill, embed it near the top of the post, after the intro/truncate:
 
 ```mdx
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
-<CastPlayer src="/casts/examples/demo-component-versions/vendor-versions.cast" title="atmos component version vendoring" chrome controls scrubber />
+<CastEmbed src="/casts/examples/demo-component-versions/vendor-versions.cast" title="atmos component version vendoring" chrome controls scrubber />
 ```
 
 - `src` points under `website/static/casts/{examples,demo}/...`.
 - Always carry the `chrome controls scrubber` flags.
-- Multiple `<CastPlayer>` tags are fine in one post if there are multiple relevant recordings.
+- Multiple `<CastEmbed>` tags are fine in one post if there are multiple relevant recordings.
+- `CastEmbed` wraps `CastPlayer` and adds Download (rendered GIF/MP4/SVG/WEBM via Atmos Pro) and Share controls,
+  on by default against `cloudposse/atmos` @ `main`. If the `.cast` file isn't committed to `main` yet (e.g. it
+  ships in the same PR as the post), pass `download={false}` and/or `share={false}` to suppress the controls
+  until it lands.
 - Follow it with a plain link to the full example when one exists: `[View the full example](/examples/<name>)`.
 - Don't use `EmbedExample` in blog posts — that component's README/file-listing duplicates content the post's
   own prose already covers; it's for docs pages that need the "browse the full example" callout instead.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -92,25 +92,25 @@ Get this right the first time:
 
 1. Verify your local git is configured to sign automatically before your first commit:
 
-   ```bash
-   git config --get commit.gpgsign       # should print: true
-   git config --get gpg.format            # "openpgp" or "ssh"
-   git config --get user.signingkey       # your signing key
-   ```
+    ```bash
+    git config --get commit.gpgsign       # should print: true
+    git config --get gpg.format            # "openpgp" or "ssh"
+    git config --get user.signingkey       # your signing key
+    ```
 
-   If `commit.gpgsign` is not `true`, set it for the repo:
+    If `commit.gpgsign` is not `true`, set it for the repo:
 
-   ```bash
-   git config commit.gpgsign true
-   ```
+    ```bash
+    git config commit.gpgsign true
+    ```
 
 2. After your first commit, verify it's signed:
 
-   ```bash
-   git log --show-signature -1
-   ```
+    ```bash
+    git log --show-signature -1
+    ```
 
-   Look for `gpg: Good signature from ...` or `Good "git" signature for ...`. If you see "no signature found", **stop and fix your git config before pushing**.
+    Look for `gpg: Good signature from ...` or `Good "git" signature for ...`. If you see "no signature found", **stop and fix your git config before pushing**.
 
 3. **Never bypass signing with `--no-gpg-sign` or `-c commit.gpgsign=false`** even temporarily. The CLAUDE.md rules forbid this, and the resulting commit cannot be merged.
 
@@ -131,11 +131,11 @@ Run through these in order before `git push`. Every item has burned someone befo
 1. **Identify the smallest accurate label.** Use the decision tree above. Default to `no-release` for plumbing.
 2. **Confirm commit signing is on** (see above). One unsigned commit blocks the entire PR from merging.
 3. **If `minor` or `major`:**
-   - Create a blog post at `website/blog/YYYY-MM-DD-<slug>.mdx`.
-   - Read `website/blog/tags.yml` and pick a defined tag.
-   - Check `website/blog/authors.yml` for your handle; add yourself if missing.
-   - Embed the feature's cast (`CastEmbed`) if one exists or was recorded for this PR.
-   - Delegate the roadmap update to the `roadmap` skill (do not touch `featured[]`).
+    - Create a blog post at `website/blog/YYYY-MM-DD-<slug>.mdx`.
+    - Read `website/blog/tags.yml` and pick a defined tag.
+    - Check `website/blog/authors.yml` for your handle; add yourself if missing.
+    - Embed the feature's cast (`CastEmbed`) if one exists or was recorded for this PR.
+    - Delegate the roadmap update to the `roadmap` skill (do not touch `featured[]`).
 4. **Build the website** to verify MDX renders: `cd website && npm run build`.
 5. **Commit and push.**
 
@@ -181,15 +181,15 @@ If a PR has already been opened without a label, or with the wrong one:
 2. Apply the decision tree to pick the correct label.
 3. **If the PR has no semver label yet:** add it.
 
-   ```bash
-   gh pr edit <num> --add-label <label>
-   ```
+    ```bash
+    gh pr edit <num> --add-label <label>
+    ```
 
 4. **If the PR has a different semver label already:** remove the old one and add the new one in a single invocation, so you never have two semver labels at once (which fails CI):
 
-   ```bash
-   gh pr edit <num> --remove-label <old-label> --add-label <new-label>
-   ```
+    ```bash
+    gh pr edit <num> --remove-label <old-label> --add-label <new-label>
+    ```
 
 5. If you changed from `no-release`/`patch` to `minor`/`major`, you now owe a blog post and roadmap update — add them in a new commit on the same branch.
 6. If you changed from `minor`/`major` to a lower label, you can (optionally) remove the blog post and roadmap update in a new commit, but it's also fine to leave them.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -134,7 +134,7 @@ Run through these in order before `git push`. Every item has burned someone befo
    - Create a blog post at `website/blog/YYYY-MM-DD-<slug>.mdx`.
    - Read `website/blog/tags.yml` and pick a defined tag.
    - Check `website/blog/authors.yml` for your handle; add yourself if missing.
-   - Embed the feature's cast (`CastPlayer`) if one exists or was recorded for this PR.
+   - Embed the feature's cast (`CastEmbed`) if one exists or was recorded for this PR.
    - Delegate the roadmap update to the `roadmap` skill (do not touch `featured[]`).
 4. **Build the website** to verify MDX renders: `cd website && npm run build`.
 5. **Commit and push.**

--- a/website/blog/2025-10-21-introducing-atmos-auth-list.md
+++ b/website/blog/2025-10-21-introducing-atmos-auth-list.md
@@ -10,7 +10,7 @@ tags:
 release: v1.196.0
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 We're excited to announce a powerful new command for managing authentication in Atmos: [`atmos auth list`](/cli/commands/auth/list). This command provides comprehensive visibility into your authentication configuration, making it easier than ever to understand and manage complex authentication chains across multiple cloud providers and identities.
 
@@ -18,7 +18,7 @@ We're excited to announce a powerful new command for managing authentication in 
 
 See it in action:
 
-<CastPlayer src="/casts/examples/demo-auth/auth-list.cast" title="atmos auth identities" chrome controls scrubber />
+<CastEmbed src="/casts/examples/demo-auth/auth-list.cast" title="atmos auth identities" chrome controls scrubber />
 
 [View the full example](/examples/demo-auth)
 

--- a/website/blog/2025-10-21-introducing-atmos-auth-list.md
+++ b/website/blog/2025-10-21-introducing-atmos-auth-list.md
@@ -8,6 +8,8 @@ authors:
 tags:
   - feature
 release: v1.196.0
+cast: "/casts/examples/demo-auth/auth-list.cast"
+castTitle: "atmos auth identities"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2025-11-18-atmos-profiles.mdx
+++ b/website/blog/2025-11-18-atmos-profiles.mdx
@@ -9,7 +9,7 @@ tags:
 release: v1.199.0
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Stop fighting with different Atmos configurations for development, CI/CD, and production. Profiles let you switch contexts with a single flag while keeping your core configuration consistent.
 
@@ -195,7 +195,7 @@ The output shows you exactly what settings the profile provides, where it's loca
 
 See it in action — listing available profiles and inspecting one in detail:
 
-<CastPlayer src="/casts/examples/config-profiles/list-and-show.cast" title="atmos config profiles" chrome controls scrubber />
+<CastEmbed src="/casts/examples/config-profiles/list-and-show.cast" title="atmos config profiles" chrome controls scrubber />
 
 [View the full example](/examples/config-profiles)
 

--- a/website/blog/2025-11-18-atmos-profiles.mdx
+++ b/website/blog/2025-11-18-atmos-profiles.mdx
@@ -7,6 +7,8 @@ authors:
 tags:
   - feature
 release: v1.199.0
+cast: "/casts/examples/config-profiles/list-and-show.cast"
+castTitle: "atmos config profiles"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2025-12-06-native-devcontainer-support.mdx
+++ b/website/blog/2025-12-06-native-devcontainer-support.mdx
@@ -6,7 +6,7 @@ tags: [feature]
 date: 2025-12-06T12:00:00.000Z
 release: v1.201.0
 ---
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -404,13 +404,13 @@ brew upgrade atmos
 
 ### 2. Check Out the Examples
 
-<CastPlayer src="/casts/examples/devcontainer/config.cast" title="atmos devcontainer config" chrome controls scrubber />
+<CastEmbed src="/casts/examples/devcontainer/config.cast" title="atmos devcontainer config" chrome controls scrubber />
 
 [View the full example](/examples/devcontainer)
 
 Prefer to build your own image instead of pulling one? Here's the same workflow with a custom devcontainer build:
 
-<CastPlayer src="/casts/examples/devcontainer-build/build-config.cast" title="atmos devcontainer build config" chrome controls scrubber />
+<CastEmbed src="/casts/examples/devcontainer-build/build-config.cast" title="atmos devcontainer build config" chrome controls scrubber />
 
 [View the full example](/examples/devcontainer-build)
 

--- a/website/blog/2025-12-06-native-devcontainer-support.mdx
+++ b/website/blog/2025-12-06-native-devcontainer-support.mdx
@@ -5,6 +5,8 @@ authors: [osterman]
 tags: [feature]
 date: 2025-12-06T12:00:00.000Z
 release: v1.201.0
+cast: "/casts/examples/devcontainer/config.cast"
+castTitle: "atmos devcontainer config"
 ---
 import CastEmbed from '@site/src/components/CastEmbed'
 import Tabs from '@theme/Tabs';

--- a/website/blog/2025-12-10-stack-manifest-name-override.mdx
+++ b/website/blog/2025-12-10-stack-manifest-name-override.mdx
@@ -8,7 +8,7 @@ tags:
 date: 2025-12-10T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 You can now specify an explicit `name` field in stack manifests to override the logical stack name. This is especially useful when migrating from other tools like Terragrunt, or when your infrastructure doesn't follow a strict naming convention.
 
@@ -16,7 +16,7 @@ You can now specify an explicit `name` field in stack manifests to override the 
 
 See it in action:
 
-<CastPlayer src="/casts/examples/stack-names/explicit-names.cast" title="atmos stack names" chrome controls scrubber />
+<CastEmbed src="/casts/examples/stack-names/explicit-names.cast" title="atmos stack names" chrome controls scrubber />
 
 [View the full example](/examples/stack-names)
 

--- a/website/blog/2025-12-10-stack-manifest-name-override.mdx
+++ b/website/blog/2025-12-10-stack-manifest-name-override.mdx
@@ -6,6 +6,8 @@ authors:
 tags:
   - feature
 date: 2025-12-10T12:00:00.000Z
+cast: "/casts/examples/stack-names/explicit-names.cast"
+castTitle: "atmos stack names"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2025-12-12-automatic-backend-provisioning.mdx
+++ b/website/blog/2025-12-12-automatic-backend-provisioning.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 We're excited to introduce **automatic backend provisioning** in Atmos, a feature that solves the Terraform bootstrap problem. No more manual S3 bucket creation, no more chicken-and-egg workarounds—Atmos provisions your state backend automatically with secure defaults, making it fully compatible with Terraform-managed infrastructure.
 
@@ -157,7 +157,7 @@ Provisioning failures return non-zero exit codes, ensuring CI/CD pipelines fail 
 
 Here's the full `create` / `update` / `delete` lifecycle running end-to-end against a local sandbox — no AWS account required:
 
-<CastPlayer src="/casts/examples/backend-provisioning/lifecycle.cast" title="atmos terraform backend lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/backend-provisioning/lifecycle.cast" title="atmos terraform backend lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/backend-provisioning)
 

--- a/website/blog/2025-12-12-automatic-backend-provisioning.mdx
+++ b/website/blog/2025-12-12-automatic-backend-provisioning.mdx
@@ -4,6 +4,8 @@ title: "Solving the Terraform Bootstrap Problem with Automatic Backend Provision
 date: 2025-12-12T12:00:00.000Z
 authors: [osterman]
 tags: [feature, dx]
+cast: "/casts/examples/backend-provisioning/lifecycle.cast"
+castTitle: "atmos terraform backend lifecycle"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2025-12-30-terraform-source-provisioner.mdx
+++ b/website/blog/2025-12-30-terraform-source-provisioner.mdx
@@ -4,6 +4,8 @@ title: "Just-in-Time Component Vendoring with source"
 date: 2025-12-30T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/source-provisioning/sources.cast"
+castTitle: "atmos source provisioning"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2025-12-30-terraform-source-provisioner.mdx
+++ b/website/blog/2025-12-30-terraform-source-provisioner.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now supports just-in-time (JIT) vendoring of components directly from stack configuration using the top-level `source` field. This works for **Terraform**, **Helmfile**, and **Packer** components. Declare component sources inline without requiring separate `component.yaml` files—components are automatically downloaded on first use.
 
@@ -14,7 +14,7 @@ Atmos now supports just-in-time (JIT) vendoring of components directly from stac
 
 See it in action:
 
-<CastPlayer src="/casts/examples/source-provisioning/sources.cast" title="atmos source provisioning" chrome controls scrubber />
+<CastEmbed src="/casts/examples/source-provisioning/sources.cast" title="atmos source provisioning" chrome controls scrubber />
 
 [View the full example](/examples/source-provisioning)
 

--- a/website/blog/2026-01-05-declarative-file-generation.mdx
+++ b/website/blog/2026-01-05-declarative-file-generation.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now supports declarative file generation for Terraform components via the new `generate` section in stack configuration.
 
@@ -14,7 +14,7 @@ Atmos now supports declarative file generation for Terraform components via the 
 
 See it in action:
 
-<CastPlayer src="/casts/examples/generate-files/component-files.cast" title="atmos generate files" chrome controls scrubber />
+<CastEmbed src="/casts/examples/generate-files/component-files.cast" title="atmos generate files" chrome controls scrubber />
 
 [View the full example](/examples/generate-files)
 

--- a/website/blog/2026-01-05-declarative-file-generation.mdx
+++ b/website/blog/2026-01-05-declarative-file-generation.mdx
@@ -4,6 +4,8 @@ title: "Declarative File Generation for Terraform Components"
 date: 2026-01-05T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/generate-files/component-files.cast"
+castTitle: "atmos generate files"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-01-20-locals-context-access-and-design-patterns.mdx
+++ b/website/blog/2026-01-20-locals-context-access-and-design-patterns.mdx
@@ -8,7 +8,7 @@ tags:
 date: 2026-01-20T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Locals can access `{{ .settings }}`, `{{ .vars }}`, and `{{ .env }}` from the same file during template resolution.
 
@@ -44,7 +44,7 @@ components:
 
 See it resolve with structured values:
 
-<CastPlayer src="/casts/examples/locals/structured-values.cast" title="atmos locals structured values" chrome controls scrubber />
+<CastEmbed src="/casts/examples/locals/structured-values.cast" title="atmos locals structured values" chrome controls scrubber />
 
 [View the full example](/examples/locals)
 

--- a/website/blog/2026-01-20-locals-context-access-and-design-patterns.mdx
+++ b/website/blog/2026-01-20-locals-context-access-and-design-patterns.mdx
@@ -6,6 +6,8 @@ authors:
 tags:
   - enhancement
 date: 2026-01-20T12:00:00.000Z
+cast: "/casts/examples/locals/structured-values.cast"
+castTitle: "atmos locals structured values"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-01-23-custom-secrets-masking.mdx
+++ b/website/blog/2026-01-23-custom-secrets-masking.mdx
@@ -4,6 +4,8 @@ title: "Custom Secrets Masking Patterns"
 date: 2026-01-23T12:00:00.000Z
 authors: [osterman]
 tags: [feature, security]
+cast: "/casts/examples/secrets-masking/masked-plan.cast"
+castTitle: "atmos secrets masking"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-01-23-custom-secrets-masking.mdx
+++ b/website/blog/2026-01-23-custom-secrets-masking.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature, security]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Provably safe secrets masking with custom patterns, comprehensive output coverage, and configurable replacement strings.
 
@@ -64,7 +64,7 @@ Atmos includes 120+ patterns from the Gitleaks library covering:
 
 See a masked `terraform plan` in action:
 
-<CastPlayer src="/casts/examples/secrets-masking/masked-plan.cast" title="atmos secrets masking" chrome controls scrubber />
+<CastEmbed src="/casts/examples/secrets-masking/masked-plan.cast" title="atmos secrets masking" chrome controls scrubber />
 
 [View the full example](/examples/secrets-masking)
 

--- a/website/blog/2026-02-16-ansible-component-support.mdx
+++ b/website/blog/2026-02-16-ansible-component-support.mdx
@@ -6,7 +6,7 @@ authors: [rosesecurity]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now supports Ansible as a first-class component type, enabling unified orchestration of infrastructure provisioning (Terraform) and configuration management (Ansible) from the same stack manifests.
 
@@ -14,7 +14,7 @@ Atmos now supports Ansible as a first-class component type, enabling unified orc
 
 See it in action:
 
-<CastPlayer src="/casts/examples/demo-ansible/playbook.cast" title="atmos Ansible playbook" chrome controls scrubber />
+<CastEmbed src="/casts/examples/demo-ansible/playbook.cast" title="atmos Ansible playbook" chrome controls scrubber />
 
 [View the full example](/examples/demo-ansible)
 

--- a/website/blog/2026-02-16-ansible-component-support.mdx
+++ b/website/blog/2026-02-16-ansible-component-support.mdx
@@ -4,6 +4,8 @@ title: "Ansible Component Support"
 date: 2026-02-16T12:00:00.000Z
 authors: [rosesecurity]
 tags: [feature]
+cast: "/casts/examples/demo-ansible/playbook.cast"
+castTitle: "atmos Ansible playbook"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-02-22-store-identity-support.mdx
+++ b/website/blog/2026-02-22-store-identity-support.mdx
@@ -6,7 +6,7 @@ authors: [aknysh]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos stores now support identity-based authentication. You can configure stores to authenticate using the same named identities from [`atmos auth`](/cli/commands/auth/usage) instead of relying on default credential chains.
 
@@ -14,7 +14,7 @@ Atmos stores now support identity-based authentication. You can configure stores
 
 See it in action:
 
-<CastPlayer src="/casts/examples/auth-stores/identity-backed-stores.cast" title="atmos auth-backed stores" chrome controls scrubber />
+<CastEmbed src="/casts/examples/auth-stores/identity-backed-stores.cast" title="atmos auth-backed stores" chrome controls scrubber />
 
 [View the full example](/examples/auth-stores)
 

--- a/website/blog/2026-02-22-store-identity-support.mdx
+++ b/website/blog/2026-02-22-store-identity-support.mdx
@@ -4,6 +4,8 @@ slug: store-identity-support
 title: "Identity-Based Authentication for Stores"
 authors: [aknysh]
 tags: [feature]
+cast: "/casts/examples/auth-stores/identity-backed-stores.cast"
+castTitle: "atmos auth-backed stores"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-05-24-remote-stack-imports.mdx
+++ b/website/blog/2026-05-24-remote-stack-imports.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now supports importing stack configurations from remote URLs. Reference shared configurations from GitHub, S3, GCS, or any HTTP endpoint directly in your stack files.
 
@@ -107,7 +107,7 @@ atmos describe stacks
 
 Here's the remote import resolving end to end:
 
-<CastPlayer src="/casts/examples/remote-stack-imports/remote-vars.cast" title="atmos remote stack imports" chrome controls scrubber />
+<CastEmbed src="/casts/examples/remote-stack-imports/remote-vars.cast" title="atmos remote stack imports" chrome controls scrubber />
 
 [View the full example](/examples/remote-stack-imports)
 

--- a/website/blog/2026-05-24-remote-stack-imports.mdx
+++ b/website/blog/2026-05-24-remote-stack-imports.mdx
@@ -4,6 +4,8 @@ title: "Remote Stack Imports"
 date: 2026-05-24T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/remote-stack-imports/remote-vars.cast"
+castTitle: "atmos remote stack imports"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-04-custom-component-types.mdx
+++ b/website/blog/2026-06-04-custom-component-types.mdx
@@ -6,6 +6,8 @@ authors:
 tags:
   - feature
 date: 2026-06-04T12:00:00.000Z
+cast: "/casts/examples/custom-components/script-command.cast"
+castTitle: "atmos custom component command"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-04-custom-component-types.mdx
+++ b/website/blog/2026-06-04-custom-component-types.mdx
@@ -8,7 +8,7 @@ tags:
 date: 2026-06-04T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos custom commands can now define their own component types beyond `terraform`, `helmfile`, and `packer`. Use Atmos's stack configuration system with any tool: Ansible, Kubernetes manifests, shell scripts, CDK, and more.
 
@@ -67,7 +67,7 @@ atmos script deploy-app -s dev
 
 Here's the `script` component type running end-to-end:
 
-<CastPlayer src="/casts/examples/custom-components/script-command.cast" title="atmos custom component command" chrome controls scrubber />
+<CastEmbed src="/casts/examples/custom-components/script-command.cast" title="atmos custom component command" chrome controls scrubber />
 
 [View the full example](/examples/custom-components)
 

--- a/website/blog/2026-06-14-atmos-gitops.mdx
+++ b/website/blog/2026-06-14-atmos-gitops.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now treats Git as a foundational platform capability — on par with Toolchain, Auth, and Hooks — built to enable GitOps workflows where you need to commit artifacts to a source of truth: deployment repos consumed by Argo CD or Flux, provider lock files, rendered manifests. Define managed repositories once in `atmos.yaml`, then clone, inspect, diff, commit, and push them through a new [`atmos git`](/cli/commands/git/usage) command group, or publish generated artifacts automatically on lifecycle events with the new `git` hook kind.
 
@@ -88,7 +88,7 @@ atmos git push flux-deploy
 
 Here's what reconciling a configured repository looks like end to end:
 
-<CastPlayer src="/casts/examples/gitops/reconcile.cast" title="atmos gitops reconcile" chrome controls scrubber />
+<CastEmbed src="/casts/examples/gitops/reconcile.cast" title="atmos gitops reconcile" chrome controls scrubber />
 
 [View the full example](/examples/gitops)
 

--- a/website/blog/2026-06-14-atmos-gitops.mdx
+++ b/website/blog/2026-06-14-atmos-gitops.mdx
@@ -4,6 +4,8 @@ title: "Atmos Git: A Foundational Capability for GitOps Pipelines"
 date: 2026-06-14T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/gitops/reconcile.cast"
+castTitle: "atmos gitops reconcile"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-14-secrets-management.mdx
+++ b/website/blog/2026-06-14-secrets-management.mdx
@@ -5,7 +5,7 @@ date: 2026-06-14T12:00:00.000Z
 authors: [osterman]
 tags: [feature, security]
 ---
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now has first-class **secrets management**: you declare the secrets each component depends on,
 provision their values per environment, and reference them at runtime with a single YAML function.
@@ -75,7 +75,7 @@ Any store becomes a secret backend by setting `secret: true`, and the dedicated 
 
 Here's the 1Password Connect emulator in action, backed by the Mockoon-based mock:
 
-<CastPlayer src="/casts/examples/onepassword-secrets/connect-mock.cast" title="atmos 1Password Connect mock" chrome controls scrubber />
+<CastEmbed src="/casts/examples/onepassword-secrets/connect-mock.cast" title="atmos 1Password Connect mock" chrome controls scrubber />
 
 [View the full example](/examples/onepassword-secrets)
 
@@ -175,7 +175,7 @@ The `sops-secrets` example below is fully self-contained — it manages age-encr
 credentials**. Give it a spin with the bundled `atmos test` command to watch the whole lifecycle: set, get,
 list, validate, and masked-without-credentials inspection.
 
-<CastPlayer src="/casts/examples/sops-secrets/secret-lifecycle.cast" title="atmos sops secrets lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/sops-secrets/secret-lifecycle.cast" title="atmos sops secrets lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/sops-secrets)
 

--- a/website/blog/2026-06-14-secrets-management.mdx
+++ b/website/blog/2026-06-14-secrets-management.mdx
@@ -4,6 +4,8 @@ title: "Introducing Secrets Management in Atmos"
 date: 2026-06-14T12:00:00.000Z
 authors: [osterman]
 tags: [feature, security]
+cast: "/casts/examples/onepassword-secrets/connect-mock.cast"
+castTitle: "atmos 1Password Connect mock"
 ---
 import CastEmbed from '@site/src/components/CastEmbed'
 

--- a/website/blog/2026-06-14-terraform-registry-cache.mdx
+++ b/website/blog/2026-06-14-terraform-registry-cache.mdx
@@ -4,6 +4,8 @@ title: "Terraform Registry Cache: Reproducible Infrastructure Builds"
 authors: [osterman]
 tags: [feature, experimental]
 date: 2026-06-14T12:00:00.000Z
+cast: "/casts/examples/caching/registry-cache.cast"
+castTitle: "atmos terraform registry cache"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-14-terraform-registry-cache.mdx
+++ b/website/blog/2026-06-14-terraform-registry-cache.mdx
@@ -6,7 +6,7 @@ tags: [feature, experimental]
 date: 2026-06-14T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos can now transparently **cache Terraform and OpenTofu providers and modules** behind a single feature flag. Turn it on and repeated runs — local or CI — stop re-downloading the same artifacts, keep working when upstream registries are slow or down, and capture the exact versions a deployment used so builds stay reproducible. No changes to your Terraform code, provider declarations, or module sources.
 
@@ -14,7 +14,7 @@ Atmos can now transparently **cache Terraform and OpenTofu providers and modules
 
 See it in action:
 
-<CastPlayer src="/casts/examples/caching/registry-cache.cast" title="atmos terraform registry cache" chrome controls scrubber />
+<CastEmbed src="/casts/examples/caching/registry-cache.cast" title="atmos terraform registry cache" chrome controls scrubber />
 
 [View the full example](/examples/caching)
 

--- a/website/blog/2026-06-23-container-components.mdx
+++ b/website/blog/2026-06-23-container-components.mdx
@@ -6,7 +6,7 @@ tags: [feature, experimental]
 date: 2026-06-23
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now has a first-class **container component kind**. Where a `type: container` workflow step is a
 procedural `docker run --rm`, a `components.container` entry is declarative, stack-scoped
@@ -82,7 +82,7 @@ compositions:
 Run [`atmos composition validate storefront -s dev`](/cli/commands/composition/usage) to see which declared services are fulfilled vs. not
 yet provided in a given stack — a closed contract for membership, open for fulfillment.
 
-<CastPlayer src="/casts/examples/compositions/validate.cast" title="atmos composition validation" chrome controls scrubber />
+<CastEmbed src="/casts/examples/compositions/validate.cast" title="atmos composition validation" chrome controls scrubber />
 
 [View the full example](/examples/compositions)
 
@@ -97,7 +97,7 @@ atmos container up api -s local
 atmos container list
 ```
 
-<CastPlayer src="/casts/examples/container-component/lifecycle.cast" title="atmos container component lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/container-component/lifecycle.cast" title="atmos container component lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/container-component)
 

--- a/website/blog/2026-06-23-container-components.mdx
+++ b/website/blog/2026-06-23-container-components.mdx
@@ -4,6 +4,8 @@ title: "Container Components and Compositions"
 authors: [osterman]
 tags: [feature, experimental]
 date: 2026-06-23
+cast: "/casts/examples/compositions/validate.cast"
+castTitle: "atmos composition validation"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-23-native-container-steps.mdx
+++ b/website/blog/2026-06-23-native-container-steps.mdx
@@ -6,7 +6,7 @@ tags: [feature, experimental]
 date: 2026-06-23T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos workflows and custom commands can now run containers natively. A new `type: container` step
 builds images, pushes them to registries, and runs containerized tools — Docker or Podman — through
@@ -134,7 +134,7 @@ cd examples/container-step
 atmos workflow build -f container-step
 ```
 
-<CastPlayer src="/casts/examples/container-step/build-run.cast" title="atmos container build run" chrome controls scrubber />
+<CastEmbed src="/casts/examples/container-step/build-run.cast" title="atmos container build run" chrome controls scrubber />
 
 [View the full example](/examples/container-step)
 

--- a/website/blog/2026-06-23-native-container-steps.mdx
+++ b/website/blog/2026-06-23-native-container-steps.mdx
@@ -4,6 +4,8 @@ title: "Native Container Steps in Atmos Workflows"
 authors: [osterman]
 tags: [feature, experimental]
 date: 2026-06-23T12:00:00.000Z
+cast: "/casts/examples/container-step/build-run.cast"
+castTitle: "atmos container build run"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-24-http-step-type.mdx
+++ b/website/blog/2026-06-24-http-step-type.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Workflows and custom commands now support a native `http` step type that performs an HTTP request — any verb, query-string parameters, headers, and a request body (raw or form/JSON) — with per-attempt timeouts and retries that compose with the existing `retry:` policy. No more shelling out to `curl`. (Prefer `type: webhook`? It's an accepted alias.)
 
@@ -65,7 +65,7 @@ Everything templates, including the URL, headers, query params, and body — so 
 
 Here's the `http` step calling a local endpoint end to end:
 
-<CastPlayer src="/casts/examples/http-webhooks/local-endpoints.cast" title="atmos HTTP webhooks" chrome controls scrubber />
+<CastEmbed src="/casts/examples/http-webhooks/local-endpoints.cast" title="atmos HTTP webhooks" chrome controls scrubber />
 
 [View the full example](/examples/http-webhooks)
 

--- a/website/blog/2026-06-24-http-step-type.mdx
+++ b/website/blog/2026-06-24-http-step-type.mdx
@@ -4,6 +4,8 @@ title: "HTTP Step Type: Call HTTP Endpoints from Workflows and Custom Commands"
 date: 2026-06-24T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/http-webhooks/local-endpoints.cast"
+castTitle: "atmos HTTP webhooks"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-24-say-step.mdx
+++ b/website/blog/2026-06-24-say-step.mdx
@@ -4,6 +4,8 @@ title: "Atmos Can Finally Speak for Itself"
 date: 2026-06-24T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/say-something/pipeline.cast"
+castTitle: "atmos say steps"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-24-say-step.mdx
+++ b/website/blog/2026-06-24-say-step.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Workflows now have a `say` step type that speaks a message out loud using text-to-speech — an audible cue for when a long-running workflow finishes or needs your attention, even after you've switched to another window. When no speech engine is available (or you're in CI), it degrades gracefully and prints the message instead, so the same workflow works everywhere.
 
@@ -76,7 +76,7 @@ atmos workflow pipeline -f say      # announce each build milestone
 
 Here's the build pipeline announcing its milestones end to end:
 
-<CastPlayer src="/casts/examples/say-something/pipeline.cast" title="atmos say steps" chrome controls scrubber />
+<CastEmbed src="/casts/examples/say-something/pipeline.cast" title="atmos say steps" chrome controls scrubber />
 
 [View the full example](/examples/say-something)
 

--- a/website/blog/2026-06-25-hooks-step-types.mdx
+++ b/website/blog/2026-06-25-hooks-step-types.mdx
@@ -4,6 +4,8 @@ title: "Run Any Step Type as a Lifecycle Hook"
 authors: [osterman]
 tags: [feature]
 date: 2026-06-25T12:00:00.000Z
+cast: "/casts/examples/hooks-custom-command/hook-config.cast"
+castTitle: "atmos custom command hook"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-25-hooks-step-types.mdx
+++ b/website/blog/2026-06-25-hooks-step-types.mdx
@@ -6,7 +6,7 @@ tags: [feature]
 date: 2026-06-25T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos hooks can now run any workflow step type. A new `kind: step` hook bridges the
 component lifecycle (before/after `terraform plan`, `apply`, `deploy`, `init`) to the same
@@ -15,7 +15,7 @@ step registry that powers workflows and custom commands — so a `container`, `t
 
 Here's a `kind: step` hook wired to a custom command, running end to end:
 
-<CastPlayer src="/casts/examples/hooks-custom-command/hook-config.cast" title="atmos custom command hook" chrome controls scrubber />
+<CastEmbed src="/casts/examples/hooks-custom-command/hook-config.cast" title="atmos custom command hook" chrome controls scrubber />
 
 [View the full example](/examples/hooks-custom-command)
 

--- a/website/blog/2026-06-27-introducing-emulators.mdx
+++ b/website/blog/2026-06-27-introducing-emulators.mdx
@@ -6,7 +6,7 @@ tags: [feature]
 date: 2026-06-27T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 A big challenge for infrastructure developers is how hard it is to iterate locally. Every
 `terraform apply` needs a real cloud account, costs real money, and touches a live environment. And in
@@ -143,13 +143,13 @@ See the [emulator component reference](/stacks/components/emulator) and the
 
 See the AWS emulator lifecycle in action:
 
-<CastPlayer src="/casts/examples/emulator-aws/lifecycle.cast" title="atmos emulator aws lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/emulator-aws/lifecycle.cast" title="atmos emulator aws lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/emulator-aws)
 
 And the Kubernetes emulator lifecycle:
 
-<CastPlayer src="/casts/examples/emulator-k8s/lifecycle.cast" title="atmos kubernetes emulator lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/emulator-k8s/lifecycle.cast" title="atmos kubernetes emulator lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/emulator-k8s)
 

--- a/website/blog/2026-06-27-introducing-emulators.mdx
+++ b/website/blog/2026-06-27-introducing-emulators.mdx
@@ -4,6 +4,8 @@ title: "Introducing Emulators: Run Real Cloud Infrastructure Locally"
 authors: [osterman]
 tags: [feature]
 date: 2026-06-27T12:00:00.000Z
+cast: "/casts/examples/emulator-aws/lifecycle.cast"
+castTitle: "atmos emulator aws lifecycle"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-29-background-container-services.mdx
+++ b/website/blog/2026-06-29-background-container-services.mdx
@@ -4,6 +4,8 @@ title: "Background Container Services in Atmos Workflows"
 authors: [osterman]
 tags: [feature, dx]
 date: 2026-06-29T12:00:00.000Z
+cast: "/casts/examples/background-steps/service.cast"
+castTitle: "atmos background service"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-29-background-container-services.mdx
+++ b/website/blog/2026-06-29-background-container-services.mdx
@@ -6,7 +6,7 @@ tags: [feature, dx]
 date: 2026-06-29T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos workflows can now start long-running container services in the background, wait for them to become healthy, and tear them down automatically. Bring up an emulator, database, or registry with `background: true`, gate the next step on its container health check, and stop it with a `cancel` step — no shell scripts, no background jobs, no orphaned containers.
 
@@ -77,7 +77,7 @@ Atmos starts the emulator, blocks until its health check reports healthy, runs `
 
 Here it is running end to end:
 
-<CastPlayer src="/casts/examples/background-steps/service.cast" title="atmos background service" chrome controls scrubber />
+<CastEmbed src="/casts/examples/background-steps/service.cast" title="atmos background service" chrome controls scrubber />
 
 [View the full example](/examples/background-steps)
 

--- a/website/blog/2026-06-29-parallel-matrix-workflow-steps.mdx
+++ b/website/blog/2026-06-29-parallel-matrix-workflow-steps.mdx
@@ -6,7 +6,7 @@ tags: [feature, dx]
 date: 2026-06-29T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos workflows can now run independent work concurrently with first-class `parallel` and `matrix` control steps. Add dependency-aware fan-out, readable grouped or live-prefixed output, and explicit failure behavior directly to your workflow YAML.
 
@@ -185,7 +185,7 @@ atmos workflow matrix -f parallel
 
 Here are the control steps running end to end:
 
-<CastPlayer src="/casts/examples/parallel-steps/control-steps.cast" title="atmos parallel workflow steps" chrome controls scrubber />
+<CastEmbed src="/casts/examples/parallel-steps/control-steps.cast" title="atmos parallel workflow steps" chrome controls scrubber />
 
 [View the full example](/examples/parallel-steps)
 

--- a/website/blog/2026-06-29-parallel-matrix-workflow-steps.mdx
+++ b/website/blog/2026-06-29-parallel-matrix-workflow-steps.mdx
@@ -4,6 +4,8 @@ title: "Parallel and Matrix Steps for Atmos Workflows"
 authors: [osterman]
 tags: [feature, dx]
 date: 2026-06-29T12:00:00.000Z
+cast: "/casts/examples/parallel-steps/control-steps.cast"
+castTitle: "atmos parallel workflow steps"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-06-30-flag-aware-custom-commands.mdx
+++ b/website/blog/2026-06-30-flag-aware-custom-commands.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [enhancement, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Custom command steps can now read their own command-line flags through `{{ .Flags.<name> }}`, and the [`table`](/workflows/steps/type/table) step templates its `data`, `columns`, and `title` per-step. Together they let you build flag-driven runbooks — rich, dynamic output assembled declaratively in `atmos.yaml`, no shell scripting required.
 
@@ -60,7 +60,7 @@ atmos platform status -s plat-ue2-dev
 
 Every `{{ .Flags.stack }}` resolves to `plat-ue2-dev`, the stage titles and table rows fill in, and the shell steps run against the right stack.
 
-<CastPlayer src="/casts/examples/interactive-workflows/table-and-build.cast" title="atmos interactive workflow steps" chrome controls scrubber />
+<CastEmbed src="/casts/examples/interactive-workflows/table-and-build.cast" title="atmos interactive workflow steps" chrome controls scrubber />
 
 [View the full example](/examples/interactive-workflows)
 

--- a/website/blog/2026-06-30-flag-aware-custom-commands.mdx
+++ b/website/blog/2026-06-30-flag-aware-custom-commands.mdx
@@ -4,6 +4,8 @@ title: "Flag-Aware Custom Commands and Dynamic Tables"
 date: 2026-06-30T12:00:00.000Z
 authors: [osterman]
 tags: [enhancement, dx]
+cast: "/casts/examples/interactive-workflows/table-and-build.cast"
+castTitle: "atmos interactive workflow steps"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-01-local-terraform-tests-with-emulators.mdx
+++ b/website/blog/2026-07-01-local-terraform-tests-with-emulators.mdx
@@ -4,6 +4,8 @@ title: "Run Terraform Tests Locally Against Cloud Emulators"
 authors: [osterman]
 tags: [feature, dx]
 date: 2026-07-01T12:00:00.000Z
+cast: "/casts/examples/terraform-tests/stack-discovery.cast"
+castTitle: "atmos terraform tests"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-01-local-terraform-tests-with-emulators.mdx
+++ b/website/blog/2026-07-01-local-terraform-tests-with-emulators.mdx
@@ -6,7 +6,7 @@ tags: [feature, dx]
 date: 2026-07-01T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Terraform's native testing framework (`*.tftest.hcl`) is great — until you hit a `run` block with
 `command = apply`. Those blocks create **real** infrastructure, so running them means a cloud account,
@@ -51,7 +51,7 @@ the app resources against that VPC, and everything is torn down — no AWS accou
 
 Here's that stack discovery and test run end to end:
 
-<CastPlayer src="/casts/examples/terraform-tests/stack-discovery.cast" title="atmos terraform tests" chrome controls scrubber />
+<CastEmbed src="/casts/examples/terraform-tests/stack-discovery.cast" title="atmos terraform tests" chrome controls scrubber />
 
 [View the full example](/examples/terraform-tests)
 

--- a/website/blog/2026-07-01-native-kubernetes-components.mdx
+++ b/website/blog/2026-07-01-native-kubernetes-components.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now treats Kubernetes as a first-class component type. Define Kubernetes
 objects — inline manifests, files, directories, or Kustomize overlays — in your
@@ -50,7 +50,7 @@ atmos kubernetes apply  argocd -s plat-ue2-dev    # server-side apply
 [`--all`](/cli/commands/kubernetes/usage) and [`--affected`](/cli/commands/kubernetes/usage) run components in dependency order, so the same change
 detection that drives Terraform pipelines works for Kubernetes.
 
-<CastPlayer src="/casts/examples/kubernetes/lifecycle.cast" title="atmos kubernetes lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/kubernetes/lifecycle.cast" title="atmos kubernetes lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/kubernetes)
 

--- a/website/blog/2026-07-01-native-kubernetes-components.mdx
+++ b/website/blog/2026-07-01-native-kubernetes-components.mdx
@@ -4,6 +4,8 @@ title: "Native Kubernetes Components: Render, Apply, and Publish to GitOps Repos
 date: 2026-07-01T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/kubernetes/lifecycle.cast"
+castTitle: "atmos kubernetes lifecycle"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-02-native-helm-components.mdx
+++ b/website/blog/2026-07-02-native-helm-components.mdx
@@ -4,6 +4,8 @@ title: "Native Helm Components and `atmos helmfile template`"
 date: 2026-07-02T12:00:00.000Z
 authors: [osterman]
 tags: [feature, experimental]
+cast: "/casts/examples/helm/lifecycle.cast"
+castTitle: "atmos native helm lifecycle"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-02-native-helm-components.mdx
+++ b/website/blog/2026-07-02-native-helm-components.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature, experimental]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos now treats Helm as a first-class component type. Define a Helm release —
 local chart, remote repository chart, or OCI chart — in your stack configuration,
@@ -74,7 +74,7 @@ atmos helm apply monitoring -s plat-ue2-dev
 
 Here's the full lifecycle end to end:
 
-<CastPlayer src="/casts/examples/helm/lifecycle.cast" title="atmos native helm lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/helm/lifecycle.cast" title="atmos native helm lifecycle" chrome controls scrubber />
 
 [View the full example](/examples/helm)
 

--- a/website/blog/2026-07-07-cast-record-render.mdx
+++ b/website/blog/2026-07-07-cast-record-render.mdx
@@ -6,7 +6,7 @@ tags: [feature, dx]
 date: 2026-07-07T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Atmos can now record terminal sessions as asciicast files and render them into
 shareable formats for documentation, demos, and CI artifacts.
@@ -19,15 +19,15 @@ atmos cast render demo.cast --output=demo.out --format=html
 
 The `render` command turns a recording into a rendered artifact — here it's converted straight to a GIF:
 
-<CastPlayer src="/casts/cli/commands/cast/render.cast" title="atmos cast render" chrome controls scrubber />
+<CastEmbed src="/casts/cli/commands/cast/render.cast" title="atmos cast render" chrome controls scrubber />
 
 Replaying a recording in the terminal with `play` reproduces it exactly as it was captured:
 
-<CastPlayer src="/casts/cli/commands/cast/play.cast" title="atmos cast play" chrome controls scrubber />
+<CastEmbed src="/casts/cli/commands/cast/play.cast" title="atmos cast play" chrome controls scrubber />
 
 And any command can capture its own session as it runs with `--cast`, no separate recording step required:
 
-<CastPlayer src="/casts/cli/commands/cast/usage.cast" title="record a cast with --cast" chrome controls scrubber />
+<CastEmbed src="/casts/cli/commands/cast/usage.cast" title="record a cast with --cast" chrome controls scrubber />
 
 <!--truncate-->
 

--- a/website/blog/2026-07-07-cast-record-render.mdx
+++ b/website/blog/2026-07-07-cast-record-render.mdx
@@ -4,6 +4,8 @@ title: "Record and Render Terminal Sessions with Atmos Cast"
 authors: [osterman]
 tags: [feature, dx]
 date: 2026-07-07T12:00:00.000Z
+cast: "/casts/cli/commands/cast/render.cast"
+castTitle: "atmos cast render"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-08-atmos-demo-workflows.mdx
+++ b/website/blog/2026-07-08-atmos-demo-workflows.mdx
@@ -4,6 +4,8 @@ title: "See Atmos in Action"
 authors: [osterman]
 tags: [feature, dx]
 date: 2026-07-08T12:00:00.000Z
+cast: "/casts/demo/fixtures/native-terraform/plan.cast"
+castTitle: "atmos terraform plan"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-08-atmos-demo-workflows.mdx
+++ b/website/blog/2026-07-08-atmos-demo-workflows.mdx
@@ -6,11 +6,11 @@ tags: [feature, dx]
 date: 2026-07-08T12:00:00.000Z
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Start with the recording.
 
-<CastPlayer src="/casts/demo/fixtures/native-terraform/plan.cast" title="atmos terraform plan" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/native-terraform/plan.cast" title="atmos terraform plan" chrome controls scrubber />
 
 That is the point of this update: the docs now have short terminal casts for the parts of Atmos that are easier to understand by watching them run.
 
@@ -37,9 +37,9 @@ Each cast is meant to answer the same question: what will I see when I run this?
 
 The plan cast starts the set. The next two show the follow-up runs:
 
-<CastPlayer src="/casts/demo/fixtures/native-terraform/deploy.cast" title="atmos terraform deploy" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/native-terraform/deploy.cast" title="atmos terraform deploy" chrome controls scrubber />
 
-<CastPlayer src="/casts/demo/fixtures/native-terraform/output.cast" title="atmos terraform output" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/native-terraform/output.cast" title="atmos terraform output" chrome controls scrubber />
 
 Together, they show the basic path from preview to apply to result.
 
@@ -47,7 +47,7 @@ Together, they show the basic path from preview to apply to result.
 
 This cast shows the source pull by itself:
 
-<CastPlayer src="/casts/demo/fixtures/demo-vendoring/pull.cast" title="atmos vendor pull" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/demo-vendoring/pull.cast" title="atmos vendor pull" chrome controls scrubber />
 
 It is intentionally plain. You can see what is fetched and what the terminal prints when it finishes.
 
@@ -55,11 +55,11 @@ It is intentionally plain. You can see what is fetched and what the terminal pri
 
 Sometimes the next step is to inspect the project before changing anything.
 
-<CastPlayer src="/casts/demo/fixtures/basic/list-stacks.cast" title="atmos list stacks" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/basic/list-stacks.cast" title="atmos list stacks" chrome controls scrubber />
 
-<CastPlayer src="/casts/demo/fixtures/basic/describe-component.cast" title="atmos describe component" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/basic/describe-component.cast" title="atmos describe component" chrome controls scrubber />
 
-<CastPlayer src="/casts/demo/fixtures/basic/describe-stacks.cast" title="atmos describe stacks" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/basic/describe-stacks.cast" title="atmos describe stacks" chrome controls scrubber />
 
 These casts show what Atmos sees before you ask it to do anything else.
 
@@ -67,7 +67,7 @@ These casts show what Atmos sees before you ask it to do anything else.
 
 The longest cast shows a full local AWS run:
 
-<CastPlayer src="/casts/examples/emulator-aws/lifecycle.cast" title="atmos emulator aws lifecycle" chrome controls scrubber />
+<CastEmbed src="/casts/examples/emulator-aws/lifecycle.cast" title="atmos emulator aws lifecycle" chrome controls scrubber />
 
 It brings the local service up, waits for it, runs against it, prints the result, and shuts it down.
 

--- a/website/blog/2026-07-08-atmos-version-tracker.mdx
+++ b/website/blog/2026-07-08-atmos-version-tracker.mdx
@@ -4,6 +4,8 @@ title: "One Catalog for Every Version Pin: the Atmos Version Tracker"
 date: 2026-07-08T12:00:00.000Z
 authors: [osterman]
 tags: [feature]
+cast: "/casts/examples/demo-component-versions/vendor-versions.cast"
+castTitle: "atmos component version vendoring"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-08-atmos-version-tracker.mdx
+++ b/website/blog/2026-07-08-atmos-version-tracker.mdx
@@ -6,13 +6,13 @@ authors: [osterman]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Your infrastructure's versions live everywhere except one place. `actions/checkout@v4` in a dozen workflow files, `TOFU_VERSION=1.9.0` in a Dockerfile, `nginx:1.27` in a stack, `kubectl` wherever your bootstrap script says. When a version needs to move, you grep and hope. When it shouldn't move, nothing enforces that either — and every unpinned mutable tag is a supply-chain incident waiting for its moment. The Atmos Version Tracker gives all of those versions a single source of truth: a catalog in `atmos.yaml`, a deterministic lock file, policy-driven updates, and file managers that rewrite your workflows, Dockerfiles, and rendered files from the lock.
 
 Here's the same idea applied to vendored component versions:
 
-<CastPlayer src="/casts/examples/demo-component-versions/vendor-versions.cast" title="atmos component version vendoring" chrome controls scrubber />
+<CastEmbed src="/casts/examples/demo-component-versions/vendor-versions.cast" title="atmos component version vendoring" chrome controls scrubber />
 
 [View the full example](/examples/demo-component-versions)
 

--- a/website/blog/2026-07-17-init-real-starter-project.mdx
+++ b/website/blog/2026-07-17-init-real-starter-project.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [enhancement, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Initializing a project should establish a useful local starting point, not leave a developer with
 an empty directory and a list of conventions to reconstruct. Modern development platforms provide
@@ -20,7 +20,7 @@ rather than asking every team to assemble it from scratch.
 
 <!--truncate-->
 
-<CastPlayer src="/casts/examples/init/init-basic.cast" title="atmos init a working project" chrome controls scrubber />
+<CastEmbed src="/casts/examples/init/init-basic.cast" title="atmos init a working project" chrome controls scrubber />
 
 [View the full init example](/examples/init)
 

--- a/website/blog/2026-07-17-init-real-starter-project.mdx
+++ b/website/blog/2026-07-17-init-real-starter-project.mdx
@@ -4,6 +4,8 @@ title: "Initialize an Atmos project from a proven starting point"
 date: 2026-07-17T12:00:00.000Z
 authors: [osterman]
 tags: [enhancement, dx]
+cast: "/casts/examples/init/init-basic.cast"
+castTitle: "atmos init a working project"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-17-scaffold-conditional-generation-and-hooks.mdx
+++ b/website/blog/2026-07-17-scaffold-conditional-generation-and-hooks.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Platform teams build golden paths so application teams can begin with the right architecture,
 guardrails, and operational conventions. A GitHub template repository is an excellent way to
@@ -25,7 +25,7 @@ blindly replacing the custom work that happened after initialization.
 
 <!--truncate-->
 
-<CastPlayer src="/casts/examples/scaffolding/generate-example.cast" title="atmos scaffold golden path" chrome controls scrubber />
+<CastEmbed src="/casts/examples/scaffolding/generate-example.cast" title="atmos scaffold golden path" chrome controls scrubber />
 
 [View the full scaffolding example](/examples/scaffolding)
 

--- a/website/blog/2026-07-17-scaffold-conditional-generation-and-hooks.mdx
+++ b/website/blog/2026-07-17-scaffold-conditional-generation-and-hooks.mdx
@@ -4,6 +4,8 @@ title: "Scaffolds turn your golden paths into a platform product"
 date: 2026-07-17T12:00:00.000Z
 authors: [osterman]
 tags: [feature, dx]
+cast: "/casts/examples/scaffolding/generate-example.cast"
+castTitle: "atmos scaffold golden path"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-17-toolchain-proxies.mdx
+++ b/website/blog/2026-07-17-toolchain-proxies.mdx
@@ -4,6 +4,8 @@ title: "Toolchain proxies install only the commands you use"
 date: 2026-07-17T12:00:00.000Z
 authors: [atmos]
 tags: [feature, dx]
+cast: "/casts/examples/toolchain/proxies.cast"
+castTitle: "atmos toolchain proxies"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-07-17-toolchain-proxies.mdx
+++ b/website/blog/2026-07-17-toolchain-proxies.mdx
@@ -6,7 +6,7 @@ authors: [atmos]
 tags: [feature, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Installing every tool a repository might eventually need makes project setup slow and wasteful.
 Atmos toolchain proxies provide on-demand, just-in-time installation instead: invoking a configured
@@ -21,7 +21,7 @@ aliases, copied shims, or a different invocation in every repository.
 
 <!--truncate-->
 
-<CastPlayer src="/casts/examples/toolchain/proxies.cast" title="atmos toolchain proxies" chrome controls scrubber />
+<CastEmbed src="/casts/examples/toolchain/proxies.cast" title="atmos toolchain proxies" chrome controls scrubber />
 
 ## Install on Demand, Keep Versions Pinned
 

--- a/website/blog/2026-07-24-terraform-tfmigrate.mdx
+++ b/website/blog/2026-07-24-terraform-tfmigrate.mdx
@@ -6,7 +6,7 @@ authors: [osterman]
 tags: [feature, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Refactoring Terraform code leaves state behind. Rename a resource, or move it between root modules, and every plan shows a destroy-and-recreate for infrastructure that never changed. You can fix this by hand with `terraform state mv`, but that command only fixes one workspace at a time. It is easy to get wrong, and no one can review it before it runs.
 
@@ -19,7 +19,7 @@ atmos terraform migrate apply s3-bucket -s plat-ue2-dev
 
 <!--truncate-->
 
-<CastPlayer src="/casts/examples/hooks-tfmigrate/tfmigrate-example.cast" title="atmos terraform migrate" chrome controls scrubber />
+<CastEmbed src="/casts/examples/hooks-tfmigrate/tfmigrate-example.cast" title="atmos terraform migrate" chrome controls scrubber />
 
 ## What Changed
 

--- a/website/blog/2026-07-24-terraform-tfmigrate.mdx
+++ b/website/blog/2026-07-24-terraform-tfmigrate.mdx
@@ -4,6 +4,8 @@ title: "Terraform state migrations with tfmigrate"
 date: 2026-07-24T12:00:00.000Z
 authors: [osterman]
 tags: [feature, dx]
+cast: "/casts/examples/hooks-tfmigrate/tfmigrate-example.cast"
+castTitle: "atmos terraform migrate"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-08-14-scaffold-matrix.mdx
+++ b/website/blog/2026-08-14-scaffold-matrix.mdx
@@ -6,7 +6,7 @@ authors: [jorrite]
 tags: [feature]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Every file a scaffold template declares renders at most once. `when:` can skip a file, but it
 can never multiply one. You could work around that by authoring every combination up front and
@@ -95,7 +95,7 @@ prunes the combination down to each environment's actual regions, so `dev` never
 
 ## How to Use It
 
-<CastPlayer src="/casts/examples/scaffolding-matrix/generate-example.cast" title="atmos scaffold: one file per selection via matrix" chrome controls scrubber />
+<CastEmbed src="/casts/examples/scaffolding-matrix/generate-example.cast" title="atmos scaffold: one file per selection via matrix" chrome controls scrubber />
 
 The [scaffolding-matrix example](/examples/scaffolding-matrix) is a minimal, runnable template —
 one `multiselect` field driving one matrix axis:

--- a/website/blog/2026-08-14-scaffold-matrix.mdx
+++ b/website/blog/2026-08-14-scaffold-matrix.mdx
@@ -4,6 +4,8 @@ title: "Generate one file per selection with matrix"
 date: 2026-08-14T12:00:00.000Z
 authors: [jorrite]
 tags: [feature]
+cast: "/casts/examples/scaffolding-matrix/generate-example.cast"
+castTitle: "atmos scaffold: one file per selection via matrix"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-08-25-terraform-streaming-ui.mdx
+++ b/website/blog/2026-08-25-terraform-streaming-ui.mdx
@@ -3,6 +3,8 @@ slug: terraform-streaming-ui
 title: "Introducing Streaming UI: Real-Time Progress for Terraform Commands"
 authors: [osterman]
 tags: [feature, dx]
+cast: "/casts/demo/fixtures/streaming-ui/terraform-ui.cast"
+castTitle: "atmos terraform --ui: plan, apply, destroy"
 ---
 
 import CastEmbed from '@site/src/components/CastEmbed'

--- a/website/blog/2026-08-25-terraform-streaming-ui.mdx
+++ b/website/blog/2026-08-25-terraform-streaming-ui.mdx
@@ -5,13 +5,13 @@ authors: [osterman]
 tags: [feature, dx]
 ---
 
-import CastPlayer from '@site/src/components/CastPlayer'
+import CastEmbed from '@site/src/components/CastEmbed'
 
 Say goodbye to overwhelming Terraform output. The new [streaming UI](/cli/configuration/components/terraform) mode transforms verbose terraform output into a clean, Docker-build-style progress display with interactive confirmations, resource dependency tree visualization, and attribute-level change details.
 
 <!--truncate-->
 
-<CastPlayer src="/casts/demo/fixtures/streaming-ui/terraform-ui.cast" title="atmos terraform --ui: plan, apply, destroy" chrome controls scrubber />
+<CastEmbed src="/casts/demo/fixtures/streaming-ui/terraform-ui.cast" title="atmos terraform --ui: plan, apply, destroy" chrome controls scrubber />
 
 ## What Changed
 

--- a/website/src/components/CastEmbed/index.tsx
+++ b/website/src/components/CastEmbed/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import CastPlayer from '@site/src/components/CastPlayer';
+import CastProDownload from '@site/src/components/CastProDownload';
+import CastShareLink from '@site/src/components/CastShareLink';
+import { siteCastPath } from '@site/src/components/CastProArtifact/url.mjs';
+import type { CastFormat } from '@site/src/components/CastProArtifact/useCastArtifact';
+
+import styles from './styles.module.css';
+
+type CastPlayerProps = React.ComponentProps<typeof CastPlayer>;
+
+export interface CastEmbedProps extends CastPlayerProps {
+  owner?: string;
+  repo?: string;
+  gitRef?: string;
+  download?: boolean;
+  share?: boolean;
+  formats?: CastFormat[];
+  ttlSeconds?: number;
+  soundtrack?: string;
+}
+
+/**
+ * `CastPlayer` plus the Atmos Pro "Download" and "Share" controls, wired to
+ * the same repo path convention as the examples-gallery pages
+ * (`FileBrowser/DirectoryPage.tsx`). Used for blog/changelog cast embeds so
+ * readers can download a rendered GIF/MP4/SVG/WEBM or share the cast, not
+ * just play it inline.
+ */
+export default function CastEmbed({
+  owner,
+  repo,
+  gitRef = 'main',
+  download = true,
+  share = true,
+  formats,
+  ttlSeconds,
+  soundtrack,
+  ...playerProps
+}: CastEmbedProps): JSX.Element {
+  const path = siteCastPath(playerProps.src);
+  const showActions = (download || share) && !playerProps.static;
+
+  return (
+    <div>
+      <CastPlayer {...playerProps} />
+      {showActions && (
+        <div className={styles.castActions}>
+          {share && (
+            <CastShareLink owner={owner} repo={repo} gitRef={gitRef} path={path} />
+          )}
+          {download && (
+            <CastProDownload
+              owner={owner}
+              repo={repo}
+              gitRef={gitRef}
+              path={path}
+              formats={formats}
+              ttlSeconds={ttlSeconds}
+              soundtrack={soundtrack}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/CastEmbed/styles.module.css
+++ b/website/src/components/CastEmbed/styles.module.css
@@ -1,0 +1,6 @@
+.castActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/website/src/components/CastPlayer/index.tsx
+++ b/website/src/components/CastPlayer/index.tsx
@@ -42,6 +42,8 @@ type Props = {
    * instead of clipping to a 16:9 viewport. Used for docs screengrabs.
    */
   static?: boolean;
+  /** Extra class name(s) merged onto the root element, e.g. to override the `thumbnail` width cap. */
+  className?: string;
 };
 
 export default function CastPlayer({
@@ -65,6 +67,7 @@ export default function CastPlayer({
   enterDelay = 0.5,
   exitDelay = 0.6,
   static: staticFrame = false,
+  className,
 }: Props) {
   const [events, setEvents] = useState<CastEvent[]>([]);
   const [content, setContent] = useState("");
@@ -289,6 +292,7 @@ export default function CastPlayer({
     chrome ? styles.window : styles.plain,
     thumbnail ? styles.thumbnail : "",
     staticFrame ? styles.staticFrame : "",
+    className || "",
   ]
     .filter(Boolean)
     .join(" ");

--- a/website/src/components/CastProArtifact/url.mjs
+++ b/website/src/components/CastProArtifact/url.mjs
@@ -2,6 +2,12 @@ const ATMOS_PRO_BASE_URL = "https://atmos-pro.com";
 
 export const CAST_FORMATS = ["gif", "mp4", "svg", "webm"];
 
+// .cast files are committed under website/static/**, so the Atmos Pro
+// rendering service's repo-relative path is that literal static path.
+export function siteCastPath(src) {
+  return `website/static${src}`;
+}
+
 function encodePathSegments(path) {
   return path
     .replace(/^\/+/, "")

--- a/website/src/components/CastProArtifact/url.test.mjs
+++ b/website/src/components/CastProArtifact/url.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { CAST_FORMATS, buildArtifactUrl, buildEmbedUrl } from "./url.mjs";
+import { CAST_FORMATS, buildArtifactUrl, buildEmbedUrl, siteCastPath } from "./url.mjs";
 
 test("buildArtifactUrl defaults owner/repo to cloudposse/atmos", () => {
   const url = buildArtifactUrl({ ref: "main", path: "examples/quickstart.cast", format: "gif" });
@@ -83,4 +83,11 @@ test("buildEmbedUrl includes ttlSeconds and moves a slash-containing ref to the 
   assert.equal(url.pathname, "/casts/cloudposse/atmos/demo.cast");
   assert.equal(url.searchParams.get("ref"), "feature/foo");
   assert.equal(url.searchParams.get("ttlSeconds"), "60");
+});
+
+test("siteCastPath resolves a blog/docs cast src to its committed website/static path", () => {
+  assert.equal(
+    siteCastPath("/casts/examples/demo-component-versions/vendor-versions.cast"),
+    "website/static/casts/examples/demo-component-versions/vendor-versions.cast",
+  );
 });

--- a/website/src/components/ChangelogTimeline/TimelineEntry.tsx
+++ b/website/src/components/ChangelogTimeline/TimelineEntry.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
+import CastPlayer from '@site/src/components/CastPlayer';
 import type { BlogPostItem } from './utils';
 import { getTagColorClass } from './utils';
 import styles from './styles.module.css';
@@ -15,8 +16,9 @@ export default function TimelineEntry({
   position,
 }: TimelineEntryProps): JSX.Element {
   // Docusaurus provides metadata and frontMatter as siblings on content.
-  const { metadata } = item.content;
+  const { metadata, frontMatter } = item.content;
   const { title, permalink, date, tags = [], description } = metadata;
+  const { cast, castTitle } = frontMatter;
 
   const formattedDate = new Date(date).toLocaleDateString('en-US', {
     month: 'short',
@@ -54,6 +56,25 @@ export default function TimelineEntry({
         </Link>
         {description && (
           <p className={styles.entryExcerpt}>{description}</p>
+        )}
+        {typeof cast === 'string' && cast && (
+          <Link
+            to={permalink}
+            className={styles.entryCastPreview}
+            aria-hidden="true"
+            tabIndex={-1}
+          >
+            <CastPlayer
+              src={cast}
+              title={typeof castTitle === 'string' && castTitle ? castTitle : title}
+              chrome
+              thumbnail
+              controls={false}
+              scrubber={false}
+              showCommand={false}
+              className={styles.entryCastThumbnail}
+            />
+          </Link>
         )}
       </div>
     </article>

--- a/website/src/components/ChangelogTimeline/styles.module.css
+++ b/website/src/components/ChangelogTimeline/styles.module.css
@@ -357,6 +357,21 @@
   line-height: 1.6;
 }
 
+/* Small cast preview - decorative duplicate of the entryTitle link, see TimelineEntry.tsx */
+.entryCastPreview,
+.entryCastPreview:hover {
+  display: block;
+  margin-top: 0.75rem;
+  border: none !important;
+  text-decoration: none !important;
+}
+
+/* Override CastPlayer's thumbnail max-width so the preview spans the card's text width. */
+.entryCastThumbnail {
+  width: 100% !important;
+  max-width: none !important;
+}
+
 /* ==================== */
 /* TAGS                 */
 /* ==================== */

--- a/website/src/components/ChangelogTimeline/utils.ts
+++ b/website/src/components/ChangelogTimeline/utils.ts
@@ -5,6 +5,10 @@
 
 export interface BlogPostFrontMatter {
   release?: string;
+  /** Path to a committed .cast recording, shown as a small preview on the timeline card. */
+  cast?: string;
+  /** Title shown in the timeline cast preview's chrome bar (falls back to the post title). */
+  castTitle?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## what

- Added a `CastEmbed` component (`website/src/components/CastEmbed/`) that wraps `CastPlayer` with the existing `CastShareLink` and `CastProDownload` controls, on by default.
- Added a `siteCastPath()` helper to `CastProArtifact/url.mjs` (with a unit test) that resolves a cast's public `src` to its committed `website/static/...` path, replacing an inline convention previously duplicated only in the file-browser example pages.
- Retrofitted all 38 existing blog posts under `website/blog/` from bare `<CastPlayer>` to `<CastEmbed>`, so every previously published changelog post's cast embed also gets Download/Share.
- Updated the `changelog`, `atmos-asciicast`, and `pull-request` skills to reference `CastEmbed` (with opt-out guidance via `download={false}`/`share={false}`) instead of bare `CastPlayer` for future blog posts.

## why

- Blog/changelog posts embedded casts with only play/pause and a scrubber — there was no way to download a rendered GIF/MP4/SVG/WEBM or share the cast, even though that capability (`CastProDownload`/`CastShareLink`) already existed and was wired into the examples-gallery pages.
- Centralizing the player+download+share composition in one `CastEmbed` component avoids every blog post (and future skill guidance) re-deriving the owner/repo/gitRef/path wiring by hand.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced cast embeds with optional Download and Share controls.
  - Controls are enabled by default for supported casts and can be individually hidden.
  - Download options support configurable formats and expiration settings.
  - Added cast previews to changelog timeline entries, linking recordings to their related posts.

- **Documentation**
  - Updated blog posts and authoring guidance to use enhanced cast embeds.
  - Existing recordings retain their sources, titles, and playback settings while gaining the new controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->