### PR TITLE
fix(helm): carry `create_namespace` through the stack processor

### DIFF
--- a/docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md
+++ b/docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md
@@ -57,17 +57,17 @@ raw stack manifest into the final, resolved component config. That whitelist liv
 
 ```go
 var helmComponentSectionKeys = []string{
-	cfg.ChartSectionName,
-	cfg.ValuesSectionName,
-	cfg.ValuesFilesSectionName,
-	cfg.RepositoriesSectionName,
-	cfg.RenderSectionName,
-	"version",
-	"repository",
-	"namespace",
-	"name",
-	cfg.HelmReleaseSectionName,
-	// create_namespace was missing here
+  cfg.ChartSectionName,
+  cfg.ValuesSectionName,
+  cfg.ValuesFilesSectionName,
+  cfg.RepositoriesSectionName,
+  cfg.RenderSectionName,
+  "version",
+  "repository",
+  "namespace",
+  "name",
+  cfg.HelmReleaseSectionName,
+  // create_namespace was missing here
 }
 ```
 
@@ -95,20 +95,34 @@ processing) — hence "validates fine, shows up nowhere."
   `TestExtractHelmComponentSectionCreateNamespace` — a regression test that confirms
   `create_namespace: false`/`true` survives `extractHelmComponentSection`, survives the full
   `extractComponentSections` path into `result.ComponentHelm`, is carried as a stack-level
-  lifecycle default, and is left unset (so the reader default applies) when the key is absent.
+  lifecycle default, is dropped from an `overrides:` block (current contract — see below), and
+  is left unset (so the reader default applies) when the key is absent.
+- `internal/exec/stack_processor_merge_test.go`: added
+  `TestMergeComponentConfigurations_CreateNamespacePrecedence` — proves a component-level value
+  wins over a stack-level default, and an unset component inherits the stack default.
 
-### Deliberate non-changes
+### Precedence
 
-- `helmOverrideSectionKeys` (the `overrides:` block whitelist) was **left narrow** — it still
-  accepts only `values`. Its comment states the intent to keep it narrow "until other Helm
-  fields have documented override semantics," so allowing `create_namespace` there is a
-  separate, documented decision rather than part of this bug fix. Setting `create_namespace`
-  directly on a component or as a stack-level `helm:` default both work; setting it inside an
-  `overrides:` block is intentionally not supported yet.
+The toggle can be set in two places (this fix); the more specific wins:
+
+| Where | Precedence | Use case |
+|-------|-----------|----------|
+| component field (`helmComponentSectionKeys`) | wins | per-release opt-out |
+| stack-level `helm:` default (`helmLifecycleSectionKeys`) | weaker — a component can override it | convenience default across components |
+
+### Deliberate non-change: overrides block
+
+`create_namespace` in an `overrides:` block is **intentionally not supported in this PR** and is
+tracked as a separate follow-up. Empirical CLI testing showed it needs more than a whitelist
+entry: the `helm_overrides` JSON schema is `additionalProperties: false` and rejects the key, and
+the type/global-level override propagation (what a platform team would use to enforce a setting
+across every component) is a separate mechanism that a `helmOverrideSectionKeys` change alone does
+not wire. `helmOverrideSectionKeys` is left narrow (only `values`), and a test guards that current
+contract.
 
 ## Why the original PR's tests missed it
 
-#3034's unit tests exercised `resolveCreateNamespace`/`buildChartSpec` by passing a section
+PR #3034's unit tests exercised `resolveCreateNamespace`/`buildChartSpec` by passing a section
 map with `create_namespace` already populated. They never ran through the stack processor's
 extraction whitelist, which is what strips the key at runtime. The regression test added here
 goes through `extractHelmComponentSection`/`extractComponentSections` — the layer that
@@ -118,11 +132,17 @@ actually dropped the field.
 
 - `go test ./internal/exec/ -run TestExtractHelmComponentSectionCreateNamespace -v` — the new
   test fails on the pre-fix whitelist (reproduces the drop) and passes after adding the key.
+- `go test ./internal/exec/ -run TestMergeComponentConfigurations_CreateNamespacePrecedence -v`
+  — proves component value > stack-default, and stack-default applies when the component is unset.
 - `go test ./internal/exec/ -run 'Helm'` — passes.
+- Empirical CLI run against a copy of `examples/helm` with `create_namespace: false` on the
+  component: `atmos describe stacks -s dev --components demo --component-types helm --sections
+  create_namespace` returned `create_namespace: false` (was `{}` before the fix).
 - `go build ./...`, `go test ./pkg/config/... ./pkg/component/helm/...` — pass.
 - `gofumpt` clean on all changed Go files.
 
 ## Follow-ups
 
-- Consider whether `create_namespace` should also be accepted in `overrides:` blocks
-  (`helmOverrideSectionKeys`); currently intentionally excluded.
+- Support `create_namespace` in an `overrides:` block (component, type, and global levels),
+  including the `helm_overrides` JSON schema and type/global override propagation. Deferred to a
+  separate PR. See "Deliberate non-change: overrides block" above.

--- a/docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md
+++ b/docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md
@@ -1,0 +1,128 @@
+# Fix: native-Helm `create_namespace` toggle silently dropped by the stack processor
+
+**Date:** 2026-09-11
+
+## Summary
+
+The `create_namespace` setting added to native Helm components in PR #3034 had no effect.
+Setting `create_namespace: false` on a component validated fine but was silently dropped
+during stack processing — it never reached the Helm executor, never appeared in
+`atmos describe stacks`, and the default of `true` always won. Installs into a
+platform-owned, pre-existing namespace still forced a namespace create, which fails with a
+`403` for an identity scoped to a single namespace (Helm issues the create request before
+the already-exists check applies).
+
+## Symptom
+
+Reported against Atmos 1.228.0 with a component like:
+
+```yaml
+components:
+  helm:
+    api:
+      chart: .
+      name: api
+      namespace: lakehouse-api
+      create_namespace: false   # cw-infra owns the namespace; Helm must not create it
+      values:
+        # ...
+```
+
+The toggle was invisible in the resolved config:
+
+```console
+$ atmos describe stacks -s dev --components api --component-types helm --sections namespace
+dev:
+  components:
+    helm:
+      api:
+        namespace: lakehouse-api
+
+$ atmos describe stacks -s dev --components api --component-types helm --sections create_namespace
+{}
+```
+
+`namespace` (a whitelisted field) survived; `create_namespace` came back empty.
+
+## Root cause
+
+PR #3034 wired the *reading* side of the toggle — `resolveCreateNamespace` /
+`boolFieldDefault` in `pkg/component/helm/values.go`, the `CreateNamespace` field on
+`chartSpec`, the install-action plumbing in `pkg/component/helm/client.go`, and the JSON
+schemas — but never wired it through the **stack processor**.
+
+The stack processor carries only a fixed whitelist of native-Helm fields from a component's
+raw stack manifest into the final, resolved component config. That whitelist lives in
+`internal/exec/stack_processor_process_stacks_helpers_extraction.go`:
+
+```go
+var helmComponentSectionKeys = []string{
+	cfg.ChartSectionName,
+	cfg.ValuesSectionName,
+	cfg.ValuesFilesSectionName,
+	cfg.RepositoriesSectionName,
+	cfg.RenderSectionName,
+	"version",
+	"repository",
+	"namespace",
+	"name",
+	cfg.HelmReleaseSectionName,
+	// create_namespace was missing here
+}
+```
+
+`extractHelmComponentSection` copies only these keys; any unrecognized key (including
+`create_namespace`) is dropped before the resolved section reaches
+`buildChartSpec`/`resolveCreateNamespace`. The reader then never sees the key and falls back
+to its `true` default.
+
+The JSON schema and the runtime whitelist are two independent lists. #3034 updated the schema
+(so validation accepted the key) but not the whitelist (so the key never survived
+processing) — hence "validates fine, shows up nowhere."
+
+## Changes
+
+- `pkg/config/const.go`: added `HelmCreateNamespaceSectionName = "create_namespace"` so the
+  key is referenced by a named constant rather than a bare string literal.
+- `internal/exec/stack_processor_process_stacks_helpers_extraction.go`:
+  - Added `cfg.HelmCreateNamespaceSectionName` to `helmComponentSectionKeys` so the toggle
+    flows through base-component inheritance and into the final component config (the core
+    fix — this is what the customer hit).
+  - Added `cfg.HelmCreateNamespaceSectionName` to `helmLifecycleSectionKeys` so the toggle
+    can also be set once as a stack-level `helm:` default and apply to every Helm component
+    (useful when a platform team owns all namespaces).
+- `internal/exec/stack_processor_process_stacks_helpers_test.go`: added
+  `TestExtractHelmComponentSectionCreateNamespace` — a regression test that confirms
+  `create_namespace: false`/`true` survives `extractHelmComponentSection`, survives the full
+  `extractComponentSections` path into `result.ComponentHelm`, is carried as a stack-level
+  lifecycle default, and is left unset (so the reader default applies) when the key is absent.
+
+### Deliberate non-changes
+
+- `helmOverrideSectionKeys` (the `overrides:` block whitelist) was **left narrow** — it still
+  accepts only `values`. Its comment states the intent to keep it narrow "until other Helm
+  fields have documented override semantics," so allowing `create_namespace` there is a
+  separate, documented decision rather than part of this bug fix. Setting `create_namespace`
+  directly on a component or as a stack-level `helm:` default both work; setting it inside an
+  `overrides:` block is intentionally not supported yet.
+
+## Why the original PR's tests missed it
+
+#3034's unit tests exercised `resolveCreateNamespace`/`buildChartSpec` by passing a section
+map with `create_namespace` already populated. They never ran through the stack processor's
+extraction whitelist, which is what strips the key at runtime. The regression test added here
+goes through `extractHelmComponentSection`/`extractComponentSections` — the layer that
+actually dropped the field.
+
+## Validation
+
+- `go test ./internal/exec/ -run TestExtractHelmComponentSectionCreateNamespace -v` — the new
+  test fails on the pre-fix whitelist (reproduces the drop) and passes after adding the key.
+- `go test ./internal/exec/ -run 'Helm'` — passes.
+- `go build ./...`, `go test ./pkg/config/... ./pkg/component/helm/...` — pass.
+- `gofumpt` clean on all changed Go files.
+
+## Follow-ups
+
+- Consider whether `create_namespace` should also be accepted in `overrides:` blocks
+  (`helmOverrideSectionKeys`); currently intentionally excluded.

--- a/internal/exec/stack_processor_merge_test.go
+++ b/internal/exec/stack_processor_merge_test.go
@@ -575,6 +575,52 @@ func TestMergeComponentConfigurations_HelmLifecyclePrecedence(t *testing.T) {
 	assert.Equal(t, map[string]any{"source": "override"}, component[cfg.ValuesSectionName])
 }
 
+// TestMergeComponentConfigurations_CreateNamespacePrecedence proves the precedence
+// chain for the native-Helm `create_namespace` toggle through the merge: a stack-level
+// `helm:` default is the weakest and a component-level value wins over it, while an
+// unset component inherits the stack default. (Overrides-block support is a separate
+// follow-up; not exercised here.)
+func TestMergeComponentConfigurations_CreateNamespacePrecedence(t *testing.T) {
+	atmosCfg := &schema.AtmosConfiguration{}
+
+	t.Run("component-value-wins-over-stack-default", func(t *testing.T) {
+		opts := ComponentProcessorOptions{
+			ComponentType: cfg.HelmComponentType,
+			Component:     "api",
+			AtmosConfig:   atmosCfg,
+			GlobalHelmLifecycle: map[string]any{
+				cfg.HelmCreateNamespaceSectionName: true,
+			},
+		}
+		result := minimalComponentResult()
+		result.ComponentHelm = map[string]any{
+			cfg.HelmCreateNamespaceSectionName: false,
+		}
+
+		component, _, err := mergeComponentConfigurations(atmosCfg, &opts, result)
+		require.NoError(t, err)
+		assert.Equal(t, false, component[cfg.HelmCreateNamespaceSectionName],
+			"a component-level create_namespace=false must win over a stack-level default of true")
+	})
+
+	t.Run("stack-default-applies-when-component-unset", func(t *testing.T) {
+		opts := ComponentProcessorOptions{
+			ComponentType: cfg.HelmComponentType,
+			Component:     "api",
+			AtmosConfig:   atmosCfg,
+			GlobalHelmLifecycle: map[string]any{
+				cfg.HelmCreateNamespaceSectionName: false,
+			},
+		}
+		result := minimalComponentResult()
+
+		component, _, err := mergeComponentConfigurations(atmosCfg, &opts, result)
+		require.NoError(t, err)
+		assert.Equal(t, false, component[cfg.HelmCreateNamespaceSectionName],
+			"a stack-level create_namespace=false must apply when the component does not set it")
+	})
+}
+
 func TestMergeComponentConfigurations_HelmReleaseIgnoresListMergeStrategy(t *testing.T) {
 	atmosCfg := &schema.AtmosConfiguration{Settings: schema.AtmosSettings{ListMergeStrategy: "append"}}
 	opts := ComponentProcessorOptions{

--- a/internal/exec/stack_processor_process_stacks_helpers_extraction.go
+++ b/internal/exec/stack_processor_process_stacks_helpers_extraction.go
@@ -348,12 +348,14 @@ var helmComponentSectionKeys = []string{
 	"namespace",
 	"name",
 	cfg.HelmReleaseSectionName,
+	cfg.HelmCreateNamespaceSectionName,
 }
 
 var helmLifecycleSectionKeys = []string{
 	cfg.ValuesSectionName,
 	cfg.RepositoriesSectionName,
 	cfg.HelmReleaseSectionName,
+	cfg.HelmCreateNamespaceSectionName,
 }
 
 // helmOverrideSectionKeys are native Helm fields accepted in a component or

--- a/internal/exec/stack_processor_process_stacks_helpers_extraction.go
+++ b/internal/exec/stack_processor_process_stacks_helpers_extraction.go
@@ -361,6 +361,12 @@ var helmLifecycleSectionKeys = []string{
 // helmOverrideSectionKeys are native Helm fields accepted in a component or
 // type-level overrides block. Keep this intentionally narrow until other Helm
 // fields have documented override semantics.
+//
+// `create_namespace` is deliberately NOT included yet: making it work through an
+// overrides block also requires adding it to the `helm_overrides` JSON schema
+// (which is `additionalProperties: false`) and wiring the type/global-level
+// override propagation, neither of which this focused fix covers. Tracked as a
+// follow-up.
 var helmOverrideSectionKeys = []string{
 	cfg.ValuesSectionName,
 }

--- a/internal/exec/stack_processor_process_stacks_helpers_test.go
+++ b/internal/exec/stack_processor_process_stacks_helpers_test.go
@@ -795,6 +795,83 @@ func TestExtractHelmSectionsIgnoreBareNullValues(t *testing.T) {
 	assert.NotContains(t, extractHelmOverrideSection(section), cfg.ValuesSectionName)
 }
 
+// TestExtractHelmComponentSectionCreateNamespace is a regression test for the
+// native-Helm `create_namespace` toggle being silently dropped by the stack
+// processor. The toggle is read downstream in pkg/component/helm, but the stack
+// processor only carries a whitelist of Helm fields into the final component
+// config, so before the fix `create_namespace` never reached the executor and
+// the default of true always won (see docs/fixes for details).
+func TestExtractHelmComponentSectionCreateNamespace(t *testing.T) {
+	// Compile-time guard: a rename of the constant fails the build.
+	_ = cfg.HelmCreateNamespaceSectionName
+
+	t.Run("explicit-false-survives-extraction", func(t *testing.T) {
+		section := map[string]any{
+			cfg.ChartSectionName:               ".",
+			"namespace":                        "lakehouse-api",
+			cfg.HelmCreateNamespaceSectionName: false,
+		}
+
+		component := extractHelmComponentSection(section)
+		require.Contains(t, component, cfg.HelmCreateNamespaceSectionName,
+			"create_namespace must be carried through to the final component config")
+		assert.Equal(t, false, component[cfg.HelmCreateNamespaceSectionName])
+	})
+
+	t.Run("explicit-true-survives-extraction", func(t *testing.T) {
+		section := map[string]any{
+			cfg.ChartSectionName:               ".",
+			cfg.HelmCreateNamespaceSectionName: true,
+		}
+
+		component := extractHelmComponentSection(section)
+		require.Contains(t, component, cfg.HelmCreateNamespaceSectionName)
+		assert.Equal(t, true, component[cfg.HelmCreateNamespaceSectionName])
+	})
+
+	t.Run("absent-key-left-unset-so-reader-default-applies", func(t *testing.T) {
+		section := map[string]any{
+			cfg.ChartSectionName: ".",
+		}
+
+		component := extractHelmComponentSection(section)
+		assert.NotContains(t, component, cfg.HelmCreateNamespaceSectionName)
+	})
+
+	t.Run("survives-full-component-extraction", func(t *testing.T) {
+		opts := ComponentProcessorOptions{
+			ComponentType: cfg.HelmComponentType,
+			Component:     "api",
+			StackName:     "dev",
+			ComponentMap: map[string]any{
+				cfg.ChartSectionName:               ".",
+				"name":                             "api",
+				"namespace":                        "lakehouse-api",
+				cfg.HelmCreateNamespaceSectionName: false,
+			},
+			AtmosConfig: &schema.AtmosConfiguration{},
+		}
+		result := &ComponentProcessorResult{}
+		require.NoError(t, extractComponentSections(&opts, result))
+
+		require.Contains(t, result.ComponentHelm, cfg.HelmCreateNamespaceSectionName,
+			"create_namespace must reach result.ComponentHelm to flow into the final component config")
+		assert.Equal(t, false, result.ComponentHelm[cfg.HelmCreateNamespaceSectionName])
+	})
+
+	t.Run("carried-as-stack-level-helm-lifecycle-default", func(t *testing.T) {
+		section := map[string]any{
+			cfg.ValuesSectionName:              map[string]any{"cluster": "shared"},
+			cfg.HelmCreateNamespaceSectionName: false,
+		}
+
+		defaults := extractHelmLifecycleSection(section)
+		require.Contains(t, defaults, cfg.HelmCreateNamespaceSectionName,
+			"create_namespace set on stack-level helm defaults must apply to every helm component")
+		assert.Equal(t, false, defaults[cfg.HelmCreateNamespaceSectionName])
+	})
+}
+
 // Compile-time guard: a rename of the schema Plugins fields fails the build.
 var (
 	_ = schema.Helm{Plugins: []string{"diff@v3.9.4"}}

--- a/internal/exec/stack_processor_process_stacks_helpers_test.go
+++ b/internal/exec/stack_processor_process_stacks_helpers_test.go
@@ -870,6 +870,19 @@ func TestExtractHelmComponentSectionCreateNamespace(t *testing.T) {
 			"create_namespace set on stack-level helm defaults must apply to every helm component")
 		assert.Equal(t, false, defaults[cfg.HelmCreateNamespaceSectionName])
 	})
+
+	t.Run("not-accepted-in-overrides-block-yet", func(t *testing.T) {
+		// create_namespace via an overrides block is a separate follow-up (needs the
+		// helm_overrides schema + type/global override propagation). Guard the current
+		// contract: the overrides whitelist stays narrow and drops it for now.
+		section := map[string]any{
+			cfg.ValuesSectionName:              map[string]any{"cluster": "shared"},
+			cfg.HelmCreateNamespaceSectionName: false,
+		}
+
+		overrides := extractHelmOverrideSection(section)
+		assert.NotContains(t, overrides, cfg.HelmCreateNamespaceSectionName)
+	})
 }
 
 // Compile-time guard: a rename of the schema Plugins fields fails the build.

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -148,6 +148,7 @@ const (
 	HelmChartHooksSectionName         = "chart_hooks"
 	HelmCRDsSectionName               = "crds"
 	HelmDependencyUpdateSectionName   = "dependency_update"
+	HelmCreateNamespaceSectionName    = "create_namespace"
 	HelmDefaultMaxHistory             = 10
 	InheritanceSectionName            = "inheritance"
 	IntegrationsSectionName           = "integrations"

--- a/pkg/datafetcher/schema_section_coverage_test.go
+++ b/pkg/datafetcher/schema_section_coverage_test.go
@@ -112,6 +112,7 @@ var nonManifestSections = map[string]struct{}{
 	"chart_hooks":        {}, // Native Helm chart-hook policy.
 	"crds":               {}, // Native Helm CRD policy.
 	"dependency_update":  {}, // Native Helm invocation summary field; not stack-authored.
+	"create_namespace":   {}, // Native Helm component sub-field (modeled in helm_component_manifest); not a standalone section.
 	"workspace":          {}, // Terraform workspace (derived/metadata).
 	"inheritance":        {}, // Describe output.
 	"integrations":       {}, // atmos.yaml / describe output.


### PR DESCRIPTION
## what

- Fix the native-Helm `create_namespace` setting (added in #3034) being **silently dropped** by the stack processor, so `create_namespace: false` had no effect.
- The stack processor carries only a fixed whitelist of native-Helm fields into the resolved component config, and `create_namespace` was not on it — so the key was stripped before it reached the Helm executor. `atmos describe stacks --sections create_namespace` returned `{}`, and the default of `true` always won.
- Add `create_namespace` to the per-component whitelist (`helmComponentSectionKeys`) and the stack-level `helm:` defaults whitelist (`helmLifecycleSectionKeys`), plus a `HelmCreateNamespaceSectionName` constant, regression + precedence tests, and a fix doc.

## why

- `create_namespace: false` validated fine (the JSON schema already accepted it) but was invisible in the resolved config and never reached `helm apply`. The JSON schema and the stack processor's runtime whitelist are two independent lists; #3034 updated the schema but not the whitelist — hence "validates fine, shows up nowhere."
- Without the fix, an identity scoped to a single, pre-existing namespace still forced a namespace create (Helm issues the create request before the already-exists check applies), which fails with a `403` — exactly the case `create_namespace: false` was meant to solve. Reported by a customer on Atmos 1.228.0.
- Backward compatible: the default remains `true`; only components that explicitly set `create_namespace: false` change behavior.

## Root cause

PR #3034 wired the **reader** side of the toggle — `resolveCreateNamespace` / `boolFieldDefault` in `pkg/component/helm/values.go`, the `CreateNamespace` field on `chartSpec`, the install-action plumbing in `pkg/component/helm/client.go`, and the JSON schemas — but never wired it through the **stack processor**. `extractHelmComponentSection` (`internal/exec/stack_processor_process_stacks_helpers_extraction.go`) copies only keys in `helmComponentSectionKeys`; any unrecognized key (including `create_namespace`) was dropped before the resolved section reached `buildChartSpec`, so the reader fell back to its `true` default.

## Fix

- `pkg/config/const.go`: add `HelmCreateNamespaceSectionName = "create_namespace"`.
- `internal/exec/stack_processor_process_stacks_helpers_extraction.go`:
  - add `cfg.HelmCreateNamespaceSectionName` to `helmComponentSectionKeys` (core fix — per-component, flows through base-component inheritance and into the final component config);
  - add it to `helmLifecycleSectionKeys` so it can also be set once as a stack-level `helm:` default and apply to every Helm component.
- `internal/exec/stack_processor_process_stacks_helpers_test.go`: `TestExtractHelmComponentSectionCreateNamespace`.
- `internal/exec/stack_processor_merge_test.go`: `TestMergeComponentConfigurations_CreateNamespacePrecedence`.
- `docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md`: fix record.

### Precedence (this PR)

| Where | Precedence | Use case |
|-------|-----------|----------|
| component field (`helmComponentSectionKeys`) | wins | per-release opt-out |
| stack-level `helm:` default (`helmLifecycleSectionKeys`) | weaker — a component can override it | convenience default across components |

## Testing

The concern was to prove `create_namespace` reaches the Helm SDK install action end-to-end (native Helm uses `action.Install`, not the `helm` binary), not just that it survives the whitelist. Every link was traced and verified.

| # | Stage | Carries `create_namespace`? | How verified |
|---|-------|-----------------------------|--------------|
| 1 | Stack manifest YAML | ✅ | JSON schema accepts it (#3034) |
| 2 | Stack processor `extractHelmComponentSection` | ✅ **(fix)** | new unit test; added to `helmComponentSectionKeys` |
| 3 | Merge → flatten into component map (`stack_processor_merge.go`) | ✅ | `comp[key]=value` over `finalComponentHelm`; `TestMergeComponentConfigurations_CreateNamespacePrecedence` |
| 4 | Resolved stacks map (read by `describe stacks`) | ✅ | **ran the built binary** — see below |
| 5 | `processComponentConfig` → `info.ComponentSection` | ✅ | `utils.go:310` copies the whole component map wholesale (no helm sub-filter) |
| 6 | Template + YAML-function round-trips | ✅ | round-trip type is `AtmosSectionMapType = map[string]any` (generic map — no typed-struct drop) |
| 7 | `buildChartSpec` / `resolveCreateNamespace` reads it | ✅ | `TestBuildChartSpec_CreateNamespacePropagates` (default-true and explicit-false) |
| 8 | `newInstallClient`: `client.CreateNamespace = spec.CreateNamespace` | ✅ | `TestNewInstallClient_WiresCreateNamespace` |
| 9 | Helm SDK install action honors it | ✅ | `TestApplyRelease_CreateNamespaceControlsNamespaceCreate` (recording kube client asserts namespace create only fires when `true`) |

**Two traps specifically ruled out:**
- **Typed-struct drop:** `schema.Helm` (the struct) is only the *global* `components.helm:` type defaults (base_path, plugins, repositories…). The **per-component** section travels as `map[string]any` and is never unmarshaled through a typed struct that would silence unknown keys. The template/YAML re-conversions use `map[string]any`.
- **Second whitelist:** `describe stacks` uses its own `extractDescribeComponentSections`, but that only pulls named sub-sections; it passes top-level scalar keys through (proof: `namespace`, also not in that struct, already appears in output).

**Empirical run** (built from this branch, against a copy of `examples/helm` with `create_namespace: false` added to the `demo` component):

```
$ atmos describe stacks -s dev --components demo --component-types helm --sections create_namespace
dev:
  components:
    helm:
      demo:
        create_namespace: false     # ← was {} before the fix
```

That output comes from the same resolved component map the executor feeds to `buildChartSpec`; steps 7–9 carry it the rest of the way to `client.CreateNamespace = false`.

**Automated tests + coverage (all pass):**
- `go test ./internal/exec/ -run TestExtractHelmComponentSectionCreateNamespace` — fails on the pre-fix whitelist (reproduces the drop), passes after the fix.
- `go test ./internal/exec/ -run TestMergeComponentConfigurations_CreateNamespacePrecedence` — component value wins over stack default; stack default applies when the component is unset.
- Coverage of the changed functions: `extractHelmComponentSection`, `extractHelmLifecycleSection`, `extractHelmOverrideSection` **100%**; `mergeComponentConfigurations` 97.6%.
- `go test ./internal/exec/ -run 'Helm'`, plus the full `./internal/exec/` suite; `go test ./pkg/component/helm/... ./pkg/config/...`.
- `go build ./...`; `gofumpt` clean.

## references

- Fixes the field added in #3034 (`Add create_namespace setting to native Helm components`).
- Docs: [Helm components](https://atmos.tools/stacks/components/helm)
- Fix record: `docs/fixes/2026-09-11-helm-create-namespace-stack-processor-drop.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Helm’s `create_namespace` setting is now preserved during stack processing.
  - Component-level values take precedence over stack-level defaults.
  - Explicit `true` and `false` values flow through correctly; omitted values retain existing defaults.
  - The setting remains unsupported in Helm overrides.

- **Tests**
  - Added regression coverage for extraction, lifecycle defaults, precedence, and unset values.

- **Documentation**
  - Added documentation covering the issue, supported behavior, validation steps, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->