### PR TITLE
chore(deps): add 14-day cooldown for Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "labels": ["no-release"],
   "rebaseWhen": "behind-base-branch",
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "14 days",
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "labels": ["no-release"],
   "rebaseWhen": "behind-base-branch",
+  "minimumReleaseAge": "7 days",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## what

- Add a repo-wide `minimumReleaseAge: "14 days"` cooldown to `renovate.json`.

## why

- Renovate was opening dependency-update PRs (e.g. `floci/floci` and `floci/floci-az` Docker digest bumps) the moment a new release/digest was published, with no waiting period.
- A cooldown lets a freshly published artifact prove itself before Atmos proposes pulling it in, reducing the chance of adopting a digest/version that's pulled or patched shortly after release.
- 14 days matches the `cooldown.default-days: 14` already set for every ecosystem in `.github/dependabot.yml`, so cooldown policy is consistent regardless of which bot opens the PR.
- Applying it repo-wide (not scoped to Docker only) covers Go modules, GitHub Actions, and npm updates the same way.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates now wait at least 14 days after release before being considered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->